### PR TITLE
Fix Kubernetes version string handling by stripping metadata

### DIFF
--- a/charts/hami/templates/_helpers.tpl
+++ b/charts/hami/templates/_helpers.tpl
@@ -85,3 +85,24 @@ Image registry secret name
 imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 2 }}
 {{- end }}
 
+{{/*
+    Resolve the tag for kubeScheduler.
+*/}}
+{{- define "resolvedKubeSchedulerTag" -}}
+{{- if .Values.scheduler.kubeScheduler.imageTag }}
+{{- .Values.scheduler.kubeScheduler.imageTag | trim -}}
+{{- else }}
+{{- include "strippedKubeVersion" . | trim -}}
+{{- end }}
+{{- end }}
+
+
+{{/*
+    Remove the part after the `+` in the Kubernetes version string.
+    v1.31.1+k3s1 -> v1.31.1
+    v1.31.1 -> v1.31.1
+*/}}
+{{- define "strippedKubeVersion" -}}
+{{- $parts := split "+" .Capabilities.KubeVersion.Version -}}
+{{- print $parts._0 -}}
+{{- end -}}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       {{- if .Values.scheduler.kubeScheduler.enabled }}
         - name: kube-scheduler
-          image: {{ .Values.scheduler.kubeScheduler.image }}:{{ .Capabilities.KubeVersion.Version }}
+          image: "{{ .Values.scheduler.kubeScheduler.image }}:{{ include "resolvedKubeSchedulerTag" . }}"
           imagePullPolicy: {{ .Values.scheduler.kubeScheduler.imagePullPolicy | quote }}
           command:
             - kube-scheduler

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -20,9 +20,9 @@ data:
       defaultMemory: 0
       defaultCores: 0
       defaultGPUNum: 1
-      deviceSplitCount: 10
-      deviceMemoryScaling: 1
-      deviceCoreScaling: 1
+      deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+      deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+      deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
     cambricon:
       resourceCountName: {{ .Values.mluResourceName }}
       resourceMemoryName: {{ .Values.mluResourceMem }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -59,6 +59,7 @@ scheduler:
     # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.
     enabled: true
     image: registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler
+    imageTag: ""
     imagePullPolicy: IfNotPresent
     extraNewArgs:
       - --config=/config/config.yaml
@@ -111,6 +112,9 @@ devicePlugin:
   monitorimage: "projecthami/hami"
   monitorctrPath: /usr/local/vgpu/containers
   imagePullPolicy: IfNotPresent
+  deviceSplitCount: 10
+  deviceMemoryScaling: 1
+  deviceCoreScaling: 1
   runtimeClassName: ""
   migStrategy: "none"
   disablecorelimit: "false"

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,9 +1,19 @@
 # Global Config
+**Note:**
+All the configurations listed below are managed within the hami-scheduler-device ConfigMap.
+You can update these configurations using one of the following methods:
+
+1. Directly edit the ConfigMap: If HAMi has already been successfully installed, you can manually update the hami-scheduler-device ConfigMap using the kubectl edit command to manually update the hami-scheduler-device ConfigMap.
+    ```bash
+    kubectl edit configmap hami-scheduler-device -n <namespace>
+    ```
+    After making changes, restart the related HAMi components to apply the updated configurations.
+2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](../charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
 you can customize your vGPU support by setting the following parameters using `-set`, for example
 
 ```
-helm install vgpu-charts/vgpu vgpu --set devicePlugin.deviceMemoryScaling=5 ...
+helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
 ```
 
 * `devicePlugin.service.schedulerPort:`


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes an issue where Kubernetes version strings with additional metadata (e.g., `+k3s1`) caused problems in dynamically generated image tags. The new `strippedKubeVersion` function removes the part after the `+` in the Kubernetes version string, ensuring consistent and predictable image tagging.

**Which issue(s) this PR fixes**:
Fixes #621

**Special notes for your reviewer**:
@archlitchi
@wawa0210

**Does this PR introduce a user-facing change?**:
Yes, this PR restores compatibility for specifying certain parameters during `helm install/upgrade`. 

After version 2.4.1, users were unable to specify parameters like `scheduler.kubeScheduler.tag` (scheduler image version), `devicePlugin.deviceSplitCount`, `devicePlugin.deviceMemoryScaling`, and `devicePlugin.deviceCoreScaling` directly during Helm operations. 

With this PR merged:
- Users can now specify the scheduler image version using `scheduler.kubeScheduler.tag` during `helm install` or `helm upgrade`. If the parameter is not provided, the image version will continue to be auto-generated based on the Kubernetes version.
- Parameters like `deviceSplitCount`, `deviceMemoryScaling`, and `deviceCoreScaling` are also restored for direct specification during Helm operations.
