### PR TITLE
Add support for setting libcuda verbosity

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -83,6 +83,7 @@ spec:
             - --resource-cores={{ .Values.resourceCores }}
             - --resource-mem-percentage={{ .Values.resourceMemPercentage }}
             - --resource-priority={{ .Values.resourcePriority }}
+            - --libcuda-log-verbosity-level={{ .Values.libcudaLogVerbosity }}
             - --http_bind=0.0.0.0:443
             - --cert_file=/tls/tls.crt
             - --key_file=/tls/tls.key

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -11,6 +11,8 @@ resourceMem: "nvidia.com/gpumem"
 resourceMemPercentage: "nvidia.com/gpumem-percentage"
 resourceCores: "nvidia.com/gpucores"
 resourcePriority: "nvidia.com/priority"
+## Use environment variable LIBCUDA_LOG_LEVEL to set the visibility of logs in containers
+libcudaLogVerbosity: "2"
 
 #MLU Parameters
 mluResourceName: "cambricon.com/vmlu"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add support for setting `LIBCUDA_LOG_LEVEL` during admission.

**Which issue(s) this PR fixes**:
Resolves: #544

**Special notes for your reviewer**:
I added a new function, `setOrUpdateEnvVar`, as I couldn’t find an existing alternative in the source code. However, I believe it should be placed in a more accessible location other than `pkg/device/nvidia/device.go`.

**Does this PR introduce a user-facing change?**:
Default log level stays the same.
Users should upgrade their `values.yaml` files if they want to change default verbosity. 