### PR TITLE
docs: update ascend910b-support docs

### DIFF
--- a/docs/ascend910b-support.md
+++ b/docs/ascend910b-support.md
@@ -24,7 +24,7 @@ HAMi supports virtualization of Huawei Ascend 910A, 910B series devices (910B2, 
 kubectl label node {ascend-node} accelerator=huawei-Ascend910
 ```
 
-* Deploy [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+* Deploy [Ascend docker runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
 
 * Deploy [ascend-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin)
 

--- a/docs/ascend910b-support_cn.md
+++ b/docs/ascend910b-support_cn.md
@@ -24,7 +24,7 @@ HAMi 支持复用华为昇腾 910A、910B 系列设备（910B、910B2、910B3、
 kubectl label node {ascend-node} accelerator=huawei-Ascend910
 ```
 
-* 部署[Ascend docker runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
+* 部署 [Ascend docker runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
 
 * 部署 [ascend-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin)
 

--- a/docs/ascend910b-support_cn.md
+++ b/docs/ascend910b-support_cn.md
@@ -24,7 +24,7 @@ HAMi 支持复用华为昇腾 910A、910B 系列设备（910B、910B2、910B3、
 kubectl label node {ascend-node} accelerator=huawei-Ascend910
 ```
 
-* 部署[Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+* 部署[Ascend docker runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
 
 * 部署 [ascend-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin)
 


### PR DESCRIPTION
`Ascend docker runtime` project has been migrated to GitCode [`Ascend/mind-cluster`](https://gitcode.com/Ascend/mind-cluster), so the link for `Ascend docker runtime` need to be updated.