### PR TITLE
rename helm chart 4pd to hami

### DIFF
--- a/charts/hami/templates/_helpers.tpl
+++ b/charts/hami/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "4pd-vgpu.name" -}}
+{{- define "hami-vgpu.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "4pd-vgpu.fullname" -}}
+{{- define "hami-vgpu.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else }}
@@ -26,44 +26,44 @@ If release name contains chart name it will be used as a full name.
 {{/*
 The app name for Scheduler
 */}}
-{{- define "4pd-vgpu.scheduler" -}}
-{{- printf "%s-scheduler" ( include "4pd-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
+{{- define "hami-vgpu.scheduler" -}}
+{{- printf "%s-scheduler" ( include "hami-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 The app name for DevicePlugin
 */}}
-{{- define "4pd-vgpu.device-plugin" -}}
-{{- printf "%s-device-plugin" ( include "4pd-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
+{{- define "hami-vgpu.device-plugin" -}}
+{{- printf "%s-device-plugin" ( include "hami-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 The tls secret name for Scheduler
 */}}
-{{- define "4pd-vgpu.scheduler.tls" -}}
-{{- printf "%s-scheduler-tls" ( include "4pd-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
+{{- define "hami-vgpu.scheduler.tls" -}}
+{{- printf "%s-scheduler-tls" ( include "hami-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 The webhook name
 */}}
-{{- define "4pd-vgpu.scheduler.webhook" -}}
-{{- printf "%s-webhook" ( include "4pd-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
+{{- define "hami-vgpu.scheduler.webhook" -}}
+{{- printf "%s-webhook" ( include "hami-vgpu.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "4pd-vgpu.chart" -}}
+{{- define "hami-vgpu.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "4pd-vgpu.labels" -}}
-helm.sh/chart: {{ include "4pd-vgpu.chart" . }}
-{{ include "4pd-vgpu.selectorLabels" . }}
+{{- define "hami-vgpu.labels" -}}
+helm.sh/chart: {{ include "hami-vgpu.chart" . }}
+{{ include "hami-vgpu.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -73,15 +73,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "4pd-vgpu.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "4pd-vgpu.name" . }}
+{{- define "hami-vgpu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hami-vgpu.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Image registry secret name
 */}}
-{{- define "4pd-vgpu.imagePullSecrets" -}}
+{{- define "hami-vgpu.imagePullSecrets" -}}
 imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 2 }}
 {{- end }}
 

--- a/charts/hami/templates/device-plugin/configmap.yaml
+++ b/charts/hami/templates/device-plugin/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}
+  name: {{ include "hami-vgpu.device-plugin" . }}
   labels:
-    app.kubernetes.io/component: 4pd-device-plugin
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-device-plugin
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 data:
   config.json: |
     {

--- a/charts/hami/templates/device-plugin/daemonsethygon.yaml
+++ b/charts/hami/templates/device-plugin/daemonsethygon.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}-hygon
+  name: {{ include "hami-vgpu.device-plugin" . }}-hygon
   labels:
-    app.kubernetes.io/component: 4pd-device-plugin-hygon
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-device-plugin-hygon
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -14,20 +14,20 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: 4pd-device-plugin-hygon
-      {{- include "4pd-vgpu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hami-device-plugin-hygon
+      {{- include "hami-vgpu.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: 4pd-device-plugin-hygon
-        4pd.io/webhook: ignore
-        {{- include "4pd-vgpu.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hami-device-plugin-hygon
+        hami.io/webhook: ignore
+        {{- include "hami-vgpu.selectorLabels" . | nindent 8 }}
       {{- if .Values.devicePlugin.podAnnotations }}
       annotations: {{ toYaml .Values.devicePlugin.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
-      serviceAccountName: {{ include "4pd-vgpu.device-plugin" . }}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
+      serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
       hostNetwork: true
@@ -73,7 +73,7 @@ spec:
             path: /sys
         - name: deviceconfig
           configMap:
-            name: {{ template "4pd-vgpu.device-plugin" . }}
+            name: {{ template "hami-vgpu.device-plugin" . }}
         - name: lib
           hostPath:
             path: {{ .Values.devicePlugin.libPath }}

--- a/charts/hami/templates/device-plugin/daemonsetmlu.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetmlu.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}-mlu
+  name: {{ include "hami-vgpu.device-plugin" . }}-mlu
   labels:
-    app.kubernetes.io/component: 4pd-device-plugin-mlu
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-device-plugin-mlu
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -14,20 +14,20 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: 4pd-device-plugin-mlu
-      {{- include "4pd-vgpu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hami-device-plugin-mlu
+      {{- include "hami-vgpu.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: 4pd-device-plugin-mlu
-        4pd.io/webhook: ignore
-        {{- include "4pd-vgpu.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hami-device-plugin-mlu
+        hami.io/webhook: ignore
+        {{- include "hami-vgpu.selectorLabels" . | nindent 8 }}
       {{- if .Values.devicePlugin.podAnnotations }}
       annotations: {{ toYaml .Values.devicePlugin.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
-      serviceAccountName: {{ include "4pd-vgpu.device-plugin" . }}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
+      serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
             path: /sys
         - name: deviceconfig
           configMap:
-            name: {{ template "4pd-vgpu.device-plugin" . }}
+            name: {{ template "hami-vgpu.device-plugin" . }}
         - name: lib
           hostPath:
             path: {{ .Values.devicePlugin.libPath }}

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}
+  name: {{ include "hami-vgpu.device-plugin" . }}
   labels:
-    app.kubernetes.io/component: 4pd-device-plugin
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-device-plugin
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -14,14 +14,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: 4pd-device-plugin
-      {{- include "4pd-vgpu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hami-device-plugin
+      {{- include "hami-vgpu.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: 4pd-device-plugin
-        4pd.io/webhook: ignore
-        {{- include "4pd-vgpu.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hami-device-plugin
+        hami.io/webhook: ignore
+        {{- include "hami-vgpu.selectorLabels" . | nindent 8 }}
       {{- if .Values.devicePlugin.podAnnotations }}
       annotations: {{ toYaml .Values.devicePlugin.podAnnotations | nindent 8 }}
       {{- end }}
@@ -29,9 +29,9 @@ spec:
       {{- if .Values.devicePlugin.runtimeClassName }}
       runtimeClassName: {{ .Values.devicePlugin.runtimeClassName }}
       {{- end }}
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
       # serviceAccountName:
-      serviceAccountName: {{ include "4pd-vgpu.device-plugin" . }}
+      serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
       hostNetwork: true
@@ -136,7 +136,7 @@ spec:
             path: /var
         - name: deviceconfig
           configMap:
-            name: {{ template "4pd-vgpu.device-plugin" . }}
+            name: {{ template "hami-vgpu.device-plugin" . }}
       {{- if .Values.devicePlugin.nvidianodeSelector }}
       nodeSelector: {{ toYaml .Values.devicePlugin.nvidianodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/hami/templates/device-plugin/monitorrole.yaml
+++ b/charts/hami/templates/device-plugin/monitorrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name:  {{ include "4pd-vgpu.device-plugin" . }}-monitor
+  name:  {{ include "hami-vgpu.device-plugin" . }}-monitor
 rules:
   - apiGroups:
       - ""

--- a/charts/hami/templates/device-plugin/monitorrolebinding.yaml
+++ b/charts/hami/templates/device-plugin/monitorrolebinding.yaml
@@ -1,16 +1,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}
+  name: {{ include "hami-vgpu.device-plugin" . }}
   labels:
-    app.kubernetes.io/component: "4pd-device-plugin"
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "hami-device-plugin"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   #name: cluster-admin
-  name: {{ include "4pd-vgpu.device-plugin" . }}-monitor
+  name: {{ include "hami-vgpu.device-plugin" . }}-monitor
 subjects:
   - kind: ServiceAccount
-    name: {{ include "4pd-vgpu.device-plugin" . }}
+    name: {{ include "hami-vgpu.device-plugin" . }}
     namespace: {{ .Release.Namespace | quote }}

--- a/charts/hami/templates/device-plugin/monitorservice.yaml
+++ b/charts/hami/templates/device-plugin/monitorservice.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}-monitor
+  name: {{ include "hami-vgpu.device-plugin" . }}-monitor
   labels:
-    app.kubernetes.io/component: 4pd-device-plugin
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- if .Values.scheduler.service.labels }}
     {{ toYaml .Values.scheduler.service.labels | indent 4 }}
     {{- end }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   selector:
-    app.kubernetes.io/component: 4pd-device-plugin
+    app.kubernetes.io/component: hami-device-plugin
   type: NodePort
   ports:
     - name: monitorport

--- a/charts/hami/templates/device-plugin/monitorserviceaccount.yaml
+++ b/charts/hami/templates/device-plugin/monitorserviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "4pd-vgpu.device-plugin" . }}
+  name: {{ include "hami-vgpu.device-plugin" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: "4pd-device-plugin"
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "hami-device-plugin"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}
+  name: {{ include "hami-vgpu.scheduler" . }}
   labels:
-    app.kubernetes.io/component: 4pd-scheduler
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 data:
   config.json: |
     {

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}-newversion
+  name: {{ include "hami-vgpu.scheduler" . }}-newversion
   labels:
-    app.kubernetes.io/component: 4pd-scheduler
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 data:
   config.yaml: |
     {{- if gt (.Values.scheduler.kubeScheduler.imageTag | substr 3 5| atoi) 25}}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}
+  name: {{ include "hami-vgpu.scheduler" . }}
   labels:
-    app.kubernetes.io/component: 4pd-scheduler
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -15,20 +15,20 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: 4pd-scheduler
-      {{- include "4pd-vgpu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hami-scheduler
+      {{- include "hami-vgpu.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: 4pd-scheduler
-        {{- include "4pd-vgpu.selectorLabels" . | nindent 8 }}
-        4pd.io/webhook: ignore
+        app.kubernetes.io/component: hami-scheduler
+        {{- include "hami-vgpu.selectorLabels" . | nindent 8 }}
+        hami.io/webhook: ignore
       {{- if .Values.scheduler.podAnnotations }}
       annotations: {{ toYaml .Values.scheduler.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
-      serviceAccountName: {{ include "4pd-vgpu.scheduler" . }}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
+      serviceAccountName: {{ include "hami-vgpu.scheduler" . }}
       priorityClassName: system-node-critical
       containers:
       {{- if .Values.scheduler.kubeScheduler.enabled }}
@@ -81,14 +81,14 @@ spec:
       volumes:
         - name: tls-config
           secret:
-            secretName: {{ template "4pd-vgpu.scheduler.tls" . }}
+            secretName: {{ template "hami-vgpu.scheduler.tls" . }}
         {{- if .Values.scheduler.kubeScheduler.enabled }}
         - name: scheduler-config
           configMap:
             {{- if ge (.Values.scheduler.kubeScheduler.imageTag | substr 3 5| atoi) 22 }}
-            name: {{ template "4pd-vgpu.scheduler" . }}-newversion
+            name: {{ template "hami-vgpu.scheduler" . }}-newversion
             {{- else }}
-            name: {{ template "4pd-vgpu.scheduler" . }}
+            name: {{ template "hami-vgpu.scheduler" . }}
             {{- end }}
         {{- end }}
       {{- if .Values.scheduler.nodeSelector }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 rules:
   - apiGroups:
@@ -22,5 +22,5 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
-    - {{ include "4pd-vgpu.fullname" . }}-admission
+    - {{ include "hami-vgpu.fullname" . }}-admission
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
@@ -1,18 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  {{ include "4pd-vgpu.fullname" . }}-admission
+  name:  {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
 subjects:
   - kind: ServiceAccount
-    name: {{ include "4pd-vgpu.fullname" . }}-admission
+    name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ .Release.Namespace | quote }}

--- a/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission-create
+  name: {{ include "hami-vgpu.fullname" . }}-admission-create
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
@@ -15,16 +15,16 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: {{ include "4pd-vgpu.fullname" . }}-admission-create
+      name: {{ include "hami-vgpu.fullname" . }}-admission-create
       {{- if .Values.scheduler.patch.podAnnotations }}
       annotations: {{ toYaml .Values.scheduler.patch.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "4pd-vgpu.labels" . | nindent 8 }}
+        {{- include "hami-vgpu.labels" . | nindent 8 }}
         app.kubernetes.io/component: admission-webhook
-        4pd.io/webhook: ignore
+        hami.io/webhook: ignore
     spec:
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
       {{- if .Values.scheduler.patch.priorityClassName }}
       priorityClassName: {{ .Values.scheduler.patch.priorityClassName }}
       {{- end }}
@@ -41,14 +41,14 @@ spec:
             - --cert-name=tls.crt
             - --key-name=tls.key
             {{- if .Values.scheduler.customWebhook.enabled }}
-            - --host={{ printf "%s.%s.svc,127.0.0.1,%s" (include "4pd-vgpu.scheduler" .) .Release.Namespace .Values.scheduler.customWebhook.host}}
+            - --host={{ printf "%s.%s.svc,127.0.0.1,%s" (include "hami-vgpu.scheduler" .) .Release.Namespace .Values.scheduler.customWebhook.host}}
             {{- else }}
-            - --host={{ printf "%s.%s.svc,127.0.0.1" (include "4pd-vgpu.scheduler" .) .Release.Namespace }}
+            - --host={{ printf "%s.%s.svc,127.0.0.1" (include "hami-vgpu.scheduler" .) .Release.Namespace }}
             {{- end }}
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ include "4pd-vgpu.scheduler.tls" . }}
+            - --secret-name={{ include "hami-vgpu.scheduler.tls" . }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "4pd-vgpu.fullname" . }}-admission
+      serviceAccountName: {{ include "hami-vgpu.fullname" . }}-admission
       {{- if .Values.scheduler.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.scheduler.patch.nodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission-patch
+  name: {{ include "hami-vgpu.fullname" . }}-admission-patch
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
@@ -15,16 +15,16 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: {{ include "4pd-vgpu.fullname" . }}-admission-patch
+      name: {{ include "hami-vgpu.fullname" . }}-admission-patch
       {{- if .Values.scheduler.patch.podAnnotations }}
       annotations: {{ toYaml .Values.scheduler.patch.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "4pd-vgpu.labels" . | nindent 8 }}
+        {{- include "hami-vgpu.labels" . | nindent 8 }}
         app.kubernetes.io/component: admission-webhook
-        4pd.io/webhook: ignore
+        hami.io/webhook: ignore
     spec:
-      {{- include "4pd-vgpu.imagePullSecrets" . | nindent 6}}
+      {{- include "hami-vgpu.imagePullSecrets" . | nindent 6}}
       {{- if .Values.scheduler.patch.priorityClassName }}
       priorityClassName: {{ .Values.scheduler.patch.priorityClassName }}
       {{- end }}
@@ -38,13 +38,13 @@ spec:
           imagePullPolicy: {{ .Values.scheduler.patch.imagePullPolicy }}
           args:
             - patch
-            - --webhook-name={{ include "4pd-vgpu.scheduler.webhook" . }}
+            - --webhook-name={{ include "hami-vgpu.scheduler.webhook" . }}
             - --namespace={{ .Release.Namespace }}
             - --patch-validating=false
-            - --secret-name={{ include "4pd-vgpu.scheduler.tls" . }}
+            - --secret-name={{ include "hami-vgpu.scheduler.tls" . }}
             - --patch-failure-policy=Fail
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "4pd-vgpu.fullname" . }}-admission
+      serviceAccountName: {{ include "hami-vgpu.fullname" . }}-admission
       {{- if .Values.scheduler.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.scheduler.patch.nodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/psp.yaml
+++ b/charts/hami/templates/scheduler/job-patch/psp.yaml
@@ -2,12 +2,12 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 spec:
   allowPrivilegeEscalation: false

--- a/charts/hami/templates/scheduler/job-patch/role.yaml
+++ b/charts/hami/templates/scheduler/job-patch/role.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name:  {{ include "4pd-vgpu.fullname" . }}-admission
+  name:  {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 rules:
   - apiGroups:

--- a/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
@@ -1,18 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
 subjects:
   - kind: ServiceAccount
-    name: {{ include "4pd-vgpu.fullname" . }}-admission
+    name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ .Release.Namespace | quote }}

--- a/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
+++ b/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "4pd-vgpu.fullname" . }}-admission
+  name: {{ include "hami-vgpu.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook

--- a/charts/hami/templates/scheduler/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}
+  name: {{ include "hami-vgpu.scheduler" . }}
   labels:
-    app.kubernetes.io/component: "4pd-scheduler"
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "4pd-vgpu.scheduler" . }}
+    name: {{ include "hami-vgpu.scheduler" . }}
     namespace: {{ .Release.Namespace | quote }}

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}
+  name: {{ include "hami-vgpu.scheduler" . }}
   labels:
-    app.kubernetes.io/component: 4pd-scheduler
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- if .Values.scheduler.service.labels }}
     {{ toYaml .Values.scheduler.service.labels | indent 4 }}
     {{- end }}
@@ -25,6 +25,6 @@ spec:
       nodePort: {{ .Values.scheduler.service.monitorPort }}
       protocol: TCP
   selector:
-    app.kubernetes.io/component: 4pd-scheduler
-    {{- include "4pd-vgpu.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.selectorLabels" . | nindent 4 }}
 

--- a/charts/hami/templates/scheduler/serviceaccount.yaml
+++ b/charts/hami/templates/scheduler/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "4pd-vgpu.scheduler" . }}
+  name: {{ include "hami-vgpu.scheduler" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: "4pd-scheduler"
-    {{- include "4pd-vgpu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ include "4pd-vgpu.scheduler.webhook" . }}
+  name: {{ include "hami-vgpu.scheduler.webhook" . }}
 webhooks:
   - admissionReviewVersions:
     - v1beta1
@@ -10,23 +10,23 @@ webhooks:
       url: https://{{ .Values.scheduler.customWebhook.host}}:{{.Values.scheduler.customWebhook.port}}{{.Values.scheduler.customWebhook.path}}
       {{- else }}
       service:
-        name: {{ include "4pd-vgpu.scheduler" . }}
+        name: {{ include "hami-vgpu.scheduler" . }}
         namespace: {{ .Release.Namespace }}
         path: /webhook
         port: {{ .Values.scheduler.service.httpPort }}
       {{- end }}
     failurePolicy: {{ .Values.scheduler.mutatingWebhookConfiguration.failurePolicy }}
     matchPolicy: Equivalent
-    name: vgpu.4pd.io
+    name: vgpu.hami.io
     namespaceSelector:
       matchExpressions:
-      - key: 4pd.io/webhook
+      - key: hami.io/webhook
         operator: NotIn
         values:
         - ignore
     objectSelector:
       matchExpressions:
-      - key: 4pd.io/webhook
+      - key: hami.io/webhook
         operator: NotIn
         values:
         - ignore

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -1,4 +1,4 @@
-# Default values for 4pd-vgpu.
+# Default values for hami-vgpu.
 
 nameOverride: ""
 fullnameOverride: ""
@@ -21,7 +21,7 @@ dcuResourceName: "hygon.com/dcunum"
 dcuResourceMem: "hygon.com/dcumem"
 dcuResourceCores: "hygon.com/dcucores"
 
-schedulerName: "4pd-scheduler"
+schedulerName: "hami-scheduler"
 
 podSecurityPolicy:
   enabled: false
@@ -62,7 +62,7 @@ scheduler:
   #nodeSelector: 
   #  gpu: "on"
   tolerations: []
-  #serviceAccountName: "4pd-vgpu-scheduler-sa"
+  #serviceAccountName: "hami-vgpu-scheduler-sa"
   customWebhook:
     enabled: false
     # must be an endpoint using https.


### PR DESCRIPTION
from https://github.com/Project-HAMi/HAMi/issues/164

Rename hami helm charts and change the content of 4pd to hami


test result

Deploy the modified helm charts and all components run normally
```bash
➜  ~ helm list
NAME       	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART     	APP VERSION
nvidia-vgpu	default  	1       	2024-02-23 15:24:11.620889 +0800 CST	deployed	hami-2.0.0	0.0.2

➜  ~ helm get manifest nvidia-vgpu | grep 4pd
          image: 4pdosc/vdcu-device-plugin:v1.0

Make sure that except for the hygonimage, all other 4pd-related modifications have been completed.

➜  ~ kubectl get po
NAME                                         READY   STATUS    RESTARTS   AGE
nvidia-vgpu-hami-device-plugin-2fjw4         2/2     Running   0          16m
nvidia-vgpu-hami-scheduler-c798d9f46-ms79l   2/2     Running   0          16m
```

Deploy demo and vgpu is successfully allocated

```bash
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: gpu-test
  name: gpu-test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: gpu-test
  template:
    metadata:
      labels:
        app: gpu-test
    spec:
      containers:
      - args:
        - "6000"
        image: chrstnhntschl/gpu_burn
        imagePullPolicy: IfNotPresent
        name: aliyun-gpu-test
        resources:
          limits:
            nvidia.com/gpu: "1"
            nvidia.com/gpumem-percentage: 30

EOF

➜  ~ kubectl get po
NAME                                         READY   STATUS    RESTARTS   AGE
gpu-test-59cdd94745-s4ctz                    1/1     Running   0          13m

➜  ~ kubectl exec -it  gpu-test-59cdd94745-s4ctz nvidia-smi
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
[4pdvGPU Msg(14:140404318472000:libvgpu.c:836)]: Initializing.....
Fri Feb 23 07:27:24 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.86.10              Driver Version: 535.86.10    CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla P4                       On  | 00000000:13:00.0 Off |                    0 |
| N/A   49C    P0              68W /  75W |   2064MiB /  2304MiB |    100%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
+---------------------------------------------------------------------------------------+
[4pdvGPU Msg(14:140404318472000:multiprocess_memory_limit.c:434)]: Calling exit handler 14
```