### PR TITLE
fix HostGPUMemoryUsage wrong unit on grafana

### DIFF
--- a/docs/gpu-dashboard.json
+++ b/docs/gpu-dashboard.json
@@ -932,7 +932,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:1087",
-          "format": "mbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "show": true


### PR DESCRIPTION
**What type of PR is this?**
HostGPUMemoryUsage unit on grafana dashboard is wrong
if my metric is 500MiB, but grafana dashboard will show me almost 500Ti

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: