### PR TITLE
fix: Skip admission webhook when Pod's scheduler is already assigned.

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -60,6 +60,10 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.Warningf(template+" - Denying admission as pod has no containers", req.Namespace, req.Name, req.UID)
 		return admission.Denied("pod has no containers")
 	}
+	if pod.Spec.SchedulerName != "" {
+		klog.Infof(template+" - Pod already has scheduler assigned", req.Namespace, req.Name, req.UID)
+		return admission.Allowed("pod already has scheduler assigned")
+	}
 	klog.Infof(template, req.Namespace, req.Name, req.UID)
 	hasResource := false
 	for idx, ctr := range pod.Spec.Containers {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If pod has a scheduler already assigned, we should not override user's explicit scheduler choice.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: