### PR TITLE
feat: support scheduler replicas > 1

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -12,7 +12,11 @@ metadata:
   annotations: {{ toYaml .Values.global.annotations | nindent 4}}
   {{- end }}
 spec:
+  {{- if .Values.scheduler.leaderElect }}
+  replicas: {{ .Values.scheduler.replicas }}
+  {{- else }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: hami-scheduler

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -55,6 +55,8 @@ scheduler:
   metricsBindAddress: ":9395"
   livenessProbe: false
   leaderElect: true
+  # when leaderElect is true, replicas is available, otherwise replicas is 1.
+  replicas: 1
   kubeScheduler:
     # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.
     enabled: true


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enhance the stability of the scheduler
**Which issue(s) this PR fixes**:
Fixes #877

**Special notes for your reviewer**:
When the scheduler replicas > 1 and leaderElect is on, each instances will try to create or acquire the lease resource. Instance which acquires the lease will become the leader of the scheduler cluster. It will be responsible for handling scheduling tasks, making decisions on resource allocation, and coordinating the overall scheduling operations.
Meanwhile, the non - leader instances will be in a standby state, monitoring the leader's activities. If the leader fails or loses the lease for some reason, these standby instances will compete again to acquire the lease and take over the leadership role to ensure the continuous and stable operation of the scheduler.
![图片](https://github.com/user-attachments/assets/c4c21ec4-540f-4d6a-b63f-e5ab0efca495)
![图片](https://github.com/user-attachments/assets/88bf98e4-337d-489d-bfce-b6a552422d07)

**Does this PR introduce a user-facing change?**: