### PR TITLE
refactor: handle terminating pods in scheduler cache refresh

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -101,7 +101,7 @@ func (s *Scheduler) onAddPod(obj any) {
 	if !ok {
 		return
 	}
-	if util.IsPodInTerminatedState(pod) {
+	if util.IsPodTerminatingOrFinished(pod) {
 		pi, ok := s.podManager.GetPod(pod)
 		if ok {
 			s.quotaManager.RmUsage(pod, pi.Devices)
@@ -174,6 +174,7 @@ func (s *Scheduler) Start() {
 	})
 	informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { s.doNodeNotify() },
+		UpdateFunc: func(_, _ any) { s.doNodeNotify() },
 		DeleteFunc: func(_ any) { s.doNodeNotify() },
 	})
 	informerFactory.Core().V1().ResourceQuotas().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -214,7 +214,15 @@ func GetGPUSchedulerPolicyByPod(defaultPolicy string, task *corev1.Pod) string {
 	return userGPUPolicy
 }
 
-func IsPodInTerminatedState(pod *corev1.Pod) bool {
+// IsPodTerminatingOrFinished returns true once the pod either finished execution
+// (Succeeded/Failed) or is in the process of terminating (DeletionTimestamp set).
+func IsPodTerminatingOrFinished(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	if pod.DeletionTimestamp != nil {
+		return true
+	}
 	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -376,7 +377,7 @@ func TestPatchPodAnnotations(t *testing.T) {
 	}
 }
 
-func Test_IsPodInTerminatedState(t *testing.T) {
+func Test_IsPodTerminatingOrFinished(t *testing.T) {
 	tests := []struct {
 		name string
 		args *corev1.Pod
@@ -396,6 +397,18 @@ func Test_IsPodInTerminatedState(t *testing.T) {
 			args: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodSucceeded,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod terminating",
+			args: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
 				},
 			},
 			want: true,
@@ -431,7 +444,7 @@ func Test_IsPodInTerminatedState(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := IsPodInTerminatedState(test.args)
+			got := IsPodTerminatingOrFinished(test.args)
 			assert.Equal(t, test.want, got)
 		})
 	}


### PR DESCRIPTION
  - treat pods with a deletion timestamp as finished via the renamed helper `IsPodTerminatingOrFinished` and update its unit tests
  - drop terminating pods from the scheduler’s pod/quota caches and trigger node refreshes on informer updates to eliminate stale state
  - add scheduler-level tests covering pod termination cleanup and node update notifications

**What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:
  - treat pods with a deletion timestamp as already finished via the renamed helper `IsPodTerminatingOrFinished`, and update the accompanying unit tests
  - drop terminating pods from the scheduler’s pod/quota caches and trigger node refreshes on informer updates to eliminate stale device state
  - add scheduler-level tests covering pod termination cleanup and node update notifications

  **Which issue(s) this PR fixes**:
  Fixes #1368 