### PR TITLE
enhance get current node pendding pods

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -287,7 +287,7 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 
 // Allocate which return list of devices.
 func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdevicepluginv1beta1.AllocateRequest) (*kubeletdevicepluginv1beta1.AllocateResponse, error) {
-	klog.Infoln("Allocate", reqs.ContainerRequests)
+	klog.InfoS("Allocate", "request", reqs)
 	responses := kubeletdevicepluginv1beta1.AllocateResponse{}
 	nodename := os.Getenv(util.NodeNameEnvName)
 	current, err := util.GetPendingPod(nodename)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,7 +61,13 @@ func GetNode(nodename string) (*corev1.Node, error) {
 }
 
 func GetPendingPod(node string) (*corev1.Pod, error) {
-	podlist, err := client.GetClient().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+
+	// filter pods for this node.
+	selector := fmt.Sprintf("spec.nodeName=%s", node)
+	podListOptions := metav1.ListOptions{
+		FieldSelector: selector,
+	}
+	podlist, err := client.GetClient().CoreV1().Pods("").List(context.Background(), podListOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

During the device allocation phase, we only need to fetch the pods of the current node, not all pods, so we can podListOptions to filter accurately and improve efficiency.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: