### PR TITLE
add event handlers registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.4 // indirect
 	github.com/go-openapi/swag v0.22.9 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/pkg/scheduler/event.go
+++ b/pkg/scheduler/event.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// Define events for ResourceBinding, ResourceFilter objects and their associated resources.
+const (
+	// EventReasonFilteringFailed indicates that filtering failed.
+	EventReasonFilteringFailed = "FilteringFailed"
+	// EventReasonFilteringSucceed indicates that filtering succeed.
+	EventReasonFilteringSucceed = "FilteringSucceed"
+
+	// EventReasonBindingFailed indicates that  binding failed.
+	EventReasonBindingFailed = "BindingFailed"
+	// EventReasonBindingSucceed indicates that  binding succeed.
+	EventReasonBindingSucceed = "BindingSucceed"
+)
+
+func (s *Scheduler) addAllEventHandlers() {
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: s.kubeClient.CoreV1().Events(metav1.NamespaceAll)})
+	schema := runtime.NewScheme()
+
+	_ = clientgoscheme.AddToScheme(schema)
+	s.eventRecorder = eventBroadcaster.NewRecorder(schema, corev1.EventSource{Component: config.SchedulerName})
+}
+
+func (s *Scheduler) recordScheduleBindingResultEvent(pod *corev1.Pod, eventReason string, nodeResult []string, schedulerErr error) {
+	if pod == nil {
+		return
+	}
+	if schedulerErr == nil {
+		successMsg := fmt.Sprintf("Successfully binding node %v to %v/%v", nodeResult, pod.Namespace, pod.Name)
+		s.eventRecorder.Event(pod, corev1.EventTypeNormal, eventReason, successMsg)
+	} else {
+		s.eventRecorder.Event(pod, corev1.EventTypeWarning, eventReason, schedulerErr.Error())
+	}
+}
+
+func (s *Scheduler) recordScheduleFilterResultEvent(pod *corev1.Pod, eventReason string, nodeResult []string, schedulerErr error) {
+	if pod == nil {
+		return
+	}
+	if schedulerErr == nil {
+		successMsg := fmt.Sprintf("Successfully filtered to following nodes: %v for %v/%v ", nodeResult, pod.Namespace, pod.Name)
+		s.eventRecorder.Event(pod, corev1.EventTypeNormal, eventReason, successMsg)
+	} else {
+		s.eventRecorder.Event(pod, corev1.EventTypeWarning, eventReason, schedulerErr.Error())
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -122,6 +122,7 @@ test case matrix.
 func Test_Filter(t *testing.T) {
 	s := NewScheduler()
 	client.KubeClient = fake.NewSimpleClientset()
+	s.kubeClient = client.KubeClient
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour*1)
 	s.podLister = informerFactory.Core().V1().Pods().Lister()
 	informer := informerFactory.Core().V1().Pods().Informer()
@@ -132,6 +133,7 @@ func Test_Filter(t *testing.T) {
 	})
 	informerFactory.Start(s.stopCh)
 	informerFactory.WaitForCacheSync(s.stopCh)
+	s.addAllEventHandlers()
 
 	pod1 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Current, if a pod schedule fails, it's too difficult to troubleshoot, because the pod doesn't have the scheduler event .

This feature wants to add the scheduler process(filter and binding) event to accolated the pod

Sure. Currently, the event of all filters and bindings that do not meet the conditions are not detailed enough. They can be enhance later.


Test results

### If a pod scheduler succeed, we can describe the pod

```
(base) ➜  scheduler git:(master) ✗ kubectl describe  po nginx-deployment-7bd89f854c-5p2xv
Name:             nginx-deployment-7bd89f854c-5p2xv
Namespace:        default
Priority:         0
Service Account:  default
...
...
...
Events:
  Type    Reason            Age   From            Message
  ----    ------            ----  ----            -------
  Normal  Scheduled         6s    hami-scheduler  Successfully assigned default/nginx-deployment-67f97f4d9d-wtzzd to controller-node-1
  Normal  FilteringSucceed  7s    hami-scheduler  Successfully filtered to following nodes: [controller-node-1] for default/nginx-deployment-67f97f4d9d-wtzzd
  Normal  BindingSucceed    7s    hami-scheduler  Successfully binding node [controller-node-1] to default/nginx-deployment-67f97f4d9d-wtzzd
  Normal  Pulling           6s    kubelet         Pulling image "docker.m.daocloud.io/nginx:latest"
  Normal  Pulled            5s    kubelet         Successfully pulled image "docker.m.daocloud.io/nginx:latest" in 1.075344559s (1.075360343s including waiting)
  Normal  Created           5s    kubelet         Created container nginx
  Normal  Started           5s    kubelet         Started container nginx
```


###If a pod scheduler failed, we can describe the pod to quickly troubleshoot 

```
(base) ➜  scheduler git:(master) ✗ kubectl describe po nginx-deployment-8dc9c4774-txbzf
Name:             nginx-deployment-8dc9c4774-txbzf
Namespace:        default
Priority:         0
...
...
...
Events:
  Type     Reason            Age   From            Message
  ----     ------            ----  ----            -------
  Warning  FailedScheduling  8s    hami-scheduler  0/2 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/unreachable: }. preemption: 0/2 nodes are available: 1 No preemption victims found for incoming pod, 1 Preemption is not helpful for scheduling.
  Warning  FilteringFailed   9s    hami-scheduler  no available node, all node scores do not meet
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: