### PR TITLE
add robot to cleanup stale issue and upgrade the latest version for go mod and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily" 

--- a/.github/workflows/close-stale-issues-pr.yaml
+++ b/.github/workflows/close-stale-issues-pr.yaml
@@ -1,0 +1,40 @@
+
+name: Clean Stale Issues And PR
+
+on:
+  schedule:
+    # each day
+    - cron: "0 20 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+env:
+  STALE_ISSUE_LABEL: issue/stale
+  STALE_PR_LABEL: pr/stale
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v6.0.1
+        with:
+          # ===== for issue
+          stale-issue-label: ${{ env.STALE_ISSUE_LABEL }}
+          # exclude all issues/PRs with milestones
+          exempt-all-issue-assignees: true
+          # exclude issues/PRs with the specified labels
+          exempt-issue-labels: pinned,security,good-first-issue
+
+          # reach idle days and marked as stale
+          days-before-issue-stale: 30
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed if no further activity occurs.
+          # after marked stale, how long will close it
+          days-before-issue-close: 14
+          close-issue-message: |
+            This issue has not seen any activity since it was marked stale.
+            Closing.


### PR DESCRIPTION
for these cases:

1. the number of isseus is increasing because issue has not been answered for a long time.
2. The package version is not updated in time

the robot can help us to marks as stale for issue not been answered for 30 days and close the issue after 14 days. like this:
<img width="650" alt="image" src="https://github.com/Project-HAMi/HAMi/assets/45745657/d2135262-4774-466e-a717-a1b3a8dfdac5">

and pull a request to upgrade the latest version for go mod and actions, like this:

<img width="711" alt="image" src="https://github.com/Project-HAMi/HAMi/assets/45745657/d6356c8a-ce64-49c0-b8fd-bebd7c21e47f">
