### PR TITLE
fix: check pod nil in `ReleaseNodeLock`

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -108,6 +108,9 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 }
 
 func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNodeLockOwnerCheck bool) error {
+	if pod == nil {
+		return fmt.Errorf("pod is nil")
+	}
 	lock.Lock()
 	defer lock.Unlock()
 	ctx := context.Background()


### PR DESCRIPTION
In some cases, the `pod` parameter passed in `ReleaseNodeLock` may be nil, which can cause a panic.
such as  https://github.com/Project-HAMi/ascend-device-plugin/blob/main/internal/server/server.go#L346