### PR TITLE
分离 client 中的真实和 mock 调用 k8s api，以便于 ut 不依赖于当前的 k8s 环境。

### DIFF
--- a/pkg/util/client/factory.go
+++ b/pkg/util/client/factory.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"sync"
+)
+
+// 工厂类（单例模式）.
+type KubeClientFactory struct {
+	client KubeInterface
+}
+
+var (
+	instance    *KubeClientFactory
+	factoryOnce sync.Once
+)
+
+// GetInstance 直接获取Kubernetes客户端实例.
+func GetInstance() KubeInterface {
+	return GetFactory().GetClient()
+}
+
+// GetFactory 获取单例工厂对象.
+func GetFactory() *KubeClientFactory {
+	factoryOnce.Do(func() {
+		instance = &KubeClientFactory{
+			client: NewRealClient(), // 默认使用 RealClient
+		}
+	})
+	return instance
+}
+
+// GetClient 获取当前 client.
+func (f *KubeClientFactory) GetClient() KubeInterface {
+	return f.client
+}
+
+// SetMock 将工厂客户端设置为MockClient.
+func (f *KubeClientFactory) SetMock() *KubeClientFactory {
+	f.client = NewMockClient()
+	return f
+}
+
+// SetReal 将工厂客户端设置为RealClient.
+func (f *KubeClientFactory) SetReal() *KubeClientFactory {
+	f.client = NewRealClient()
+	return f
+}

--- a/pkg/util/client/interface.go
+++ b/pkg/util/client/interface.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// 统一的 Kubernetes 客户端接口.
+type KubeInterface interface {
+	GetNode(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Node, error)
+	ListPods(ctx context.Context, namespace string, opts metav1.ListOptions) (*corev1.PodList, error)
+	GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error)
+	PatchNode(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Node, error)
+	PatchPod(ctx context.Context, namespace string, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Pod, error)
+	CreateNode(ctx context.Context, node *corev1.Node, opts metav1.CreateOptions) (*corev1.Node, error)
+}

--- a/pkg/util/client/mock_client.go
+++ b/pkg/util/client/mock_client.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Mock Kubernetes 客户端（用于测试）.
+type MockClient struct {
+	nodes map[string]*corev1.Node
+	pods  map[types.NamespacedName]*corev1.Pod
+}
+
+var _ KubeInterface = (*MockClient)(nil)
+
+var (
+	mockClientOnce sync.Once
+	mockClient     *MockClient
+)
+
+// NewMockClient 创建模拟的 Kubernetes 客户端（单例模式）.
+func NewMockClient() *MockClient {
+	mockClientOnce.Do(func() {
+		mockClient = &MockClient{
+			nodes: make(map[string]*corev1.Node),
+			pods:  make(map[types.NamespacedName]*corev1.Pod),
+		}
+	})
+	return mockClient
+}
+
+// 模拟获取单个 Node 信息.
+func (m *MockClient) GetNode(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Node, error) {
+	if m.nodes == nil {
+		m.nodes = make(map[string]*corev1.Node)
+	}
+
+	node, exists := m.nodes[name]
+	if !exists {
+		return nil, fmt.Errorf("node %s not found", name)
+	}
+	return node, nil
+}
+
+// 模拟获取单个 Pod 信息.
+func (m *MockClient) GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error) {
+	if m.pods == nil {
+		m.pods = make(map[types.NamespacedName]*corev1.Pod)
+	}
+
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+	pod, exists := m.pods[key]
+	if !exists {
+		return nil, fmt.Errorf("pod %s/%s not found", namespace, name)
+	}
+	return pod, nil
+}
+
+// 模拟获取 Pod 列表.
+func (m *MockClient) ListPods(ctx context.Context, namespace string, opts metav1.ListOptions) (*corev1.PodList, error) {
+	if m.pods == nil {
+		m.pods = make(map[types.NamespacedName]*corev1.Pod)
+		return &corev1.PodList{Items: []corev1.Pod{}}, nil
+	}
+
+	podList := &corev1.PodList{
+		Items: []corev1.Pod{},
+	}
+
+	for key, pod := range m.pods {
+		if namespace == "" || key.Namespace == namespace {
+			// 支持简单的标签选择器过滤
+			if opts.LabelSelector != "" && !podMatchesSelector(pod, opts.LabelSelector) {
+				continue
+			}
+			podList.Items = append(podList.Items, *pod)
+		}
+	}
+
+	return podList, nil
+}
+
+// 简单的标签选择器匹配逻辑 (实际实现中可能需要更复杂的解析).
+func podMatchesSelector(pod *corev1.Pod, selector string) bool {
+	// 这里简化处理，实际应该使用 k8s 的标签选择器解析
+	// 假设 selector 格式为 "key=value"
+	for k, v := range pod.Labels {
+		if fmt.Sprintf("%s=%s", k, v) == selector {
+			return true
+		}
+	}
+	return false
+}
+
+// 模拟修补 Node.
+func (m *MockClient) PatchNode(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Node, error) {
+	if m.nodes == nil {
+		m.nodes = make(map[string]*corev1.Node)
+	}
+
+	node, exists := m.nodes[name]
+	if !exists {
+		return nil, fmt.Errorf("node %s not found", name)
+	}
+
+	// 实际场景中应该根据 patch 数据修改节点
+	// 这里简化处理，仅返回存储的节点
+	return node, nil
+}
+
+// 模拟修补 Pod.
+func (m *MockClient) PatchPod(ctx context.Context, namespace string, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Pod, error) {
+	if m.pods == nil {
+		m.pods = make(map[types.NamespacedName]*corev1.Pod)
+	}
+
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+	pod, exists := m.pods[key]
+	if !exists {
+		return nil, fmt.Errorf("pod %s/%s not found", namespace, name)
+	}
+
+	// 实际场景中应该根据 patch 数据修改 pod
+	// 这里简化处理，仅返回存储的 pod
+	return pod, nil
+}
+
+// 模拟创建 Node.
+func (m *MockClient) CreateNode(ctx context.Context, node *corev1.Node, opts metav1.CreateOptions) (*corev1.Node, error) {
+	if m.nodes == nil {
+		m.nodes = make(map[string]*corev1.Node)
+	}
+
+	if _, exists := m.nodes[node.Name]; exists {
+		return nil, fmt.Errorf("node %s already exists", node.Name)
+	}
+
+	// 创建一个深拷贝以避免外部修改
+	nodeCopy := node.DeepCopy()
+	m.nodes[node.Name] = nodeCopy
+
+	return nodeCopy, nil
+}

--- a/pkg/util/client/real_client.go
+++ b/pkg/util/client/real_client.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+// 真实的 Kubernetes 客户端.
+type RealClient struct {
+	client kubernetes.Interface
+}
+
+var _ KubeInterface = (*RealClient)(nil)
+
+var (
+	realClientOnce sync.Once
+	realClient     *RealClient
+)
+
+// NewRealClient 创建真实的 Kubernetes 客户端（单例模式）.
+func NewRealClient() *RealClient {
+	var err error
+	realClientOnce.Do(func() {
+		realClient, err = createRealClient()
+		if err != nil {
+			klog.Fatalf("Failed to create Kubernetes client: %v", err)
+		}
+	})
+	return realClient
+}
+
+// createRealClient 初始化真实的 Kubernetes 客户端.
+func createRealClient() (*RealClient, error) {
+	kubeConfigPath := os.Getenv("KUBECONFIG")
+	if kubeConfigPath == "" {
+		kubeConfigPath = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		klog.ErrorS(err, "BuildConfigFromFlags failed for file %s: %v. Using in-cluster config.", kubeConfigPath, err)
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return &RealClient{client: clientset}, nil
+}
+
+// 获取单个 Node 信息.
+func (r *RealClient) GetNode(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Node, error) {
+	klog.V(4).InfoS("Retrieving node", "node", name)
+	node, err := r.client.CoreV1().Nodes().Get(ctx, name, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get node", "node", name)
+		return nil, fmt.Errorf("failed to get node %s: %w", name, err)
+	}
+	klog.V(4).InfoS("Successfully retrieved node", "node", name)
+	return node, nil
+}
+
+// 获取单个 Pod 信息.
+func (r *RealClient) GetPod(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Pod, error) {
+	klog.V(4).InfoS("Retrieving pod", "namespace", namespace, "pod", name)
+	pod, err := r.client.CoreV1().Pods(namespace).Get(ctx, name, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get pod", "namespace", namespace, "pod", name)
+		return nil, fmt.Errorf("failed to get pod %s/%s: %w", namespace, name, err)
+	}
+	klog.V(4).InfoS("Successfully retrieved pod", "namespace", namespace, "pod", name)
+	return pod, nil
+}
+
+// 获取 Pod 列表.
+func (r *RealClient) ListPods(ctx context.Context, namespace string, opts metav1.ListOptions) (*corev1.PodList, error) {
+	klog.V(4).InfoS("Listing pods", "namespace", namespace, "options", opts)
+	pods, err := r.client.CoreV1().Pods(namespace).List(ctx, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to list pods", "namespace", namespace)
+		return nil, fmt.Errorf("failed to list pods in namespace %s: %w", namespace, err)
+	}
+	klog.V(4).InfoS("Successfully listed pods", "namespace", namespace, "count", len(pods.Items))
+	return pods, nil
+}
+
+// 修补 Node.
+func (r *RealClient) PatchNode(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Node, error) {
+	klog.V(4).InfoS("Patching node", "node", name, "patchType", pt)
+	node, err := r.client.CoreV1().Nodes().Patch(ctx, name, pt, data, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to patch node", "node", name)
+		return nil, fmt.Errorf("failed to patch node %s: %w", name, err)
+	}
+	klog.V(4).InfoS("Successfully patched node", "node", name)
+	return node, nil
+}
+
+// 修补 Pod.
+func (r *RealClient) PatchPod(ctx context.Context, namespace string, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*corev1.Pod, error) {
+	klog.V(4).InfoS("Patching pod", "namespace", namespace, "pod", name, "patchType", pt)
+	pod, err := r.client.CoreV1().Pods(namespace).Patch(ctx, name, pt, data, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to patch pod", "namespace", namespace, "pod", name)
+		return nil, fmt.Errorf("failed to patch pod %s/%s: %w", namespace, name, err)
+	}
+	klog.V(4).InfoS("Successfully patched pod", "namespace", namespace, "pod", name)
+	return pod, nil
+}
+
+// 创建 Node.
+func (r *RealClient) CreateNode(ctx context.Context, node *corev1.Node, opts metav1.CreateOptions) (*corev1.Node, error) {
+	klog.V(4).InfoS("Creating node", "node", node.Name)
+	createdNode, err := r.client.CoreV1().Nodes().Create(ctx, node, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create node", "node", node.Name)
+		return nil, fmt.Errorf("failed to create node %s: %w", node.Name, err)
+	}
+	klog.V(4).InfoS("Successfully created node", "node", node.Name)
+	return createdNode, nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -63,7 +63,8 @@ func GetNode(nodename string) (*corev1.Node, error) {
 	}
 
 	klog.InfoS("Fetching node", "nodeName", nodename)
-	n, err := client.GetClient().CoreV1().Nodes().Get(context.Background(), nodename, metav1.GetOptions{})
+
+	n, err := client.GetInstance().GetNode(context.Background(), nodename, metav1.GetOptions{})
 	if err != nil {
 		switch {
 		case apierrors.IsNotFound(err):
@@ -95,7 +96,7 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 	podListOptions := metav1.ListOptions{
 		FieldSelector: selector,
 	}
-	podlist, err := client.GetClient().CoreV1().Pods("").List(ctx, podListOptions)
+	podlist, err := client.GetInstance().ListPods(ctx, "", podListOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 }
 
 func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, error) {
-	node, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	node, err := client.GetInstance().GetNode(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 		if ns == "" || name == "" {
 			return nil, nil
 		}
-		return client.GetClient().CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		return client.GetInstance().GetPod(ctx, ns, name, metav1.GetOptions{})
 	}
 	return nil, nil
 }
@@ -342,8 +343,7 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	if err != nil {
 		return err
 	}
-	_, err = client.GetClient().CoreV1().Nodes().
-		Patch(context.Background(), node.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+	_, err = client.GetInstance().PatchNode(context.Background(), node.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infoln("annotations=", annotations)
 		klog.Infof("patch pod %v failed, %v", node.Name, err)
@@ -374,8 +374,7 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 		return err
 	}
 	klog.V(5).Infof("patch pod %s/%s annotation content is %s", pod.Namespace, pod.Name, string(bytes))
-	_, err = client.GetClient().CoreV1().Pods(pod.Namespace).
-		Patch(context.Background(), pod.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+	_, err = client.GetInstance().PatchPod(context.Background(), pod.Namespace, pod.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infof("patch pod %v failed, %v", pod.Name, err)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -23,12 +23,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
 
 var inRequestDevices map[string]string
@@ -626,8 +624,7 @@ func Test_CheckHealth(t *testing.T) {
 }
 
 func TestMarkAnnotationsToDelete(t *testing.T) {
-	client.KubeClient = fake.NewSimpleClientset()
-	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+	client.GetFactory().SetMock().GetClient().CreateNode(context.TODO(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-worker2"},
 	}, metav1.CreateOptions{})
 	type args struct {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Project-HAMi/HAMi/pkg/util/client"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
 
 var inRequestDevices map[string]string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -36,7 +36,7 @@ func init() {
 	inRequestDevices["NVIDIA"] = "hami.io/vgpu-devices-to-allocate"
 }
 
-func TestExtractMigTemplatesFromUUID(t *testing.T) {
+func Test_ExtractMigTemplatesFromUUID(t *testing.T) {
 	testCases := []struct {
 		name          string
 		uuid          string
@@ -108,7 +108,7 @@ func TestExtractMigTemplatesFromUUID(t *testing.T) {
 	}
 }
 
-func TestEmptyContainerDevicesCoding(t *testing.T) {
+func Test_EmptyContainerDevicesCoding(t *testing.T) {
 	cd1 := ContainerDevices{}
 	s := EncodeContainerDevices(cd1)
 	fmt.Println(s)
@@ -116,7 +116,7 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 	assert.DeepEqual(t, cd1, cd2)
 }
 
-func TestEmptyPodDeviceCoding(t *testing.T) {
+func Test_EmptyPodDeviceCoding(t *testing.T) {
 	pd1 := PodDevices{}
 	s := EncodePodDevices(inRequestDevices, pd1)
 	fmt.Println(s)
@@ -124,7 +124,7 @@ func TestEmptyPodDeviceCoding(t *testing.T) {
 	assert.DeepEqual(t, pd1, pd2)
 }
 
-func TestPodDevicesCoding(t *testing.T) {
+func Test_PodDevicesCoding(t *testing.T) {
 	tests := []struct {
 		name string
 		args PodDevices
@@ -250,7 +250,7 @@ func Test_DecodePodDevices(t *testing.T) {
 	}
 }
 
-func TestMarshalNodeDevices(t *testing.T) {
+func Test_MarshalNodeDevices(t *testing.T) {
 	type args struct {
 		dlist []*DeviceInfo
 	}
@@ -330,7 +330,7 @@ func TestMarshalNodeDevices(t *testing.T) {
 	}
 }
 
-func TestUnMarshalNodeDevices(t *testing.T) {
+func Test_UnMarshalNodeDevices(t *testing.T) {
 	type args struct {
 		str string
 	}
@@ -623,7 +623,7 @@ func Test_CheckHealth(t *testing.T) {
 	}
 }
 
-func TestMarkAnnotationsToDelete(t *testing.T) {
+func Test_MarkAnnotationsToDelete(t *testing.T) {
 	client.GetFactory().SetMock().GetClient().CreateNode(context.TODO(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-worker2"},
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
ut 不依赖于当前的 k8s 环境，更快速进行 ut。

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
如果该 mock 方式可以的话，会逐步优化当前 client.GetClient的调用点，将所有方法统一起来。

**Does this PR introduce a user-facing change?**:
nope