### PR TITLE
docs: fix deployments path in README

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,7 +17,7 @@ Please refer to  [Quick Start](https://github.com/NVIDIA/k8s-device-plugin?tab=r
 ## Run the benchmark
 
 ```bash
-cd HAMi/deployments
+cd HAMi/benchmarks/deployments
 
 kubectl apply -f job-on-hami.yml
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Correct the deployments path from HAMi/deployments to HAMi/benchmarks/deployments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: