### PR TITLE
fix gpu type matching mechanism,  Enable the combination of GPUInUse and GPUNoUse

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -160,35 +160,33 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container) bool {
 }
 
 func checkGPUtype(annos map[string]string, cardtype string) bool {
+	cardtype = strings.ToUpper(cardtype)
 	if inuse, ok := annos[GPUInUse]; ok {
-		if !strings.Contains(inuse, ",") {
-			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(inuse)) {
-				return true
-			}
-		} else {
-			for _, val := range strings.Split(inuse, ",") {
-				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
-					return true
-				}
-			}
+		useTypes := strings.Split(inuse, ",")
+		if !ContainsSliceFunc(useTypes, func(useType string) bool {
+			return strings.Contains(cardtype, strings.ToUpper(useType))
+		}) {
+			return false
 		}
-		return false
 	}
-	if nouse, ok := annos[GPUNoUse]; ok {
-		if !strings.Contains(nouse, ",") {
-			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(nouse)) {
-				return false
-			}
-		} else {
-			for _, val := range strings.Split(nouse, ",") {
-				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
-					return false
-				}
-			}
+	if unuse, ok := annos[GPUNoUse]; ok {
+		unuseTypes := strings.Split(unuse, ",")
+		if ContainsSliceFunc(unuseTypes, func(unuseType string) bool {
+			return strings.Contains(cardtype, strings.ToUpper(unuseType))
+		}) {
+			return false
 		}
-		return true
 	}
 	return true
+}
+
+func ContainsSliceFunc[S ~[]E, E any](s S, match func(E) bool) bool {
+	for _, e := range s {
+		if match(e) {
+			return true
+		}
+	}
+	return false
 }
 
 func assertNuma(annos map[string]string) bool {

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -206,3 +206,72 @@ func Test_CheckUUID(t *testing.T) {
 		})
 	}
 }
+
+func Test_CheckType(t *testing.T) {
+	gpuDevices := &NvidiaGPUDevices{}
+	tests := []struct {
+		name string
+		args struct {
+			annos map[string]string
+			d     util.DeviceUsage
+		}
+		want bool
+	}{
+		{
+			name: "use set GPUInUse don't set GPUNoUse annotation,device match",
+			args: struct {
+				annos map[string]string
+				d     util.DeviceUsage
+			}{
+				annos: map[string]string{
+					GPUInUse: "A10",
+				},
+				d: util.DeviceUsage{
+					Type: "NVIDIA A100",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "use set GPUInUse set GPUNoUse annotation,device don't match",
+			args: struct {
+				annos map[string]string
+				d     util.DeviceUsage
+			}{
+				annos: map[string]string{
+					GPUInUse: "A10",
+					GPUNoUse: "A100",
+				},
+				d: util.DeviceUsage{
+					Type: "NVIDIA A100",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "use set GPUInUse set GPUNoUse annotation,device match",
+			args: struct {
+				annos map[string]string
+				d     util.DeviceUsage
+			}{
+				annos: map[string]string{
+					GPUInUse: "A10",
+					GPUNoUse: "A100",
+				},
+				d: util.DeviceUsage{
+					Type: "NVIDIA A10",
+				},
+			},
+			want: true,
+		},
+	}
+	req := util.ContainerDeviceRequest{
+		Type: NvidiaGPUDevice,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, got, _ := gpuDevices.CheckType(test.args.annos, test.args.d, req)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
At present, the selection of GPU type can be matched with device type by commenting `nvidia.com/use-gputype` and `nvidia.com/nouse-gputype` , similar to black and white lists,  But both cannot take effect simultaneously. 

The code uses substring matching as a filtering criterion，this may lead to users wanting to use A10 type GPUs, but ultimately being assigned to A100

To solve this problem, we can use `nvidia.com/use-gputype` and `nvidia.com/nouse-gputype` together

```yaml
metadata.:
  annotations:
    nvidia.com/use-gputype: A10
    nvidia.com/nouse-gputype: A100
```
This specifies the required device types and excludes unnecessary device types
