### PR TITLE
feat: Return the nodes that failed to be scheduled back to the scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -24,12 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Project-HAMi/HAMi/pkg/device"
-	"github.com/Project-HAMi/HAMi/pkg/k8sutil"
-	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
-	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
-	"github.com/Project-HAMi/HAMi/pkg/util"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,6 +34,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/k8sutil"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 type Scheduler struct {
@@ -461,7 +461,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	if len(failedNodes) != 0 {
 		klog.V(5).InfoS("getNodesUsage failed nodes", "nodes", failedNodes)
 	}
-	nodeScores, err := s.calcScore(nodeUsage, nums, annos, args.Pod)
+	nodeScores, err := s.calcScore(nodeUsage, nums, annos, args.Pod, failedNodes)
 	if err != nil {
 		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, []string{}, err)

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -19,13 +19,13 @@ import (
 	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
 	"github.com/Project-HAMi/HAMi/pkg/util"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 )
 
 func viewStatus(usage NodeUsage) {
@@ -195,7 +195,7 @@ func fitInDevices(node *NodeUsage, requests util.ContainerDeviceRequests, annos 
 	return true, 0
 }
 
-func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, nums util.PodDeviceRequests, annos map[string]string, task *corev1.Pod) (*policy.NodeScoreList, error) {
+func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, nums util.PodDeviceRequests, annos map[string]string, task *corev1.Pod, failedNodes map[string]string) (*policy.NodeScoreList, error) {
 	userNodePolicy := config.NodeSchedulerPolicy
 	if annos != nil {
 		if value, ok := annos[policy.NodeSchedulerPolicyAnnotationKey]; ok {
@@ -236,6 +236,7 @@ func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, nums util.PodDeviceR
 			ctrfit = fit
 			if !fit {
 				klog.InfoS("calcScore:node not fit pod", "pod", klog.KObj(task), "node", nodeID)
+				failedNodes[nodeID] = "node not fit pod"
 				break
 			}
 		}

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -19,15 +19,15 @@ package scheduler
 import (
 	"testing"
 
-	"github.com/Project-HAMi/HAMi/pkg/device"
-	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
-	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
-	"github.com/Project-HAMi/HAMi/pkg/util"
-
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 func TestMain(m *testing.M) {
@@ -75,8 +75,9 @@ func Test_calcScore(t *testing.T) {
 			task  *corev1.Pod
 		}
 		wants struct {
-			want *policy.NodeScoreList
-			err  error
+			want        *policy.NodeScoreList
+			failedNodes map[string]string
+			err         error
 		}
 	}{
 		{
@@ -146,8 +147,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -241,8 +243,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -352,8 +355,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -463,8 +467,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -574,8 +579,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -692,8 +698,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -817,8 +824,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -952,8 +960,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -1071,8 +1080,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -1190,8 +1200,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -1323,8 +1334,9 @@ func Test_calcScore(t *testing.T) {
 				},
 			},
 			wants: struct {
-				want *policy.NodeScoreList
-				err  error
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
 			}{
 				want: &policy.NodeScoreList{
 					Policy: util.NodeSchedulerPolicyBinpack.String(),
@@ -1360,18 +1372,104 @@ func Test_calcScore(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "one node one device one pod one container use one device and not enough resource,node should be failed.",
+			args: struct {
+				nodes *map[string]*NodeUsage
+				nums  util.PodDeviceRequests
+				annos map[string]string
+				task  *corev1.Pod
+			}{
+				nodes: &map[string]*NodeUsage{
+					"node1": {
+						Devices: policy.DeviceUsageList{
+							Policy: util.GPUSchedulerPolicySpread.String(),
+							DeviceLists: []*policy.DeviceListsScore{
+								{
+									Device: &util.DeviceUsage{
+										ID:        "uuid1",
+										Index:     0,
+										Used:      0,
+										Count:     10,
+										Usedmem:   0,
+										Totalmem:  50, // not enough mem
+										Totalcore: 100,
+										Usedcores: 0,
+										Numa:      0,
+										Type:      nvidia.NvidiaGPUDevice,
+										Health:    true,
+									},
+									Score: 0,
+								},
+							},
+						},
+					},
+				},
+				nums: util.PodDeviceRequests{
+					{
+						"hami.io/vgpu-devices-to-allocate": util.ContainerDeviceRequest{
+							Nums:     1,
+							Type:     nvidia.NvidiaGPUDevice,
+							Memreq:   1000,
+							Coresreq: 30,
+						},
+					},
+				},
+				annos: make(map[string]string),
+				task: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "gpu-burn",
+								Image: "chrstnhntschl/gpu_burn",
+								Args:  []string{"6000"},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+										"hami.io/gpucores": *resource.NewQuantity(30, resource.BinarySI),
+										"hami.io/gpumem":   *resource.NewQuantity(1000, resource.BinarySI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wants: struct {
+				want        *policy.NodeScoreList
+				failedNodes map[string]string
+				err         error
+			}{
+				want: &policy.NodeScoreList{
+					Policy:   util.NodeSchedulerPolicyBinpack.String(),
+					NodeList: []*policy.NodeScore{},
+				},
+				failedNodes: map[string]string{
+					"node1": "node not fit pod",
+				},
+				err: nil,
+			},
+		},
 	}
 	s := NewScheduler()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := s.calcScore(test.args.nodes, test.args.nums, test.args.annos, test.args.task)
+			failedNodes := map[string]string{}
+			got, gotErr := s.calcScore(test.args.nodes, test.args.nums, test.args.annos, test.args.task, failedNodes)
 			assert.DeepEqual(t, test.wants.err, gotErr)
 			wantMap := make(map[string]*policy.NodeScore)
 			for index, node := range (*(test.wants.want)).NodeList {
 				wantMap[node.NodeID] = (*(test.wants.want)).NodeList[index]
 			}
-			if gotErr == nil && len(got.NodeList) == 0 {
+			if gotErr == nil && len(got.NodeList) == 0 && len(failedNodes) == 0 {
 				t.Fatal("empty error and empty result")
+			}
+			if len(failedNodes) != 0 {
+				assert.DeepEqual(t, test.wants.failedNodes, failedNodes)
+				return
 			}
 			for i := 0; i < got.Len(); i++ {
 				gotI := (*(got)).NodeList[i]


### PR DESCRIPTION

**What type of PR is this?**
feat: Return the nodes that failed to be scheduled back to the scheduler

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

According to the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/1819-scheduler-extender/README.md) requirements, nodes that cannot be scheduled should be returned to the scheduler.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

When there is no node in the cluster that meets the scheduling requirements, HAMi currently does not return any information to the scheduler, which does not meet the KEP specifications. According to the KEP requirements, the information of nodes that do not meet the requirements and the errors should be returned to the scheduler.

**Does this PR introduce a user-facing change?**: