### PR TITLE
If the mem applied for the Mig device is the same as the template value,>will result in CardNotFoundCustom Filter Rule.

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -491,7 +491,7 @@ func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *util.PodDevices, reques
 		for _, val := range toAllocate {
 			found := false
 			for idx := range deviceUsageCurrent.UsageList {
-				if !deviceUsageCurrent.UsageList[idx].InUse && deviceUsageCurrent.UsageList[idx].Memory > val.Usedmem {
+				if !deviceUsageCurrent.UsageList[idx].InUse && deviceUsageCurrent.UsageList[idx].Memory >= val.Usedmem {
 					deviceUsageCurrent.UsageList[idx].InUse = true
 					found = true
 					break
@@ -503,7 +503,7 @@ func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *util.PodDevices, reques
 			}
 		}
 		for idx := range deviceUsageCurrent.UsageList {
-			if !deviceUsageCurrent.UsageList[idx].InUse && deviceUsageCurrent.UsageList[idx].Memory > request.Memreq {
+			if !deviceUsageCurrent.UsageList[idx].InUse && deviceUsageCurrent.UsageList[idx].Memory >= request.Memreq {
 				deviceUsageCurrent.UsageList[idx].InUse = true
 				klog.Infoln("MIG entry device usage true=", deviceUsageCurrent.UsageList, "request", request, "toAllocate", toAllocate)
 				return true
@@ -553,7 +553,7 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *util.DeviceUsa
 		} else {
 			found := false
 			for idx, val := range n.MigUsage.UsageList {
-				if !val.InUse && val.Memory > ctr.Usedmem {
+				if !val.InUse && val.Memory >= ctr.Usedmem {
 					n.MigUsage.UsageList[idx].InUse = true
 					ctr.Usedmem = n.MigUsage.UsageList[idx].Memory
 					if !strings.Contains(ctr.UUID, "[") {


### PR DESCRIPTION
I0709 03:08:54.092406 1 score.go:95] "scoring pod" pod="default/gpu-35-84568fbf8f-wbglr" node="gpuserver-h20-01" device="GPU-1e839017-65c7-a6ff-438d-9b6ee962c53c" Memreq=33280 MemPercentagereq=101 Coresreq=0 Nums=1 device index=3
I0709 03:08:54.092416 1 score.go:43] "Type check" device="NVIDIA-NVIDIA Graphics Device" req="NVIDIA"
I0709 03:08:54.092428 1 score.go:64] checkUUID result is true for NVIDIA type
I0709 03:08:54.092446 1 device.go:511] MIG entry device usage false= [{1g.35gb 33280 false} {1g.35gb 33280 false} {1g.35gb 33280 false} {1g.35gb 33280 false}]
I0709 03:08:54.092465 1 score.go:159] "CardNotFoundCustomFilterRule" pod="default/gpu-35-84568fbf8f-wbglr" node="gpuserver-h20-01" device="GPU-1e839017-65c7-a6ff-438d-9b6ee962c53c" device index=3

What type of PR is this?

What this PR does / why we need it:
Fixes an edge case in MIG device allocation where memory requests exactly matching template values would fail due to strict inequality check (>). Modifies the condition to use >= comparison to allow equal memory values.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

The original condition deviceUsageCurrent.UsageList[idx].Memory > request.Memreq caused CardNotFoundCustomFilterRule errors when requested memory exactly matched MIG template values. This change ensures proper device matching for equal memory requests.

Does this PR introduce a user-facing change?:

Fixed GPU device allocation failure when memory requests exactly match MIG template values