### PR TITLE
The annotation of the device that has been deleted is incorrect.

### DIFF
--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -128,7 +128,7 @@ func (dev *DCUDevices) GetNodeDevices(n corev1.Node) ([]*api.DeviceInfo, error) 
 }
 
 func (dev *DCUDevices) NodeCleanUp(nn string) error {
-	return util.MarkAnnotationsToDelete(HygonDCUDevice, nn)
+	return util.MarkAnnotationsToDelete(HandshakeAnnos, nn)
 }
 
 func (dev *DCUDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -78,7 +78,7 @@ func (dev *NvidiaGPUDevices) ParseConfig(fs *flag.FlagSet) {
 }
 
 func (dev *NvidiaGPUDevices) NodeCleanUp(nn string) error {
-	return util.MarkAnnotationsToDelete(NvidiaGPUDevice, nn)
+	return util.MarkAnnotationsToDelete(HandshakeAnnos, nn)
 }
 
 func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

before:

```
apiVersion: v1
kind: Node
metadata:
  annotations:
    NVIDIA: Deleted_2024.05.27 09:30:07
    hami.io/node-handshake: Requesting_2024.05.27 09:48:48
    hami.io/node-nvidia-register: 'GPU-26a583dd-542e-09bb-5dd1-9cc5bd6eb552,10,16384,200,NVIDIA-Tesla

```


after:

```
apiVersion: v1
kind: Node
metadata:
  annotations:
    hami.io/node-handshake: Deleted_2024.05.27 09:30:07
    hami.io/node-nvidia-register: 'GPU-26a583dd-542e-09bb-5dd1-9cc5bd6eb552,10,16384,200,NVIDIA-Tesla

```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

https://github.com/Project-HAMi/HAMi/blob/master/pkg/util/util.go#L347-L357


It can be seen that the `handshake` is used to determine whether the device is healthy.




**Does this PR introduce a user-facing change?**: