### PR TITLE
scheduler: fix removing node devices from node manager

### DIFF
--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -213,12 +213,11 @@ func Test_GetNode(t *testing.T) {
 	}
 }
 
-func Test_rmNodeDevice(t *testing.T) {
+func Test_rmNodeDevices(t *testing.T) {
 	tests := []struct {
 		name string
 		args struct {
 			nodeID       string
-			nodeInfo     *util.NodeInfo
 			deviceVendor string
 		}
 	}{
@@ -226,7 +225,6 @@ func Test_rmNodeDevice(t *testing.T) {
 			name: "no device",
 			args: struct {
 				nodeID       string
-				nodeInfo     *util.NodeInfo
 				deviceVendor string
 			}{
 				nodeID: "node-06",
@@ -236,22 +234,9 @@ func Test_rmNodeDevice(t *testing.T) {
 			name: "exist device info",
 			args: struct {
 				nodeID       string
-				nodeInfo     *util.NodeInfo
 				deviceVendor string
 			}{
-				nodeID: "node-05",
-				nodeInfo: &util.NodeInfo{
-					ID:   "node-05",
-					Node: &corev1.Node{},
-					Devices: []util.DeviceInfo{
-						{
-							ID:      "GPU-0",
-							Count:   int32(1),
-							Devcore: int32(1),
-							Devmem:  int32(2000),
-						},
-					},
-				},
+				nodeID:       "node-05",
 				deviceVendor: "NVIDIA",
 			},
 		},
@@ -259,22 +244,9 @@ func Test_rmNodeDevice(t *testing.T) {
 			name: "the different devicevendor",
 			args: struct {
 				nodeID       string
-				nodeInfo     *util.NodeInfo
 				deviceVendor string
 			}{
-				nodeID: "node-07",
-				nodeInfo: &util.NodeInfo{
-					ID:   "node-07",
-					Node: &corev1.Node{},
-					Devices: []util.DeviceInfo{
-						{
-							ID:      "GPU-0",
-							Count:   int32(1),
-							Devcore: int32(1),
-							Devmem:  int32(2000),
-						},
-					},
-				},
+				nodeID:       "node-07",
 				deviceVendor: "NVIDIA",
 			},
 		},
@@ -282,28 +254,9 @@ func Test_rmNodeDevice(t *testing.T) {
 			name: "the same of device id no less than one",
 			args: struct {
 				nodeID       string
-				nodeInfo     *util.NodeInfo
 				deviceVendor string
 			}{
-				nodeID: "node-08",
-				nodeInfo: &util.NodeInfo{
-					ID:   "node-08",
-					Node: &corev1.Node{},
-					Devices: []util.DeviceInfo{
-						{
-							ID:      "GPU-2",
-							Count:   int32(1),
-							Devcore: int32(1),
-							Devmem:  int32(2000),
-						},
-						{
-							ID:      "GPU-1",
-							Count:   int32(1),
-							Devcore: int32(1),
-							Devmem:  int32(2000),
-						},
-					},
-				},
+				nodeID:       "node-08",
 				deviceVendor: "NVIDIA",
 			},
 		},
@@ -365,7 +318,7 @@ func Test_rmNodeDevice(t *testing.T) {
 					},
 				},
 			}
-			m.rmNodeDevice(test.args.nodeID, test.args.nodeInfo, test.args.deviceVendor)
+			m.rmNodeDevices(test.args.nodeID, test.args.deviceVendor)
 		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -193,11 +193,7 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 						klog.ErrorS(err, "Node cleanup failed", "nodeName", val.Name, "deviceVendor", devhandsk)
 					}
 
-					info, ok := s.nodes[val.Name]
-					if ok {
-						klog.InfoS("Removing device from node", "nodeName", val.Name, "deviceVendor", devhandsk, "remainingDevices", s.nodes[val.Name].Devices)
-						s.rmNodeDevice(val.Name, info, devhandsk)
-					}
+					s.rmNodeDevices(val.Name, devhandsk)
 					continue
 				}
 				if !needUpdate {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -351,8 +351,7 @@ func Test_Filter(t *testing.T) {
 	initNode := func() {
 		nodes, _ := s.ListNodes()
 		for index := range nodes {
-			node := nodes[index]
-			s.rmNodeDevice(node.ID, node, nvidia.NvidiaGPUDevice)
+			s.rmNodeDevices(index, nvidia.NvidiaGPUDevice)
 		}
 		pods, _ := s.ListPodsUID()
 		for index := range pods {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
This PR mainly fixes the following issues in rmNodeDevice:

1. Incorrectly deleting some devices from the node.
https://github.com/Project-HAMi/HAMi/blob/38bed6fb23cfd913b6ce009ee8f8a79cb014db23/pkg/scheduler/nodes.go#L85-L93
This will cause anything inconsistent with the vendor to be deleted, which doesn't seem to align with the function's purpose. Please let me know if I've misunderstood.

2. Concurrent read/write issues for `nodes`. Although this problem is frequent in the code, this PR fixes the issue in this specific function :smile:
3. The log exists before the `rmNodeDevice` function, so the printed device information is incorrect.
https://github.com/Project-HAMi/HAMi/blob/38bed6fb23cfd913b6ce009ee8f8a79cb014db23/pkg/scheduler/scheduler.go#L198-L200


the following issues have been optimized:
1. Modified the function name `rmNodeDevice` to `rmNodeDevices`. Since multiple devices are involved, it is changed to rmNodeDevices.
2. Modified the parameters. Repeatedly passing nodeInfo makes the entire function difficult to understand. Even if you want to restrict the device ID in the future, there are other better design methods.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: