### PR TITLE
feat: support device plugin daemonset update strategy

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -12,6 +12,10 @@ metadata:
   annotations: {{ toYaml .Values.global.annotations | nindent 4}}
   {{- end }}
 spec:
+  updateStrategy:
+    {{- with .Values.devicePlugin.updateStrategy }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: hami-device-plugin

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -131,6 +131,14 @@ devicePlugin:
   nvidianodeSelector:
     gpu: "on"
   tolerations: []
+  # The updateStrategy for DevicePlugin DaemonSet.
+  # If you want to update the DaemonSet by manual, set type as "OnDelete".
+  # We recommend use OnDelete update strategy because DevicePlugin pod restart will cause business pod restart, this behavior is destructive.
+  # Otherwise, you can use RollingUpdate update strategy to rolling update DevicePlugin pod.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
 
 devices:
   mthreads:


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

DevicePlugin pod restart will cause business pod restart, this behavior is destructive.

We can provide users with the option to confirm the policy of rolling updates of deviceplugin

**Which issue(s) this PR fixes**:
Fixes #627

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Users can modify the update policy, and the default is rolling update