### PR TITLE
fix: when multi container use device allocate fail

### DIFF
--- a/pkg/device-plugin/hygon/dcu/server.go
+++ b/pkg/device-plugin/hygon/dcu/server.go
@@ -547,7 +547,7 @@ func (p *Plugin) Allocate(ctx context.Context, reqs *pluginapi.AllocateRequest) 
 		responses.ContainerResponses = append(responses.ContainerResponses, &car)
 	}
 	klog.Infoln("response=", responses)
-	device.PodAllocationTrySuccess(nodename, current)
+	device.PodAllocationTrySuccess(nodename, hygon.HygonDCUDevice, current)
 	return &responses, nil
 }
 

--- a/pkg/device-plugin/mlu/server.go
+++ b/pkg/device-plugin/mlu/server.go
@@ -334,7 +334,7 @@ func (m *CambriconDevicePlugin) allocateMLUShare(ctx context.Context, reqs *plug
 		responses.ContainerResponses = append(responses.ContainerResponses, &resp)
 	}
 	klog.Infoln("response=", responses)
-	device.PodAllocationTrySuccess(nodename, current)
+	device.PodAllocationTrySuccess(nodename, cambricon.CambriconMLUDevice, current)
 	return &responses, nil
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -294,6 +294,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 		nodelock.ReleaseNodeLock(nodename)
 		return &pluginapi.AllocateResponse{}, err
 	}
+	klog.V(5).Infof("allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 
 	for idx, req := range reqs.ContainerRequests {
 		// If the devices being allocated are replicas, then (conditionally)
@@ -406,7 +407,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 		}
 	}
 	klog.Infoln("Allocate Response", responses.ContainerResponses)
-	device.PodAllocationTrySuccess(nodename, current)
+	device.PodAllocationTrySuccess(nodename, nvidia.NvidiaGPUDevice, current)
 	return &responses, nil
 }
 

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -56,9 +56,13 @@ func init() {
 	DevicesToHandle = append(DevicesToHandle, iluvatar.IluvatarGPUCommonWord)
 }
 
-func PodAllocationTrySuccess(nodeName string, pod *v1.Pod) {
-	refreshed, _ := client.GetClient().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-	annos := refreshed.Annotations[util.AssignedIDsToAllocateAnnotations]
+func PodAllocationTrySuccess(nodeName string, devName string, pod *v1.Pod) {
+	refreshed, err := client.GetClient().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("get pods %s/%s error: %+v", pod.Namespace, pod.Name, err)
+		return
+	}
+	annos := refreshed.Annotations[util.InRequestDevices[devName]]
 	klog.Infoln("TrySuccess:", annos)
 	for _, val := range DevicesToHandle {
 		if strings.Contains(annos, val) {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -165,10 +165,11 @@ func (dev *NvidiaGPUDevices) CheckType(annos map[string]string, d util.DeviceUsa
 func (dev *NvidiaGPUDevices) PatchAnnotations(annoinput *map[string]string, pd util.PodDevices) map[string]string {
 	devlist, ok := pd[NvidiaGPUDevice]
 	if ok && len(devlist) > 0 {
-		(*annoinput)[util.InRequestDevices[NvidiaGPUDevice]] = util.EncodePodSingleDevice(devlist)
-		(*annoinput)[util.SupportDevices[NvidiaGPUDevice]] = util.EncodePodSingleDevice(devlist)
-		//InRequestDevices := util.EncodePodDevices(util.InRequestDevices, m.devices)
-		//supportDevices := util.EncodePodDevices(util.SupportDevices, m.devices)
+		deviceStr := util.EncodePodSingleDevice(devlist)
+		(*annoinput)[util.InRequestDevices[NvidiaGPUDevice]] = deviceStr
+		(*annoinput)[util.SupportDevices[NvidiaGPUDevice]] = deviceStr
+		klog.V(5).Infof("pod add notation key [%s], values is [%s]", util.InRequestDevices[NvidiaGPUDevice], deviceStr)
+		klog.V(5).Infof("pod add notation key [%s], values is [%s]", util.SupportDevices[NvidiaGPUDevice], deviceStr)
 	}
 	return *annoinput
 }

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -23,12 +23,10 @@ import (
 const (
 	//ResourceName = "nvidia.com/gpu"
 	//ResourceName = "hami.io/vgpu"
-	AssignedTimeAnnotations          = "hami.io/vgpu-time"
-	AssignedIDsAnnotations           = "hami.io/vgpu-ids-new"
-	AssignedIDsToAllocateAnnotations = "hami.io/devices-to-allocate"
-	AssignedNodeAnnotations          = "hami.io/vgpu-node"
-	BindTimeAnnotations              = "hami.io/bind-time"
-	DeviceBindPhase                  = "hami.io/bind-phase"
+	AssignedTimeAnnotations = "hami.io/vgpu-time"
+	AssignedNodeAnnotations = "hami.io/vgpu-node"
+	BindTimeAnnotations     = "hami.io/bind-time"
+	DeviceBindPhase         = "hami.io/bind-phase"
 
 	DeviceBindAllocating = "allocating"
 	DeviceBindFailed     = "failed"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -202,6 +202,7 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 }
 
 func DecodePodDevices(checklist map[string]string, annos map[string]string) (PodDevices, error) {
+	klog.V(5).Infof("checklist is [%+v], annos is [%+v]", checklist, annos)
 	if len(annos) == 0 {
 		return PodDevices{}, nil
 	}
@@ -232,7 +233,7 @@ func GetNextDeviceRequest(dtype string, p v1.Pod) (v1.Container, ContainerDevice
 	if err != nil {
 		return v1.Container{}, ContainerDevices{}, err
 	}
-	klog.InfoS("pdevices", pdevices)
+	klog.Infof("pod annotation decode vaule is %+v", pdevices)
 	res := ContainerDevices{}
 
 	pd, ok := pdevices[dtype]
@@ -325,6 +326,7 @@ func PatchPodAnnotations(pod *v1.Pod, annotations map[string]string) error {
 	if err != nil {
 		return err
 	}
+	klog.V(5).Infof("patch pod %s/%s annotation content is %s", pod.Namespace, pod.Name, string(bytes))
 	_, err = client.GetClient().CoreV1().Pods(pod.Namespace).
 		Patch(context.Background(), pod.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/Project-HAMi/HAMi/issues/212#issuecomment-2007150458

Kubelet is a loop to allocate GPU devices for multiple container requests using GPU resources, currently in `PodAllocationTrySuccess` method will check whether need release node lock, but `hami.io/devices-to-allocate` this annotation key is not use, so check failed, because current key is use `hami.io/vgpu-devices-to-allocate`.