### PR TITLE
Fix: Calculation error for quotas

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -102,6 +102,10 @@ func (s *Scheduler) onAddPod(obj any) {
 		return
 	}
 	if util.IsPodInTerminatedState(pod) {
+		pi, ok := s.podManager.GetPod(pod)
+		if ok {
+			s.quotaManager.RmUsage(pod, pi.Devices)
+		}
 		s.podManager.DelPod(pod)
 		return
 	}
@@ -141,8 +145,8 @@ func (s *Scheduler) onAddQuota(obj interface{}) {
 	s.quotaManager.AddQuota(quota)
 }
 
-func (s *Scheduler) onUpdateQuota(_, newObj interface{}) {
-	s.onDelQuota(newObj)
+func (s *Scheduler) onUpdateQuota(oldObj, newObj interface{}) {
+	s.onDelQuota(oldObj)
 	s.onAddQuota(newObj)
 }
 


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

1. Remove usage of quotas when pod is terminated status.
When setting replicas from 1 to 0, the scheduler got update event first and run `s.podManager.DelPod(pod)`, then the deletion event to fail to remove usage normally.

2. Delete quotas when clear the hard quota of Resourceqota(not deleted the cr resource).
