### PR TITLE
rename golang code 4pd to hami

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	HandshakeAnnos         = "4pd.io/node-handshake-mlu"
-	RegisterAnnos          = "4pd.io/node-mlu-register"
+	HandshakeAnnos         = "hami.io/node-handshake-mlu"
+	RegisterAnnos          = "hami.io/node-mlu-register"
 	CambriconMLUDevice     = "MLU"
 	CambriconMLUCommonWord = "MLU"
 	MluMemSplitLimit       = "CAMBRICON_SPLIT_MEMS"

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -13,8 +13,8 @@ type DCUDevices struct {
 }
 
 const (
-	HandshakeAnnos     = "4pd.io/node-handshake-dcu"
-	RegisterAnnos      = "4pd.io/node-dcu-register"
+	HandshakeAnnos     = "hami.io/node-handshake-dcu"
+	RegisterAnnos      = "hami.io/node-dcu-register"
 	HygonDCUDevice     = "DCU"
 	HygonDCUCommonWord = "DCU"
 	DCUInUse           = "hygon.com/use-dcutype"

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	HandshakeAnnos      = "4pd.io/node-handshake"
-	RegisterAnnos       = "4pd.io/node-nvidia-register"
+	HandshakeAnnos      = "hami.io/node-handshake"
+	RegisterAnnos       = "hami.io/node-nvidia-register"
 	NvidiaGPUDevice     = "NVIDIA"
 	NvidiaGPUCommonWord = "GPU"
 	GPUInUse            = "nvidia.com/use-gputype"

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	NodeLockTime = "4pd.io/mutex.lock"
+	NodeLockTime = "hami.io/mutex.lock"
 	MaxLockRetry = 5
 )
 

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -22,13 +22,13 @@ import (
 
 const (
 	//ResourceName = "nvidia.com/gpu"
-	//ResourceName = "4pd.io/vgpu"
-	AssignedTimeAnnotations          = "4pd.io/vgpu-time"
-	AssignedIDsAnnotations           = "4pd.io/vgpu-ids-new"
-	AssignedIDsToAllocateAnnotations = "4pd.io/devices-to-allocate"
-	AssignedNodeAnnotations          = "4pd.io/vgpu-node"
-	BindTimeAnnotations              = "4pd.io/bind-time"
-	DeviceBindPhase                  = "4pd.io/bind-phase"
+	//ResourceName = "hami.io/vgpu"
+	AssignedTimeAnnotations          = "hami.io/vgpu-time"
+	AssignedIDsAnnotations           = "hami.io/vgpu-ids-new"
+	AssignedIDsToAllocateAnnotations = "hami.io/devices-to-allocate"
+	AssignedNodeAnnotations          = "hami.io/vgpu-node"
+	BindTimeAnnotations              = "hami.io/bind-time"
+	DeviceBindPhase                  = "hami.io/bind-phase"
 
 	DeviceBindAllocating = "allocating"
 	DeviceBindFailed     = "failed"


### PR DESCRIPTION
from https://github.com/Project-HAMi/HAMi/issues/164

Rename hami golang code and change the content of `4pd.io` to `hami.io`

test results

we can find the node annotations has been change by use the latest device-plugin binrary

```bash
➜  ~ kubectl describe no controller-node-1 | grep 'hami.io'
  hami.io/node-handshake: Reported 2024-02-27 14:11:45.338336866 +0000 UTC m=+30.239803637
  hami.io/node-nvidia-register: GPU-e290caca-2f0c-9582-acab-67a142b61ffa,10,7680,100,NVIDIA-Tesla P4,0,true:
```

Deploy demo and vgpu is successfully allocated

```bash
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: gpu-test
  name: gpu-test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: gpu-test
  template:
    metadata:
      labels:
        app: gpu-test
    spec:
      containers:
      - args:
        - "6000"
        image: chrstnhntschl/gpu_burn
        imagePullPolicy: IfNotPresent
        name: aliyun-gpu-test
        resources:
          limits:
            nvidia.com/vgpu: "1"
            nvidia.com/gpumem-percentage: 30

EOF
```

and the running pod with hami.io annotation

```bash
kubectl get po gpu-test-77fd8bd455-4xfg6 -o yaml  | grep 'hami.io'
    hami.io/bind-phase: success
    hami.io/bind-time: "1709049041"
    hami.io/vgpu-node: controller-node-1
    hami.io/vgpu-time: "1709049041"
```