### PR TITLE
scheduler server add leader elect

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - {{ . }}
             {{- end }}
             {{- end }}
+            - --leader-elect={{ .Values.scheduler.leaderElect }}
+            - --leader-elect-resource-name={{ .Values.schedulerName }}
+            - --leader-elect-resource-namespace={{ .Release.Namespace }}
           volumeMounts:
             - name: scheduler-config
               mountPath: /config

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -2,7 +2,7 @@
 
 nameOverride: ""
 fullnameOverride: ""
-imagePullSecrets: []
+imagePullSecrets: [ ]
 version: "v2.3.9"
 
 #Nvidia GPU Parameters
@@ -46,6 +46,7 @@ scheduler:
   defaultCores: 0
   defaultGPUNum: 1
   metricsBindAddress: ":9395"
+  leaderElect: true
   kubeScheduler:
     # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.
     enabled: true
@@ -57,7 +58,6 @@ scheduler:
       - -v=4
     extraArgs:
       - --policy-config-file=/config/config.json
-      - --leader-elect=false
       - -v=4
   extender:
     image: "projecthami/hami"


### PR DESCRIPTION
Cureent kube-scheduler and scheduler-extender can't run more than one pod because they do not use leader election, This PR adds `leaderElect` to controller `kube-scheduler` and `hami-scheduler` servers, whether use leader election.  default: use helm `.Release.Namespace` value to set `leader-elect-resource-namespace`.

Fixes: https://github.com/Project-HAMi/HAMi/issues/195

Test:
-  Start two scheduler pods; only one pod can execute the scheduler flow.
![image](https://github.com/Project-HAMi/HAMi/assets/15009201/17ec4963-4eac-41f1-99c3-f7c83b02765f)

- Start three use gpu pods that can running success.
![image](https://github.com/Project-HAMi/HAMi/assets/15009201/c5e20a69-3f9a-4101-8790-1d9e48d24675)

