### PR TITLE
feat: Update webhook.yaml to whitelist kube-system and istio-system n…

### DIFF
--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -20,10 +20,10 @@ webhooks:
     name: vgpu.hami.io
     namespaceSelector:
       matchExpressions:
-      - key: hami.io/webhook
+      - key: kubernetes.io/metadata.name
         operator: NotIn
         values:
-        - ignore
+        {{- toYaml .Values.scheduler.customWebhook.whitelistNamespaces | nindent 10 }}
     objectSelector:
       matchExpressions:
       - key: hami.io/webhook

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -85,6 +85,9 @@ scheduler:
     host: 127.0.0.1 # hostname or ip, can be your node'IP if you want to use https://<nodeIP>:<schedulerPort>/<path>
     port: 31998
     path: /webhook
+    whitelistNamespaces:
+      - kube-system
+      - istio-system
   patch:
     image: docker.io/jettech/kube-webhook-certgen:v1.5.2
     imageNew: liangjw/kube-webhook-certgen:v1.1.1


### PR DESCRIPTION
…amespaces

The code changes in `webhook.yaml` modify the namespace whitelist for the webhook. The `kube-system` and `istio-system` namespaces are added to the whitelist. This change aims to allow the webhook to function properly in these namespaces.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

This pull request updates the `webhook.yaml` within our application, implementing a change to the namespace selector configuration within the mutating webhook configuration. 

The purpose of this change is to whitelist `kube-system` and `istio-system` namespaces, following [Kubernetes best practices for webhooks](https://kubernetes.io/zh-cn/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace). This prevents the Kubernetes system components and Istio components from being unnecessarily intercepted and possibly affected by our application's webhook. 


In conclusion, this update not only enables our application to respect Kubernetes' best practices for mutating webhooks, but also improves stability of both our application and the overall Kubernetes ecosystem through the use of selectors and whitelisting namespaces.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: