### PR TITLE
feat: Support for using RuntimeClass with nvidia devices

### DIFF
--- a/charts/hami/templates/device-plugin/runtime-class.yaml
+++ b/charts/hami/templates/device-plugin/runtime-class.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.devicePlugin.createRuntimeClass .Values.devicePlugin.runtimeClassName }}
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: {{ .Values.devicePlugin.runtimeClassName }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+handler: nvidia
+{{- end }}

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -25,6 +25,7 @@ data:
       deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
       deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
       gpuCorePolicy: {{ .Values.devices.nvidia.gpuCorePolicy }}
+      runtimeClassName: "{{ .Values.devicePlugin.runtimeClassName }}"
       knownMigGeometries:
       - models: [ "A30" ]
         allowedGeometries:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -150,6 +150,8 @@ devicePlugin:
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
   runtimeClassName: ""
+  # Whether to create runtime class, name comes from runtimeClassName when it is set
+  createRuntimeClass: false
   migStrategy: "none"
   disablecorelimit: "false"
   passDeviceSpecsEnabled: false

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -149,6 +149,7 @@ devicePlugin:
   deviceSplitCount: 10
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
+  # The runtime class name to be used by the device plugin, and added to the pod.spec.runtimeClassName of applications utilizing NVIDIA GPUs
   runtimeClassName: ""
   # Whether to create runtime class, name comes from runtimeClassName when it is set
   createRuntimeClass: false

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -105,6 +105,8 @@ type NvidiaConfig struct {
 	MigGeometriesList []util.AllowedMigGeometries `yaml:"knownMigGeometries"`
 	// GPUCorePolicy through webhook automatic injected to container env
 	GPUCorePolicy GPUCoreUtilizationPolicy `yaml:"gpuCorePolicy"`
+	// RuntimeClassName is the name of the runtime class to be added to pod.spec.runtimeClassName
+	RuntimeClassName string `yaml:"runtimeClassName"`
 }
 
 type FilterDevice struct {
@@ -274,9 +276,28 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 		})
 	}
 
+	hasResource := dev.mutateContainerResource(ctr)
+
+	if hasResource {
+		// Set runtime class name if it is not set by user and the runtime class name is configured
+		if p.Spec.RuntimeClassName == nil && dev.config.RuntimeClassName != "" {
+			p.Spec.RuntimeClassName = &dev.config.RuntimeClassName
+		}
+	}
+
+	if !hasResource && dev.config.OverwriteEnv {
+		ctr.Env = append(ctr.Env, corev1.EnvVar{
+			Name:  "NVIDIA_VISIBLE_DEVICES",
+			Value: "none",
+		})
+	}
+	return hasResource, nil
+}
+
+func (dev *NvidiaGPUDevices) mutateContainerResource(ctr *corev1.Container) bool {
 	_, resourceNameOK := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceCountName)]
 	if resourceNameOK {
-		return resourceNameOK, nil
+		return true
 	}
 
 	_, resourceCoresOK := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceCoreName)]
@@ -286,17 +307,10 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 	if resourceCoresOK || resourceMemOK || resourceMemPercentageOK {
 		if dev.config.DefaultGPUNum > 0 {
 			ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceCountName)] = *resource.NewQuantity(int64(dev.config.DefaultGPUNum), resource.BinarySI)
-			resourceNameOK = true
+			return true
 		}
 	}
-
-	if !resourceNameOK && dev.config.OverwriteEnv {
-		ctr.Env = append(ctr.Env, corev1.EnvVar{
-			Name:  "NVIDIA_VISIBLE_DEVICES",
-			Value: "none",
-		})
-	}
-	return resourceNameOK, nil
+	return false
 }
 
 func checkGPUtype(annos map[string]string, cardtype string) bool {

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -76,10 +76,7 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 				klog.Errorf("validating pod failed:%s", err.Error())
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
-			if found {
-				hasResource = true
-				break
-			}
+			hasResource = hasResource || found
 		}
 	}
 

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -76,7 +76,10 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 				klog.Errorf("validating pod failed:%s", err.Error())
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
-			hasResource = hasResource || found
+			if found {
+				hasResource = true
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
1. helm `values.yaml` adds the `devicePlugin.createRuntimeClass` parameter, which allows you to choose whether or not to create the corresponding `RuntimeClass` resource if the user sets the parameter `devicePlugin.runtimeClassName`.
2. After the hami-schedule webhook determines that the pod is using nvidia resources, it will set the `pod.Spec.RuntimeClassName` according to the `runtimeClassName` parameter if the user has not set it.

Benefits:

- Using RuntimeClass is more convenient and flexible than setting up a default container runtime.
- In the cri runtime environment, it is no longer necessary to set the default container runtime.
Ref: https://github.com/NVIDIA/k8s-device-plugin/blob/main/README.md#install-the-nvidia-container-toolkit
<img width="795" alt="image" src="https://github.com/user-attachments/assets/54429091-5285-4c41-94a8-63b077338e1d" />


**Does this PR introduce a user-facing change?**:

No.