### PR TITLE
Fix scheduler allocate incorrect mig instance

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -45,8 +45,7 @@ func TestGenerateMigTemplate(t *testing.T) {
 				Models: []string{"A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB", "A100-SXM4-40GB"},
 				Geometries: []device.Geometry{
 					{device.MigTemplate{Name: "1g.5gb", Core: 14, Memory: 5120, Count: 7}},
-					{device.MigTemplate{Name: "2g.10gb", Core: 28, Memory: 10240, Count: 3}},
-					{device.MigTemplate{Name: "1g.5gb", Core: 14, Memory: 5120, Count: 1}},
+					{device.MigTemplate{Name: "1g.5gb", Core: 14, Memory: 5120, Count: 1}, device.MigTemplate{Name: "2g.10gb", Core: 28, Memory: 10240, Count: 3}},
 					{device.MigTemplate{Name: "3g.20gb", Core: 42, Memory: 20480, Count: 2}},
 					{device.MigTemplate{Name: "7g.40gb", Core: 100, Memory: 40960, Count: 1}},
 				},
@@ -55,8 +54,7 @@ func TestGenerateMigTemplate(t *testing.T) {
 				Models: []string{"A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"},
 				Geometries: []device.Geometry{
 					{device.MigTemplate{Name: "1g.10gb", Core: 14, Memory: 10240, Count: 7}},
-					{device.MigTemplate{Name: "2g.20gb", Core: 28, Memory: 20480, Count: 3}},
-					{device.MigTemplate{Name: "1g.10gb", Core: 14, Memory: 10240, Count: 1}},
+					{device.MigTemplate{Name: "1g.10gb", Core: 14, Memory: 10240, Count: 1}, device.MigTemplate{Name: "2g.20gb", Core: 28, Memory: 20480, Count: 3}},
 					{device.MigTemplate{Name: "3g.40gb", Core: 42, Memory: 40960, Count: 2}},
 					{device.MigTemplate{Name: "7g.80gb", Core: 100, Memory: 81920, Count: 1}},
 				},
@@ -96,11 +94,12 @@ func TestGenerateMigTemplate(t *testing.T) {
 			containerDev: device.ContainerDevice{
 				Idx:     0,
 				UUID:    "aaaaabbbb[1-1]",
-				Usedmem: 3000,
+				Usedmem: 8000,
 			},
 			expectedPos:   1,
 			expectedReset: true,
 			expectedMig: map[string]int32{
+				"1g.5gb": 1,
 				"2g.10gb": 3,
 			},
 		},
@@ -131,7 +130,7 @@ func TestGenerateMigTemplate(t *testing.T) {
 			expectedPos:   2,
 			expectedReset: false,
 			expectedMig: map[string]int32{
-				"1g.5gb": 8,
+				"1g.5gb": 7,
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently the logic of match mig template is `FirstAvaliable`. However the geometry with multiple types of template is not in order, resulting in incorrect allocation. 
For example, task need 5gb gpu memory will be allocated to 10gb template in the 1g.5gb x 1 and 2g.10gb x 3 geometry for A100 40G.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

The default mig template config has been changed.