### PR TITLE
refactor: Ranging over SplitSeq is more efficient

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -120,7 +120,7 @@ func GetIndexAndTypeFromUUID(uuid string) (string, int) {
 
 func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 	migmode := false
-	for _, val := range strings.Split(output, "\n") {
+	for val := range strings.SplitSeq(output, "\n") {
 		if !strings.Contains(val, "MIG") && strings.Contains(val, uuid) {
 			migmode = true
 			continue

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -226,7 +226,7 @@ func getAdditionalXids(input string) []uint64 {
 	}
 
 	var additionalXids []uint64
-	for _, additionalXid := range strings.Split(input, ",") {
+	for additionalXid := range strings.SplitSeq(input, ",") {
 		trimmed := strings.TrimSpace(additionalXid)
 		if trimmed == "" {
 			continue

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -180,8 +180,7 @@ func (dev *EnflameDevices) checkUUID(annos map[string]string, d util.DeviceUsage
 	if ok {
 		klog.V(5).Infof("check uuid for Iluvatar user uuid [%s], device id is %s", userUUID, d.ID)
 		// use , symbol to connect multiple uuid
-		userUUIDs := strings.Split(userUUID, ",")
-		for _, uuid := range userUUIDs {
+		for uuid := range strings.SplitSeq(userUUID, ",") {
 			if d.ID == uuid {
 				return true
 			}
@@ -193,8 +192,7 @@ func (dev *EnflameDevices) checkUUID(annos map[string]string, d util.DeviceUsage
 	if ok {
 		klog.V(5).Infof("check uuid for Iluvatar not user uuid [%s], device id is %s", noUserUUID, d.ID)
 		// use , symbol to connect multiple uuid
-		noUserUUIDs := strings.Split(noUserUUID, ",")
-		for _, uuid := range noUserUUIDs {
+		for uuid := range strings.SplitSeq(noUserUUID, ",") {
 			if d.ID == uuid {
 				return false
 			}

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -95,7 +95,7 @@ func checkDCUtype(annos map[string]string, cardtype string) bool {
 				return true
 			}
 		} else {
-			for _, val := range strings.Split(inuse, ",") {
+			for val := range strings.SplitSeq(inuse, ",") {
 				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
 					return true
 				}
@@ -109,7 +109,7 @@ func checkDCUtype(annos map[string]string, cardtype string) bool {
 				return false
 			}
 		} else {
-			for _, val := range strings.Split(nouse, ",") {
+			for val := range strings.SplitSeq(nouse, ",") {
 				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
 					return false
 				}

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -270,8 +270,7 @@ func parseInterconnection() [][]int {
 
 func parseInterconnection2() [][]int {
 	var interconnection2 [][]int
-	groups := strings.Split(InterGroupConnection2, ",")
-	for _, group := range groups {
+	for group := range strings.SplitSeq(InterGroupConnection2, ",") {
 		values := strings.Split(group, "-")
 		connect := make([]int, 4)
 		for i, value := range values {
@@ -293,8 +292,7 @@ func interconnect(devices []*util.DeviceUsage, count int) []int {
 				if val2.Used > 0 || val2.Index == val.Index {
 					continue
 				}
-				pairs := strings.Split(InterGroupConnection, ",")
-				for _, p := range pairs {
+				for p := range strings.SplitSeq(InterGroupConnection, ",") {
 					lw, _ := strconv.Atoi(strings.Split(p, "-")[0])
 					rw, _ := strconv.Atoi(strings.Split(p, "-")[1])
 					klog.V(5).InfoS("interconnect", "lw", lw, "rw", rw, "left device", val.Index, "right device", val2.Index)

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3011,8 +3011,7 @@ func makeDevice(id string, numa int, Type string, used, count, totalmem, usedmem
 // This function parses the string and returns a map where the key is the reason and the value is the corresponding count.
 func convertReasonToMap(reason string) map[string]int {
 	var reasonMap map[string]int
-	reasonSlice := strings.Split(reason, ", ")
-	for _, r := range reasonSlice {
+	for r := range strings.SplitSeq(reason, ", ") {
 		parts := strings.SplitN(r, " ", 2)
 		if len(parts) != 2 {
 			continue

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -333,7 +333,7 @@ func DecodePodDevices(checklist map[string]string, annos map[string]string) (Pod
 			continue
 		}
 		pd[devID] = make(PodSingleDevice, 0)
-		for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+		for s := range strings.SplitSeq(str, OnePodMultiContainerSplitSymbol) {
 			cd, err := DecodeContainerDevices(s)
 			if err != nil {
 				return PodDevices{}, nil


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
The `SplitSeq` method is introduced in strings package since Go 1.24.0, and ranging over `SplitSeq` is more efficient

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: