### PR TITLE
add a option to disable kube scheduler in chart

### DIFF
--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.kubeScheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,3 +69,4 @@ data:
             }
         ]
     }
+{{- end }}

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.kubeScheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -48,3 +49,4 @@ data:
         ignoredByScheduler: true
       - name: {{ .Values.dcuResourceCores }}
         ignoredByScheduler: true
+{{- end }}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       serviceAccountName: {{ include "4pd-vgpu.scheduler" . }}
       priorityClassName: system-node-critical
       containers:
+      {{- if .Values.scheduler.kubeScheduler.enabled }}
         - name: kube-scheduler
           image: {{ .Values.scheduler.kubeScheduler.image }}:{{ .Values.scheduler.kubeScheduler.imageTag }}
           imagePullPolicy: {{ .Values.scheduler.kubeScheduler.imagePullPolicy | quote }}
@@ -49,6 +50,7 @@ spec:
           volumeMounts:
             - name: scheduler-config
               mountPath: /config
+        {{- end }}      
         - name: vgpu-scheduler-extender
           image: {{ .Values.scheduler.extender.image }}:{{ .Values.version }}
           imagePullPolicy: {{ .Values.scheduler.extender.imagePullPolicy | quote }}
@@ -80,6 +82,7 @@ spec:
         - name: tls-config
           secret:
             secretName: {{ template "4pd-vgpu.scheduler.tls" . }}
+        {{- if .Values.scheduler.kubeScheduler.enabled }}
         - name: scheduler-config
           configMap:
             {{- if ge (.Values.scheduler.kubeScheduler.imageTag | substr 3 5| atoi) 22 }}
@@ -87,6 +90,7 @@ spec:
             {{- else }}
             name: {{ template "4pd-vgpu.scheduler" . }}
             {{- end }}
+        {{- end }}
       {{- if .Values.scheduler.nodeSelector }}
       nodeSelector: {{ toYaml .Values.scheduler.nodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -40,6 +40,8 @@ scheduler:
   defaultCores: 0
   metricsBindAddress: ":9395"
   kubeScheduler:
+    # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.
+    enabled: true
     imageTag: "v1.20.0"
     image: registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
in our scenario, we have instanlled component `scheduler-plugins` replace the kube-scheduer, and want only install the vgpu-scheduler as a extender. we need to suport this way to deploy vgpu scheduler only. 

the test results:
```shell
helm install hami -n hami-system ./charts/hami --create-namespace --set scheduler.kubeScheduler.enabled=false --dry-run
```
<img width="743" alt="image" src="https://github.com/Project-HAMi/HAMi/assets/45745657/961e41f4-f24f-4399-9ff1-1d2f08327874">




