### PR TITLE
fix EncodePodSingleDevice method

### DIFF
--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -83,6 +83,7 @@ var (
 //	   Containers []ContainerDevices `json:"containers,omitempty"`
 //	}
 type ContainerDevice struct {
+	// TODO current Idx cannot use, because EncodeContainerDevices method not encode this filed.
 	Idx       int
 	UUID      string
 	Type      string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -47,18 +47,57 @@ func TestEmptyPodDeviceCoding(t *testing.T) {
 }
 
 func TestPodDevicesCoding(t *testing.T) {
-	pd1 := PodDevices{
-		"NVIDIA": PodSingleDevice{
-			ContainerDevices{
-				ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+	tests := []struct {
+		name string
+		args PodDevices
+	}{
+		{
+			name: "one pod one container use zero device",
+			args: PodDevices{
+				"NVIDIA": PodSingleDevice{},
 			},
-			ContainerDevices{
-				ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+		},
+		{
+			name: "one pod one container use one device",
+			args: PodDevices{
+				"NVIDIA": PodSingleDevice{
+					ContainerDevices{
+						ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+					},
+				},
+			},
+		},
+		{
+			name: "one pod two container, every container use one device",
+			args: PodDevices{
+				"NVIDIA": PodSingleDevice{
+					ContainerDevices{
+						ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+					},
+					ContainerDevices{
+						ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+					},
+				},
+			},
+		},
+		{
+			name: "one pod one container use two devices",
+			args: PodDevices{
+				"NVIDIA": PodSingleDevice{
+					ContainerDevices{
+						ContainerDevice{0, "UUID1", "Type1", 1000, 30},
+						ContainerDevice{0, "UUID2", "Type1", 1000, 30},
+					},
+				},
 			},
 		},
 	}
-	s := EncodePodDevices(inRequestDevices, pd1)
-	fmt.Println(s)
-	pd2, _ := DecodePodDevices(inRequestDevices, s)
-	assert.DeepEqual(t, pd1, pd2)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := EncodePodDevices(inRequestDevices, test.args)
+			fmt.Println(s)
+			got, _ := DecodePodDevices(inRequestDevices, s)
+			assert.DeepEqual(t, test.args, got)
+		})
+	}
 }


### PR DESCRIPTION
fix `EncodePodSingleDevice` method, when one pod having more then one container use device, this method encode device string will error.

- add many case to run unit tests.
- fix this bug.
- use const `OneContainerMultiDeviceSplitSymbol` and `OnePodMultiContainerSplitSymbol` to replace hardcode.