### PR TITLE
docs(issue-tmpl): add FAQ link to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: FAQ
+    url: https://github.com/Project-HAMi/HAMi/issues/646
+    about: Frequently asked questions and common solutions.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
- Adds a FAQ link to the issue templates for better user guidance and to reduce repetitive questions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@archlitchi If there are no issues with this PR, please pin the FAQ Issue to the top of the Issues list.

**Does this PR introduce a user-facing change?**:
No