### PR TITLE
feat: Add GPU node selector to scheduler deployment

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -113,9 +113,11 @@ spec:
             httpGet:
               path: /healthz
               port: 443
+              scheme: HTTPS
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
+            timeoutSeconds: 5
       volumes:
         - name: tls-config
           secret:

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -67,6 +67,13 @@ spec:
         - name: vgpu-scheduler-extender
           image: {{ .Values.scheduler.extender.image }}:{{ .Values.version }}
           imagePullPolicy: {{ .Values.scheduler.extender.imagePullPolicy | quote }}
+          env:
+          {{- if .Values.global.vmBmMixMode }}
+          {{- range $key, $value := .Values.global.vmBmMixModeSelector }}
+            - name: NODE_SELECTOR_{{ $key | upper | replace "-" "_" }}
+              value: "{{ $value }}"
+          {{- end }}
+          {{- end }}
           command:
             - scheduler
             - --resource-name={{ .Values.resourceName }}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -70,8 +70,8 @@ spec:
           image: {{ .Values.scheduler.extender.image }}:{{ .Values.version }}
           imagePullPolicy: {{ .Values.scheduler.extender.imagePullPolicy | quote }}
           env:
-          {{- if .Values.global.vmBmMixMode }}
-          {{- range $key, $value := .Values.global.vmBmMixModeSelector }}
+          {{- if .Values.global.managedNodeSelectorEnable }}
+          {{- range $key, $value := .Values.global.managedNodeSelector }}
             - name: NODE_SELECTOR_{{ $key | upper | replace "-" "_" }}
               value: "{{ $value }}"
           {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -40,11 +40,15 @@ global:
   gpuHookPath: /usr/local
   labels: {}
   annotations: {}
+  vmBmMixMode: false
+  vmBmMixModeSelector:
+    gpu: "on"
+
 
 scheduler:
   # @param nodeName defines the node name and the nvidia-vgpu-scheduler-scheduler will schedule to the node.
-  # if we install the nvidia-vgpu-scheduler-scheduler as default scheduler, we need to remove the k8s defualt
-  # scheduler pod from the cluster first, we must specified node name to skip the schedule workflow.
+  # if we install the nvidia-vgpu-scheduler-scheduler as default scheduler, we need to remove the k8s default
+  # scheduler pod from the cluster first, we must specify node name to skip the schedule workflow.
   nodeName: ""
   defaultMem: 0
   defaultCores: 0
@@ -74,8 +78,6 @@ scheduler:
       - --debug
       - -v=4
   podAnnotations: {}
-  #nodeSelector: 
-  #  gpu: "on"
   tolerations: []
   #serviceAccountName: "hami-vgpu-scheduler-sa"
   customWebhook:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -45,9 +45,9 @@ global:
   gpuHookPath: /usr/local
   labels: {}
   annotations: {}
-  vmBmMixMode: false
-  vmBmMixModeSelector:
-    gpu: "on"
+  managedNodeSelectorEnable: false
+  managedNodeSelector:
+    usage: "gpu"
 
 
 scheduler:

--- a/pkg/scheduler/utils.go
+++ b/pkg/scheduler/utils.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getNodeSelectorFromEnv() map[string]string {
+	nodeSelector := make(map[string]string)
+	for _, env := range os.Environ() {
+		pair := strings.SplitN(env, "=", 2)
+		if strings.HasPrefix(pair[0], "NODE_SELECTOR_") {
+			key := strings.ToLower(strings.TrimPrefix(pair[0], "NODE_SELECTOR_"))
+			value := pair[1]
+			nodeSelector[key] = value
+		}
+	}
+	return nodeSelector
+}
+
+func filterNodesBySelector(nodes []*corev1.Node, nodeSelector map[string]string) []*corev1.Node {
+	// If no nodeSelector is specified, return all nodes.
+	if len(nodeSelector) == 0 {
+		return nodes
+	}
+	// Filter nodes by nodeSelector.
+	var filteredNodes []*corev1.Node
+	for _, node := range nodes {
+		if matchesNodeSelector(node, nodeSelector) {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	return filteredNodes
+}
+
+func matchesNodeSelector(node *corev1.Node, nodeSelector map[string]string) bool {
+	for key, value := range nodeSelector {
+		if nodeValue, ok := node.Labels[key]; !ok || nodeValue != value {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/scheduler/utils_test.go
+++ b/pkg/scheduler/utils_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Mock environment variables for testing.
+func mockEnvVars(vars map[string]string) func() {
+	originalEnv := os.Environ()
+	os.Clearenv()
+	for k, v := range vars {
+		os.Setenv(k, v)
+	}
+	return func() {
+		os.Clearenv()
+		for _, e := range originalEnv {
+			pair := strings.SplitN(e, "=", 2)
+			if len(pair) == 2 {
+				os.Setenv(pair[0], pair[1])
+			}
+		}
+	}
+}
+
+func Test_getNodeSelectorFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupEnv map[string]string // Environment variables to set up for each test
+		want     map[string]string
+	}{
+		{
+			name: "No NODE_SELECTOR_ env vars",
+			setupEnv: map[string]string{
+				"UNRELATED_ENV_VAR": "value",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "Single NODE_SELECTOR_ env var",
+			setupEnv: map[string]string{
+				"NODE_SELECTOR_REGION": "us-west-2",
+			},
+			want: map[string]string{
+				"region": "us-west-2",
+			},
+		},
+		{
+			name: "Multiple NODE_SELECTOR_ env vars",
+			setupEnv: map[string]string{
+				"NODE_SELECTOR_REGION":   "us-west-2",
+				"NODE_SELECTOR_INSTANCE": "large",
+				"UNRELATED_ENV_VAR":      "value",
+			},
+			want: map[string]string{
+				"region":   "us-west-2",
+				"instance": "large",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment variables and defer their cleanup
+			cleanup := mockEnvVars(tt.setupEnv)
+			defer cleanup()
+
+			if got := getNodeSelectorFromEnv(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getNodeSelectorFromEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_filterNodesBySelector(t *testing.T) {
+	// Create mock nodes to use in tests
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"region": "us-west-2",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+				Labels: map[string]string{
+					"region": "eu-central-1",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		nodes        []*corev1.Node
+		nodeSelector map[string]string
+		wantFiltered []*corev1.Node
+	}{
+		{
+			name:         "Filter by region",
+			nodes:        nodes,
+			nodeSelector: map[string]string{"region": "us-west-2"},
+			wantFiltered: []*corev1.Node{nodes[0]},
+		},
+		{
+			name:         "No matching nodes",
+			nodes:        nodes,
+			nodeSelector: map[string]string{"instance-type": "large"},
+			wantFiltered: nil,
+		},
+		{
+			name:         "Empty node selector",
+			nodes:        nodes,
+			nodeSelector: map[string]string{},
+			wantFiltered: nodes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterNodesBySelector(tt.nodes, tt.nodeSelector); !reflect.DeepEqual(got, tt.wantFiltered) {
+				t.Errorf("filterNodesBySelector() = %v, want %v", got, tt.wantFiltered)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The code changes in `deployment.yaml` add the GPU node selector to the scheduler deployment. This change allows the scheduler to select nodes with the `gpu` label set to `"on"`. The environment variables are updated accordingly to include the `NODE_SELECTOR_GPU` variable.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind feature

**What this PR does / why we need it**:
This PR introduces a new feature to enhance our scheduler by allowing it to filter BM (Bare Metal) nodes based on a node selector. This is particularly useful in our cluster environment where only BM nodes have GPUs, ensuring that tasks requiring GPUs are scheduled appropriately. 

**Which issue(s) this PR fixes**:
Fixes # https://github.com/Project-HAMi/HAMi/issues/375

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: