### PR TITLE
Improve: Replace `StrategicMergePatchType` by `MergePatchType`

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -133,12 +133,11 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	type patchMetadata struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 	}
-	type patchPod struct {
+	type patchNode struct {
 		Metadata patchMetadata `json:"metadata"`
-		//Spec     patchSpec     `json:"spec,omitempty"`
 	}
 
-	p := patchPod{}
+	p := patchNode{}
 	p.Metadata.Annotations = annotations
 
 	bytes, err := json.Marshal(p)
@@ -146,7 +145,7 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 		return err
 	}
 	_, err = client.GetClient().CoreV1().Nodes().
-		Patch(context.Background(), node.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+		Patch(context.Background(), node.Name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infoln("annotations=", annotations)
 		klog.Infof("patch node %v failed, %v", node.Name, err)
@@ -161,7 +160,6 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	}
 	type patchPod struct {
 		Metadata patchMetadata `json:"metadata"`
-		//Spec     patchSpec     `json:"spec,omitempty"`
 	}
 
 	p := patchPod{}
@@ -178,7 +176,7 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	}
 	klog.V(5).Infof("patch pod %s/%s annotation content is %s", pod.Namespace, pod.Name, string(bytes))
 	_, err = client.GetClient().CoreV1().Pods(pod.Namespace).
-		Patch(context.Background(), pod.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+		Patch(context.Background(), pod.Name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infof("patch pod %v failed, %v", pod.Name, err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

`MergePatchType` method is more stable. `StrategicMergePatchTyp`e requires the k8s resource schema field to have a corresponding key.
Strategic merge patch is not supported for custom resources or metadata.
refer to [update-api-object-kubectl-patch](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: