### PR TITLE
fix: fix golangci-lint error

### DIFF
--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -734,7 +734,7 @@ func TestMetaxSDevices_Fit(t *testing.T) {
 		},
 		{
 			name: "fit fail: device unhealthy",
-			devices: []*util.DeviceUsage{{
+			devices: []*device.DeviceUsage{{
 				ID:        "dev-0",
 				Index:     0,
 				Used:      0,
@@ -747,7 +747,7 @@ func TestMetaxSDevices_Fit(t *testing.T) {
 				Health:    false,
 				Type:      MetaxSGPUDevice,
 			}},
-			request: util.ContainerDeviceRequest{
+			request: device.ContainerDeviceRequest{
 				Nums:             1,
 				Type:             MetaxSGPUDevice,
 				Memreq:           512,


### PR DESCRIPTION
`lint` action broken since #1296  was merged. refer https://github.com/Project-HAMi/HAMi/actions/runs/17365157637/job/49290770904
`
  Running [/home/runner/golangci-lint-2.0.2-linux-amd64/golangci-lint run] in [/home/runner/work/HAMi/HAMi] ...
  pkg/device/metax/config.go:1: : # github.com/Project-HAMi/HAMi/pkg/device/metax [github.com/Project-HAMi/HAMi/pkg/device/metax.test]
  Error: pkg/device/metax/sdevice_test.go:737:16: undefined: util
  Error: pkg/device/metax/sdevice_test.go:750:13: undefined: util (typecheck)
`