### PR TITLE
docs: Remove ACTIVE_OOM_KILLER environment variable description

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -128,13 +128,6 @@ In Kubernetes, in order for the API server to communicate with the webhook compo
   - default: false
   - "true" means the HAMi-core will not be used inside container, as a result, there will be no resource isolation and limitation in that container, only for debug. 
 
-* `ACTIVE_OOM_KILLER`:
-  
-  Bool type, "true", "false"
-
-  - default: false
-  - "true" means there will be a daemon process which monitors all running tasks inside this container, and instantly kill any process which exceeds the limitation set by "nvidia.com/gpumem" or "nvidia.com/gpumemory"
-
 * `CUDA_DISABLE_CONTROL`:
 
   Bool type, "true", "false"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Per https://github.com/Project-HAMi/HAMi/issues/372 and https://github.com/Project-HAMi/HAMi/issues/1003, ACTIVE_OOM_KILLER is deprecated and needs to be removed from the documentation.

**Which issue(s) this PR fixes**:
Fixes #372