### PR TITLE
fix: Set passDeviceSpecsEnabled to false by default in device plugin

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -137,7 +137,7 @@ devicePlugin:
   runtimeClassName: ""
   migStrategy: "none"
   disablecorelimit: "false"
-  passDeviceSpecsEnabled: true
+  passDeviceSpecsEnabled: false
   extraArgs:
     - -v=4
   


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Sets `passDeviceSpecsEnabled` to `false` by default in the device plugin to prevent pod startup failures in certain environments.

While `passDeviceSpecsEnabled=true` can help solve GPU access issues during runtime (especially in systemd-managed environments), it may cause pod startup failures in some cases (see #867 #776). Users who need this feature can still explicitly enable it through Helm values.

**Which issue(s) this PR fixes**:
Fixes #867 #776

**Special notes for your reviewer**:
- Default value changed from `true` to `false`
- No functional changes to the feature itself

**Does this PR introduce a user-facing change?**:
YES

NOTE: This is a breaking change for users who rely on the current default behavior. They will need to explicitly set `passDeviceSpecsEnabled: true` in their Helm values after updating.