### PR TITLE
fix nvidia device plugin nodename init sort error

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -154,6 +154,7 @@ func loadConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
 
 func start(c *cli.Context, flags []cli.Flag) error {
 	klog.Info("Starting FS watcher.")
+	util.NodeName = os.Getenv(util.NodeNameEnvName)
 	watcher, err := newFSWatcher(kubeletdevicepluginv1beta1.DevicePluginPath)
 	if err != nil {
 		return fmt.Errorf("failed to create FS watcher: %v", err)

--- a/cmd/device-plugin/nvidia/vgpucfg.go
+++ b/cmd/device-plugin/nvidia/vgpucfg.go
@@ -150,6 +150,5 @@ func generateDeviceConfigFromNvidia(cfg *spec.Config, c *cli.Context, flags []cl
 		}
 	}
 	readFromConfigFile()
-	util.NodeName = os.Getenv(util.NodeNameEnvName)
 	return devcfg, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

HAMi use `util.NodeName` before init. we need init first

![image](https://github.com/Project-HAMi/HAMi/assets/7907809/8d502fc8-4c35-4430-ad3c-04413b860edf)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: