### PR TITLE
specify nvidia gpu by indexes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -92,6 +92,18 @@ In Kubernetes, in order for the API server to communicate with the webhook compo
 
   If set, devices allocated by this pod will NOT in UUIDs defined in this string.
 
+`nvidia.com/use-gpuindexes`:
+
+String type, ie: "0,1"
+
+If set, devices allocated by this pod must be one of indexes defined in this string.
+
+* `nvidia.com/nouse-gpuindexes`:
+
+  String type, ie: "0,1"
+
+  If set, devices allocated by this pod will NOT in indexes defined in this string.
+
 * `nvidia.com/nouse-gputype`:
 
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"

--- a/examples/nvidia/specify_index_not_use.yaml
+++ b/examples/nvidia/specify_index_not_use.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    # You can run command: kubectl get node $node -o jsonpath='{.metadata.annotations.hami\.io/node-nvidia-register}' to get gpu-type
+    # index is like 0
+    nvidia.com/nouse-gpuindex: "0" # Specify the blacklist card indexs for this job, use comma to seperate, will not launch job on specified cards
+    # In this job, we don't want our job to run on index 0.
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:18.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          nvidia.com/gpu: 2 # declare how many physical GPUs the pod needs

--- a/examples/nvidia/specify_index_to_use.yaml
+++ b/examples/nvidia/specify_index_to_use.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    # You can run command: kubectl get node $node -o jsonpath='{.metadata.annotations.hami\.io/node-nvidia-register}' to get gpu-type
+    # Index is like 0
+    nvidia.com/use-gpuindex: "0,1" # Specify the card indexs for this job, separated by commas. The job will run on the specified cards
+    # In this example, we want to run this job on index 0 or index 1
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:18.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # declare how many physical GPUs the pod needs

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -231,6 +231,10 @@ func (dev *Devices) checkUUID(annos map[string]string, d util.DeviceUsage) bool 
 	return true
 }
 
+func (dev *Devices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *Devices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return util.CheckHealth(devType, n)
 }

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -206,6 +206,10 @@ func (dev *AWSNeuronDevices) checkUUID(annos map[string]string, d util.DeviceUsa
 	return true
 }
 
+func (dev *AWSNeuronDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *AWSNeuronDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return true, true
 }

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -240,6 +240,10 @@ func (dev *CambriconDevices) checkUUID(annos map[string]string, d util.DeviceUsa
 	return true
 }
 
+func (dev *CambriconDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *CambriconDevices) GenerateResourceRequests(ctr *corev1.Container) util.ContainerDeviceRequest {
 	klog.Info("Start to count mlu devices for container ", ctr.Name)
 	mluResourceCount := corev1.ResourceName(MLUResourceCount)

--- a/pkg/device/common/common.go
+++ b/pkg/device/common/common.go
@@ -24,6 +24,7 @@ import (
 const (
 	CardTypeMismatch                  = "CardTypeMismatch"
 	CardUUIDMismatch                  = "CardUuidMismatch"
+	CardIndexMismatch                 = "CardIndexMismatch"
 	CardTimeSlicingExhausted          = "CardTimeSlicingExhausted"
 	CardComputeUnitsExhausted         = "CardComputeUnitsExhausted"
 	CardInsufficientMemory            = "CardInsufficientMemory"

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -202,6 +202,10 @@ func (dev *EnflameDevices) checkUUID(annos map[string]string, d util.DeviceUsage
 	return true
 }
 
+func (dev *EnflameDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *EnflameDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return true, true
 }

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -201,6 +201,10 @@ func (dev *DCUDevices) checkUUID(annos map[string]string, d util.DeviceUsage) bo
 	return true
 }
 
+func (dev *DCUDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *DCUDevices) GenerateResourceRequests(ctr *corev1.Container) util.ContainerDeviceRequest {
 	klog.Info("Start to count dcu devices for container ", ctr.Name)
 	dcuResourceCount := corev1.ResourceName(HygonResourceCount)

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -169,6 +169,10 @@ func (dev *IluvatarDevices) checkUUID(annos map[string]string, d util.DeviceUsag
 	return true
 }
 
+func (dev *IluvatarDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *IluvatarDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return true, true
 }

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -155,6 +155,10 @@ func (dev *KunlunDevices) CheckUUID(annos map[string]string, d util.DeviceUsage)
 	return true
 }
 
+func (dev *KunlunDevices) CheckIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *KunlunDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return true, true
 }

--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -119,6 +119,10 @@ func (dev *MetaxDevices) checkUUID(annos map[string]string, d util.DeviceUsage) 
 	return true
 }
 
+func (dev *MetaxDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *MetaxDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	count, _ := n.Status.Capacity.Name(corev1.ResourceName(MetaxResourceCount), resource.DecimalSI).AsInt64()
 

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -220,6 +220,10 @@ func (sdev *MetaxSDevices) checkUUID(annos map[string]string, d util.DeviceUsage
 	return true
 }
 
+func (sdev *MetaxSDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (sdev *MetaxSDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	devices, _ := sdev.getMetaxSDevices(*n)
 

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -193,6 +193,10 @@ func (dev *MthreadsDevices) checkUUID(annos map[string]string, d util.DeviceUsag
 	return true
 }
 
+func (dev *MthreadsDevices) checkIndex(annos map[string]string, d util.DeviceUsage) bool {
+	return true
+}
+
 func (dev *MthreadsDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
 	return true, true
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -503,3 +503,49 @@ func GetGPUSchedulerPolicyByPod(defaultPolicy string, task *corev1.Pod) string {
 	}
 	return userGPUPolicy
 }
+
+// ContainsTargetNonNegativeInt checks if the input string contains the target non-negative integer (including 0) as a distinct element.
+// It splits the input string by the given separator, trims whitespace from each element,
+// and verifies if any element is exactly equal to the target non-negative integer.
+// Parameters:
+//
+//	input:      The input string to be parsed (e.g., "0, 5, 10")
+//	separator:  The delimiter used to split the input string (e.g., ",", "|")
+//	target:     The non-negative integer to check for (must be greater than or equal to 0)
+//
+// Returns:
+//
+//	bool: true if the target exists as a distinct non-negative integer element; false otherwise
+func ContainsTargetNonNegativeInt(input, separator string, target int) bool {
+	// Target must be a non-negative integer (greater than or equal to 0)
+	if target < 0 {
+		return false
+	}
+
+	// Split the input string into elements using the separator
+	elements := strings.Split(input, separator)
+
+	// Check each element
+	for _, elem := range elements {
+		// Remove leading and trailing whitespace from the element
+		trimmedElem := strings.TrimSpace(elem)
+		if trimmedElem == "" {
+			continue // Skip empty elements (e.g., from consecutive separators like ",,")
+		}
+
+		// Check for leading zeros (invalid unless the element is exactly "0")
+		if len(trimmedElem) > 1 && trimmedElem[0] == '0' {
+			continue // Skip elements with leading zeros (e.g., "01", "005")
+		}
+
+		// Convert the trimmed element to an integer
+		num, err := strconv.Atoi(trimmedElem)
+		// Check if conversion succeeded and the number matches the target (non-negative check is implicit via target validation)
+		if err == nil && num == target {
+			return true
+		}
+	}
+
+	// Target not found in any valid element
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1147,3 +1147,116 @@ func TestPatchPodAnnotations(t *testing.T) {
 		})
 	}
 }
+
+// ContainsTargetNonNegativeInt verifies the strict validation logic
+func TestContainsTargetNonNegativeInt(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		separator string
+		target    int
+		want      bool
+	}{
+		{
+			name:      "target 0 with valid element '0'",
+			input:     "0, 1, 2",
+			separator: ",",
+			target:    0,
+			want:      true,
+		},
+		{
+			name:      "target 0 with invalid leading zeros '00'",
+			input:     "00, 1, 2",
+			separator: ",",
+			target:    0,
+			want:      false,
+		},
+		{
+			name:      "target 5 with valid element '5'",
+			input:     "3, 5, 7",
+			separator: ",",
+			target:    5,
+			want:      true,
+		},
+		{
+			name:      "target 5 with invalid leading zero '05'",
+			input:     "3, 05, 7",
+			separator: ",",
+			target:    5,
+			want:      false,
+		},
+		{
+			name:      "element with whitespace and valid format",
+			input:     "  10  , 20, 30",
+			separator: ",",
+			target:    10,
+			want:      true,
+		},
+		{
+			name:      "element with whitespace and leading zeros",
+			input:     " 010  , 20",
+			separator: ",",
+			target:    10,
+			want:      false,
+		},
+		{
+			name:      "custom separator and valid element",
+			input:     "15;25;35",
+			separator: ";",
+			target:    25,
+			want:      true,
+		},
+		{
+			name:      "custom separator and leading zeros",
+			input:     "15;025;35",
+			separator: ";",
+			target:    25,
+			want:      false,
+		},
+		{
+			name:      "non-integer elements",
+			input:     "abc, 123, def",
+			separator: ",",
+			target:    123,
+			want:      true,
+		},
+		{
+			name:      "negative target (invalid)",
+			input:     "5, 10, 15",
+			separator: ",",
+			target:    -5,
+			want:      false,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			separator: ",",
+			target:    0,
+			want:      false,
+		},
+		{
+			name:      "single element with leading zero",
+			input:     "000",
+			separator: ",",
+			target:    0,
+			want:      false,
+		},
+		{
+			name:      "element is float (non-integer)",
+			input:     "5.0, 5",
+			separator: ",",
+			target:    5,
+			want:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ContainsTargetNonNegativeInt(tc.input, tc.separator, tc.target)
+			if got != tc.want {
+				t.Errorf("ContainsTargetNonNegativeInt(%q, %q, %d) = %v, want %v",
+					tc.input, tc.separator, tc.target, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

Specifying the nvidia GPU by uuid is not convenient because each physical machine needs to be checked, and it is not easy to know which GPU is running by using the nvidia-smi command.
If you specify the GPU by index, this method is easy to use. If there are several cards, the index will limit this range.

**What this PR does / why we need it**:
Spedify GPU by indexes，using pod's annotations 'nvidia.com/use-gpuindexes'
Exclude index usage，using pod's annotations 'nvidia.com/nouse-gpuindexes'

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: