### PR TITLE
add httpTargetPort to values.yaml

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -237,6 +237,7 @@ scheduler:
     schedulerPort: 31998  # NodePort for HTTP
     monitorPort: 31993    # Monitoring port
     monitorTargetPort: 9395
+    httpTargetPort: 443
     labels: {}
     annotations: {}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds the missing default value for `scheduler.service.httpTargetPort` in values.yaml . The` service.yaml`template references this value, but it was not defined in the configuration file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None