### PR TITLE
fix ubuntu base image in Dockerfile.withlib

### DIFF
--- a/docker/Dockerfile.withlib
+++ b/docker/Dockerfile.withlib
@@ -10,8 +10,8 @@ RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
 RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
 
-#FROM ubuntu:24.04
-FROM harbor.4pd.io/sagegpt-aio/pk_platform/ubuntu:22.04
+FROM ubuntu:24.04
+#FROM harbor.4pd.io/sagegpt-aio/pk_platform/ubuntu:22.04
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=utility


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `harbor.4pd.io/sagegpt-aio/pk_platform/ubuntu:22.04` image cannot be accessed.
```
Dockerfile.withlib:14
--------------------
  12 |     
  13 |     #FROM ubuntu:24.04
  14 | >>> FROM harbor.4pd.io/sagegpt-aio/pk_platform/ubuntu:22.04
  15 |     ENV NVIDIA_DISABLE_REQUIRE="true"
  16 |     ENV NVIDIA_VISIBLE_DEVICES=all
--------------------
ERROR: failed to solve: harbor.4pd.io/sagegpt-aio/pk_platform/ubuntu:22.04: failed to do request: Head "https://harbor.4pd.io/v2/sagegpt-aio/pk_platform/ubuntu/manifests/22.04": EOF


```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: