### PR TITLE
fix(nodelock): improve parsing of lock annotation

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -255,8 +255,7 @@ func ParseNodeLock(value string) (lockTime time.Time, ns, name string, err error
 	}
 	s := strings.Split(value, NodeLockSep)
 	if len(s) != 3 {
-		lockTime, err = time.Parse(time.RFC3339, value)
-		return lockTime, "", "", err
+		return time.Time{}, "", "", fmt.Errorf("malformed lock annotation: expected 3 parts, got %d from %s", len(s), value)
 	}
 	lockTime, err = time.Parse(time.RFC3339, s[0])
 	return lockTime, s[1], s[2], err


### PR DESCRIPTION
This pull request fixes a bug in the ParseNodeLock function that caused confusing error messages when processing malformed lock annotations. The function is now more robust and will return a specific error if the annotation is not in the expected format, improving the node locking mechanism's correctness by catching and reporting such errors early.