### PR TITLE
refactor(vGPUmonitor): change Run to RunE and return errors

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -94,11 +94,11 @@ func start() error {
 	klog.Info("listen on ", config.HTTPBind)
 	if len(tlsCertFile) == 0 || len(tlsKeyFile) == 0 {
 		if err := http.ListenAndServe(config.HTTPBind, router); err != nil {
-			return fmt.Errorf("Listen and Serve error, %v", err)
+			return fmt.Errorf("listen and Serve error, %v", err)
 		}
 	} else {
 		if err := http.ListenAndServeTLS(config.HTTPBind, tlsCertFile, tlsKeyFile, router); err != nil {
-			return fmt.Errorf("Listen and Serve error, %v", err)
+			return fmt.Errorf("listen and Serve error, %v", err)
 		}
 	}
 	return nil

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -42,9 +42,9 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "vGPUmonitor",
 		Short: "Hami vgpu vGPUmonitor",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			flag.PrintPFlags(cmd.Flags())
-			start()
+			return start()
 		},
 	}
 )
@@ -55,14 +55,14 @@ func init() {
 	rootCmd.Flags().AddGoFlagSet(util.InitKlogFlags())
 }
 
-func start() {
+func start() error {
 	if err := ValidateEnvVars(); err != nil {
-		klog.Fatalf("Failed to validate environment variables: %v", err)
+		return fmt.Errorf("Failed to validate environment variables: %v", err)
 	}
 
 	containerLister, err := nvidia.NewContainerLister()
 	if err != nil {
-		klog.Fatalf("Failed to create container lister: %v", err)
+		return fmt.Errorf("Failed to create container lister: %v", err)
 	}
 
 	cgroupDriver = 0 // Explicitly initialize
@@ -107,6 +107,7 @@ func start() {
 	// Wait for all goroutines to complete
 	wg.Wait()
 	close(errCh)
+	return nil
 }
 
 func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) error {

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -57,12 +57,12 @@ func init() {
 
 func start() error {
 	if err := ValidateEnvVars(); err != nil {
-		return fmt.Errorf("Failed to validate environment variables: %v", err)
+		return fmt.Errorf("failed to validate environment variables: %v", err)
 	}
 
 	containerLister, err := nvidia.NewContainerLister()
 	if err != nil {
-		return fmt.Errorf("Failed to create container lister: %v", err)
+		return fmt.Errorf("failed to create container lister: %v", err)
 	}
 
 	cgroupDriver = 0 // Explicitly initialize


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This pull request includes important changes to the `cmd/vGPUmonitor/main.go` file to improve error handling by modifying functions to return errors instead of terminating the program.

Error handling improvements:

* Changed the `Run` function in the `rootCmd` to `RunE` to handle errors and return them instead of calling `start()` directly. (`[cmd/vGPUmonitor/main.goL45-R47](diffhunk://#diff-093602e3776eeab4544178697b6844906795d96cfede8a687dc0bd52062cd4a7L45-R47)`)
* Modified the `start` function to return an error instead of terminating the program with `klog.Fatalf` when encountering validation or creation errors. (`[cmd/vGPUmonitor/main.goL58-R65](diffhunk://#diff-093602e3776eeab4544178697b6844906795d96cfede8a687dc0bd52062cd4a7L58-R65)`)
* Ensured the `start` function returns `nil` after successful completion by adding a return statement at the end. (`[cmd/vGPUmonitor/main.goR110](diffhunk://#diff-093602e3776eeab4544178697b6844906795d96cfede8a687dc0bd52062cd4a7R110)`)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None