### PR TITLE
feat(Actions): Add an action to label pr automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+"kind/bug":
+  - '^[Ff]ix(\(.*\))?:?.*'
+"kind/cleanup":
+  - '^[Cc]hore(\(.*\))?:?.*'
+"kind/documentation":
+  - '^[Dd]ocs?(\(.*\))?:?.*'
+"kind/enhancement":
+  - '^[Rr]efactor(\(.*\))?:?.*'
+"kind/feature":
+  - '^[Ff]eat(\(.*\))?:?.*'

--- a/.github/workflows/auto-label-pr.yaml
+++ b/.github/workflows/auto-label-pr.yaml
@@ -1,0 +1,22 @@
+name: "PR Labeler"
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+   labeling:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.4
+      with:
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        sync-labels: 1
+        include-title: 1
+        include-body: 0
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR add an action in workflow that when a pull request is created, this action will help labeling this pull request automatically based on the rules in `.github/labeler.yml`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are some test results in my [repo](https://github.com/Shouren/test-labeler)
**Does this PR introduce a user-facing change?**: