### PR TITLE
Synchronise podManager cache periodically in goroutine

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -136,6 +136,7 @@ func (s *Scheduler) onDelPod(obj any) {
 		}
 	default:
 		klog.Errorf("Received unknown object type on pod delete")
+		return
 	}
 
 	_, ok = pod.Annotations[util.AssignedNodeAnnotations]


### PR DESCRIPTION
…t intervals

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Pod Delete EventHandler correctly handle the special objects linked to delete events during re-listing caused by the missing of object delete event when the watch connection between informer and apiserver disconnects. This prevents the podManager from persistently caching entries for pods that have been acutually deleted in cluster, ensuring that the node's remaining available resources consistent with reality. Consequently, it guarantees the availability of node resources during scheduling and the accuracy of metrics.

**Which issue(s) this PR fixes**:
Fixes #1458 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No