### PR TITLE
optimization map init in test

### DIFF
--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -30,6 +30,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestMain(m *testing.M) {
+	device.InitDevicesWithConfig(&device.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+		},
+	})
+	m.Run()
+}
+
 // test case matrix
 /**
 | node num | per node device | pod use device | device having use | score |
@@ -1352,14 +1364,6 @@ func Test_calcScore(t *testing.T) {
 	s := NewScheduler()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			device.InitDevicesWithConfig(&device.Config{
-				NvidiaConfig: nvidia.NvidiaConfig{
-					ResourceCountName:            "hami.io/gpu",
-					ResourceMemoryName:           "hami.io/gpumem",
-					ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
-					ResourceCoreName:             "hami.io/gpucores",
-				},
-			})
 			got, gotErr := s.calcScore(test.args.nodes, test.args.nums, test.args.annos, test.args.task)
 			assert.DeepEqual(t, test.wants.err, gotErr)
 			wantMap := make(map[string]*policy.NodeScore)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
From the race process, the cause is that two tests in a package have write and read operations on the same map, resulting in concurrency issues.

Currently, the write operation of the map is initialized in TestMain to avoid simultaneous reading and writing.


**Which issue(s) this PR fixes**:
Fixes # https://github.com/Project-HAMi/HAMi/actions/runs/12136056293/job/33836479355?pr=673

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: