### PR TITLE
Improved support for iluvatar GPUs

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -43,13 +43,6 @@ This document provides detailed descriptions of all configurable values paramete
 | `dcuResourceMem` | DCU memory resource name | `"hygon.com/dcumem"` |
 | `dcuResourceCores` | DCU core resource name | `"hygon.com/dcucores"` |
 
-### Iluvatar GPU Resources
-| Parameter | Description | Default Value |
-|-----------|-------------|---------------|
-| `iluvatarResourceName` | GPU resource name | `"iluvatar.ai/vgpu"` |
-| `iluvatarResourceMem` | GPU memory resource name | `"iluvatar.ai/vcuda-memory"` |
-| `iluvatarResourceCore` | GPU core resource name | `"iluvatar.ai/vcuda-core"` |
-
 ### Metax GPU Resources
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|
@@ -231,3 +224,9 @@ This document provides detailed descriptions of all configurable values paramete
 | `devices.ascend.nodeSelector` | Node selector | `{"ascend": "on"}` |
 | `devices.ascend.tolerations` | Tolerations | `[]` |
 | `devices.ascend.customresources` | Custom resources | `["huawei.com/Ascend910A", "huawei.com/Ascend910A-memory", ...]` |
+
+### Iluvatar
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `devices.iluvatar.enabled` | Whether to enable | `false` |
+| `devices.iluvatar.customresources` | Custom resources | `["iluvatar.ai/BI-V150-vgpu", "iluvatar.ai/BI-V150.vMem","iluvatar.ai/BI-V150.vCore", ...]` |

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -63,6 +63,14 @@ data:
                       "ignoredByScheduler": true
                     },
                     {{- end }}
+                    {{- if .Values.devices.iluvatar.enabled }}
+                    {{- range .Values.devices.iluvatar.customresources }}
+                    {
+                      "name": "{{ . }}",
+                      "ignoredByScheduler": true
+                    },
+                    {{- end }}
+                    {{- end }}
                     {
                         "name": "{{ .Values.resourceName }}",
                         "ignoredByScheduler": true
@@ -97,10 +105,6 @@ data:
                     },
                     {
                         "name": "{{ .Values.dcuResourceCores }}",
-                        "ignoredByScheduler": true
-                    },
-                    {
-                        "name": "{{ .Values.iluvatarResourceName }}",
                         "ignoredByScheduler": true
                     },
                     {

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -48,8 +48,6 @@ data:
         ignoredByScheduler: true
       - name: {{ .Values.dcuResourceCores }}
         ignoredByScheduler: true
-      - name: {{ .Values.iluvatarResourceName }}
-        ignoredByScheduler: true
       - name: "metax-tech.com/gpu"
         ignoredByScheduler: true
       - name: {{ .Values.metaxResourceName }}
@@ -85,5 +83,11 @@ data:
       {{- range .Values.devices.awsneuron.customresources }}
       - name: {{ . }}
         ignoredByScheduler: true
+      {{- end }}
+      {{- if .Values.devices.iluvatar.enabled }}
+      {{- range .Values.devices.iluvatar.customresources }}
+      - name: {{ . }}
+        ignoredByScheduler: true
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -108,6 +108,9 @@ spec:
             {{- if .Values.devices.ascend.enabled }}
             - --enable-ascend=true
             {{- end }}
+            {{- if .Values.devices.iluvatar.enabled }}
+            - --enable-iluvatar=true
+            {{- end }}
             {{- if .Values.scheduler.nodeLabelSelector }}
             - --node-label-selector={{- $first := true -}}
               {{- range $key, $value := .Values.scheduler.nodeLabelSelector -}}

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -106,10 +106,27 @@ data:
       resourceCountName: "mthreads.com/vgpu"
       resourceMemoryName: "mthreads.com/sgpu-memory"
       resourceCoreName: "mthreads.com/sgpu-core"
-    iluvatar:
-      resourceCountName: {{ .Values.iluvatarResourceName }}
-      resourceMemoryName: {{ .Values.iluvatarResourceMem }}
-      resourceCoreName: {{ .Values.iluvatarResourceCore }}
+    iluvatars:
+    - chipName: MR-V100
+      commonWord: MR-V100
+      resourceCountName: iluvatar.ai/MR-V100-vgpu
+      resourceMemoryName: iluvatar.ai/MR-V100.vMem
+      resourceCoreName: iluvatar.ai/MR-V100.vCore
+    - chipName: MR-V50
+      commonWord: MR-V50
+      resourceCountName: iluvatar.ai/MR-V50-vgpu
+      resourceMemoryName: iluvatar.ai/MR-V50.vMem
+      resourceCoreName: iluvatar.ai/MR-V50.vCore
+    - chipName: BI-V150
+      commonWord: BI-V150
+      resourceCountName: iluvatar.ai/BI-V150-vgpu
+      resourceMemoryName: iluvatar.ai/BI-V150.vMem
+      resourceCoreName: iluvatar.ai/BI-V150.vCore
+    - chipName: BI-V100
+      commonWord: BI-V100
+      resourceCountName: iluvatar.ai/BI-V100-vgpu
+      resourceMemoryName: iluvatar.ai/BI-V100.vMem
+      resourceCoreName: iluvatar.ai/BI-V100.vCore
     kunlun:
       resourceCountName: {{ .Values.kunlunResourceName }}
       resourceVCountName: {{ .Values.kunlunResourceVCountName }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -38,11 +38,6 @@ dcuResourceName: "hygon.com/dcunum"
 dcuResourceMem: "hygon.com/dcumem"
 dcuResourceCores: "hygon.com/dcucores"
 
-#Iluvatar GPU Parameters
-iluvatarResourceName: "iluvatar.ai/vgpu"
-iluvatarResourceMem: "iluvatar.ai/vcuda-memory"
-iluvatarResourceCore: "iluvatar.ai/vcuda-core"
-
 #Metax sGPU Parameters
 metaxResourceName: "metax-tech.com/sgpu"
 metaxResourceCore: "metax-tech.com/vcore"
@@ -389,4 +384,20 @@ devices:
       - huawei.com/Ascend910B4-1-memory
       - huawei.com/Ascend310P
       - huawei.com/Ascend310P-memory
+  iluvatar:
+    enabled: false
+    customresources:
+      - iluvatar.ai/BI-V100-vgpu
+      - iluvatar.ai/BI-V100.vCore
+      - iluvatar.ai/BI-V100.vMem
+      - iluvatar.ai/BI-V150-vgpu
+      - iluvatar.ai/BI-V150.vCore
+      - iluvatar.ai/BI-V150.vMem
+      - iluvatar.ai/MR-V100-vgpu
+      - iluvatar.ai/MR-V100.vCore
+      - iluvatar.ai/MR-V100.vMem
+      - iluvatar.ai/MR-V50-vgpu
+      - iluvatar.ai/MR-V50.vCore
+      - iluvatar.ai/MR-V50.vMem
+
 

--- a/docs/iluvatar-gpu-support_cn.md
+++ b/docs/iluvatar-gpu-support_cn.md
@@ -24,20 +24,38 @@
 
 > **注意:** *只需要安装gpu-manager，不要安装gpu-admission.*
 
-* 部署'gpu-manager'之后，你需要确认显存和核组对应的资源名称(例如 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
-
-* 在安装HAMi时配置'iluvatarResourceMem'和'iluvatarResourceCore'参数
-
+* 在安装HAMi时配置设置devices.iluvatar.enabled=true
 ```
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set iluvatarResourceMem=iluvatar.ai/vcuda-memory --set iluvatarResourceCore=iluvatar.ai/vcuda-core -n kube-system
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true
 ```
 
-> **说明:** 默认资源名称如下：
-> - `iluvatar.ai/vgpu` 用于 GPU 数量
-> - `iluvatar.ai/vcuda-memory` 用于内存分配
-> - `iluvatar.ai/vcuda-core` 用于核心分配
->
-> 你可以通过上述参数自定义这些名称。
+* 部署'gpu-manager'之后，会根据GPU设备型号上报资源名称
+
+
+> **说明:** 目前默认支持的GPU型号和资源名称在(https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml)定义：
+```yaml
+    iluvatars:
+    - chipName: MR-V100
+      commonWord: MR-V100
+      resourceCountName: iluvatar.ai/MR-V100-vgpu
+      resourceMemoryName: iluvatar.ai/MR-V100.vMem
+      resourceCoreName: iluvatar.ai/MR-V100.vCore
+    - chipName: MR-V50
+      commonWord: MR-V50
+      resourceCountName: iluvatar.ai/MR-V50-vgpu
+      resourceMemoryName: iluvatar.ai/MR-V50.vMem
+      resourceCoreName: iluvatar.ai/MR-V50.vCore
+    - chipName: BI-V150
+      commonWord: BI-V150
+      resourceCountName: iluvatar.ai/BI-V150-vgpu
+      resourceMemoryName: iluvatar.ai/BI-V150.vMem
+      resourceCoreName: iluvatar.ai/BI-V150.vCore
+    - chipName: BI-V100
+      commonWord: BI-V100
+      resourceCountName: iluvatar.ai/BI-V100-vgpu
+      resourceMemoryName: iluvatar.ai/BI-V100.vMem
+      resourceCoreName: iluvatar.ai/BI-V100.vCore
+```
 
 ## 设备粒度切分
 
@@ -45,13 +63,13 @@ HAMi 将每个天数智芯 GPU 划分为 100 个单元进行资源分配。当�
 
 ### 内存分配
 
-- 每个 `iluvatar.ai/vcuda-memory` 单位代表 256MB 的设备内存
+- 每个 `iluvatar.ai/<card-type>.vMem` 单位代表 256MB 的设备内存
 - 如果不指定内存请求，系统将默认使用 100% 的可用内存
 - 内存分配通过硬限制强制执行，确保任务不会超过其分配的内存
 
 ### 核心分配
 
-- 每个 `iluvatar.ai/vcuda-core` 单位代表 1% 的可用计算核心
+- 每个 `iluvatar.ai/<card-type>.vCore` 单位代表 1% 的可用计算核心
 - 核心分配通过硬限制强制执行，确保任务不会超过其分配的核心
 - 当请求多个 GPU 时，系统会根据请求的 GPU 数量自动设置核心资源
 
@@ -61,12 +79,12 @@ HAMi 将每个天数智芯 GPU 划分为 100 个单元进行资源分配。当�
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
+  name: BI-V150-poddemo
 spec:
   restartPolicy: Never
   containers:
-  - name: poddemo
-    image: harbor.4pd.io/vgpu/corex_transformers@sha256:36a01ec452e6ee63c7aa08bfa1fa16d469ad19cc1e6000cf120ada83e4ceec1e
+  - name: BI-V150-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
     command:
     - bash
     args:
@@ -80,16 +98,16 @@ spec:
       sleep 360000
     resources:
       requests:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
       limits:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **注意1:** *每一单位的vcuda-memory代表256M的显存.*
+> **注意1:** *每一单位的vMem代表256M的显存.*
 
 > **注意2:** *查看更多的[用例](../examples/iluvatar/).*
 
@@ -104,14 +122,12 @@ metadata:
   name: poddemo
   annotations:
     # 使用特定的 GPU 设备（逗号分隔的列表）
-    iluvatar.ai/use-gpuuuid: "node1-iluvatar-0,node1-iluvatar-1"
+    hami.io/use-<card-type>-uuid: "device-uuid-1,device-uuid-2"
     # 或者排除特定的 GPU 设备（逗号分隔的列表）
-    iluvatar.ai/nouse-gpuuuid: "node1-iluvatar-2,node1-iluvatar-3"
+    hami.io/no-use-<card-type>-uuid: "device-uuid-1,device-uuid-2"
 spec:
   # ... 其余 Pod 配置
 ```
-
-> **说明:** 设备 ID 格式为 `{节点名称}-iluvatar-{索引}`。你可以在节点状态中找到可用的设备 ID。
 
 ### 查找设备 UUID
 
@@ -124,7 +140,7 @@ kubectl get pod <pod-name> -o yaml | grep -A 10 "hami.io/<card-type>-devices-all
 或者通过检查节点注解：
 
 ```bash
-kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-type>"
+kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-<card-type>-register"
 ```
 
 在节点注解中查找包含设备信息的注解。
@@ -143,6 +159,6 @@ kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-t
 
 2. 共享模式只对申请一张GPU的容器生效（iluvatar.ai/vgpu=1）。当请求多个 GPU 时，系统会根据请求的 GPU 数量自动设置核心资源。
 
-3. `iluvatar.ai/vcuda-memory` 资源仅在 `iluvatar.ai/vgpu=1` 时有效。
+3. `iluvatar.ai/<card-type>.vMem` 资源仅在 `iluvatar.ai/<card-type>-vgpu=1` 时有效。
 
-4. 多设备请求（`iluvatar.ai/vgpu > 1`）不支持 vGPU 模式。
+4. 多设备请求（`iluvatar.ai/<card-type>-vgpu > 1`）不支持 vGPU 模式。

--- a/examples/iluvatar/default_use_BI-V100.yaml
+++ b/examples/iluvatar/default_use_BI-V100.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
+  name: BI-V100-poddemo
 spec:
   restartPolicy: Never
   containers:
-  - name: poddemo
-    image: harbor.4pd.io/vgpu/corex_transformers@sha256:36a01ec452e6ee63c7aa08bfa1fa16d469ad19cc1e6000cf120ada83e4ceec1e
+  - name: BI-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/bi100-3.2.0-x86-ubuntu20.04-py3.10-poc-llm-finetune:v1.1
     command: 
     - bash
     args:
@@ -20,6 +20,10 @@ spec:
       sleep 360000
     resources:
       requests:
-        iluvatar.ai/vgpu: 2
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64
       limits:
-        iluvatar.ai/vgpu: 2
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64

--- a/examples/iluvatar/default_use_BI-V150.yaml
+++ b/examples/iluvatar/default_use_BI-V150.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: BI-V150-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: BI-V150-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
+    command:
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
+      limits:
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64

--- a/examples/iluvatar/default_use_MR-V100.yaml
+++ b/examples/iluvatar/default_use_MR-V100.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: MR-V100-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: MR-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
+    command: 
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64
+      limits:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64

--- a/examples/iluvatar/multi-containers_BI-V100.yaml
+++ b/examples/iluvatar/multi-containers_BI-V100.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: BI-V100-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: BI-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/bi100-3.2.0-x86-ubuntu20.04-py3.10-poc-llm-finetune:v1.1
+    command: 
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64
+      limits:
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64
+  - name: BI-V100-poddemo1
+    image: registry.iluvatar.com.cn:10443/saas/bi100-3.2.0-x86-ubuntu20.04-py3.10-poc-llm-finetune:v1.1
+    command:
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64
+      limits:
+        iluvatar.ai/BI-V100-vgpu: 1
+        iluvatar.ai/BI-V100.vCore: 50
+        iluvatar.ai/BI-V100.vMem: 64

--- a/examples/iluvatar/multi-containers_BI-V150.yaml
+++ b/examples/iluvatar/multi-containers_BI-V150.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
+  name: BI-V150-poddemo
 spec:
   restartPolicy: Never
   containers:
-  - name: poddemo
+  - name: BI-V150-poddemo
     image: harbor.4pd.io/vgpu/corex_transformers@sha256:36a01ec452e6ee63c7aa08bfa1fa16d469ad19cc1e6000cf120ada83e4ceec1e
     command: 
     - bash
@@ -20,15 +20,15 @@ spec:
       sleep 360000
     resources:
       requests:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
       limits:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
-  - name: poddemo1
-    image: harbor.4pd.io/vgpu/corex_transformers@sha256:36a01ec452e6ee63c7aa08bfa1fa16d469ad19cc1e6000cf120ada83e4ceec1e
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
+  - name: BI-V150-poddemo1
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
     command:
     - bash
     args:
@@ -42,10 +42,10 @@ spec:
       sleep 360000
     resources:
       requests:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64
       limits:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/BI-V150-vgpu: 1
+        iluvatar.ai/BI-V150.vCore: 50
+        iluvatar.ai/BI-V150.vMem: 64

--- a/examples/iluvatar/multi-containers_MR-V100.yaml
+++ b/examples/iluvatar/multi-containers_MR-V100.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: MR-V100-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: MR-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
+    command: 
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64
+      limits:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64
+  - name: MR-V100-poddemo1
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
+    command:
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64
+      limits:
+        iluvatar.ai/MR-V100-vgpu: 1
+        iluvatar.ai/MR-V100.vCore: 50
+        iluvatar.ai/MR-V100.vMem: 64

--- a/examples/iluvatar/multi-devices_BI-V100.yaml
+++ b/examples/iluvatar/multi-devices_BI-V100.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: BI-V100-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: BI-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/bi100-3.2.0-x86-ubuntu20.04-py3.10-poc-llm-finetune:v1.1
+    command: 
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/BI-V100-vgpu: 2
+      limits:
+        iluvatar.ai/BI-V100-vgpu: 2

--- a/examples/iluvatar/multi-devices_BI-V150.yaml
+++ b/examples/iluvatar/multi-devices_BI-V150.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: BI-V150-poddemo
+spec:
+  restartPolicy: Never
+  containers:
+  - name: BI-V150-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
+    command: 
+    - bash
+    args:
+    - -c
+    - |
+      set -ex
+      echo "export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH">> /root/.bashrc
+      cp -f /usr/local/iluvatar/lib64/libcuda.* /usr/local/corex/lib64/
+      cp -f /usr/local/iluvatar/lib64/libixml.* /usr/local/corex/lib64/
+      source /root/.bashrc
+      sleep 360000
+    resources:
+      requests:
+        iluvatar.ai/BI-V150-vgpu: 2
+      limits:
+        iluvatar.ai/BI-V150-vgpu: 2

--- a/examples/iluvatar/multi-devices_MR-V100.yaml
+++ b/examples/iluvatar/multi-devices_MR-V100.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
+  name: MR-V100-poddemo
 spec:
   restartPolicy: Never
   containers:
-  - name: poddemo
-    image: harbor.4pd.io/vgpu/corex_transformers@sha256:36a01ec452e6ee63c7aa08bfa1fa16d469ad19cc1e6000cf120ada83e4ceec1e
+  - name: MR-V100-poddemo
+    image: registry.iluvatar.com.cn:10443/saas/mr-bi150-4.3.0-x86-ubuntu22.04-py3.10-base-base:v1.0
     command: 
     - bash
     args:
@@ -20,10 +20,6 @@ spec:
       sleep 360000
     resources:
       requests:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/MR-V100-vgpu: 2
       limits:
-        iluvatar.ai/vgpu: 1
-        iluvatar.ai/vcuda-core: 50
-        iluvatar.ai/vcuda-memory: 64
+        iluvatar.ai/MR-V100-vgpu: 2

--- a/pkg/device/iluvatar/device_test.go
+++ b/pkg/device/iluvatar/device_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package iluvatar
 
 import (
+	"errors"
 	"flag"
+	"fmt"
 	"maps"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 
@@ -29,73 +29,105 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 func TestGetNodeDevices(t *testing.T) {
-	IluvatarResourceCores = "iluvatar.ai/MR-V100.vCore"
-	IluvatarResourceMemory = "iluvatar.ai/MR-V100.vMem"
-
+	dev := IluvatarDevices{
+		config: IluvatarConfig{
+			CommonWord:         "MR-V100",
+			ChipName:           "MR-V100",
+			ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+		},
+	}
 	tests := []struct {
-		name     string
-		node     corev1.Node
-		expected []*device.DeviceInfo
-		err      error
+		name string
+		args corev1.Node
+		want []*device.DeviceInfo
+		err  error
 	}{
 		{
-			name: "Test with valid node",
-			node: corev1.Node{
+			name: "exist device",
+			args: corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Status: corev1.NodeStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceName(IluvatarResourceCores):  *resource.NewQuantity(100, resource.DecimalSI),
-						corev1.ResourceName(IluvatarResourceMemory): *resource.NewQuantity(128, resource.DecimalSI),
+					Name: "node-01",
+					Annotations: map[string]string{
+						dev.nodeRegisterAnno: "GPU-bad51c5a-ed4c-591d-91bf-c04a12e19eae,10,8192,100,MR-V100,0,true:",
 					},
 				},
 			},
-			expected: []*device.DeviceInfo{
+			want: []*device.DeviceInfo{
 				{
-					Index:   0,
-					ID:      "test-iluvatar-0",
-					Count:   100,
-					Devmem:  32768,
-					Devcore: 100,
-					Type:    IluvatarGPUDevice,
+					ID:      "GPU-bad51c5a-ed4c-591d-91bf-c04a12e19eae",
+					Count:   int32(10),
+					Devcore: int32(100),
+					Devmem:  int32(8192),
+					Type:    "MR-V100",
 					Numa:    0,
 					Health:  true,
 				},
 			},
 			err: nil,
 		},
+		{
+			name: "no device",
+			args: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-02",
+					Annotations: map[string]string{
+						dev.nodeRegisterAnno: "[]",
+					},
+				},
+			},
+			want: []*device.DeviceInfo{},
+			err:  errors.New("no device found on node"),
+		},
+		{
+			name: "no annotation",
+			args: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-03",
+				},
+			},
+			want: []*device.DeviceInfo{},
+			err:  fmt.Errorf("annos not found"),
+		},
+		{
+			name: "failed to unmarshal node devices",
+			args: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-04",
+					Annotations: map[string]string{
+						dev.nodeRegisterAnno: "",
+					},
+				},
+			},
+			want: []*device.DeviceInfo{},
+			err:  fmt.Errorf("failed to unmarshal node devices"),
+		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dev := &IluvatarDevices{}
-			got, err := dev.GetNodeDevices(tt.node)
-			if (err != nil) != (tt.err != nil) {
-				t.Errorf("GetNodeDevices() error = %v, expected %v", err, tt.err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := dev.GetNodeDevices(test.args)
+			if (err != nil) != (test.err != nil) {
+				klog.ErrorS(err, "failed to unmarshal node devices", "node", test.args.Name)
+			}
+			if len(result) != len(test.want) {
+				t.Errorf("GetNodeDevices got %d devices, want %d", len(result), len(test.want))
 				return
 			}
-
-			if len(got) != len(tt.expected) {
-				t.Errorf("GetNodeDevices() got %d devices, expected %d", len(got), len(tt.expected))
-				return
-			}
-
-			for i, device := range got {
-				if device.Index != tt.expected[i].Index {
-					t.Errorf("Expected index %d, got %d", tt.expected[i].Index, device.Index)
-				}
-				if device.ID != tt.expected[i].ID {
-					t.Errorf("Expected id %s, got %s", tt.expected[i].ID, device.ID)
-				}
-				if device.Devcore != tt.expected[i].Devcore {
-					t.Errorf("Expected devcore %d, got %d", tt.expected[i].Devcore, device.Devcore)
-				}
-				if device.Devmem != tt.expected[i].Devmem {
-					t.Errorf("Expected cevmem %d, got %d", tt.expected[i].Devmem, device.Devmem)
+			if err == nil && len(result) != 0 {
+				for k, v := range test.want {
+					assert.Equal(t, v.Index, result[k].Index)
+					assert.Equal(t, v.ID, result[k].ID)
+					assert.Equal(t, v.Count, result[k].Count)
+					assert.Equal(t, v.Devcore, result[k].Devcore)
+					assert.Equal(t, v.Devmem, result[k].Devmem)
+					assert.Equal(t, v.Type, result[k].Type)
+					assert.Equal(t, v.Numa, result[k].Numa)
+					assert.Equal(t, v.Health, result[k].Health)
 				}
 			}
 		})
@@ -103,8 +135,15 @@ func TestGetNodeDevices(t *testing.T) {
 }
 
 func TestPatchAnnotations(t *testing.T) {
-	InitIluvatarDevice(IluvatarConfig{})
-
+	dev := IluvatarDevices{
+		config: IluvatarConfig{
+			CommonWord:         "MR-V100",
+			ChipName:           "MR-V100",
+			ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+		},
+	}
 	tests := []struct {
 		name       string
 		annoInput  map[string]string
@@ -121,22 +160,19 @@ func TestPatchAnnotations(t *testing.T) {
 			name:      "With devices",
 			annoInput: map[string]string{},
 			podDevices: device.PodDevices{
-				IluvatarGPUDevice: device.PodSingleDevice{
+				dev.config.CommonWord: device.PodSingleDevice{
 					[]device.ContainerDevice{
 						{
 							Idx:  0,
 							UUID: "k8s-gpu-iluvatar-0",
-							Type: "Iluvatar",
+							Type: "MR-V100",
 						},
 					},
 				},
 			},
 			expected: map[string]string{
-				device.InRequestDevices[IluvatarGPUDevice]: "k8s-gpu-iluvatar-0,Iluvatar,0,0:;",
-				device.SupportDevices[IluvatarGPUDevice]:   "k8s-gpu-iluvatar-0,Iluvatar,0,0:;",
-				"iluvatar.ai/gpu-assigned":                 "false",
-				"iluvatar.ai/predicate-time":               strconv.FormatInt(time.Now().UnixNano(), 10),
-				IluvatarDeviceSelection + "0":              "0",
+				device.InRequestDevices[dev.config.CommonWord]: "k8s-gpu-iluvatar-0,MR-V100,0,0:;",
+				device.SupportDevices[dev.config.CommonWord]:   "k8s-gpu-iluvatar-0,MR-V100,0,0:;",
 			},
 		},
 	}
@@ -145,8 +181,6 @@ func TestPatchAnnotations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			annoInputCopy := make(map[string]string)
 			maps.Copy(annoInputCopy, tt.annoInput)
-
-			dev := &IluvatarDevices{}
 			got := dev.PatchAnnotations(&corev1.Pod{}, &annoInputCopy, tt.podDevices)
 
 			if len(got) != len(tt.expected) {
@@ -189,8 +223,8 @@ func Test_MutateAdmission(t *testing.T) {
 				ctr: &corev1.Container{
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							"iluvatar.ai/vgpu":       *resource.NewQuantity(2, resource.DecimalSI),
-							"iluvatar.ai/vcuda-core": *resource.NewQuantity(1, resource.DecimalSI),
+							"iluvatar.ai/MR-V100-vgpu":  *resource.NewQuantity(2, resource.DecimalSI),
+							"iluvatar.ai/MR-V100.vCore": *resource.NewQuantity(1, resource.DecimalSI),
 						},
 					},
 				},
@@ -201,13 +235,15 @@ func Test_MutateAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			config := IluvatarConfig{
-				ResourceCountName:  "iluvatar.ai/vgpu",
-				ResourceCoreName:   "iluvatar.ai/vcuda-core",
-				ResourceMemoryName: "iluvatar.ai/vcuda-memory",
+			dev := IluvatarDevices{
+				config: IluvatarConfig{
+					CommonWord:         "MR-V100",
+					ChipName:           "MR-V100",
+					ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+					ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+					ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+				},
 			}
-			InitIluvatarDevice(config)
-			dev := IluvatarDevices{}
 			result, _ := dev.MutateAdmission(test.args.ctr, test.args.p)
 			assert.Equal(t, result, test.want)
 		})
@@ -215,6 +251,11 @@ func Test_MutateAdmission(t *testing.T) {
 }
 
 func Test_checkType(t *testing.T) {
+	dev := IluvatarDevices{
+		config: IluvatarConfig{
+			CommonWord: "MR-V100",
+		},
+	}
 	tests := []struct {
 		name string
 		args struct {
@@ -236,7 +277,7 @@ func Test_checkType(t *testing.T) {
 				annos: map[string]string{},
 				d:     device.DeviceUsage{},
 				n: device.ContainerDeviceRequest{
-					Type: IluvatarGPUDevice,
+					Type: "MR-V100",
 				},
 			},
 			want1: true,
@@ -263,7 +304,6 @@ func Test_checkType(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dev := IluvatarDevices{}
 			result1, result2, result3 := dev.checkType(test.args.annos, test.args.d, test.args.n)
 			assert.Equal(t, result1, test.want1)
 			assert.Equal(t, result2, test.want2)
@@ -288,7 +328,7 @@ func Test_checkUUID(t *testing.T) {
 				d     device.DeviceUsage
 			}{
 				annos: map[string]string{
-					"iluvatar.ai/use-gpuuuid": "test1",
+					"hami.io/use-MR-V100-uuid": "test1",
 				},
 				d: device.DeviceUsage{
 					ID: "test1",
@@ -303,7 +343,7 @@ func Test_checkUUID(t *testing.T) {
 				d     device.DeviceUsage
 			}{
 				annos: map[string]string{
-					"iluvatar.ai/use-gpuuuid": "test2",
+					"hami.io/use-MR-V100-uuid": "test2",
 				},
 				d: device.DeviceUsage{
 					ID: "test1",
@@ -331,7 +371,7 @@ func Test_checkUUID(t *testing.T) {
 				d     device.DeviceUsage
 			}{
 				annos: map[string]string{
-					"iluvatar.ai/nouse-gpuuuid": "test1",
+					"hami.io/no-use-MR-V100-uuid": "test1",
 				},
 				d: device.DeviceUsage{
 					ID: "test1",
@@ -346,7 +386,7 @@ func Test_checkUUID(t *testing.T) {
 				d     device.DeviceUsage
 			}{
 				annos: map[string]string{
-					"iluvatar.ai/nouse-gpuuuid": "test1",
+					"hami.io/no-use-MR-V100-uuid": "test1",
 				},
 				d: device.DeviceUsage{
 					ID: "test2",
@@ -357,7 +397,17 @@ func Test_checkUUID(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dev := IluvatarDevices{}
+			dev := IluvatarDevices{
+				config: IluvatarConfig{
+					CommonWord:         "MR-V100",
+					ChipName:           "MR-V100",
+					ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+					ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+					ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+				},
+				useUUIDAnno:   "hami.io/use-MR-V100-uuid",
+				noUseUUIDAnno: "hami.io/no-use-MR-V100-uuid",
+			}
 			result := dev.checkUUID(test.args.annos, test.args.d)
 			assert.Equal(t, result, test.want)
 		})
@@ -375,20 +425,20 @@ func Test_GenerateResourceRequests(t *testing.T) {
 			args: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"iluvatar.ai/vgpu":         resource.MustParse("1"),
-						"iluvatar.ai/vcuda-memory": resource.MustParse("1000"),
-						"iluvatar.ai/vcuda-core":   resource.MustParse("100"),
+						"iluvatar.ai/MR-V100-vgpu":  resource.MustParse("1"),
+						"iluvatar.ai/MR-V100.vMem":  resource.MustParse("1000"),
+						"iluvatar.ai/MR-V100.vCore": resource.MustParse("100"),
 					},
 					Requests: corev1.ResourceList{
-						"iluvatar.ai/vgpu":         resource.MustParse("1"),
-						"iluvatar.ai/vcuda-memory": resource.MustParse("1000"),
-						"iluvatar.ai/vcuda-core":   resource.MustParse("100"),
+						"iluvatar.ai/MR-V100-vgpu":  resource.MustParse("1"),
+						"iluvatar.ai/MR-V100.vMem":  resource.MustParse("1000"),
+						"iluvatar.ai/MR-V100.vCore": resource.MustParse("100"),
 					},
 				},
 			},
 			want: device.ContainerDeviceRequest{
 				Nums:             int32(1),
-				Type:             IluvatarGPUDevice,
+				Type:             "MR-V100",
 				Memreq:           int32(256000),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(100),
@@ -409,16 +459,16 @@ func Test_GenerateResourceRequests(t *testing.T) {
 			args: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"iluvatar.ai/vgpu": resource.MustParse("1"),
+						"iluvatar.ai/MR-V100-vgpu": resource.MustParse("1"),
 					},
 					Requests: corev1.ResourceList{
-						"iluvatar.ai/vgpu": resource.MustParse("1"),
+						"iluvatar.ai/MR-V100-vgpu": resource.MustParse("1"),
 					},
 				},
 			},
 			want: device.ContainerDeviceRequest{
 				Nums:             int32(1),
-				Type:             IluvatarGPUDevice,
+				Type:             "MR-V100",
 				Memreq:           int32(0),
 				MemPercentagereq: int32(100),
 				Coresreq:         int32(0),
@@ -427,7 +477,15 @@ func Test_GenerateResourceRequests(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dev := IluvatarDevices{}
+			dev := IluvatarDevices{
+				config: IluvatarConfig{
+					CommonWord:         "MR-V100",
+					ChipName:           "MR-V100",
+					ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+					ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+					ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+				},
+			}
 			fs := flag.FlagSet{}
 			ParseConfig(&fs)
 			result := dev.GenerateResourceRequests(test.args)
@@ -437,13 +495,16 @@ func Test_GenerateResourceRequests(t *testing.T) {
 }
 
 func Test_Fit(t *testing.T) {
-	config := IluvatarConfig{
-		ResourceCountName:  "iluvatar.ai/vgpu",
-		ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
-		ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
-	}
-	dev := InitIluvatarDevice(config)
 
+	dev := IluvatarDevices{
+		config: IluvatarConfig{
+			CommonWord:         "MR-V100",
+			ChipName:           "MR-V100",
+			ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+		},
+	}
 	tests := []struct {
 		name       string
 		devices    []*device.DeviceUsage
@@ -466,7 +527,7 @@ func Test_Fit(t *testing.T) {
 					Totalcore: 100,
 					Usedcores: 0,
 					Numa:      0,
-					Type:      IluvatarGPUDevice,
+					Type:      "MR-V100",
 					Health:    true,
 				},
 				{
@@ -479,13 +540,13 @@ func Test_Fit(t *testing.T) {
 					Totalcore: 100,
 					Usedcores: 0,
 					Numa:      0,
-					Type:      IluvatarGPUDevice,
+					Type:      "MR-V100",
 					Health:    true,
 				},
 			},
 			request: device.ContainerDeviceRequest{
 				Nums:             1,
-				Type:             IluvatarGPUDevice,
+				Type:             "MR-V100",
 				Memreq:           64,
 				MemPercentagereq: 0,
 				Coresreq:         50,
@@ -507,12 +568,12 @@ func Test_Fit(t *testing.T) {
 				Totalcore: 100,
 				Usedcores: 0,
 				Numa:      0,
-				Type:      IluvatarGPUDevice,
+				Type:      "MR-V100",
 				Health:    true,
 			}},
 			request: device.ContainerDeviceRequest{
 				Nums:             1,
-				Type:             IluvatarGPUDevice,
+				Type:             "MR-V100",
 				Memreq:           512,
 				MemPercentagereq: 0,
 				Coresreq:         50,
@@ -534,12 +595,12 @@ func Test_Fit(t *testing.T) {
 				Totalcore: 100,
 				Usedcores: 100,
 				Numa:      0,
-				Type:      IluvatarGPUDevice,
+				Type:      "MR-V100",
 				Health:    true,
 			}},
 			request: device.ContainerDeviceRequest{
 				Nums:             1,
-				Type:             IluvatarGPUDevice,
+				Type:             "MR-V100",
 				Memreq:           512,
 				MemPercentagereq: 0,
 				Coresreq:         50,
@@ -561,7 +622,7 @@ func Test_Fit(t *testing.T) {
 				Totalcore: 100,
 				Usedcores: 0,
 				Numa:      0,
-				Type:      IluvatarGPUDevice,
+				Type:      "MR-V100",
 				Health:    true,
 			}},
 			request: device.ContainerDeviceRequest{
@@ -588,12 +649,12 @@ func Test_Fit(t *testing.T) {
 			}
 			ok, result, _ := dev.Fit(test.devices, test.request, pod, &device.NodeInfo{}, allocated)
 			if test.wantOK {
-				if len(result[IluvatarGPUDevice]) != test.wantLen {
-					t.Errorf("expected %d, got %d", test.wantLen, len(result[IluvatarGPUDevice]))
+				if len(result["MR-V100"]) != test.wantLen {
+					t.Errorf("expected %d, got %d", test.wantLen, len(result["MR-V100"]))
 				}
 				for idx, id := range test.wantDevIDs {
-					if id != result[IluvatarGPUDevice][idx].UUID {
-						t.Errorf("expected %s, got %s", id, result[IluvatarGPUDevice][idx].UUID)
+					if id != result["MR-V100"][idx].UUID {
+						t.Errorf("expected %s, got %s", id, result["MR-V100"][idx].UUID)
 					}
 				}
 				if !ok {
@@ -603,8 +664,8 @@ func Test_Fit(t *testing.T) {
 				if ok {
 					t.Errorf("expected ok false, got true")
 				}
-				if len(result[IluvatarGPUDevice]) != test.wantLen {
-					t.Errorf("expected %d, got %d", test.wantLen, len(result[IluvatarGPUDevice]))
+				if len(result["MR-V100"]) != test.wantLen {
+					t.Errorf("expected %d, got %d", test.wantLen, len(result["MR-V100"]))
 				}
 			}
 		})

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -70,10 +70,27 @@ mthreads:
   resourceCountName: "mthreads.com/vgpu"
   resourceMemoryName: "mthreads.com/sgpu-memory"
   resourceCoreName: "mthreads.com/sgpu-core"
-iluvatar: 
-  resourceCountName: iluvatar.ai/vgpu
-  resourceMemoryName: iluvatar.ai/vcuda-memory
-  resourceCoreName: iluvatar.ai/vcuda-core
+iluvatars:
+- chipName: MR-V100
+  commonWord: MR-V100
+  resourceCountName: iluvatar.ai/MR-V100-vgpu
+  resourceMemoryName: iluvatar.ai/MR-V100.vMem
+  resourceCoreName: iluvatar.ai/MR-V100.vCore
+- chipName: MR-V50
+  commonWord: MR-V50
+  resourceCountName: iluvatar.ai/MR-V50-vgpu
+  resourceMemoryName: iluvatar.ai/MR-V50.vMem
+  resourceCoreName: iluvatar.ai/MR-V50.vCore
+- chipName: BI-V150
+  commonWord: BI-V150
+  resourceCountName: iluvatar.ai/BI-V150-vgpu
+  resourceMemoryName: iluvatar.ai/BI-V150.vMem
+  resourceCoreName: iluvatar.ai/BI-V150.vCore
+- chipName: BI-V100
+  commonWord: BI-V100
+  resourceCountName: iluvatar.ai/BI-V100-vgpu
+  resourceMemoryName: iluvatar.ai/BI-V100.vMem
+  resourceCoreName: iluvatar.ai/BI-V100.vCore
 kunlun:
   resourceCountName: "kunlunxin.com/xpu"
 vnpus:
@@ -188,7 +205,6 @@ func Test_LoadConfig(t *testing.T) {
 		{"NVIDIA Config", createNvidiaConfig(), configData.NvidiaConfig},
 		{"Cambricon Config", createCambriconConfig(), configData.CambriconConfig},
 		{"Hygon Config", createHygonConfig(), configData.HygonConfig},
-		{"Iluvatar Config", createIluvatarConfig(), configData.IluvatarConfig},
 		{"Mthreads Config", createMthreadsConfig(), configData.MthreadsConfig},
 		{"Metax Config", createMetaxConfig(), configData.MetaxConfig},
 		{"Enflame Config", createEnflameConfig(), configData.EnflameConfig},
@@ -203,6 +219,8 @@ func Test_LoadConfig(t *testing.T) {
 
 	expectedVNPUs := createVNPUConfigs()
 	assert.DeepEqual(t, configData.VNPUs, expectedVNPUs)
+	expectedIluvatars := createIluvatarConfigs()
+	assert.DeepEqual(t, configData.IluvatarConfig, expectedIluvatars)
 }
 
 func createNvidiaConfig() nvidia.NvidiaConfig {
@@ -349,6 +367,39 @@ func createVNPUConfigs() []ascend.VNPUConfig {
 	}
 }
 
+func createIluvatarConfigs() []iluvatar.IluvatarConfig {
+	return []iluvatar.IluvatarConfig{
+		{
+			ChipName:           "MR-V100",
+			CommonWord:         "MR-V100",
+			ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+		},
+		{
+			ChipName:           "MR-V50",
+			CommonWord:         "MR-V50",
+			ResourceCountName:  "iluvatar.ai/MR-V50-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V50.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V50.vCore",
+		},
+		{
+			ChipName:           "BI-V150",
+			CommonWord:         "BI-V150",
+			ResourceCountName:  "iluvatar.ai/BI-V150-vgpu",
+			ResourceMemoryName: "iluvatar.ai/BI-V150.vMem",
+			ResourceCoreName:   "iluvatar.ai/BI-V150.vCore",
+		},
+		{
+			ChipName:           "BI-V100",
+			CommonWord:         "BI-V100",
+			ResourceCountName:  "iluvatar.ai/BI-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/BI-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/BI-V100.vCore",
+		},
+	}
+}
+
 func setupTest(t *testing.T) (map[string]string, map[string]device.Devices) {
 	t.Helper()
 
@@ -365,7 +416,6 @@ func setupTest(t *testing.T) (map[string]string, map[string]device.Devices) {
 		nvidia.NvidiaGPUDevice:       nvidia.NvidiaGPUCommonWord,
 		cambricon.CambriconMLUDevice: cambricon.CambriconMLUCommonWord,
 		hygon.HygonDCUDevice:         hygon.HygonDCUCommonWord,
-		iluvatar.IluvatarGPUDevice:   iluvatar.IluvatarGPUCommonWord,
 		mthreads.MthreadsGPUDevice:   mthreads.MthreadsGPUCommonWord,
 		metax.MetaxGPUDevice:         metax.MetaxGPUCommonWord,
 		metax.MetaxSGPUDevice:        metax.MetaxSGPUCommonWord,
@@ -399,7 +449,9 @@ func Test_InitDevicesWithConfig_Success(t *testing.T) {
 // Test_InitDevicesWithConfig_InvalidConfig tests the behavior of InitDevicesWithConfig with invalid configurations.
 func Test_InitDevicesWithConfig_InvalidConfig(t *testing.T) {
 	// Provide an intentionally constructed invalid configuration
-	configData := Config{}
+	configData := Config{
+		IluvatarConfig: []iluvatar.IluvatarConfig{},
+	}
 
 	err := InitDevicesWithConfig(&configData)
 	assert.ErrorContains(t, err, "all configurations are empty", "Expected initialization to fail with 'NvidiaConfig is empty' error")
@@ -447,7 +499,9 @@ func Test_validateConfig(t *testing.T) {
 			DefaultGPUNum:                1,
 		},
 	}
-	emptyConfig := &Config{}
+	emptyConfig := &Config{
+		IluvatarConfig: []iluvatar.IluvatarConfig{},
+	}
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind feature

**What this PR does / why we need it**:
This PR improves support for Iluvatar GPUs, including device plugin (gpu-manager) adaptation, scheduling policy compatibility, and resource isolation and sharing capabilities.

Major changes include:
- Added support for Iluvatar's new gpu-manager version
- Support for Iluvatar multi-GPU models
- Updated documentation and sample configurations
**Which issue(s) this PR fixes**:
Fixes #
No existing issue

**Special notes for your reviewer**:
- This feature is compatible with Iluvatar CoreX GPUs and has been preliminarily verified to function correctly in a test cluster.
- Official or community users of Iluvatar are welcome to participate in testing and provide feedback.
- Currently, it supports basic device discovery, resource reporting, Pod resource request, and scheduling, and will be expanded to support advanced features such as dynamic sharing.
- Please pay special attention to changes in the following modules:
- `pkg/device/iluvatar/`
- Adjustments to device registration and scheduling parameters in `cmd/`
- Updates to sample configurations and Helm values
- 
**Does this PR introduce a user-facing change?**:
Yes, this PR introduces new user-visible features:

- Added support for device management of different Iluvatar GPU models. Users can now schedule Iluvatar GPU resources based on GPU resource name using HAMi in Kubernetes clusters.
- Users can specify `iluvatar.ai/<card-type>.` or related resource types (specific names vary by implementation) in Pod resource requests and use them with gpu-manager.
- Related documentation and usage examples have been updated; see `/examples/iluvatar/` and the updated README for details.