### PR TITLE
support set log level for device plugin

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -138,7 +138,7 @@ devicePlugin:
   disablecorelimit: "false"
   passDeviceSpecsEnabled: true
   extraArgs:
-    - -v=false
+    - -v=4
   
   service:
     httpPort: 31992


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test

/kind flake
-->

**What this PR does / why we need it**:

Support setting log level for device-plugin.


**Which issue(s) this PR fixes**:
Fixes #770 

**Special notes for your reviewer**:

Add `version` sub command to print the current version info, the `-v` parameter is used to control the log level.

```shell
Pro tmp % ./nvidia-device-plugin version    // print version 
NVIDIA Device Plugin version: v0.12
```

```shell
Pro tmp % ./nvidia-device-plugin --v=4  // set log level
```


**Does this PR introduce a user-facing change?**: