### PR TITLE
fix: make sure filter phase is idempotency

### DIFF
--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -25,9 +25,11 @@ const (
 	//ResourceName = "hami.io/vgpu".
 	AssignedTimeAnnotations = "hami.io/vgpu-time"
 	AssignedNodeAnnotations = "hami.io/vgpu-node"
+	DeviceFilterPhase       = "hami.io/filter-phase"
 	BindTimeAnnotations     = "hami.io/bind-time"
 	DeviceBindPhase         = "hami.io/bind-phase"
 
+	DeviceFilterSuccess  = "success"
 	DeviceBindAllocating = "allocating"
 	DeviceBindFailed     = "failed"
 	DeviceBindSuccess    = "success"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Problem description**:
* The `FailedScheduling` event is continuously generated in the pod event, and the event contents are all `pod <ID> is in the cache, can't be assumed.`
![20250701165256](https://github.com/user-attachments/assets/5e1a9bf5-a72c-47b0-b258-c2b3670e931d)
* Even if the pod is scheduled successfully, the `vgpu-device-allocated` in the annotation keeps changing and does not match the actual mounted device.

**Root cause analysis**:
* For older versions of kube-scheduler (<v1.21.0), kube-scheduler may schedule the same Pod repeatedly, even though the Pod has been successfully filtered and bound to a node where the device is successfully mounted and running. The FailedScheduling event is generated continuously in the pod event, and the event content is `pod is in the cache, can't be assumed`.
* Meanwhile, hami's vgpu-scheduler-extender does not consider the above issues, so when implementing Filter extension points, each call will reassign devices to the Pod and modify the Pod annotation. unnecessary **side effects** are generated.

**Solution**: Refer to the existing `bind-phase` annotation, add an extra `filter-phase` anno, and set its value to `success` when the first filter succeeds, and add a check for this anno in the filter, if it already exists, it will return the **result of the previous successful filter**.

**Test result in real environment**: after the Pod is created successfully, only 3~4 FailedScheduling will be generated, and the event will not be generated continuously (if we want to solve this event completely, we can only upgrade the cluster and the kube-scheduler version in hami-scheduler). At the same time, the Pod annotation will no longer change to correspond to the actual mounted device.
![c6d52af604ef82017c582a0a40a3ba59](https://github.com/user-attachments/assets/22db1971-145f-4193-a81d-d4c808028d55)

**Which issue(s) this PR fixes**:
Fixes #1070
Fixes #968 
Fixes #987 
Fixes #1104 

**Special notes for your reviewer**:

This method only allow the **first success filter result**.
Perhaps the added `filter-phase` annotation need to be **cleared when the bind phase fails**, to enable re-filter?

The method currently does not take into account how to handle evicted Pods.

**Does this PR introduce a user-facing change?**:
No