### PR TITLE
fix(chart): support GKE pre-release versions via kubeVersion '-0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The list of prerequisites for running the NVIDIA device plugin is described belo
 - NVIDIA drivers >= 440
 - nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
-- Kubernetes version >= 1.16
+- Kubernetes version >= 1.18
 - glibc >= 2.17 & glibc < 2.30
 - kernel version >= 3.10
 - helm > 3.0

--- a/README_cn.md
+++ b/README_cn.md
@@ -90,7 +90,7 @@ HAMi 由多个组件组成，包括统一的 mutatingwebhook、统一的调度�
 - NVIDIA 驱动 >= 440
 - nvidia-docker 版本 > 2.0
 - containerd/docker/cri-o 容器运行时的默认运行时配置为 nvidia
-- Kubernetes 版本 >= 1.16
+- Kubernetes 版本 >= 1.18
 - glibc >= 2.17 & glibc < 2.30
 - 内核版本 >= 3.10
 - helm > 3.0

--- a/charts/hami/Chart.yaml
+++ b/charts/hami/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hami
 version: 2.5.0
-kubeVersion: ">= 1.16.0"
+kubeVersion: ">= 1.18.0-0"
 description: Heterogeneous AI Computing Virtualization Middleware
 keywords:
   - vgpu


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes Helm installation failure on GKE clusters where Kubernetes versions include a pre-release suffix (e.g., `v1.32.3-gke.1785003`). Helm uses [Masterminds/semver](https://github.com/Masterminds/semver), which by spec skips pre-releases when comparing against a constraint like `>= 1.18.0`.

From the semver spec used by Helm:

> “>=1.2.3 will skip pre-releases when looking at a list of releases, while >=1.2.3-0 will evaluate and find pre-releases.”
> 

Therefore, changing the constraint to `>= 1.18.0-0` ensures compatibility with Kubernetes versions that use pre-release identifiers, including those from GKE and other distributions.

Additionally, this PR updates the minimum supported Kubernetes version in the `README` from 1.16 to 1.18, reflecting the current chart constraint.

References:

- https://helm.sh/docs/topics/charts/#the-chart-yaml-file
- https://github.com/Masterminds/semver#working-with-prerelease-versions

**Which issue(s) this PR fixes**:
Fixes #1071

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
no