### PR TITLE
update device plugin svc label name

### DIFF
--- a/charts/hami/templates/device-plugin/monitorservice.yaml
+++ b/charts/hami/templates/device-plugin/monitorservice.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "4pd-vgpu.device-plugin" . }}-monitor
   labels:
-    app.kubernetes.io/component: 4pd-scheduler
+    app.kubernetes.io/component: 4pd-device-plugin
     {{- include "4pd-vgpu.labels" . | nindent 4 }}
     {{- if .Values.scheduler.service.labels }}
     {{ toYaml .Values.scheduler.service.labels | indent 4 }}


### PR DESCRIPTION
current `device-plugin` Service label name is `app.kubernetes.io/component: 4pd-scheduler`, hope is `app.kubernetes.io/component: 4pd-device-plugin`

from this PR https://github.com/Project-HAMi/HAMi/pull/158 found this issue