### PR TITLE
feat: update helm chart version to 2.7.1

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -18,10 +18,10 @@ update-versions:
 	echo "FULL_BUILD_VERSION=$(FULL_BUILD_VERSION)"
 	@# Update chart versions to point to the current version.
 	hami_version="$(VERSION)";		\
-	chart_version=` echo $(VERSION) | tr -d 'v' ` ; \
-	sed -i 's/version: "*'$(VERSION_REGEX)'"*/version: '$$chart_version'/g' $(CHART_FILE);		\
-	sed -i 's/appVersion: "*'$(VERSION_REGEX)'"*/appVersion: "'$$chart_version'"/g' $(CHART_FILE);	\
-	sed -i 's/version: "*'$(VERSION_REGEX)'"*/version: "'$$hami_version'"/g' $(VALUES_FILE)
+	chart_version=`echo $(VERSION) | tr -d 'v'`; \
+	CHART_VERSION="$$chart_version" perl -i -pe 's/version: "*$(VERSION_REGEX)"*/version: $$ENV{CHART_VERSION}/g' $(CHART_FILE);		\
+	CHART_VERSION="$$chart_version" perl -i -pe 's/appVersion: "*$(VERSION_REGEX)"*/appVersion: "$$ENV{CHART_VERSION}"/g' $(CHART_FILE);	\
+	HAMI_VERSION="$$hami_version" perl -i -pe 's/imageTag: "*$(VERSION_REGEX)"*/imageTag: "$$ENV{HAMI_VERSION}"/g' $(VALUES_FILE)
 
 lint: update-versions
 	helm lint --with-subcharts --values ./hami/values.yaml ./hami --debug
@@ -31,4 +31,3 @@ package: lint
 
 clean:
 	rm -f *.tgz
-

--- a/charts/hami/Chart.yaml
+++ b/charts/hami/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.7.0"
+appVersion: "2.7.1"
 
 kubeVersion: ">= 1.18.0-0"
 


### PR DESCRIPTION
**What type of PR is this?**

`sed -i` command behaves differently on Linux and macOS, making the use of perl more universal.

**Which issue(s) this PR fixes**:
helm Chart version still is 2.7.0, and  replace values.yaml command need update to `imageTag`

**Special notes for your reviewer**:

helm pull from repo is still 2.6.1, your guys need to update this