### PR TITLE
Fix: After removing the device plugin from the gpu node, it can still…

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -158,7 +158,7 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 	return &res
 }
 
-func (plugin *NvidiaDevicePlugin) RegistrInAnnotation() error {
+func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() error {
 	devices := plugin.getAPIDevices()
 	klog.InfoS("start working on the devices", "devices", devices)
 	annos := make(map[string]string)
@@ -222,7 +222,7 @@ func (plugin *NvidiaDevicePlugin) WatchAndRegister(disableNVML <-chan bool, ackD
 			time.Sleep(successSleepInterval)
 			continue
 		}
-		err := plugin.RegistrInAnnotation()
+		err := plugin.RegisterInAnnotation()
 		if err != nil {
 			klog.Errorf("Failed to register annotation: %v", err)
 			klog.Infof("Retrying in %v seconds...", errorSleepInterval)

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -28,6 +28,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 type Devices interface {
@@ -160,10 +162,6 @@ const (
 )
 
 var (
-	HandshakeAnnos     = map[string]string{}
-	RegisterAnnos      = map[string]string{}
-	configFile         string
-	DebugMode          bool
 	GPUSchedulerPolicy string
 	InRequestDevices   map[string]string
 	SupportDevices     map[string]string
@@ -408,7 +406,7 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 }
 
 func CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	handshake := n.Annotations[HandshakeAnnos[devType]]
+	handshake := n.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
 		formertime, _ := time.Parse(time.DateTime, strings.Split(handshake, "_")[1])
 		return time.Now().Before(formertime.Add(time.Second * 60)), false

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -25,6 +25,8 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 var inRequestDevices map[string]string
@@ -530,6 +532,7 @@ func Test_EncodeNodeDevices(t *testing.T) {
 }
 
 func Test_CheckHealth(t *testing.T) {
+	util.HandshakeAnnos["huawei.com/Ascend910"] = "hami.io/node-handshake-ascend"
 	tests := []struct {
 		name string
 		args struct {
@@ -549,7 +552,7 @@ func Test_CheckHealth(t *testing.T) {
 				n: corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_2128-12-02 00:00:00",
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_2128-12-02 00:00:00",
 						},
 					},
 				},
@@ -567,7 +570,7 @@ func Test_CheckHealth(t *testing.T) {
 				n: corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							HandshakeAnnos["huawei.com/Ascend910"]: "Deleted",
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Deleted",
 						},
 					},
 				},
@@ -585,7 +588,7 @@ func Test_CheckHealth(t *testing.T) {
 				n: corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							HandshakeAnnos["huawei.com/Ascend910"]: "Unknown",
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Unknown",
 						},
 					},
 				},
@@ -603,7 +606,7 @@ func Test_CheckHealth(t *testing.T) {
 				n: corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_2024-01-02 00:00:00",
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_2024-01-02 00:00:00",
 						},
 					},
 				},

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/common"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -67,7 +68,7 @@ func InitIluvatarDevice(config []IluvatarConfig) []*IluvatarDevices {
 		}
 		device.InRequestDevices[commonWord] = fmt.Sprintf("hami.io/%s-devices-to-allocate", commonWord)
 		device.SupportDevices[commonWord] = fmt.Sprintf("hami.io/%s-devices-allocated", commonWord)
-		device.HandshakeAnnos[commonWord] = dev.handshakeAnno
+		util.HandshakeAnnos[commonWord] = dev.handshakeAnno
 		devs = append(devs, dev)
 		klog.Infof("load iluvatar gpu config %s: %v", commonWord, dev.config)
 	}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:

CheckHealth is always return true, true when removing the device plugin from the gpu node.
The scheduler component and plugin component continuously update different prefix values ​​for the hami.io/node-handshake key on the node annotations. The correct way is for the device plugin to update regularly and the scheduler component to check the status.