### PR TITLE
Fix: defer may not run

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -186,10 +186,10 @@ func start(c *cli.Context, flags []cli.Flag) error {
 	util.NodeName = os.Getenv(util.NodeNameEnvName)
 	client.InitGlobalClient()
 	watcher, err := newFSWatcher(kubeletdevicepluginv1beta1.DevicePluginPath)
+	defer watcher.Close()
 	if err != nil {
 		return fmt.Errorf("failed to create FS watcher: %v", err)
 	}
-	defer watcher.Close()
 	//device.InitDevices()
 
 	/*Loading config files*/


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
we should call defer before return.

