### PR TITLE
add default gpu num value

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -67,6 +67,7 @@ spec:
             - --scheduler-name={{ .Values.schedulerName }}
             - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}
             - --default-mem={{ .Values.scheduler.defaultMem }}
+            - --default-gpu={{ .Values.scheduler.defaultGPUNum }}
             - --default-cores={{ .Values.scheduler.defaultCores }}
             - --iluvatar-memory={{ .Values.iluvatarResourceMem }}
             - --iluvatar-cores={{ .Values.iluvatarResourceCore }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -43,6 +43,7 @@ scheduler:
   nodeName: ""
   defaultMem: 0
   defaultCores: 0
+  defaultGPUNum: 1
   metricsBindAddress: ":9395"
   kubeScheduler:
     # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -55,6 +55,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.SchedulerName, "scheduler-name", "", "the name to be added to pod.spec.schedulerName if not empty")
 	rootCmd.Flags().Int32Var(&config.DefaultMem, "default-mem", 0, "default gpu device memory to allocate")
 	rootCmd.Flags().Int32Var(&config.DefaultCores, "default-cores", 0, "default gpu core percentage to allocate")
+	rootCmd.Flags().Int32Var(&config.DefaultResourceNum, "default-gpu", 1, "default gpu to allocate")
 	rootCmd.Flags().StringVar(&config.MetricsBindAddress, "metrics-bind-address", ":9395", "The TCP address that the scheduler should bind to for serving prometheus metrics(e.g. 127.0.0.1:9395, :9395)")
 	rootCmd.PersistentFlags().AddGoFlagSet(device.GlobalFlagSet())
 	rootCmd.AddCommand(version.VersionCmd)

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,8 @@ helm install vgpu-charts/vgpu vgpu --set devicePlugin.deviceMemoryScaling=5 ...
   Integer type, by default: 5000. The default device memory of the current task, in MB
 * `scheduler.defaultCores:` 
   Integer type, by default: equals 0. Percentage of GPU cores reserved for the current task. If assigned to 0, it may fit in any GPU with enough device memory. If assigned to 100, it will use an entire GPU card exclusively.
+* `scheduler.defaultGPUNum:`
+  Integer type, by default: equals 1, if configuration value is 0, then the configuration value will not take effect and will be filtered. when a user does not set nvidia.com/gpu this key in pod resource, webhook should check nvidia.com/gpumem、resource-mem-percentage、nvidia.com/gpucores this three key, anyone a key having value, webhook should add nvidia.com/gpu key and this default value to resources limits map.
 * `resourceName:`
   String type, vgpu number resource name, default: "nvidia.com/gpu"
 * `resourceMem:`

--- a/docs/config_cn.md
+++ b/docs/config_cn.md
@@ -18,6 +18,8 @@ helm install vgpu vgpu-charts/vgpu --set devicePlugin.deviceMemoryScaling=5 ...
   整数类型，预设值为5000，表示不配置显存时使用的默认显存大小，单位为MB
 * `scheduler.defaultCores:`
   整数类型(0-100)，默认为0，表示默认为每个任务预留的百分比算力。若设置为0，则代表任务可能会被分配到任一满足显存需求的GPU中，若设置为100，代表该任务独享整张显卡
+* `scheduler.defaultGPUNum:`
+  整数类型，默认为1，如果配置为0，则配置不会生效。当用户在 pod 资源中没有设置 nvidia.com/gpu 这个 key 时，webhook 会检查 nvidia.com/gpumem、resource-mem-percentage、nvidia.com/gpucores 这三个 key 中的任何一个 key 有值，webhook 都会添加 nvidia.com/gpu 键和此默认值到 resources limit中。
 * `resourceName:`
   字符串类型, 申请vgpu个数的资源名, 默认: "nvidia.com/gpu"
 * `resourceMem:`

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1,0 +1,98 @@
+package nvidia
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Test_DefaultResourceNum(t *testing.T) {
+	v := *resource.NewQuantity(1, resource.BinarySI)
+	vv, ok := v.AsInt64()
+	assert.Equal(t, ok, true)
+	assert.Equal(t, vv, int64(1))
+}
+
+func Test_MutateAdmission(t *testing.T) {
+	ResourceName = "nvidia.com/gpu"
+	ResourceMem = "nvidia.com/gpumem"
+	ResourceMemPercentage = "nvidia.com/gpumem-percentage"
+	ResourceCores = "nvidia.com/gpucores"
+	DefaultResourceNum = 1
+	tests := []struct {
+		name string
+		args *corev1.Container
+		want bool
+	}{
+		{
+			name: "having ResourceName set to resource limits.",
+			args: &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "don't having ResourceName, but having ResourceCores set to resource limits",
+			args: &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpucores": *resource.NewQuantity(1, resource.BinarySI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "don't having ResourceName, but having ResourceMem set to resource limits",
+			args: &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpumem": *resource.NewQuantity(1, resource.BinarySI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "don't having ResourceName, but having ResourceMemPercentage set to resource limits",
+			args: &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(1, resource.BinarySI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "don't having math resources.",
+			args: &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{},
+				},
+			},
+			want: false,
+		},
+	}
+
+	gpuDevices := &NvidiaGPUDevices{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := gpuDevices.MutateAdmission(test.args)
+			if test.want != got {
+				t.Fatalf("exec MutateAdmission method expect return is %+v, but got is %+v", test.want, got)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -21,5 +21,6 @@ var (
 	SchedulerName      string
 	DefaultMem         int32
 	DefaultCores       int32
+	DefaultResourceNum int32
 	MetricsBindAddress string
 )


### PR DESCRIPTION
It mainly simplifies user settings of resource limits. By default, the core and memory in one GPU are used.

issue: https://github.com/Project-HAMi/HAMi/issues/171
