### PR TITLE
Remove redundant assignment code for DefaultResourceNum

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -32,7 +32,6 @@ var (
 	ResourceMemPercentage string
 	ResourcePriority      string
 	DebugMode             bool
-	DefaultResourceNum    int
 )
 
 type NvidiaGPUDevices struct {
@@ -51,7 +50,6 @@ func (dev *NvidiaGPUDevices) ParseConfig(fs *flag.FlagSet) {
 	fs.StringVar(&ResourceMemPercentage, "resource-mem-percentage", "nvidia.com/gpumem-percentage", "gpu memory fraction to allocate")
 	fs.StringVar(&ResourceCores, "resource-cores", "nvidia.com/gpucores", "cores percentage to use")
 	fs.StringVar(&ResourcePriority, "resource-priority", "vgputaskpriority", "vgpu task priority 0 for high and 1 for low")
-	fs.IntVar(&DefaultResourceNum, "default-gpu", 1, "default gpu to allocate")
 }
 
 func (dev *NvidiaGPUDevices) NodeCleanUp(nn string) error {
@@ -101,8 +99,8 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container) bool {
 	_, resourceMemPercentageOK := ctr.Resources.Limits[corev1.ResourceName(ResourceMemPercentage)]
 
 	if resourceCoresOK || resourceMemOK || resourceMemPercentageOK {
-		if DefaultResourceNum > 0 {
-			ctr.Resources.Limits[corev1.ResourceName(ResourceName)] = *resource.NewQuantity(int64(DefaultResourceNum), resource.BinarySI)
+		if config.DefaultResourceNum > 0 {
+			ctr.Resources.Limits[corev1.ResourceName(ResourceName)] = *resource.NewQuantity(int64(config.DefaultResourceNum), resource.BinarySI)
 			resourceNameOK = true
 		}
 	}

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1,6 +1,7 @@
 package nvidia
 
 import (
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -20,7 +21,7 @@ func Test_MutateAdmission(t *testing.T) {
 	ResourceMem = "nvidia.com/gpumem"
 	ResourceMemPercentage = "nvidia.com/gpumem-percentage"
 	ResourceCores = "nvidia.com/gpucores"
-	DefaultResourceNum = 1
+	config.DefaultResourceNum = 1
 	tests := []struct {
 		name string
 		args *corev1.Container


### PR DESCRIPTION
`default-gpu` is defined in two files, so there will be values that cannot be configured by the user. remove a define in `device.go` file.
issue: https://github.com/Project-HAMi/HAMi/issues/171
