### PR TITLE
[docs] fix: glibc version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The list of prerequisites for running the NVIDIA device plugin is described belo
 - nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.16
-- glibc >= 2.17 & glibc < 2.3.0
+- glibc >= 2.17 & glibc < 2.30
 - kernel version >= 3.10
 - helm > 3.0
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -91,7 +91,7 @@ HAMi 由多个组件组成，包括统一的 mutatingwebhook、统一的调度�
 - nvidia-docker 版本 > 2.0
 - containerd/docker/cri-o 容器运行时的默认运行时配置为 nvidia
 - Kubernetes 版本 >= 1.16
-- glibc >= 2.17 & glibc < 2.3.0
+- glibc >= 2.17 & glibc < 2.30
 - 内核版本 >= 3.10
 - helm > 3.0
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation



**Special notes for your reviewer**:

`glibc >= 2.17 & glibc < 2.3.0` probably typo, guessing the correct version would be 2.30.

Reference Links: https://sourceware.org/glibc/wiki/Glibc%20Timeline

<img width="678" alt="image" src="https://github.com/user-attachments/assets/3dc84b58-b929-42a9-8332-b334d7dfbaee" />
