### PR TITLE
Fix: Update handling of version strings in Helm template and helpers.tpl

### DIFF
--- a/charts/hami/templates/_helpers.tpl
+++ b/charts/hami/templates/_helpers.tpl
@@ -98,11 +98,11 @@ imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 2 }}
 
 
 {{/*
-    Remove the part after the `+` in the Kubernetes version string.
+    Return the stripped Kubernetes version string by removing extra parts after semantic version number.
     v1.31.1+k3s1 -> v1.31.1
+    v1.30.8-eks-2d5f260 -> v1.30.8
     v1.31.1 -> v1.31.1
 */}}
 {{- define "strippedKubeVersion" -}}
-{{- $parts := split "+" .Capabilities.KubeVersion.Version -}}
-{{- print $parts._0 -}}
+{{ regexReplaceAll "^(v[0-9]+\\.[0-9]+\\.[0-9]+)(.*)$" .Capabilities.KubeVersion.Version "$1" }}
 {{- end -}}

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- if gt (.Capabilities.KubeVersion.Minor | int) 25}}
+    {{- if gt (regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" | int) 25}}
     apiVersion: kubescheduler.config.k8s.io/v1
     {{- else }}
     apiVersion: kubescheduler.config.k8s.io/v1beta2

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.scheduler.kubeScheduler.imagePullPolicy | quote }}
           command:
             - kube-scheduler
-             {{- if ge (.Capabilities.KubeVersion.Minor | int) 22 }}
+             {{- if ge (regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" | int) 22 }}
             {{- range .Values.scheduler.kubeScheduler.extraNewArgs }}
             - {{ . }}
             {{- end }}
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.scheduler.kubeScheduler.enabled }}
         - name: scheduler-config
           configMap:
-            {{- if ge (.Capabilities.KubeVersion.Minor | int) 22 }}
+            {{- if ge (regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" | int) 22 }}
             name: {{ template "hami-vgpu.scheduler" . }}-newversion
             {{- else }}
             name: {{ template "hami-vgpu.scheduler" . }}

--- a/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: create
-           {{- if ge (.Capabilities.KubeVersion.Minor | int) 22 }}
+           {{- if ge (regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" | int) 22 }}
           image: {{ .Values.scheduler.patch.imageNew }}
           {{- else }}
           image: {{ .Values.scheduler.patch.image }}

--- a/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: patch
-          {{- if ge (.Capabilities.KubeVersion.Minor | int) 22 }}
+          {{- if ge (regexReplaceAll "[^0-9]" .Capabilities.KubeVersion.Minor "" | int) 22 }}
           image: {{ .Values.scheduler.patch.imageNew }}
           {{- else }}
           image: {{ .Values.scheduler.patch.image }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The current master branch was not able to handle version strings like **v1.30.8-eks-2d5f260** which is prevalent for AWS EKS. This causes HAMi charts installation failure as the minor version checking condition defaults to false and old parameters are used.
Also currently, scheduler imageTag needs to be set every time we have versions like **v1.30.8-eks-2d5f260**. However changing the definition of **strippedKubeVersion** in _helpers.tpl to a more general regexReplaceAll command solves this while being backwards compatible.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/Project-HAMi/HAMi/issues/744
https://github.com/Project-HAMi/HAMi/issues/791
**Special notes for your reviewer**: This PR will help Project HAMi to get deployed on various cloud-based Kubernetes clusters.

**Does this PR introduce a user-facing change?**: No