### PR TITLE
print flags for device-plugin and scheduler

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -27,11 +27,11 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/flag"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/fsnotify/fsnotify"
 	cli "github.com/urfave/cli/v2"
-
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -45,6 +45,7 @@ func main() {
 	c.Usage = "NVIDIA device plugin for Kubernetes"
 	c.Version = info.GetVersionString()
 	c.Action = func(ctx *cli.Context) error {
+		flag.PrintCliFlags(ctx)
 		return start(ctx, c.Flags)
 	}
 

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/routes"
 	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/flag"
 	"github.com/Project-HAMi/HAMi/pkg/version"
 
 	"github.com/julienschmidt/httprouter"
@@ -41,6 +42,7 @@ var (
 		Use:   "scheduler",
 		Short: "kubernetes vgpu scheduler",
 		Run: func(cmd *cobra.Command, args []string) {
+			flag.PrintPFlags(cmd.Flags())
 			start()
 		},
 	}

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
+)
+
+func PrintPFlags(flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		klog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
+}
+
+func PrintCliFlags(c *cli.Context) {
+	for _, flag := range c.App.Flags {
+		names := flag.Names()
+		for _, name := range names {
+			value := c.Generic(name)
+			klog.Infof("FLAG: --%s=%q\n", name, value)
+		}
+
+	}
+}

--- a/pkg/util/flag/flags_test.go
+++ b/pkg/util/flag/flags_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
+)
+
+func TestPrintPFlags(t *testing.T) {
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+	tests := []struct {
+		name     string
+		flags    func() *pflag.FlagSet
+		expected string
+	}{
+		{
+			name: "Test with name flags",
+			flags: func() *pflag.FlagSet {
+				fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				fs.String("name", "bob", "set name")
+				return fs
+			},
+			expected: `FLAG: --name="bob"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			PrintPFlags(tt.flags())
+			if got := buf.String(); !strings.Contains(got, tt.expected) {
+				t.Errorf("PrintPFlags() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPrintCliFlags(t *testing.T) {
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+
+	tests := []struct {
+		name     string
+		cliCtx   func() *cli.Context
+		expected string
+	}{
+		{
+			name: "Test with name flag",
+			cliCtx: func() *cli.Context {
+				app := &cli.App{
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "name",
+							Value: "bob",
+							Usage: "set user name",
+						},
+					},
+				}
+				flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+				flagSet.String("name", "bob", "")
+				return cli.NewContext(app, flagSet, nil)
+			},
+			expected: `FLAG: --name="bob"
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			PrintCliFlags(tt.cliCtx())
+			got := buf.String()
+			if !strings.Contains(got, tt.expected) {
+				t.Errorf("PrintCliFlags() output = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement


**What this PR does / why we need it**:

Print flags for device-plugin and scheduler.

**Which issue(s) this PR fixes**:
Fixes #755 

The output  as follows：

For device-plugin:

```shell
I1229 17:11:54.537866   13477 flags.go:21] FLAG: --mig-strategy=""
I1229 17:11:54.537921   13477 flags.go:21] FLAG: --fail-on-init-error="true"
I1229 17:11:54.537929   13477 flags.go:21] FLAG: --nvidia-driver-root="/"
I1229 17:11:54.537934   13477 flags.go:21] FLAG: --pass-device-specs="false"
I1229 17:11:54.537939   13477 flags.go:21] FLAG: --device-list-strategy="[envvar]"
I1229 17:11:54.537945   13477 flags.go:21] FLAG: --device-id-strategy="uuid"
I1229 17:11:54.537948   13477 flags.go:21] FLAG: --gds-enabled="false"
I1229 17:11:54.537951   13477 flags.go:21] FLAG: --mofed-enabled="false"
I1229 17:11:54.537953   13477 flags.go:21] FLAG: --config-file=""
I1229 17:11:54.537956   13477 flags.go:21] FLAG: --cdi-annotation-prefix="cdi.k8s.io/"
I1229 17:11:54.537959   13477 flags.go:21] FLAG: --nvidia-ctk-path="/usr/bin/nvidia-ctk"
I1229 17:11:54.537962   13477 flags.go:21] FLAG: --container-driver-root="/driver-root"
I1229 17:11:54.537965   13477 flags.go:21] FLAG: --node-name=""
I1229 17:11:54.537968   13477 flags.go:21] FLAG: --device-split-count="2"
I1229 17:11:54.537972   13477 flags.go:21] FLAG: --device-memory-scaling="1"
I1229 17:11:54.537977   13477 flags.go:21] FLAG: --device-cores-scaling="1"
I1229 17:11:54.537981   13477 flags.go:21] FLAG: --disable-core-limit="false"
I1229 17:11:54.537991   13477 flags.go:21] FLAG: --resource-name="nvidia.com/gpu"
I1229 17:11:54.537996   13477 flags.go:21] FLAG: --help="false"
I1229 17:11:54.537998   13477 flags.go:21] FLAG: --h="false"
I1229 17:11:54.538001   13477 flags.go:21] FLAG: --version="false"
I1229 17:11:54.538003   13477 flags.go:21] FLAG: --v="false"
```

For scheduler:

```shell
I1229 17:12:58.089355   13852 flags.go:12] FLAG: --http_bind="127.0.0.1:8080"
I1229 17:12:58.089406   13852 flags.go:12] FLAG: --cert_file=""
I1229 17:12:58.089409   13852 flags.go:12] FLAG: --key_file=""
I1229 17:12:58.089412   13852 flags.go:12] FLAG: --scheduler-name=""
I1229 17:12:58.089414   13852 flags.go:12] FLAG: --default-mem="0"
I1229 17:12:58.089417   13852 flags.go:12] FLAG: --default-cores="0"
I1229 17:12:58.089419   13852 flags.go:12] FLAG: --default-gpu="1"
I1229 17:12:58.089421   13852 flags.go:12] FLAG: --node-scheduler-policy="binpack"
I1229 17:12:58.089424   13852 flags.go:12] FLAG: --gpu-scheduler-policy="spread"
I1229 17:12:58.089426   13852 flags.go:12] FLAG: --metrics-bind-address=":9395"
I1229 17:12:58.089428   13852 flags.go:12] FLAG: --node-label-selector="[]"
I1229 17:12:58.089432   13852 flags.go:12] FLAG: --add_dir_header="false"
I1229 17:12:58.089434   13852 flags.go:12] FLAG: --alsologtostderr="false"
I1229 17:12:58.089436   13852 flags.go:12] FLAG: --log_backtrace_at=":0"
I1229 17:12:58.089453   13852 flags.go:12] FLAG: --log_dir=""
I1229 17:12:58.089457   13852 flags.go:12] FLAG: --log_file=""
I1229 17:12:58.089459   13852 flags.go:12] FLAG: --log_file_max_size="1800"
I1229 17:12:58.089462   13852 flags.go:12] FLAG: --logtostderr="true"
I1229 17:12:58.089464   13852 flags.go:12] FLAG: --one_output="false"
I1229 17:12:58.089466   13852 flags.go:12] FLAG: --skip_headers="false"
I1229 17:12:58.089468   13852 flags.go:12] FLAG: --skip_log_headers="false"
I1229 17:12:58.089471   13852 flags.go:12] FLAG: --stderrthreshold="2"
I1229 17:12:58.089473   13852 flags.go:12] FLAG: --v="0"
I1229 17:12:58.089476   13852 flags.go:12] FLAG: --vmodule=""
I1229 17:12:58.089478   13852 flags.go:12] FLAG: --cambricon-mlu-cores="cambricon.com/mlu.smlu.vcore"
I1229 17:12:58.089481   13852 flags.go:12] FLAG: --cambricon-mlu-memory="cambricon.com/mlu.smlu.vmemory"
I1229 17:12:58.089484   13852 flags.go:12] FLAG: --cambricon-mlu-name="cambricon.com/mlu"
I1229 17:12:58.089487   13852 flags.go:12] FLAG: --dcu-cores="hygon.com/dcucores"
I1229 17:12:58.089550   13852 flags.go:12] FLAG: --dcu-memory="hygon.com/dcumem"
I1229 17:12:58.089553   13852 flags.go:12] FLAG: --dcu-name="hygon.com/dcunum"
I1229 17:12:58.089556   13852 flags.go:12] FLAG: --debug="false"
I1229 17:12:58.089561   13852 flags.go:12] FLAG: --device-config-file=""
I1229 17:12:58.089564   13852 flags.go:12] FLAG: --enable-ascend="false"
I1229 17:12:58.089566   13852 flags.go:12] FLAG: --iluvatar-cores="iluvatar.ai/vcuda-core"
I1229 17:12:58.089568   13852 flags.go:12] FLAG: --iluvatar-memory="iluvatar.ai/vcuda-memory"
I1229 17:12:58.089570   13852 flags.go:12] FLAG: --iluvatar-name="iluvatar.ai/vgpu"
I1229 17:12:58.089572   13852 flags.go:12] FLAG: --metax-name="metax-tech.com/gpu"
I1229 17:12:58.089574   13852 flags.go:12] FLAG: --mthreads-cores="mthreads.com/sgpu-core"
I1229 17:12:58.089576   13852 flags.go:12] FLAG: --mthreads-memory="mthreads.com/sgpu-memory"
I1229 17:12:58.089578   13852 flags.go:12] FLAG: --mthreads-name="mthreads.com/vgpu"
I1229 17:12:58.089580   13852 flags.go:12] FLAG: --help="false"



```