### PR TITLE
feat(helm): optionally disable admission webhook

### DIFF
--- a/charts/hami/Chart.yaml
+++ b/charts/hami/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hami
-version: 2.6.0
+version: 2.7.0
 kubeVersion: ">= 1.18.0-0"
 description: Heterogeneous AI Computing Virtualization Middleware
 keywords:
@@ -13,4 +13,3 @@ maintainers:
   - name: zhangxiao
     email: xiaozhang0210@hotmail.com
 appVersion: "2.6.0"
-

--- a/charts/hami/Chart.yaml
+++ b/charts/hami/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hami
-version: 2.7.0
+version: 2.6.0
 kubeVersion: ">= 1.18.0-0"
 description: Heterogeneous AI Computing Virtualization Middleware
 keywords:
@@ -13,3 +13,4 @@ maintainers:
   - name: zhangxiao
     email: xiaozhang0210@hotmail.com
 appVersion: "2.6.0"
+

--- a/charts/hami/templates/scheduler/certmanager.yaml
+++ b/charts/hami/templates/scheduler/certmanager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if .Values.scheduler.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -26,4 +27,5 @@ metadata:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -24,5 +25,6 @@ rules:
     verbs:     ['use']
     resourceNames:
     - {{ include "hami-vgpu.fullname" . }}-admission
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ include "hami-vgpu.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: batch/v1
 kind: Job
@@ -60,4 +61,5 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.scheduler.patch.runAsUser }}
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: batch/v1
 kind: Job
@@ -55,4 +56,5 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.scheduler.patch.runAsUser }}
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/psp.yaml
+++ b/charts/hami/templates/scheduler/job-patch/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
@@ -34,5 +35,6 @@ spec:
   - projected
   - secret
   - downwardAPI
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/role.yaml
+++ b/charts/hami/templates/scheduler/job-patch/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -18,4 +19,5 @@ rules:
     verbs:
       - get
       - create
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -18,4 +19,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ include "hami-vgpu.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
+++ b/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 {{- if and (.Values.scheduler.patch.enabled) (not .Values.scheduler.certManager.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,4 +11,5 @@ metadata:
   labels:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.admissionWebhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -53,3 +54,4 @@ webhooks:
         scope: '*'
     sideEffects: None
     timeoutSeconds: 10
+{{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -106,6 +106,7 @@ scheduler:
   tolerations: []
   #serviceAccountName: "hami-vgpu-scheduler-sa"
   admissionWebhook:
+    enabled: true
     customURL:
       enabled: false
       # must be an endpoint using https.


### PR DESCRIPTION
This simplifies the deployment considerably and makes HAMi less intrusive inclusters where only a minority of workloads actually require GPU scheduling.

**What type of PR is this?**

**Feature** that makes the helm chart more flexible.

/kind feature

**What this PR does / why we need it**:
- In clusters where only a minority of workloads will benefit from HAMi (e.g. a cluster with a lot of nodes where only a small subset is GPU-equipped), adding a webhook on all pod creations is needlessly intrusive and risky - any downtime of this webhook blocks scheduling of all pods.
- This flag simplifies the deployment manifests considerably, making it easier to install, maintain, troubleshoot and manage HAMi and its components.
- **When this flag is active, the operator/maintainer of the cluster is now responsible for setting `schedulerName` on relevant workload pods** - this can be done with generic helm charts, which is not a problem as in these kinds of mixed clusters, GPU workloads will often anyway need extra configs (e.g. tolerations/affinities).

Simple comparison of created resource counts with this option enabled (default) and with it disabled:

```
cd charts/hami/

# leaving parameter as default
❯ helm template . --values values.yaml  | grep -E "^kind: " | cut -d' ' -f2 | sort | uniq -c
      2 ClusterRole
      3 ClusterRoleBinding
      4 ConfigMap
      1 DaemonSet
      1 Deployment
      2 Job
      1 MutatingWebhookConfiguration
      1 Role
      1 RoleBinding
      2 Service
      3 ServiceAccount

# after, disabling the webhook
❯ helm template . --values values.yaml --set scheduler.admissionWebhook.enabled=false | grep -E "^kind: " | cut -d' ' -f2 | sort | uniq -c
      1 ClusterRole
      2 ClusterRoleBinding
      4 ConfigMap
      1 DaemonSet
      1 Deployment
      2 Service
      2 ServiceAccount

```

We remove several resources: `CR, CRB, Deployment, MutatingWebhookConfiguration, R, RB, SA 2x Jobs`.


**Special notes for your reviewer**:
If this is merged I will go ahead and do a similar docs update PR in `hami/website` to make a note where relevant that the webhook component can be disabled.

- [ ] To be confirmed whether the cert-manager resource is used for anything else except the mutating webhook. Given that it's an alternative for the `patch` approach, I presumed it is only used by the webhook and can therefore be disabled here. 

**Does this PR introduce a user-facing change?**:
No, since the default value for this parameter is `enabled: true`, the behaviour of the chart does not change unless the user configures this parameter to false.
