### PR TITLE
fix(scheduler): prevent array out-of-bounds when GPU containers are placed between non-GPU containers

### DIFF
--- a/pkg/k8sutil/pod_test.go
+++ b/pkg/k8sutil/pod_test.go
@@ -123,6 +123,141 @@ func Test_Resourcereqs(t *testing.T) {
 				{},
 			},
 		},
+		{
+			name: "three containers gpu container first",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+									"hami.io/gpucores": *resource.NewQuantity(30, resource.BinarySI),
+									"hami.io/gpumem":   *resource.NewQuantity(1000, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"cpu": *resource.NewQuantity(1, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": *resource.NewQuantity(2000, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []util.ContainerDeviceRequests{
+				{
+					nvidia.NvidiaGPUDevice: util.ContainerDeviceRequest{
+						Nums:             1,
+						Type:             nvidia.NvidiaGPUDevice,
+						Memreq:           1000,
+						MemPercentagereq: 101,
+						Coresreq:         30,
+					},
+				},
+				{},
+				{},
+			},
+		},
+		{
+			name: "three containers gpu container in the middle",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"cpu": *resource.NewQuantity(1, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+									"hami.io/gpucores": *resource.NewQuantity(30, resource.BinarySI),
+									"hami.io/gpumem":   *resource.NewQuantity(1000, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": *resource.NewQuantity(2000, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []util.ContainerDeviceRequests{
+				{},
+				{
+					nvidia.NvidiaGPUDevice: util.ContainerDeviceRequest{
+						Nums:             1,
+						Type:             nvidia.NvidiaGPUDevice,
+						Memreq:           1000,
+						MemPercentagereq: 101,
+						Coresreq:         30,
+					},
+				},
+				{},
+			},
+		},
+		{
+			name: "three containers gpu container last",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"cpu": *resource.NewQuantity(1, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": *resource.NewQuantity(2000, resource.BinarySI),
+								},
+							},
+						},
+						{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+									"hami.io/gpucores": *resource.NewQuantity(30, resource.BinarySI),
+									"hami.io/gpumem":   *resource.NewQuantity(1000, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []util.ContainerDeviceRequests{
+				{},
+				{},
+				{
+					nvidia.NvidiaGPUDevice: util.ContainerDeviceRequest{
+						Nums:             1,
+						Type:             nvidia.NvidiaGPUDevice,
+						Memreq:           1000,
+						MemPercentagereq: 101,
+						Coresreq:         30,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -213,7 +213,7 @@ func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, nums util.PodDeviceR
 
 			if sums == 0 {
 				for idx := range score.Devices {
-					if len(score.Devices[idx]) <= ctrid {
+					for len(score.Devices[idx]) <= ctrid {
 						score.Devices[idx] = append(score.Devices[idx], util.ContainerDevices{})
 					}
 					score.Devices[idx][ctrid] = append(score.Devices[idx][ctrid], util.ContainerDevice{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the scheduler where an array out-of-bounds error occurs when a GPU container is placed between non-GPU containers in a multi-container Pod. The bug manifests when the GPU container must be positioned at the beginning or end of the container list, otherwise, it leads to a panic with an array index error. Ensuring that the length of `score.Devices[idx]` is sufficient before appending resolves this issue. The scheduler now handles this scenario by extending the `score.Devices` array correctly.

**Which issue(s) this PR fixes**:
Fixes #571 

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None