### PR TITLE
perf(util/nodelock): Use clientset Patch instead of Update.

### DIFF
--- a/charts/hami/templates/scheduler/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "patch", "update", "watch"]
+    verbs: ["get", "list", "patch", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "get", "list"]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Use clientset Patch instead of Update in `pkg/util/nodelock`.

**Which issue(s) this PR fixes**:
Fixes #1156 

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
None.