### PR TITLE
Fix: failed clusterrolebinding when change release name or chart name

### DIFF
--- a/charts/hami/templates/scheduler/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/clusterrolebinding.yaml
@@ -40,7 +40,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hami-scheduler
+  name: {{ include "hami-vgpu.scheduler" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.scheduler" . }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The static roleref.name will not match the clusterrole name when helm release name or chart name is not "hami".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: