### PR TITLE
feat(scheduler-role): use a scoped-down role for scheduler

### DIFF
--- a/charts/hami/templates/device-plugin/monitorrolebinding.yaml
+++ b/charts/hami/templates/device-plugin/monitorrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  #name: cluster-admin
   name: {{ include "hami-vgpu.device-plugin" . }}-monitor
 subjects:
   - kind: ServiceAccount

--- a/charts/hami/templates/scheduler/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/clusterrole.yaml
@@ -7,14 +7,15 @@ metadata:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "configmaps"]
     verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: [""]
     resources: ["pods/binding"]
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "patch", "update"]
+    verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "get", "list"]
+

--- a/charts/hami/templates/scheduler/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods/binding"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "get", "list"]

--- a/charts/hami/templates/scheduler/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ include "hami-vgpu.scheduler" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.scheduler" . }}

--- a/charts/hami/templates/scheduler/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/clusterrolebinding.yaml
@@ -1,6 +1,38 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}-kube
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hami-vgpu.scheduler" . }}
+    namespace: {{ include "hami-vgpu.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}-volume
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:volume-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hami-vgpu.scheduler" . }}
+    namespace: {{ include "hami-vgpu.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ include "hami-vgpu.scheduler" . }}
   labels:
     app.kubernetes.io/component: "hami-scheduler"
@@ -8,7 +40,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "hami-vgpu.scheduler" . }}
+  name: hami-scheduler
 subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.scheduler" . }}

--- a/charts/hami/templates/scheduler/role.yaml
+++ b/charts/hami/templates/scheduler/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}
+  namespace: {{ include "hami-vgpu.namespace" . }}
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update", "patch"]

--- a/charts/hami/templates/scheduler/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}
+  namespace: {{ include "hami-vgpu.namespace" . }}
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hami-vgpu.scheduler" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hami-vgpu.scheduler" . }}
+    namespace: {{ include "hami-vgpu.namespace" . }}


### PR DESCRIPTION
**What type of PR is this?**

Improve the `hami` helm chart by scoping down the `ClusterRole` given to `hami-scheduler`.

<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
- `cluster-admin` role for the `hami-scheduler` is overly broad. The purpose of this PR is to scope down the role following the principle of least-privilege. The permissions added were deduced from looking at the source code of `hami` and the types of calls it makes to the Kubernetes API.
- `cluster-admin` is a no-go in most organizations and is overly broad for `hami-scheduler`. A properly scope down role makes `hami` easier for orgs to adopt.
- We use the built-in system roles `kube-scheduler` and `volume-scheduler` to avoid needing to define these in fill ourselves. Custom `CR` and `R` are only used for very specific needs.

**Which issue(s) this PR fixes**:

Partially addresses https://github.com/Project-HAMi/HAMi/issues/1143

More work is needed to close that ticket in terms of linux capabilities given to the container.

**Special notes for your reviewer**:

- [ ] To be confirmed how this affects the e2e tests, if at all
- [ ] Detailed review of the suggested perms is required here!

**Does this PR introduce a user-facing change?**:

None planned.
