### PR TITLE
build(deps): upgrade golang to 1.24.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_IMAGE=golang:1.22.5-bullseye
+ARG GOLANG_IMAGE=golang:1.24.4-bullseye
 ARG NVIDIA_IMAGE=nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 FROM $GOLANG_IMAGE AS build

--- a/docs/how-to-profiling-scheduler.md
+++ b/docs/how-to-profiling-scheduler.md
@@ -28,7 +28,7 @@ go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
 - Checkout the target version
 - Building image
 ``` Dockerfile
-FROM golang:1.22.5-bullseye  
+FROM golang:1.24.4-bullseye  
 ADD . /k8s-vgpu
 RUN cd /k8s-vgpu && make tidy
 RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0

--- a/docs/how-to-profiling-scheduler_cn.md
+++ b/docs/how-to-profiling-scheduler_cn.md
@@ -28,7 +28,7 @@ go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
 - 检出目标版本
 - 构建镜像
 ```Dockerfile
-FROM golang:1.22.5-bullseye
+FROM golang:1.24.4-bullseye
 ADD . /k8s-vgpu
 RUN cd /k8s-vgpu && make tidy
 RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -22,7 +22,7 @@ export SHORT_VERSION
 export COMMIT_CODE
 export VERSION="${SHORT_VERSION}-${COMMIT_CODE}"
 export LATEST_VERSION="latest"
-export GOLANG_IMAGE="golang:1.22.5-bullseye"
+export GOLANG_IMAGE="golang:1.24.4-bullseye"
 export NVIDIA_IMAGE="nvidia/cuda:12.2.0-devel-ubuntu20.04"
 export DEST_DIR="/usr/local"
 

--- a/version.mk
+++ b/version.mk
@@ -4,7 +4,7 @@ CMDS=scheduler vGPUmonitor
 DEVICES=nvidia
 OUTPUT_DIR=bin
 TARGET_ARCH=amd64
-GOLANG_IMAGE=golang:1.22.5-bullseye
+GOLANG_IMAGE=golang:1.24.4-bullseye
 NVIDIA_IMAGE=nvidia/cuda:12.3.2-devel-ubuntu20.04
 DEST_DIR=/usr/local/vgpu/
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
To fix compile error with #1171 
```bash
5.989 go: downloading sigs.k8s.io/randfill v1.0.0
6.018 go: downloading github.com/emicklei/go-restful/v3 v3.11.3
6.022 go: downloading github.com/go-openapi/jsonpointer v0.21.0
6.025 go: downloading github.com/mailru/easyjson v0.7.7
6.066 go: downloading github.com/josharian/intern v1.0.0
6.093 go: sigs.k8s.io/controller-runtime@v0.21.0 requires go >= 1.24.0 (running go 1.22.5; GOTOOLCHAIN=local)
6.099 make: *** [Makefile:37: scheduler] Error 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@archlitchi @wawa0210 

**Does this PR introduce a user-facing change?**: