### PR TITLE
fix: remove the comment for new kubeClient in the init func

### DIFF
--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -31,11 +31,11 @@ var (
 )
 
 func init() {
-	// var err error
-	// KubeClient, err = NewClient()
-	// if err != nil {
-	// 	panic(err)
-	// }
+	var err error
+	KubeClient, err = NewClient()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func GetClient() kubernetes.Interface {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Panic after booting with the master version

```
I0114 09:03:37.517968 1423199 register.go:173] nvml registered device id=0, memory=24564, type=NVIDIA GeForce RTX 4090, numa=0
I0114 09:03:37.518229 1423199 register.go:180] "start working on the devices" devices=[{"id":"GPU-ba6025d2-cb52-0763-38ff-ce078a1419f7","count":10,"devmem":24564,"devcore":100,"type":"NVIDIA-NVIDIA GeForce RTX 4090","mode":"hami-core","health":true}]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x12e01e6]

goroutine 114 [running]:
github.com/Project-HAMi/HAMi/pkg/util.GetNode({0xc00004603a, 0x9})
	/k8s-vgpu/pkg/util/util.go:59 +0x26
github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin.(*NvidiaDevicePlugin).RegistrInAnnotation(0x25dddc0?)
	/k8s-vgpu/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go:182 +0xe8
github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin.(*NvidiaDevicePlugin).WatchAndRegister(0xc00038e580)
	/k8s-vgpu/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go:204 +0x7a
github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin.(*NvidiaDevicePlugin).Start.func2()
	/k8s-vgpu/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go:247 +0x17
created by github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin.(*NvidiaDevicePlugin).Start in goroutine 1
	/k8s-vgpu/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go:246 +0x90e
```
