### PR TITLE
fix: upgrade nvidia-mig-parted to v0.12.2 to solve security issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ADD . /k8s-vgpu
 #RUN --mount=type=cache,target=/go/pkg/mod \
 #    cd /k8s-vgpu && make all
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu

--- a/docker/Dockerfile.hamimaster
+++ b/docker/Dockerfile.hamimaster
@@ -8,7 +8,7 @@ ADD . /k8s-vgpu
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*

--- a/docker/Dockerfile.withlib
+++ b/docker/Dockerfile.withlib
@@ -8,7 +8,7 @@ ARG GOPROXY=https://goproxy.cn,direct
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.10.0
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
There are some security issues:
> Package: github.com/NVIDIA/mig-parted
Installed Version: v0.10.0
Vulnerability CVE-2025-23266
Severity: CRITICAL
Fixed Version: 0.12.2
Link: [CVE-2025-23266](https://avd.aquasec.com/nvd/cve-2025-23266)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: