### PR TITLE
refactor(scheduler): replace init methods with constructor functions

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -39,8 +39,10 @@ type nodeManager struct {
 	mutex sync.RWMutex
 }
 
-func (m *nodeManager) init() {
-	m.nodes = make(map[string]*util.NodeInfo)
+func newNodeManager() *nodeManager {
+	return &nodeManager{
+		nodes: make(map[string]*util.NodeInfo),
+	}
 }
 
 func (m *nodeManager) addNode(nodeID string, nodeInfo *util.NodeInfo) {

--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -189,9 +189,7 @@ func Test_GetNode(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := nodeManager{}
-			m.init()
-			m = nodeManager{
+			m := nodeManager{
 				nodes: map[string]*util.NodeInfo{
 					"node-04": {
 						ID:   "node-04",

--- a/pkg/scheduler/pods.go
+++ b/pkg/scheduler/pods.go
@@ -47,9 +47,12 @@ type podManager struct {
 	mutex sync.RWMutex
 }
 
-func (m *podManager) init() {
-	m.pods = make(map[k8stypes.UID]*podInfo)
-	klog.InfoS("Pod manager initialized", "podCount", len(m.pods))
+func newPodManager() *podManager {
+	pm := &podManager{
+		pods: make(map[k8stypes.UID]*podInfo),
+	}
+	klog.InfoS("Pod manager initialized", "podCount", len(pm.pods))
+	return pm
 }
 
 func (m *podManager) addPod(pod *corev1.Pod, nodeID string, devices util.PodDevices) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -44,8 +44,8 @@ import (
 )
 
 type Scheduler struct {
-	nodeManager
-	podManager
+	*nodeManager
+	*podManager
 
 	stopCh     chan struct{}
 	kubeClient kubernetes.Interface
@@ -67,8 +67,8 @@ func NewScheduler() *Scheduler {
 		cachedstatus: make(map[string]*NodeUsage),
 		nodeNotify:   make(chan struct{}, 1),
 	}
-	s.nodeManager.init()
-	s.podManager.init()
+	s.nodeManager = newNodeManager()
+	s.podManager = newPodManager()
 	klog.V(2).InfoS("Scheduler initialized successfully")
 	return s
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -41,8 +41,7 @@ import (
 )
 
 func Test_getNodesUsage(t *testing.T) {
-	nodeMage := nodeManager{}
-	nodeMage.init()
+	nodeMage := newNodeManager()
 	nodeMage.addNode("node1", &util.NodeInfo{
 		ID: "node1",
 		Devices: []util.DeviceInfo{
@@ -80,8 +79,7 @@ func Test_getNodesUsage(t *testing.T) {
 			},
 		},
 	}
-	podMap := podManager{}
-	podMap.init()
+	podMap := newPodManager()
 	podMap.addPod(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "1111",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

avoid literal copies lock value from

**Which issue(s) this PR fixes**:
This pull request simplifies the initialization of `nodeManager` and `podManager` by replacing the `init` methods with constructors. Additionally, it updates the `Scheduler` struct to use pointers for these managers and modifies the related tests accordingly.

Initialization improvements:

* [`pkg/scheduler/nodes.go`](diffhunk://#diff-ceaaf9a9ad22b7be7e62cbb755f901974473813e73b151a996e264c224eb3f42L42-R45): Replaced the `init` method with a `newNodeManager` constructor to initialize the `nodeManager` struct.
* [`pkg/scheduler/pods.go`](diffhunk://#diff-3ec08c427c616f48490edbbb2d26694e5719f799c84ad6b8a25cb77637fe9cdfL50-R55): Replaced the `init` method with a `newPodManager` constructor to initialize the `podManager` struct.

Scheduler struct updates:

* [`pkg/scheduler/scheduler.go`](diffhunk://#diff-fb3d6b36d3cd727e1dd2353fb86c0aee0bfaae1c900e0f005ab913620021d551L47-R48): Updated the `Scheduler` struct to use pointers for `nodeManager` and `podManager`, and modified the `NewScheduler` function to use the new constructors. [[1]](diffhunk://#diff-fb3d6b36d3cd727e1dd2353fb86c0aee0bfaae1c900e0f005ab913620021d551L47-R48) [[2]](diffhunk://#diff-fb3d6b36d3cd727e1dd2353fb86c0aee0bfaae1c900e0f005ab913620021d551L70-R71)

Test updates:

* [`pkg/scheduler/nodes_test.go`](diffhunk://#diff-4e47d39717ffee83a94e7a8f9ad9dd72c2ac47d120e3c185de7816c90d5816fcL192-R192): Updated tests to use the `newNodeManager` constructor instead of the `init` method.
* [`pkg/scheduler/scheduler_test.go`](diffhunk://#diff-130e36b28b6a84d355879caa6b7927c98ec18c63adad6ab4fc486458763080bfL44-R44): Updated tests to use the `newNodeManager` and `newPodManager` constructors instead of the `init` methods. [[1]](diffhunk://#diff-130e36b28b6a84d355879caa6b7927c98ec18c63adad6ab4fc486458763080bfL44-R44) [[2]](diffhunk://#diff-130e36b28b6a84d355879caa6b7927c98ec18c63adad6ab4fc486458763080bfL83-R82)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: