### PR TITLE
Use NODE_NAME as an environment variable uniformly

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsethygon.yaml
+++ b/charts/hami/templates/device-plugin/daemonsethygon.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.devicePlugin.imagePullPolicy | quote }}
           command: ["/hygon","-logtostderr=true","-stderrthreshold=INFO","-v=5"]
           env:
-            - name: NodeName
+            - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -55,7 +55,7 @@ spec:
             - {{ . }}
             {{- end }}
           env:
-            - name: NodeName
+            - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName

--- a/cmd/device-plugin/mlu/main.go
+++ b/cmd/device-plugin/mlu/main.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	options := mlu.ParseFlags()
 
-	util.NodeName = os.Getenv("NODE_NAME")
+	util.NodeName = os.Getenv(util.NodeNameEnvName)
 	log.Println("Loading CNDEV")
 	if err := cndev.Init(); err != nil {
 		log.Printf("Failed to initialize CNDEV, err: %v", err)

--- a/cmd/device-plugin/nvidia/vgpucfg.go
+++ b/cmd/device-plugin/nvidia/vgpucfg.go
@@ -17,7 +17,7 @@ func addFlags() []cli.Flag {
 	addition := []cli.Flag{
 		&cli.StringFlag{
 			Name:    "node-name",
-			Value:   os.Getenv("NodeName"),
+			Value:   os.Getenv(util.NodeNameEnvName),
 			Usage:   "node name",
 			EnvVars: []string{"NodeName"},
 		},
@@ -91,7 +91,7 @@ func readFromConfigFile() error {
 	}
 	klog.Infof("Device Plugin Configs: %v", fmt.Sprintf("%v", deviceConfigs))
 	for _, val := range deviceConfigs.Nodeconfig {
-		if strings.Compare(os.Getenv("NodeName"), val.Name) == 0 {
+		if strings.Compare(os.Getenv(util.NodeNameEnvName), val.Name) == 0 {
 			klog.Infof("Reading config from file %s", val.Name)
 			if val.Devicememoryscaling > 0 {
 				*util.DeviceMemoryScaling = val.Devicememoryscaling
@@ -134,6 +134,6 @@ func generateDeviceConfigFromNvidia(cfg *spec.Config, c *cli.Context, flags []cl
 		}
 	}
 	readFromConfigFile()
-	util.NodeName = os.Getenv("NodeName")
+	util.NodeName = os.Getenv(util.NodeNameEnvName)
 	return devcfg, nil
 }

--- a/pkg/device-plugin/hygon/dcu/register.go
+++ b/pkg/device-plugin/hygon/dcu/register.go
@@ -54,7 +54,7 @@ func (r *Plugin) RegistrInAnnotation() error {
 	devices := r.apiDevices()
 	annos := make(map[string]string)
 	if len(util.NodeName) == 0 {
-		util.NodeName = os.Getenv("NodeName")
+		util.NodeName = os.Getenv(util.NodeNameEnvName)
 	}
 	node, err := util.GetNode(util.NodeName)
 	if err != nil {

--- a/pkg/device-plugin/mlu/server.go
+++ b/pkg/device-plugin/mlu/server.go
@@ -275,7 +275,7 @@ func (m *CambriconDevicePlugin) allocateMLUShare(ctx context.Context, reqs *plug
 	defer m.Unlock()
 
 	responses := pluginapi.AllocateResponse{}
-	nodename := os.Getenv("NODE_NAME")
+	nodename := os.Getenv(util.NodeNameEnvName)
 	current, err := util.GetPendingPod(nodename)
 	if err != nil {
 		nodelock.ReleaseNodeLock(nodename)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -288,7 +288,7 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	klog.Infoln("Allocate", reqs.ContainerRequests)
 	responses := pluginapi.AllocateResponse{}
-	nodename := os.Getenv("NodeName")
+	nodename := os.Getenv(util.NodeNameEnvName)
 	current, err := util.GetPendingPod(nodename)
 	if err != nil {
 		nodelock.ReleaseNodeLock(nodename)

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -43,6 +43,9 @@ const (
 	BestEffort string = "best-effort"
 	Restricted string = "restricted"
 	Guaranteed string = "guaranteed"
+
+	// NodeNameEnvName define env var name for use get node name.
+	NodeNameEnvName = "NODE_NAME"
 )
 
 type DevicePluginConfigs struct {


### PR DESCRIPTION
Define`NodeNameEnvName` const type and all env use this var to read node name.
Fixes: https://github.com/Project-HAMi/HAMi/issues/103