### PR TITLE
fix: wrong Pod's UID and emtpy Pod's name in log of webhook.go

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -57,20 +57,20 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	if len(pod.Spec.Containers) == 0 {
-		klog.Warningf(template+" - Denying admission as pod has no containers", req.Namespace, req.Name, req.UID)
+		klog.Warningf(template+" - Denying admission as pod has no containers", pod.Namespace, pod.Name, pod.UID)
 		return admission.Denied("pod has no containers")
 	}
 	if pod.Spec.SchedulerName != "" && (len(config.SchedulerName) == 0 || pod.Spec.SchedulerName != config.SchedulerName) {
 		klog.Infof(template+" - Pod already has different scheduler assigned", req.Namespace, req.Name, req.UID)
 		return admission.Allowed("pod already has different scheduler assigned")
 	}
-	klog.Infof(template, req.Namespace, req.Name, req.UID)
+	klog.Infof(template, pod.Namespace, pod.Name, pod.UID)
 	hasResource := false
 	for idx, ctr := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[idx]
 		if ctr.SecurityContext != nil {
 			if ctr.SecurityContext.Privileged != nil && *ctr.SecurityContext.Privileged {
-				klog.Warningf(template+" - Denying admission as container %s is privileged", req.Namespace, req.Name, req.UID, c.Name)
+				klog.Warningf(template+" - Denying admission as container %s is privileged", pod.Namespace, pod.Name, pod.UID, c.Name)
 				continue
 			}
 		}
@@ -85,18 +85,18 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 	}
 
 	if !hasResource {
-		klog.Infof(template+" - Allowing admission for pod: no resource found", req.Namespace, req.Name, req.UID)
+		klog.Infof(template+" - Allowing admission for pod: no resource found", pod.Namespace, pod.Name, pod.UID)
 		//return admission.Allowed("no resource found")
 	} else if len(config.SchedulerName) > 0 {
 		pod.Spec.SchedulerName = config.SchedulerName
 		if pod.Spec.NodeName != "" {
-			klog.Infof(template+" - Pod already has node assigned", req.Namespace, req.Name, req.UID)
+			klog.Infof(template+" - Pod already has node assigned", pod.Namespace, pod.Name, pod.UID)
 			return admission.Denied("pod has node assigned")
 		}
 	}
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {
-		klog.Errorf(template+" - Failed to marshal pod, error: %v", req.Namespace, req.Name, req.UID, err)
+		klog.Errorf(template+" - Failed to marshal pod, error: %v", pod.Namespace, pod.Name, pod.UID, err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR updates the `Handle()` func in `pkg/scheduler/webhook.go`. The previous implementation using `req.UID` and `req.Name` when logging. However, according to the doc of [AdmissionRequest](https://pkg.go.dev/k8s.io/api/admission/v1#AdmissionRequest) as below:
> // UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
   // otherwise identical (parallel requests, requests when earlier requests did not modify etc)
   // The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
   // It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
   UID [types](https://pkg.go.dev/k8s.io/apimachinery/pkg/types).[UID](https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID) `json:"uid" protobuf:"bytes,1,opt,name=uid"`

`req.UID` is not equal to `pod.UID`, as shown in the following screenshot.

![CleanShot 2025-05-27 at 17 36 39](https://github.com/user-attachments/assets/049aae09-4851-4c91-8eaf-bc5ef54ae3aa)

And the `req.Name` might be empty according the above [doc](https://pkg.go.dev/k8s.io/api/admission/v1#AdmissionRequest):
> // Name is the name of the object as presented in the request.  On a CREATE operation, the client may **omit name** and
   // rely on the server to generate the name.  If that is the case, this field will contain an empty string.
   // +optional
   Name [string](https://pkg.go.dev/builtin#string) `json:"name,omitempty" protobuf:"bytes,5,opt,name=name"`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@archlitchi 

**Does this PR introduce a user-facing change?**: