### PR TITLE
Bump Github Actions version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,7 @@
 name: CI
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  pull_request:
   push:
-    branches: ['master']
-
 env:
   GO_VERSION: "1.21.6"
 
@@ -17,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout submodule
         uses: Mushus/checkout-submodule@v1.0.1
@@ -34,14 +28,14 @@ jobs:
         uses: nelonoel/branch-name@v1.0.1
 
       - name: Docker Login
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_TOKEN }}
           password: ${{ secrets.DOCKERHUB_PASSWD }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Generating image tag
         id: runtime-tag


### PR DESCRIPTION
Previously the CI pipeline images were built based on the `master` branch instead of based on `PRs`. 

This PR is to have the CI pipeline build images based on the code from `PRs` specifically. 





This PR replaces `pull_request_target` with `pull_request.` 
It also upgrades `actions/checkout` to `v3`. 

After the upgrade, the following `two variables` need to be set in the repository secrets.

<img width="1054" alt="image" src="https://github.com/Project-HAMi/HAMi/assets/17962021/52e78451-9621-4253-ba93-6e72f49539aa">
