### PR TITLE
Watch and hot reload the updated certificate

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -170,7 +170,7 @@ scheduler:
       # - kube-system
       # - istio-system
     reinvocationPolicy: Never
-    failurePolicy: Fail
+    failurePolicy: Ignore
   ## TLS Certificate Option 1: Use cert-manager to generate self-signed certificate.
   ## If enabled, always takes precedence over options 2.
   certManager:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1572 

**Special notes for your reviewer**:

There is approximately a **one-minute interval** between the actual certificate update and the certwatcher detecting the change and loading the latest certificate content. If a Pod is created during this period, the API server will still report the error `tls: bad certificate` when invoking the webhook. By changing the webhook's `failurePolicy` from `Ignore` to `Fail`, one can prevent the creation of GPU Pods with a schedulerName not matching `hami-scheduler` due to webhook invocation failures.

Logs for `vgpu-scheduler-extender` container:
<img width="1637" height="980" alt="image" src="https://github.com/user-attachments/assets/6539efbe-86ec-4ef2-bc1b-ad93f78a2be8" />

>[!note]
> Notice how the certwatcher detected current TLS certificate is updated and trigger CHMOD events to load the newest tls.crt and tls.key file content

Events for replicaSet which is deployed after certificate for hami-scheduler is updated
<img width="1294" height="208" alt="image" src="https://github.com/user-attachments/assets/51bd577d-2ad4-4f53-bf27-2ff1bc406643" />

>[!note]
> The api-server denied the pod create request from replicaSet because the webhook server returned `tls: bad certificate` error and the `failurePolicy` of webhook is set to `Fail`.
> One minute later, certwatcher has completed certificate hot reloading, the webhook server is functioning normally, and replicaSet can create Pods without issue. Consequently, the creator/user of this workload will not perceive the certificate hot reloading occurring midway.

**Does this PR introduce a user-facing change?**: No