### PR TITLE
feat: Add an action of 'Close stale issue and PRs' in github worklfow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * 2'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-issue-close: 5
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-pr-stale: 45
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-pr-close: 10
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          exempt-issue-labels: pinned,wip,security,notice
+          exempt-draft-pr: true
+          debug-only: true
+          enable-statistics: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
There are lots of issue and PRs which are already outdated remains open for this project. This PR helps close those issues and PRs automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@wawa0210 @archlitchi 
I am not sure the current parameters in the `stale.yaml` is suitable for this project. Let me know if you have any suggestions.

**Does this PR introduce a user-facing change?**: