### PR TITLE
docs: fix broken commmunity links

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-- Please check [HAMi Community Membership](https://github.com/Project-HAMi/community/blob/main/CONTRIBUTOR-LADDER.md#contributor) to find how to be a contributor.
+- Please check [HAMi Community Membership](https://github.com/Project-HAMi/community/blob/main/community-membership.md) to find how to be a contributor.
 - Here is the full list of the [MAINTAINERS](./MAINTAINERS.md).
 
 The following people, in alphabetical order, have either authored or signed off on commits in the HAMi repository:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # HAMi Community Code of Conduct
 
-Please refer to our [HAMi Community Code of Conduct](https://github.com/Project-HAMi/community/blob/main/CODE_OF_CONDUCT.md).
+Please refer to our [HAMi Community Code of Conduct](https://github.com/Project-HAMi/community/blob/main/CODE-OF-CONDUCT.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-- Please check [HAMi Community Membership](https://github.com/Project-HAMi/community/blob/main/CONTRIBUTOR-LADDER.md) to find how to level up through the project.
+- Please check [HAMi Community Membership](https://github.com/Project-HAMi/community/blob/main/community-membership.md) to find how to level up through the project.
 - Please see [Contributors](./AUTHORS.md) for the full list of contributors to the project.
 
 ## HAMi Committers


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

fixes broken community links:
- `CONTRIBUTOR_LADDER.md` -> `community-membership.md` as changed in https://github.com/Project-HAMi/community/commit/a557d69e4d4c42656ce6bef3c3e0043fc78b4944 / https://github.com/Project-HAMi/community/pull/8
- `CODE_OF_CONDUCT.md` -> `CODE-OF-CONDUCT.md` as changed in https://github.com/Project-HAMi/community/commit/fcb1d1cd86c5d7d296fdd18364df1b70a9e96135 / https://github.com/Project-HAMi/community/pull/7

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
no source code changes. fixes broken community links in the docs