### PR TITLE
Setting devicePlugin.compatWithCPUManager=true will set PASS_DEVICE_S…

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -63,6 +63,10 @@ spec:
               value: all
             - name: HOOK_PATH
               value: {{ .Values.global.gpuHookPath }}
+            {{- if typeIs "bool" .Values.devicePlugin.compatWithCPUManager }}
+            - name: PASS_DEVICE_SPECS
+              value: {{ .Values.devicePlugin.compatWithCPUManager | quote }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -118,6 +118,7 @@ devicePlugin:
   runtimeClassName: ""
   migStrategy: "none"
   disablecorelimit: "false"
+  compatWithCPUManager: null
   extraArgs:
     - -v=false
   


### PR DESCRIPTION
…PECS=true as an environment variable.

Signed-off-by: zhangchi <919474320@qq.com>

**What type of PR is this?**
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Mitigate the issue of GPU unavailability during the pod runtime.

**Which issue(s) this PR fixes**:
#658  Containerized GPU workloads may suddenly lose access to their GPUs. This situation occurs when systemd is used to manage the cgroups of the container and it is triggered to reload any Unit files that have references to NVIDIA GPUs (e.g. with something as simple as a systemctl daemon-reload).

**Special notes for your reviewer**:
[https://github.com/NVIDIA/gpu-operator/issues/485](https://github.com/Project-HAMi/HAMi/pull/url)According to the solution provided in the k8s-nvidia-plugin, adding the PASS_DEVICE_SPECS ENV to the plugin was tested and found that not setting privileged can also mitigate the issue.
Additionally, I did not find the usage of PASS_DEVICE_SPECS in hami-device-plugin, but I did find traces of its usage in nvidia's k8s-device-plugin. This is quite puzzling as to why it would work, and I haven't found a reasonable explanation yet. If you have any insights, please let me know.
**Does this PR introduce a user-facing change?**: yes