### PR TITLE
optimize MetricsBindAddress to MetricsBindPort

### DIFF
--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
     - name: monitor
       port: {{ .Values.scheduler.service.monitorPort }}
-      targetPort: 9395
+      targetPort: {{ (split ":" (printf "%s" .Values.scheduler.metricsBindAddress))._1 }}
       nodePort: {{ .Values.scheduler.service.monitorPort }}
       protocol: TCP
   selector:


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
The targetPort specified in the service.yaml is hardcoded, while the metricsBindAddress is configurable, leading to inconsistent behavior. Additionally, the metrics interface should ideally be exposed at 0.0.0.0, so flexible configuration may not be necessary. Therefore, it is recommended to optimize this to metricsBindPort.

I have successfully tested it locally
![image](https://github.com/user-attachments/assets/e2dc68d5-7a3b-437f-a952-2b4894c23fff)


Which issue(s) this PR fixes:
Fixes https://github.com/Project-HAMi/HAMi/issues/793

Special notes for your reviewer:

Does this PR introduce a user-facing change?: