### PR TITLE
fix: Add error handling for nvml.Init in NvidiaDevicePlugin

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -110,7 +110,10 @@ func parseNvidiaNumaInfo(idx int, nvidiaTopoStr string) (int, error) {
 func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*util.DeviceInfo {
 	devs := plugin.Devices()
 	klog.V(5).InfoS("getAPIDevices", "devices", devs)
-	nvml.Init()
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		klog.Errorln("nvml Init err: ", nvret)
+		panic(0)
+	}
 	res := make([]*util.DeviceInfo, 0, len(devs))
 	for UUID := range devs {
 		ndev, ret := nvml.DeviceGetHandleByUUID(UUID)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -203,7 +203,12 @@ func (plugin *NvidiaDevicePlugin) Devices() rm.Devices {
 func (plugin *NvidiaDevicePlugin) Start() error {
 	plugin.initialize()
 
-	err := plugin.Serve()
+	deviceNumbers, err := GetDeviceNums()
+	if err != nil {
+		return err
+	}
+
+	err = plugin.Serve()
 	if err != nil {
 		klog.Infof("Could not start device plugin for '%s': %s", plugin.rm.Resource(), err)
 		plugin.cleanup()
@@ -234,7 +239,7 @@ func (plugin *NvidiaDevicePlugin) Start() error {
 		if len(plugin.migCurrent.MigConfigs["current"]) == 1 && len(plugin.migCurrent.MigConfigs["current"][0].Devices) == 0 {
 			idx := 0
 			plugin.migCurrent.MigConfigs["current"][0].Devices = make([]int32, 0)
-			for idx < GetDeviceNums() {
+			for idx < deviceNumbers {
 				plugin.migCurrent.MigConfigs["current"][0].Devices = append(plugin.migCurrent.MigConfigs["current"][0].Devices, int32(idx))
 				idx++
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This pull request includes several changes to improve error handling and add additional logging in the Nvidia device plugin. The most important changes involve initializing the NVML library with error checks and modifying the `GetDeviceNums` function to return an error.

Improvements to error handling:

* [`pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go`](diffhunk://#diff-f01e6dee63f1e8bca06b5508aeaee9563a45f2e0c58c8dd4ef917c346f1552c0L113-R116): Added error handling for `nvml.Init()` in the `getAPIDevices` method. If initialization fails, an error is logged and a panic is triggered.
* [`pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go`](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5L95-R99): Updated `GetIndexAndTypeFromUUID`, `GetMigUUIDFromIndex`, and `GetMigUUIDFromSmiOutput` methods to include error handling for `nvml.Init()`. If initialization fails, an error is logged and a panic is triggered. [[1]](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5L95-R99) [[2]](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5L148-R155) [[3]](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5L178-R195)
* [`pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go`](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5L178-R195): Modified the `GetDeviceNums` function to return an error if `nvml.Init()` or `nvml.DeviceGetCount()` fails, and added logging for these errors.

Additional logging:

* [`pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go`](diffhunk://#diff-4beccb94da8e027b37416f87ed5a76a77a5ea6ea62c9a69a8b1833816754fe5aL206-R211): Added a call to `GetDeviceNums` in the `Start` method to retrieve device numbers before serving, and updated the loop condition to use the retrieved device numbers. [[1]](diffhunk://#diff-4beccb94da8e027b37416f87ed5a76a77a5ea6ea62c9a69a8b1833816754fe5aL206-R211) [[2]](diffhunk://#diff-4beccb94da8e027b37416f87ed5a76a77a5ea6ea62c9a69a8b1833816754fe5aL237-R242)

Codebase simplification:

* [`pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go`](diffhunk://#diff-8b63c6d64d45d3fd4890aafbcf25428f0747080081d88dc8d6d73cee29e31dd5R22): Added an import for the `fmt` package to handle formatted error messages.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: