### PR TITLE
fix: Add option for overwrite schedulerName

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -99,6 +99,7 @@ spec:
             - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}
             - --node-scheduler-policy={{ .Values.scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy }}
             - --gpu-scheduler-policy={{ .Values.scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy }}
+            - --force-overwrite-default-scheduler={{ .Values.scheduler.forceOverwriteDefaultScheduler}}
             - --device-config-file=/device-config.yaml
             {{- if .Values.devices.ascend.enabled }}
             - --enable-ascend=true

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -68,6 +68,8 @@ scheduler:
     nodeSchedulerPolicy: binpack
     gpuSchedulerPolicy: spread
   metricsBindAddress: ":9395"
+  # If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it
+  forceOverwriteDefaultScheduler: true
   livenessProbe: false
   leaderElect: true
   # when leaderElect is true, replicas is available, otherwise replicas is 1.
@@ -367,3 +369,4 @@ devices:
       - huawei.com/Ascend910B4-memory
       - huawei.com/Ascend310P
       - huawei.com/Ascend310P-memory
+

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -75,6 +75,7 @@ func init() {
 	rootCmd.Flags().IntVar(&config.Timeout, "kube-timeout", client.DefaultTimeout, "Timeout to use while talking with kube-apiserver.")
 	rootCmd.Flags().BoolVar(&enableProfiling, "profiling", false, "Enable pprof profiling via HTTP server")
 	rootCmd.Flags().DurationVar(&config.NodeLockTimeout, "node-lock-timeout", time.Minute*5, "timeout for node locks")
+	rootCmd.Flags().BoolVar(&config.ForceOverwriteDefaultScheduler, "force-overwrite-default-scheduler", true, "Overwrite schedulerName in Pod Spec when set to the const DefaultSchedulerName in https://k8s.io/api/core/v1 package")
 
 	rootCmd.PersistentFlags().AddGoFlagSet(device.GlobalFlagSet())
 	rootCmd.AddCommand(version.VersionCmd)

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -44,4 +44,7 @@ var (
 
 	// NodeLockTimeout is the timeout for node locks.
 	NodeLockTimeout time.Duration
+
+	// If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it, default value is true.
+	ForceOverwriteDefaultScheduler bool
 )

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -60,7 +60,9 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.Warningf(template+" - Denying admission as pod has no containers", req.Namespace, req.Name, req.UID)
 		return admission.Denied("pod has no containers")
 	}
-	if pod.Spec.SchedulerName != "" && (len(config.SchedulerName) == 0 || pod.Spec.SchedulerName != config.SchedulerName) {
+	if pod.Spec.SchedulerName != "" &&
+		pod.Spec.SchedulerName != corev1.DefaultSchedulerName || !config.ForceOverwriteDefaultScheduler &&
+		(len(config.SchedulerName) == 0 || pod.Spec.SchedulerName != config.SchedulerName) {
 		klog.Infof(template+" - Pod already has different scheduler assigned", req.Namespace, req.Name, req.UID)
 		return admission.Allowed("pod already has different scheduler assigned")
 	}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -95,6 +95,7 @@ func TestHandle(t *testing.T) {
 
 func TestPodHasNodeName(t *testing.T) {
 	config.SchedulerName = "hami-scheduler"
+	config.ForceOverwriteDefaultScheduler = true
 	config := &device.Config{
 		NvidiaConfig: nvidia.NvidiaConfig{
 			ResourceCountName:            "hami.io/gpu",


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:
According to the [code](https://github.com/kubernetes/kubernetes/blob/87562da40ac762ad62476d6f8d0f466e9825985c/pkg/apis/core/v1/defaults.go#L214), the Kubernetes API Server will set the `schedulerName` in PodSpec to default value if not set. 
This PR introduce a switch named `forceOverwriteDefaultScheduler` to fix #1162,

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@archlitchi 

**Does this PR introduce a user-facing change?**: