### PR TITLE
fix: hami-scheduler crash

### DIFF
--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -31,11 +31,11 @@ var (
 )
 
 func init() {
-	// var err error
-	// KubeClient, err = NewClient()
-	// if err != nil {
-	// 	panic(err)
-	// }
+	var err error
+	KubeClient, err = NewClient()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func GetClient() kubernetes.Interface {


### PR DESCRIPTION
**What type of PR is this?**


Add one of the following kinds:
/kind bug


**What this PR does / why we need it**:
hami-scheduler crash when init , output error message:
```
goroutine 272 [running]:
github.com/Project-HAMi/HAMi/pkg/util.GetNode({0x400005a860, 0x19})
        /k8s-vgpu/pkg/util/util.go:59 +0x30
github.com/Project-HAMi/HAMi/pkg/scheduler.(*Scheduler).RegisterFromNodeAnnotations(0x40004bc0a0)
        /k8s-vgpu/pkg/scheduler/scheduler.go:206 +0x9e0
created by main.start in goroutine 1
        /k8s-vgpu/cmd/scheduler/main.go:78 +0xd4
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: