### PR TITLE
fix: clean up metrics data when node is deleted

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -76,6 +76,15 @@ func (m *nodeManager) rmNodeDevices(nodeID string, deviceVendor string) {
 	klog.InfoS("Removing device from node", "nodeName", nodeID, "deviceVendor", deviceVendor)
 }
 
+func (m *nodeManager) rmNode(nodeID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if _, ok := m.nodes[nodeID]; ok {
+		delete(m.nodes, nodeID)
+		klog.InfoS("Removing node from nodeManager", "nodeName", nodeID)
+	}
+}
+
 func (m *nodeManager) GetNode(nodeID string) (*device.NodeInfo, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()


### PR DESCRIPTION
When a node is deleted, the overviewstatus and cachedstatus maps were not being cleaned up, causing metrics to still report data for removed nodes. This fix adds cleanup logic in onDelNode to remove the node from nodeManager and both status maps.

Fixes #1595

**What type of PR is this?**
bug fix
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1595 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: