### PR TITLE
fix filter resourcereqs duplicated GenerateResourceRequests

### DIFF
--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -42,7 +42,7 @@ func Resourcereqs(pod *corev1.Pod) (counts util.PodDeviceRequests) {
 			request := val.GenerateResourceRequests(&pod.Spec.Containers[i])
 			if request.Nums > 0 {
 				cnt += request.Nums
-				counts[i][idx] = val.GenerateResourceRequests(&pod.Spec.Containers[i])
+				counts[i][idx] = request
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

在 filter 实现里，计算 pod 请求资源的函数 Resourcereqs 中，对于每个容器计算设备资源请求量的计算重复了两次
for idx, val := range devices {
			request := val.GenerateResourceRequests(&pod.Spec.Containers[i])
			if request.Nums > 0 {
				cnt += request.Nums
				counts[i][idx] = val.GenerateResourceRequests(&pod.Spec.Containers[i])
			}
		}

**What this PR does / why we need it**:
只进行一次计算即可，否则带来重复计算的不必要的开销
for idx, val := range devices {
			request := val.GenerateResourceRequests(&pod.Spec.Containers[i])
			if request.Nums > 0 {
				cnt += request.Nums
				counts[i][idx] = request
			}
		}

**Which issue(s) this PR fixes**:
for idx, val := range devices {
			request := val.GenerateResourceRequests(&pod.Spec.Containers[i])
			if request.Nums > 0 {
				cnt += request.Nums
				counts[i][idx] = request
			}
		}

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: