### PR TITLE
optimize MetricsBindAddress to MetricsBindPort

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - --cert_file=/tls/tls.crt
             - --key_file=/tls/tls.key
             - --scheduler-name={{ .Values.schedulerName }}
-            - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}
+            - --metrics-bind-port={{ .Values.scheduler.metricsBindPort }}
             - --node-scheduler-policy={{ .Values.scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy }}
             - --gpu-scheduler-policy={{ .Values.scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy }}
             - --device-config-file=/device-config.yaml

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
     - name: monitor
       port: {{ .Values.scheduler.service.monitorPort }}
-      targetPort: 9395
+      targetPort: {{ .Values.scheduler.metricsBindPort }}
       nodePort: {{ .Values.scheduler.service.monitorPort }}
       protocol: TCP
   selector:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -52,7 +52,7 @@ scheduler:
   defaultSchedulerPolicy:
     nodeSchedulerPolicy: binpack
     gpuSchedulerPolicy: spread
-  metricsBindAddress: ":9395"
+  metricsBindPort: 9395
   livenessProbe: false
   leaderElect: true
   kubeScheduler:

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -61,7 +61,7 @@ func init() {
 	rootCmd.Flags().Int32Var(&config.DefaultResourceNum, "default-gpu", 1, "default gpu to allocate")
 	rootCmd.Flags().StringVar(&config.NodeSchedulerPolicy, "node-scheduler-policy", util.NodeSchedulerPolicyBinpack.String(), "node scheduler policy")
 	rootCmd.Flags().StringVar(&config.GPUSchedulerPolicy, "gpu-scheduler-policy", util.GPUSchedulerPolicySpread.String(), "GPU scheduler policy")
-	rootCmd.Flags().StringVar(&config.MetricsBindAddress, "metrics-bind-address", ":9395", "The TCP address that the scheduler should bind to for serving prometheus metrics(e.g. 127.0.0.1:9395, :9395)")
+	rootCmd.Flags().StringVar(&config.MetricsBindPort, "metrics-bind-port", ":9395", "The port that the scheduler should bind to for serving prometheus metrics(e.g. 9395)")
 	rootCmd.Flags().StringToStringVar(&config.NodeLabelSelector, "node-label-selector", nil, "key=value pairs separated by commas")
 	rootCmd.PersistentFlags().AddGoFlagSet(device.GlobalFlagSet())
 	rootCmd.AddCommand(version.VersionCmd)
@@ -76,7 +76,7 @@ func start() {
 
 	// start monitor metrics
 	go sher.RegisterFromNodeAnnotations()
-	go initMetrics(config.MetricsBindAddress)
+	go initMetrics(config.MetricsBindPort)
 
 	// start http server
 	router := httprouter.New()

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 
@@ -246,7 +247,7 @@ func NewClusterManager(zone string, reg prometheus.Registerer) *ClusterManager {
 	return c
 }
 
-func initMetrics(bindAddress string) {
+func initMetrics(bindPort string) {
 	// Since we are dealing with custom Collector implementations, it might
 	// be a good idea to try it out with a pedantic registry.
 	klog.Info("Initializing metrics for scheduler")
@@ -257,5 +258,7 @@ func initMetrics(bindAddress string) {
 	NewClusterManager("vGPU", reg)
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(bindAddress, nil))
+	addr := net.JoinHostPort("0.0.0.0", bindPort)
+	klog.Infof("Starting metrics server on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -19,9 +19,9 @@ package config
 import "github.com/Project-HAMi/HAMi/pkg/util"
 
 var (
-	HTTPBind           string
-	SchedulerName      string
-	MetricsBindAddress string
+	HTTPBind        string
+	SchedulerName   string
+	MetricsBindPort string
 
 	DefaultMem         int32
 	DefaultCores       int32


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
The targetPort specified in the service.yaml is hardcoded, while the metricsBindAddress is configurable, leading to inconsistent behavior. Additionally, the metrics interface should ideally be exposed at 0.0.0.0, so flexible configuration may not be necessary. Therefore, it is recommended to optimize this to metricsBindPort.

**Which issue(s) this PR fixes**:
Fixes #793

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: