### PR TITLE
Optimize scheduling cache. Accelerate the discovery and deletion of nodes

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -68,7 +68,7 @@ func start() {
 	defer sher.Stop()
 
 	// start monitor metrics
-	go sher.RegisterFromNodeAnnotatons()
+	go sher.RegisterFromNodeAnnotations()
 	go initmetrics(config.MetricsBindAddress)
 
 	// start http server

--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -62,7 +62,8 @@ func (m *nodeManager) rmNodeDevice(nodeID string, nodeInfo *util.NodeInfo) {
 	defer m.mutex.Unlock()
 	_, ok := m.nodes[nodeID]
 	if ok {
-		if m.nodes[nodeID].Devices == nil || len(m.nodes[nodeID].Devices) == 0 {
+		if len(m.nodes[nodeID].Devices) == 0 {
+			delete(m.nodes, nodeID)
 			return
 		}
 		klog.Infoln("before rm:", m.nodes[nodeID].Devices, "needs remove", nodeInfo.Devices)
@@ -80,6 +81,9 @@ func (m *nodeManager) rmNodeDevice(nodeID string, nodeInfo *util.NodeInfo) {
 			}
 		}
 		m.nodes[nodeID].Devices = tmp
+		if len(m.nodes[nodeID].Devices) == 0 {
+			delete(m.nodes, nodeID)
+		}
 		klog.Infoln("Rm Devices res:", m.nodes[nodeID].Devices)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -48,6 +48,7 @@ type Scheduler struct {
 	nodeLister listerscorev1.NodeLister
 	//Node status returned by filter
 	cachedstatus map[string]*NodeUsage
+	nodeNotify   chan struct{}
 	//Node Overview
 	overviewstatus map[string]*NodeUsage
 }
@@ -57,6 +58,7 @@ func NewScheduler() *Scheduler {
 	s := &Scheduler{
 		stopCh:       make(chan struct{}),
 		cachedstatus: make(map[string]*NodeUsage),
+		nodeNotify:   make(chan struct{}, 1),
 	}
 	s.nodeManager.init()
 	s.podManager.init()
@@ -67,6 +69,18 @@ func check(err error) {
 	if err != nil {
 		klog.Fatal(err)
 	}
+}
+
+func (s *Scheduler) onUpdateNode(_, newObj interface{}) {
+	s.nodeNotify <- struct{}{}
+}
+
+func (s *Scheduler) onDelNode(obj interface{}) {
+	s.nodeNotify <- struct{}{}
+}
+
+func (s *Scheduler) onAddNode(obj interface{}) {
+	s.nodeNotify <- struct{}{}
 }
 
 func (s *Scheduler) onAddPod(obj interface{}) {
@@ -118,7 +132,11 @@ func (s *Scheduler) Start() {
 		UpdateFunc: s.onUpdatePod,
 		DeleteFunc: s.onDelPod,
 	})
-
+	informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    s.onAddNode,
+		UpdateFunc: s.onUpdateNode,
+		DeleteFunc: s.onDelNode,
+	})
 	informerFactory.Start(s.stopCh)
 	informerFactory.WaitForCacheSync(s.stopCh)
 
@@ -128,14 +146,21 @@ func (s *Scheduler) Stop() {
 	close(s.stopCh)
 }
 
-func (s *Scheduler) RegisterFromNodeAnnotatons() error {
+func (s *Scheduler) RegisterFromNodeAnnotations() {
 	klog.V(5).Infoln("Scheduler into RegisterFromNodeAnnotations")
 	nodeInfoCopy := make(map[string]*util.NodeInfo)
+	ticker := time.NewTicker(time.Second * 15)
 	for {
+		select {
+		case <-s.nodeNotify:
+		case <-ticker.C:
+		case <-s.stopCh:
+			return
+		}
 		nodes, err := s.nodeLister.List(labels.Everything())
 		if err != nil {
 			klog.Errorln("nodes list failed", err.Error())
-			return err
+			continue
 		}
 		nodeNames := []string{}
 		for _, val := range nodes {
@@ -217,9 +242,7 @@ func (s *Scheduler) RegisterFromNodeAnnotatons() error {
 		_, _, err = s.getNodesUsage(&nodeNames, nil)
 		if err != nil {
 			klog.Errorln("get node usage failed", err.Error())
-			return err
 		}
-		time.Sleep(time.Second * 15)
 	}
 }
 
@@ -285,7 +308,7 @@ func (s *Scheduler) getNodesUsage(nodes *[]string, task *v1.Pod) (*map[string]*N
 	for _, nodeID := range *nodes {
 		node, err := s.GetNode(nodeID)
 		if err != nil {
-			klog.Errorf("get node %v device error, %v", nodeID, err)
+			klog.Warningf("get node %v device error, %v", nodeID, err)
 			failedNodes[nodeID] = "node unregisterd"
 			continue
 		}
@@ -369,11 +392,11 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		return nil, err
 	}
 	if len(*nodeScores) == 0 {
-		klog.Infoln("nodeScores_len=", len(*nodeScores))
 		return &extenderv1.ExtenderFilterResult{
 			FailedNodes: failedNodes,
 		}, nil
 	}
+	klog.V(4).Infoln("nodeScores_len=", len(*nodeScores))
 	sort.Sort(nodeScores)
 	m := (*nodeScores)[len(*nodeScores)-1]
 	klog.Infof("schedule %v/%v to %v %v", args.Pod.Namespace, args.Pod.Name, m.nodeID, m.devices)


### PR DESCRIPTION
1. Add a node informer. To notify the scheduler of cache updates. Faster discovery of new nodes and removal of old nodes.  
2. When there is no device on a node in the scheduling cache, remove it from the scheduling cache to avoid scheduling pods to these nodes.