### PR TITLE
fix: correct device filter initialization order

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/manager/nvml.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/manager/nvml.go
@@ -43,6 +43,11 @@ type nvmlmanager manager
 
 // GetPlugins returns the plugins associated with the NVML resources available on the node
 func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
+	// Initialize device filter before NewNVMLResourceManagers
+	if err := plugin.InitDeviceFilter(); err != nil {
+		return nil, fmt.Errorf("failed to init device filter: %v", err)
+	}
+
 	rms, err := rm.NewNVMLResourceManagers(m.nvmllib, m.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct NVML resource managers: %v", err)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -99,6 +99,16 @@ type NvidiaDevicePlugin struct {
 	stop   chan interface{}
 }
 
+// InitDeviceFilter initializes nvidia.DevicePluginFilterDevice from config file
+func InitDeviceFilter() error {
+	sConfig := &nvidia.NvidiaConfig{}
+	_, err := readFromConfigFile(sConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize device filter: %v", err)
+	}
+	return nil
+}
+
 func readFromConfigFile(sConfig *nvidia.NvidiaConfig) (string, error) {
 	jsonbyte, err := os.ReadFile("/config/config.json")
 	mode := "hami-core"


### PR DESCRIPTION
Found an initialization order issue where FilterDeviceToRegister always returns false because DevicePluginFilterDevice is not initialized when the function is called. This happens because NewNVMLResourceManagers (which uses FilterDeviceToRegister) is called before the config file is read in NewNvidiaDevicePlugin.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Changes:
- Added `InitDeviceFilter` function in plugin package to handle device filter initialization
- Modified `GetPlugins` to ensure device filter is initialized before creating resource managers
- Added necessary error handling

**Which issue(s) this PR fixes**:
Fixes #856

**Special notes for your reviewer**:
Testing:
1. Verified device filtering works correctly with test config
2. Confirmed existing functionality remains unchanged
3. Added device filter config works as expected
![CleanShot 2025-02-10 at 16 43 07@2x](https://github.com/user-attachments/assets/a3bb5bd0-8983-45de-b05b-d7b885ad9d43)
![CleanShot 2025-02-10 at 16 43 44@2x](https://github.com/user-attachments/assets/7623dd1e-b0be-4be0-8765-9edab5577ac1)
![CleanShot 2025-02-10 at 17 24 16@2x](https://github.com/user-attachments/assets/83731436-75a9-470d-885b-750e858d91b6)

This fix ensures the device filtering feature works as intended without any side effects on existing functionality.

**Does this PR introduce a user-facing change?**:
No