### PR TITLE
add config gpu core isolation policy for webhook

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -23,6 +23,7 @@ data:
       deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
       deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
       deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
+      gpuCorePolicy: {{ .Values.devices.nvidia.gpuCorePolicy }}
       knownMigGeometries:
       - models: [ "A30" ]
         allowedGeometries:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -194,6 +194,8 @@ devices:
     enabled: false
     customresources:
       - mthreads.com/vgpu
+  nvidia:
+    gpuCorePolicy: default
   ascend:
     enabled: false
     image: ""

--- a/docs/config.md
+++ b/docs/config.md
@@ -103,6 +103,7 @@ helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
 ## Container configs: env
 
 * `GPU_CORE_UTILIZATION_POLICY`:
+> Currently this parameter can be specified during `helm install` and then automatically injected into the container environment variables, through `--set devices.nvidia.gpuCorePolicy=force`
 
   String type, "default", "force", "disable"
 

--- a/docs/config_cn.md
+++ b/docs/config_cn.md
@@ -116,7 +116,8 @@ helm install vgpu vgpu-charts/vgpu --set devicePlugin.deviceMemoryScaling=5 ...
 
 ## 容器配置（在容器的环境变量中指定）
 
-* `GPU_CORE_UTILIZATION_POLICY`：
+* `GPU_CORE_UTILIZATION_POLICY` 
+  > 当前这个参数可以在 `helm install` 的时候指定，然后自动注入到容器环境变量中, 通过 `--set devices.nvidia.gpuCorePolicy=force`
 
   字符串类型，"default"，"force"，"disable"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/Project-HAMi/HAMi/issues/875

**Special notes for your reviewer**:

1. config `gpuCorePolicy` to `nvidia-vgpu-hami-scheduler-device` configmap, values is `defaule`、`force`、`disable`.
![image](https://github.com/user-attachments/assets/737a3830-47f2-44d7-a890-402aa047701c)

2. create use nvidia gpu will automatic injected to container env.
![image](https://github.com/user-attachments/assets/5bf7b55c-9109-4ded-bf1c-a921aa75d560)


**Does this PR introduce a user-facing change?**: