### PR TITLE
[Optimization] Fix the issue where scheduling can still occur on the node when the device-plugin crashes.

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -57,7 +57,7 @@ func (m *nodeManager) addNode(nodeID string, nodeInfo *util.NodeInfo) {
 	}
 }
 
-func (m *nodeManager) rmNodeDevice(nodeID string, nodeInfo *util.NodeInfo) {
+func (m *nodeManager) rmNodeDevice(nodeID string, nodeInfo *util.NodeInfo, deviceVendor string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	_, ok := m.nodes[nodeID]
@@ -69,6 +69,9 @@ func (m *nodeManager) rmNodeDevice(nodeID string, nodeInfo *util.NodeInfo) {
 		klog.V(5).Infoln("before rm:", m.nodes[nodeID].Devices, "needs remove", nodeInfo.Devices)
 		tmp := make([]util.DeviceInfo, 0, len(m.nodes[nodeID].Devices)-len(nodeInfo.Devices))
 		for _, val := range m.nodes[nodeID].Devices {
+			if deviceVendor != val.DeviceVendor {
+				continue
+			}
 			found := false
 			for _, rmval := range nodeInfo.Devices {
 				if strings.Compare(val.ID, rmval.ID) == 0 {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -150,7 +150,6 @@ func (s *Scheduler) Stop() {
 
 func (s *Scheduler) RegisterFromNodeAnnotations() {
 	klog.V(5).Infoln("Scheduler into RegisterFromNodeAnnotations")
-	nodeInfoCopy := make(map[string]*util.NodeInfo)
 	ticker := time.NewTicker(time.Second * 15)
 	for {
 		select {
@@ -169,20 +168,19 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 			nodeNames = append(nodeNames, val.Name)
 			for devhandsk, devInstance := range device.GetDevices() {
 				health, needUpdate := devInstance.CheckHealth(devhandsk, val)
+				klog.V(5).InfoS("node", val.Name, "deviceVendor", devhandsk, "health", health, "needUpdate", needUpdate)
 				if !health {
-					_, ok := s.nodes[val.Name]
+					err := devInstance.NodeCleanUp(val.Name)
+					// If the device is not healthy, the device is removed from the node.
+					// At the same time, this node needs to be removed from the cache.
+					if err != nil {
+						klog.Errorln("node cleanup failed", err.Error())
+					}
+					info, ok := s.nodes[val.Name]
 					if ok {
-						_, ok = nodeInfoCopy[devhandsk]
-						if ok && nodeInfoCopy[devhandsk] != nil {
-							s.rmNodeDevice(val.Name, nodeInfoCopy[devhandsk])
-							klog.Infof("node %v device %s:%v leave, %v remaining devices:%v", val.Name, devhandsk, nodeInfoCopy[devhandsk], err, s.nodes[val.Name].Devices)
-
-							err := devInstance.NodeCleanUp(val.Name)
-							if err != nil {
-								klog.ErrorS(err, "markAnnotationsToDeleteFailed")
-							}
-							continue
-						}
+						klog.Infof("node %v device %s:%v leave, %v remaining devices:%v", val.Name, devhandsk, info, err, s.nodes[val.Name].Devices)
+						s.rmNodeDevice(val.Name, info, devhandsk)
+						continue
 					}
 				}
 				if !needUpdate {
@@ -192,7 +190,7 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 				if ok {
 					tmppat := make(map[string]string)
 					tmppat[util.HandshakeAnnos[devhandsk]] = "Requesting_" + time.Now().Format("2006.01.02 15:04:05")
-					klog.Infoln("New timestamp=", util.HandshakeAnnos[devhandsk], tmppat[util.HandshakeAnnos[devhandsk]])
+					klog.V(4).InfoS("New timestamp", util.HandshakeAnnos[devhandsk], tmppat[util.HandshakeAnnos[devhandsk]], "nodeName", val.Name)
 					n, err := util.GetNode(val.Name)
 					if err != nil {
 						klog.Errorln("get node failed", err.Error())
@@ -223,21 +221,21 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 					}
 					if !found {
 						nodeInfo.Devices = append(nodeInfo.Devices, util.DeviceInfo{
-							ID:      deviceinfo.Id,
-							Index:   uint(deviceinfo.Index),
-							Count:   deviceinfo.Count,
-							Devmem:  deviceinfo.Devmem,
-							Devcore: deviceinfo.Devcore,
-							Type:    deviceinfo.Type,
-							Numa:    deviceinfo.Numa,
-							Health:  deviceinfo.Health,
+							ID:           deviceinfo.Id,
+							Index:        uint(deviceinfo.Index),
+							Count:        deviceinfo.Count,
+							Devmem:       deviceinfo.Devmem,
+							Devcore:      deviceinfo.Devcore,
+							Type:         deviceinfo.Type,
+							Numa:         deviceinfo.Numa,
+							Health:       deviceinfo.Health,
+							DeviceVendor: devhandsk,
 						})
 					}
 				}
 				s.addNode(val.Name, nodeInfo)
-				nodeInfoCopy[devhandsk] = nodeInfo
 				if s.nodes[val.Name] != nil && len(nodeInfo.Devices) > 0 {
-					klog.Infof("node %v device %s come node info=%v total=%v", val.Name, devhandsk, nodeInfoCopy[devhandsk], s.nodes[val.Name].Devices)
+					klog.Infof("node %v device %s come node info=%v total=%v", val.Name, devhandsk, nodeInfo, s.nodes[val.Name].Devices)
 				}
 			}
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -221,7 +221,7 @@ func Test_Filter(t *testing.T) {
 		nodes, _ := s.ListNodes()
 		for index := range nodes {
 			node := nodes[index]
-			s.rmNodeDevice(node.ID, node)
+			s.rmNodeDevice(node.ID, node, nvidia.NvidiaGPUDevice)
 		}
 		pods, _ := s.ListPods()
 		for index := range pods {
@@ -232,24 +232,26 @@ func Test_Filter(t *testing.T) {
 			ID: "node1",
 			Devices: []util.DeviceInfo{
 				{
-					ID:      "device1",
-					Index:   0,
-					Count:   10,
-					Devmem:  8000,
-					Devcore: 100,
-					Numa:    0,
-					Type:    nvidia.NvidiaGPUDevice,
-					Health:  true,
+					ID:           "device1",
+					Index:        0,
+					Count:        10,
+					Devmem:       8000,
+					Devcore:      100,
+					Numa:         0,
+					Type:         nvidia.NvidiaGPUDevice,
+					Health:       true,
+					DeviceVendor: nvidia.NvidiaGPUDevice,
 				},
 				{
-					ID:      "device2",
-					Index:   1,
-					Count:   10,
-					Devmem:  8000,
-					Devcore: 100,
-					Numa:    0,
-					Type:    nvidia.NvidiaGPUDevice,
-					Health:  true,
+					ID:           "device2",
+					Index:        1,
+					Count:        10,
+					Devmem:       8000,
+					Devcore:      100,
+					Numa:         0,
+					Type:         nvidia.NvidiaGPUDevice,
+					Health:       true,
+					DeviceVendor: nvidia.NvidiaGPUDevice,
 				},
 			},
 		})

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -124,14 +124,15 @@ type DeviceUsage struct {
 }
 
 type DeviceInfo struct {
-	ID      string
-	Index   uint
-	Count   int32
-	Devmem  int32
-	Devcore int32
-	Type    string
-	Numa    int
-	Health  bool
+	ID           string
+	Index        uint
+	Count        int32
+	Devmem       int32
+	Devcore      int32
+	Type         string
+	Numa         int
+	Health       bool
+	DeviceVendor string
 }
 
 type NodeInfo struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

The scheduler heavily relies on a temporary memory variable `nodeInfoCopy`. When the scheduler unexpectedly restarts, the value of `nodeInfoCopy` will be lost, causing the scheduler to malfunction.

This PR has optimized this issue by removing the scheduler's dependency on the `nodeInfoCopy` variable.


**Which issue(s) this PR fixes**:
Fixes #272

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: