### PR TITLE
修复 nvidia 插件更新的 node 握手时间注解被覆盖的问题

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	HandshakeAnnos       = "hami.io/node-handshake"
+	HandshakeAnnos       = "hami.io/node-nvidia-handshake"
 	RegisterAnnos        = "hami.io/node-nvidia-register"
 	RegisterGPUPairScore = "hami.io/node-nvidia-score"
 	NvidiaGPUDevice      = "NVIDIA"
@@ -161,7 +161,7 @@ func InitNvidiaDevice(nvconfig NvidiaConfig) *NvidiaGPUDevices {
 	klog.InfoS("initializing nvidia device", "resourceName", nvconfig.ResourceCountName, "resourceMem", nvconfig.ResourceMemoryName, "DefaultGPUNum", nvconfig.DefaultGPUNum)
 	util.InRequestDevices[NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
 	util.SupportDevices[NvidiaGPUDevice] = "hami.io/vgpu-devices-allocated"
-	util.HandshakeAnnos[NvidiaGPUDevice] = HandshakeAnnos
+	util.HandshakeAnnos[NvidiaGPUDevice] = "hami.io/node-handshake"
 	return &NvidiaGPUDevices{
 		config: nvconfig,
 	}


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
修复了 Scheduler.RegisterFromNodeAnnotations 覆盖 NvidiaDevicePlugin.RegisterInAnnotation 更新到 Node 对象上的握手时间注解信息的问题

**Which issue(s) this PR fixes**:
Fixes #1207 

**Special notes for your reviewer**:
辛苦各位有空帮忙审核一下

**Does this PR introduce a user-facing change?**:
无