### PR TITLE
refactor(.github/workflows/ci.yaml): Update golangci-lint to v2.0 and modify .golangci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,10 @@ jobs:
         run: hack/verify-license.sh
       - name: go tidy
         run: make tidy
-      - name: lint
-        run: make lint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0
       - name: import alias
         run: hack/verify-import-aliases.sh
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,137 +1,88 @@
+version: "2"
 run:
-  timeout: 10m
-
-  # The default concurrency value is the number of available CPU.
   concurrency: 4
-
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work
-  # on Windows.
-  skip-dirs:
-  - pkg/device-plugin # This code is directly lifted from the Kubernetes codebase, skip checking
-
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-
-  # One of 'readonly' and 'vendor'.
-  #  - readonly: the go command is disallowed from the implicit automatic updating of go.mod described above.
-  #              Instead, it fails when any changes to go.mod are needed. This setting is most useful to check
-  #              that go.mod does not need updates, such as in a continuous integration and testing system.
-  #  - vendor: the go command assumes that the vendor directory holds the correct copies of dependencies and ignores
-  #            the dependency descriptions in go.mod.
   modules-download-mode: readonly
-
-linters-settings:
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-  dupl:
-    threshold: 800
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-    # exclude: .errcheckignore
-  errorlint:
-    errorf: true
-    asserts: true
-    comparison: true
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - commentedOutCode
-      - whyNoLint
-    settings:
-      hugeParam:
-        sizeThreshold: 80
-      rangeExprCopy:
-        sizeThreshold: 512
-      rangeValCopy:
-        sizeThreshold: 128
-  godot:
-    scope: declarations
-    capital: false
-  gofmt:
-    simplify: true
-  gofumpt:
-    extra-rules: true
-  goimports:
-    local-prefixes: github.com/Project-HAMi/HAMi
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 20
-  nestif:
-    min-complexity: 20
-
 output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-  uniq-by-line: true
-  sort-results: true
-
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
+      colors: true 
 linters:
-  disable-all: true
-  disabled:
-    - exhaustivestruct         # Checks if all struct's fields are initialized
-    - forbidigo                # Forbids identifiers
-    - forcetypeassert          # finds forced type assertions
-    - gci                      # Gci control golang package import order and make it always deterministic.
-    - gochecknoglobals         # check that no global variables exist
-    - gochecknoinits           # Checks that no init functions are present in Go code
-    - goconst                  # Finds repeated strings that could be replaced by a constant
-    - godox                    # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113                 # Golang linter to check the errors handling expressions
-    - golint                   # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - gomnd                    # An analyzer to detect magic numbers.
-    - gomoddirectives          # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - gomodguard               # Allow and block list linter for direct Go module dependencies.
-    - interfacer               # Linter that suggests narrower interface types
-    - lll                      # Reports long lines
-    - maligned                 # Tool to detect Go structs that would take less memory if their fields were sorted
-    - promlinter               # Check Prometheus metrics naming via promlint
-    - scopelint                # Scopelint checks for unpinned variables in go programs
-    - sqlclosecheck            # Checks that sql.Rows and sql.Stmt are closed.
-    - testpackage              # Linter that makes you use a separate _test package
-    - tparallel                # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    - wrapcheck                # Checks that errors returned from external packages are wrapped
-    - wsl                      # Whitespace Linter
-    - paralleltest             # paralleltest detects missing usage of t.Parallel() method in your Go test
-    - noctx                    # noctx finds sending http request without context.Context
-    - wastedassign             # wastedassign finds wasted assignment statements.
-    - exhaustive               # check exhaustiveness of enum switch statements
-    - cyclop                   # checks function and package cyclomatic complexity
-    - errcheck                 # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    - unparam                  # Reports unused function parameters
-    - gosec                    # Inspects source code for security problems
-    - funlen                   # Tool for detection of long functions
-    - gocognit                 # Computes and checks the cognitive complexity of functions
-    - gocyclo                  # Computes and checks the cyclomatic complexity of functions
-    - nlreturn                 # nlreturn checks for a new line before return and branch statements to increase code clarity
-    - gocritic                 # Provides many diagnostics that check for bugs, performance and style issues.
-    - errorlint                # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - tagliatelle              # Checks the struct tags.
-    # need to enable
-    - nestif                   # Reports deeply nested if statements
-    - ineffassign              # Detects when assignments to existing variables are not used
-
-
+  default: none
   enable:
     - asciicheck
     - forcetypeassert
     - godot
+    - misspell
+    - staticcheck
+  settings:
+    dupl:
+      threshold: 800
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - commentedOutCode
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      settings:
+        hugeParam:
+          sizeThreshold: 80
+        rangeExprCopy:
+          sizeThreshold: 512
+        rangeValCopy:
+          sizeThreshold: 128
+    gocyclo:
+      min-complexity: 20
+    godot:
+      scope: declarations
+      capital: false
+    nestif:
+      min-complexity: 20
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - pkg/device-plugin 
+issues:
+  uniq-by-line: true
+formatters:
+  enable:
     - gofmt
     - goimports
-    - misspell
-    - stylecheck
+  settings:
+    gofmt:
+      simplify: true
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/Project-HAMi/HAMi
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/vGPUmonitor/testcollector/main.go
+++ b/cmd/vGPUmonitor/testcollector/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -136,8 +137,8 @@ func main() {
 
 	// Add the standard process and Go metrics to the custom registry.
 	reg.MustRegister(
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-		prometheus.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
 	)
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))

--- a/hack/tools/preferredimports/preferredimports.go
+++ b/hack/tools/preferredimports/preferredimports.go
@@ -93,7 +93,7 @@ func (a *analyzer) collect(dir string) {
 			replacements := make(map[string]string)
 			pathToFile := a.fset.File(file.Pos()).Name()
 			for _, imp := range file.Imports {
-				importPath := strings.Replace(imp.Path.Value, "\"", "", -1)
+				importPath := strings.ReplaceAll(imp.Path.Value, "\"", "")
 				pathSegments := strings.Split(importPath, "/")
 				importName := pathSegments[len(pathSegments)-1]
 				if imp.Name != nil {

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.57.1"
+GOLANGCI_LINT_VER="v2.1.1"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"
@@ -29,7 +29,7 @@ if util::cmd_exist golangci-lint; then
 else
   echo "Installing golangci-lint ${GOLANGCI_LINT_VER}"
   # https://golangci-lint.run/usage/install/#other-ci
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.57.1/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VER}
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VER}
 fi
 
 if golangci-lint run; then

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -89,7 +89,7 @@ func (dev *CambriconDevices) CommonWord() string {
 
 func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {
 	ctx := context.Background()
-	if _, ok := node.ObjectMeta.Annotations[DsmluLockTime]; ok {
+	if _, ok := node.Annotations[DsmluLockTime]; ok {
 		return fmt.Errorf("node %s is locked", node.Name)
 	}
 
@@ -127,10 +127,10 @@ func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 	if !found {
 		return nil
 	}
-	if _, ok := n.ObjectMeta.Annotations[DsmluLockTime]; !ok {
+	if _, ok := n.Annotations[DsmluLockTime]; !ok {
 		return dev.setNodeLock(n)
 	}
-	lockTime, err := time.Parse(time.RFC3339, n.ObjectMeta.Annotations[DsmluLockTime])
+	lockTime, err := time.Parse(time.RFC3339, n.Annotations[DsmluLockTime])
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (dev *CambriconDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) erro
 	}
 
 	newNode := n.DeepCopy()
-	delete(newNode.ObjectMeta.Annotations, DsmluLockTime)
+	delete(newNode.Annotations, DsmluLockTime)
 	_, err := client.GetClient().CoreV1().Nodes().Update(context.Background(), newNode, metav1.UpdateOptions{})
 	for i := 0; i < retry && err != nil; i++ {
 		klog.ErrorS(err, "Failed to patch node annotation", "node", n.Name, "retry", i)
@@ -166,7 +166,7 @@ func (dev *CambriconDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) erro
 	if err != nil {
 		return fmt.Errorf("releaseNodeLock exceeds retry count %d", retry)
 	}
-	delete(n.ObjectMeta.Annotations, DsmluLockTime)
+	delete(n.Annotations, DsmluLockTime)
 	klog.InfoS("Node lock released", "node", n.Name)
 	return nil
 }

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -623,7 +623,7 @@ func Test_LockNode(t *testing.T) {
 			defer teardown()
 
 			// Set up the node with the specified annotations.
-			node.ObjectMeta.Annotations = tt.annotations
+			node.Annotations = tt.annotations
 
 			dev := InitMLUDevice(CambriconConfig{
 				ResourceCountName:  MLUResourceCount,

--- a/pkg/device/metax/protocol.go
+++ b/pkg/device/metax/protocol.go
@@ -66,7 +66,7 @@ func (ni NodeMetaxSDeviceInfo) String() string {
 }
 
 func (sdev *PodMetaxSDevice) String() string {
-	str := fmt.Sprintf("\nPodMetaxSDevice:\n")
+	str := "\nPodMetaxSDevice:\n"
 
 	for ctrIdx, ctrDevices := range *sdev {
 		str += fmt.Sprintf("  container[%d]:\n", ctrIdx)

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -461,7 +461,7 @@ func Test_InitNvidiaDevice(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			devices := InitNvidiaDevice(test.args)
 			if devices == nil {
-				t.Error("Expected NvidiaGPUDevices to be initialized")
+				t.Fatalf("Expected devices to be initialized")
 			}
 			assert.DeepEqual(t, test.want.config, devices.config)
 			assert.Equal(t, "hami.io/vgpu-devices-to-allocate", util.InRequestDevices[NvidiaGPUDevice], "Expected InRequestDevices to be set")

--- a/test/utils/pod.go
+++ b/test/utils/pod.go
@@ -89,7 +89,7 @@ func WaitForPodRunning(clientSet kubernetes.Interface, namespace, podName string
 		timeout       = 5 * time.Minute // Increased timeout for GPU Pods
 	)
 
-	return wait.PollImmediate(checkInterval, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), checkInterval, timeout, true, func(context.Context) (bool, error) {
 		// Fetch the Pod object from the Kubernetes API
 		pod, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This pull request includes several important changes to improve the linting process, update dependencies, and refactor code for better readability and maintainability. Below are the most significant changes:

### Linting and Dependency Updates:

* Updated the CI workflow to use `golangci-lint-action` version 2.0 for linting instead of running `make lint` directly. (`.github/workflows/ci.yaml`)
* Updated `golangci-lint` to version 2.1.1 in `hack/verify-staticcheck.sh` and changed the installation method to use the latest script from the repository's HEAD. (`hack/verify-staticcheck.sh`) [[1]](diffhunk://#diff-dd4a155c58c25cd819d2b0025bf96bba44cd82f6dc4aad132fa48b7ec9ab3bb7L21-R21) [[2]](diffhunk://#diff-dd4a155c58c25cd819d2b0025bf96bba44cd82f6dc4aad132fa48b7ec9ab3bb7L32-R32)

### Configuration Changes:

* Refactored the `.golangci.yaml` file to update the configuration format, enable specific linters, and set new linter settings. (`.golangci.yaml`) [[1]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-L37) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R34-R88)

### Code Refactoring:

* Replaced `prometheus.NewProcessCollector` and `prometheus.NewGoCollector` with `collectors.NewProcessCollector` and `collectors.NewGoCollector` in `cmd/vGPUmonitor/testcollector/main.go` for better alignment with the Prometheus client library. (`cmd/vGPUmonitor/testcollector/main.go`)
* Simplified string formatting in `pkg/device/metax/protocol.go` by removing unnecessary `fmt.Sprintf` call. (`pkg/device/metax/protocol.go`)

### Annotation Handling:

* Simplified access to node annotations by removing `ObjectMeta` in `pkg/device/cambricon/device.go` and `pkg/util/nodelock/nodelock.go`. [[1]](diffhunk://#diff-18913db9fdb46323a9ebfa1c20bc35d6d05a0ab7948f00e1a2b4d1e953f90bc2L92-R92) [[2]](diffhunk://#diff-18913db9fdb46323a9ebfa1c20bc35d6d05a0ab7948f00e1a2b4d1e953f90bc2L130-R133) [[3]](diffhunk://#diff-18913db9fdb46323a9ebfa1c20bc35d6d05a0ab7948f00e1a2b4d1e953f90bc2L159-R159) [[4]](diffhunk://#diff-18913db9fdb46323a9ebfa1c20bc35d6d05a0ab7948f00e1a2b4d1e953f90bc2L169-R169) [[5]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L49-R53) [[6]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L64-R64) [[7]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L82-R82) [[8]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L91-R91) [[9]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L102-R102) [[10]](diffhunk://#diff-d802746cca60362723c9835a0f621444a2a7dd925e12345f8dfacf50dec319f4L118-R121)

### Testing Improvements:

* Improved error handling in test cases by replacing `t.Error` with `t.Fatalf` for better test failure reporting in `pkg/device/nvidia/device_test.go`. (`pkg/device/nvidia/device_test.go`)

These changes collectively enhance the project's code quality, maintainability, and alignment with best practices.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: