### PR TITLE
refactor(util/nodelock): replace manual polling with k8s.io/client-go/util/retry

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -28,19 +28,27 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
 const (
-	NodeLockKey  = "hami.io/mutex.lock"
-	MaxLockRetry = 5
-	NodeLockSep  = ","
+	NodeLockKey = "hami.io/mutex.lock"
+	NodeLockSep = ","
 )
 
 var (
 	lock sync.Mutex
 	// NodeLockTimeout is the global timeout for node locks.
 	NodeLockTimeout time.Duration = time.Minute * 5
+
+	DefaultStrategy = wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 )
 
 func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
@@ -54,22 +62,27 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 	if _, ok := node.Annotations[NodeLockKey]; ok {
 		return fmt.Errorf("node %s is locked", nodeName)
 	}
-	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
-	_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
-	for i := 0; i < MaxLockRetry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to update node", "node", nodeName, "retry", i)
-		time.Sleep(100 * time.Millisecond)
+	err = retry.OnError(DefaultStrategy, func(err error) bool {
+		// Retry on any error
+		return true
+	}, func() error {
 		node, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
-			klog.ErrorS(err, "Failed to get node when retry to update", "node", nodeName)
-			continue
+			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
+			return err
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
-	}
+		if err != nil {
+			klog.ErrorS(err, "Failed to patch node when retry to patch", "node", nodeName)
+			return err
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("setNodeLock exceeds retry count %d", MaxLockRetry)
+		return fmt.Errorf("failed to set node lock (node=%s, retry strategy=%+v): %w", nodeName, DefaultStrategy, err)
 	}
+
 	klog.InfoS("Node lock set", "node", nodeName, "podName", pods.Name)
 	return nil
 }
@@ -90,22 +103,27 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, timeout 
 			return nil
 		}
 	}
-	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
-	_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
-	for i := 0; i < MaxLockRetry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to update node", "node", nodeName, "retry", i)
-		time.Sleep(100 * time.Millisecond)
+	err = retry.OnError(DefaultStrategy, func(err error) bool {
+		// Retry on any error
+		return true
+	}, func() error {
 		node, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
-			klog.ErrorS(err, "Failed to get node when retry to update", "node", nodeName)
-			continue
+			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
+			return err
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
-	}
+		if err != nil {
+			klog.ErrorS(err, "Failed to patch node when retry to patch", "node", nodeName)
+			return err
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("releaseNodeLock exceeds retry count %d", MaxLockRetry)
+		return fmt.Errorf("failed to release node lock (node=%s, retry strategy=%+v): %w", nodeName, DefaultStrategy, err)
 	}
+
 	klog.InfoS("Node lock released", "node", nodeName, "podName", pod.Name)
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I replaced manual polling with `k8s.io/client-go/util/retry`, with the purpose of simplifying and improving the process of setting node annotations over and over again.

**Which issue(s) this PR fixes**:
 none

**Special notes for your reviewer**:
Especially, I use `retry.RetryOnConflict()` rather than `retry.OnError()`, because we need to handle conflic errors, which occur when the `resourceVersion` is not up to date.

**Does this PR introduce a user-facing change?**:
none