### PR TITLE
fix: scheduler may start serving before the resource state synchronization is completed

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -113,11 +113,14 @@ func start() error {
 
 	config.InitDevices()
 	sher = scheduler.NewScheduler()
-	sher.Start()
+	go sher.RegisterFromNodeAnnotations()
+	err := sher.Start()
+	if err != nil {
+		return err
+	}
 	defer sher.Stop()
 
 	// start monitor metrics
-	go sher.RegisterFromNodeAnnotations()
 	go initMetrics(config.MetricsBindAddress)
 
 	// start http server

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -60,6 +61,7 @@ type Scheduler struct {
 	overviewstatus map[string]*NodeUsage
 	eventRecorder  record.EventRecorder
 	quotaManager   *device.QuotaManager
+	started        uint32 // 0 = false, 1 = true
 }
 
 func NewScheduler() *Scheduler {
@@ -68,6 +70,7 @@ func NewScheduler() *Scheduler {
 		stopCh:       make(chan struct{}),
 		cachedstatus: make(map[string]*NodeUsage),
 		nodeNotify:   make(chan struct{}, 1),
+		started:      0,
 	}
 	s.nodeManager = newNodeManager()
 	s.podManager = device.NewPodManager()
@@ -183,7 +186,7 @@ func (s *Scheduler) onDelQuota(obj interface{}) {
 	s.quotaManager.DelQuota(quota)
 }
 
-func (s *Scheduler) Start() {
+func (s *Scheduler) Start() error {
 	klog.InfoS("Starting HAMi scheduler components")
 	s.kubeClient = client.GetClient()
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.kubeClient, time.Hour*1)
@@ -191,23 +194,35 @@ func (s *Scheduler) Start() {
 	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
 	s.quotaLister = informerFactory.Core().V1().ResourceQuotas().Lister()
 
-	informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podEventHandlerRegistration, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    s.onAddPod,
 		UpdateFunc: s.onUpdatePod,
 		DeleteFunc: s.onDelPod,
 	})
-	informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if err != nil {
+		return fmt.Errorf("failed to register pod event handler: %v", err)
+	}
+	nodeEventHandlerRegistration, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { s.doNodeNotify() },
 		DeleteFunc: s.onDelNode,
 	})
-	informerFactory.Core().V1().ResourceQuotas().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if err != nil {
+		return fmt.Errorf("failed to register node event handler: %v", err)
+	}
+	resourceQuotaEventHandlerRegistration, err := informerFactory.Core().V1().ResourceQuotas().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    s.onAddQuota,
 		UpdateFunc: s.onUpdateQuota,
 		DeleteFunc: s.onDelQuota,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to register resource quota event handler: %v", err)
+	}
 	informerFactory.Start(s.stopCh)
 	informerFactory.WaitForCacheSync(s.stopCh)
+	cache.WaitForCacheSync(s.stopCh, podEventHandlerRegistration.HasSynced, nodeEventHandlerRegistration.HasSynced, resourceQuotaEventHandlerRegistration.HasSynced)
 	s.addAllEventHandlers()
+	atomic.StoreUint32(&s.started, 1)
+	return nil
 }
 
 func (s *Scheduler) Stop() {
@@ -230,6 +245,10 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 			klog.V(5).InfoS("Received node notification")
 		case <-ticker.C:
 			klog.V(5).InfoS("Ticker triggered")
+			if atomic.LoadUint32(&s.started) == 0 {
+				klog.V(5).InfoS("Scheduler not started yet, skipping ...")
+				continue
+			}
 		case <-s.stopCh:
 			klog.InfoS("Received stop signal, exiting RegisterFromNodeAnnotations")
 			return


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1495 

**Special notes for your reviewer**:
When we call `AddEventHandler`, it returns a `ResourceEventHandlerRegistration`. By calling `HasSynced` on the `ResourceEventHandlerRegistration`, we can determine whether all the events have been synchronized.

```go
// Opaque interface representing the registration of ResourceEventHandler for
// a SharedInformer. Must be supplied back to the same SharedInformer's
// `RemoveEventHandler` to unregister the handlers.
//
// Also used to tell if the handler is synced (has had all items in the initial
// list delivered).
type ResourceEventHandlerRegistration interface {
	// HasSynced reports if both the parent has synced and all pre-sync
	// events have been delivered.
	HasSynced() bool
}
```
https://github.com/kubernetes/client-go/blob/1bb1ad283de66456c2557dea53d05dcf44b39f50/tools/cache/shared_informer.go#L239C1-L249C2

**Does this PR introduce a user-facing change?**: