### PR TITLE
fix get device ids when a specific number of devices are to be replicated

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -34,6 +34,7 @@ package rm
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 
@@ -252,7 +253,9 @@ func (d DeviceMap) getIDsOfDevicesToReplicate(r *spec.ReplicatedResource) ([]str
 		if r.Devices.Count > len(devices) {
 			return nil, fmt.Errorf("requested %d devices to be replicated, but only %d devices available", r.Devices.Count, len(devices))
 		}
-		return devices.GetIDs()[:r.Devices.Count], nil
+		ids := devices.GetIDs()
+		sort.Strings(ids)
+		return ids[:r.Devices.Count], nil
 	}
 
 	// If a specific set of devices for this resource type are to be replicated.


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

When a specific number of devices for this resource type are to be replicated, every time we get device ids different. Because the traversal map is unordered.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: