### PR TITLE
fix device plugin crash when  failed to get numa information

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -18,7 +18,6 @@ package plugin
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -36,7 +35,7 @@ func (plugin *NvidiaDevicePlugin) getNumaInformation(idx int) (int, error) {
 	cmd := exec.Command("nvidia-smi", "topo", "-m")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatalf("cmd.Run() failed with %s\n", err)
+		return 0, err
 	}
 	klog.V(5).InfoS("nvidia-smi topo -m output", "result", string(out))
 	return parseNvidiaNumaInfo(idx, string(out))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

fix https://github.com/Project-HAMi/HAMi/issues/169

**What this PR does / why we need it**:

Failed to get numa information. There is no need to crash the device-plugin. It is more reasonable to directly output the error log.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: