### PR TITLE
fix china goproxy.cn on github

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,6 @@ FROM $GOLANG_IMAGE AS build
 
 FROM $GOLANG_IMAGE AS GOBUILD
 ADD . /k8s-vgpu
-ARG GOPROXY=https://goproxy.cn,direct
 RUN cd /k8s-vgpu && make all
 
 FROM $NVIDIA_IMAGE AS NVBUILD


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

GitHub does not need a China goproxy.  Using an proxy instead leads to abnormal operation. Fix this problem.

![image](https://github.com/user-attachments/assets/e1f8d11a-f9a9-483f-af0e-9bcd88d31ea5)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: