### PR TITLE
update memory allocation of Ascend910B4-1 vnpu template

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -202,10 +202,14 @@ data:
       aiCore: 20
       aiCPU: 7
       templates:
+        # NOTE: Names of vnpu template for 910B4-1 are fixed by Ascend runtime and must not be changed.
+        # The memory is used for scheduling so the correct values must be set.
+        # Template vir05_1c_8g actually provides 16GB memory,
         - name: vir05_1c_8g
           memory: 16384
           aiCore: 5
           aiCPU: 1
+        # Template vir10_3c_16g actually provides 32GB memory
         - name: vir10_3c_16g
           memory: 32768
           aiCore: 10


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug

**What this PR does / why we need it**:

The graphics memory value in the VNPU partitioning template for the currently deployed Ascend910B4-1 does not correspond to the actual configuration.

As webhooks modify the amount of  memory requested by Ascend NPU containers based on templates, and the scheduling process subsequently caches the allocated memory, it is necessary to adjust the value of the memory field within the template. This ensures the correct utilisation of the total 64GB GPU memory for allocation purposes.

**Which issue(s) this PR fixes**:
Fixes #1497 

**Special notes for your reviewer**:

We don't know the actual aiCore and aiCPU for each 910B4-1 templates, so here we do not intend to update them. 
Fortunately, these two values bear no relation to the scheduling process and do not affect the actual scheduling outcome. 

The template names for Ascend910B4-1 mustn't be modified until Ascend910B4-1 itself changes its template infos or Ascend-Container-Runtime does this mapping for us when creating vnpu.

**Does this PR introduce a user-facing change?**: 
No