### PR TITLE
refactor(ci): use go.mod file for Go version in workflows

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
       - name: Generating image tag
         id: runtime-tag
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
       - name: verify license
         run: hack/verify-license.sh
       - name: go tidy
@@ -53,7 +53,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
       - run: make tidy
       - run: make test
       - name: Upload coverage to Codecov


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

This pull request includes changes to the CI workflows to streamline the installation of Go by using the version specified in the `go.mod` file instead of hardcoding the version number.

Changes to CI workflows:

* [`.github/workflows/ci-image-scanning.yaml`](diffhunk://#diff-98257f4321f494a80de3c4360b3eb1a01154102803728fee435cdf14bd657ad0L42-R42): Updated the Go installation to use the version specified in `go.mod` instead of a hardcoded version.
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL32-R32): Updated multiple instances of Go installation to use the version specified in `go.mod` instead of a hardcoded version. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL32-R32) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL56-R56)