### PR TITLE
Fix HAMi image is too large and uses inappropriate base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update; apt-get -y install cmake
 RUN bash ./build.sh
 
-FROM $NVIDIA_IMAGE
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=utility


### PR DESCRIPTION
**What type of PR is this?**


/kind bug


![image](https://github.com/user-attachments/assets/9a85a6a8-145a-40b2-a756-100f60d248d4)


Changes introduced by this pr https://github.com/Project-HAMi/HAMi/pull/492

This PR modifies the final base image of hami from `nvidia/cuda:12.4.1-base-ubuntu22.04` to `nvidia/cuda:12.2.0-devel-ubuntu20.04`, and the image size becomes 3.1G.

We only need the image `nvidia/cuda:12.4.1-base-ubuntu22.04`

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: