### PR TITLE
enhancement: use placeholder for node name in device plugin ConfigMap template

### DIFF
--- a/charts/hami/templates/device-plugin/configmap.yaml
+++ b/charts/hami/templates/device-plugin/configmap.yaml
@@ -10,7 +10,7 @@ data:
     {
         "nodeconfig": [
             {
-                "name": "m5-cloudinfra-online02",
+                "name": "<your-node-name>",
                 "operatingmode": "hami-core",
                 "devicememoryscaling": 1.8,
                 "devicesplitcount": 10,


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
Several users have reported issues where the device plugin configuration doesn't take effect because they didn't modify the default node name in the ConfigMap. This PR replaces the specific node name with a placeholder to make it more obvious that users need to replace it with their actual node name.

Changes:
- Changed the default node name from `m5-cloudinfra-online02` to `<your-node-name>` in the device plugin ConfigMap template to better indicate that this value needs to be replaced


**Which issue(s) this PR fixes**:
Fixes #811

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes. Users will see a more intuitive placeholder in the ConfigMap template that clearly indicates they need to replace it with their actual node name.