### PR TITLE
security: add io.LimitReader to scheduler routes to prevent DoS #554

### DIFF
--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/scheduler"
+)
+
+func TestMaxRequestSize(t *testing.T) {
+	hugePayload := strings.Repeat(" ", maxRequestSize+100)
+
+	req := httptest.NewRequest("POST", "/predicate", strings.NewReader(hugePayload))
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := PredicateRoute(s)
+	handler(w, req, nil)
+	respBody := w.Body.String()
+
+	if !strings.Contains(respBody, "EOF") && !strings.Contains(respBody, "unexpected EOF") {
+		t.Errorf("LimitReader failed to trigger EOF. Response body: %s", respBody)
+	} else {
+		t.Logf("Success! Caught expected error: %s", respBody)
+	}
+}
+func TestMaxRequestSizeBind(t *testing.T) {
+	hugePayload := strings.Repeat(" ", maxRequestSize+100)
+	req := httptest.NewRequest("POST", "/bind", strings.NewReader(hugePayload))
+	w := httptest.NewRecorder()
+	s := &scheduler.Scheduler{}
+	handler := Bind(s)
+
+	handler(w, req, nil)
+
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "EOF") && !strings.Contains(respBody, "unexpected EOF") {
+		t.Errorf("LimitReader failed in Bind. Response: %s", respBody)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Hardens the scheduler against Denial of Service (DoS) attacks. It introduces a 1MB `io.LimitReader` to the JSON decoding process in `PredicateRoute` and `Bind` handlers. This prevents resource exhaustion or stack overflows caused by deeply nested structures or excessively large malicious payloads.

**Which issue(s) this PR fixes**:
Fixes #554

**Special notes for your reviewer**:
Included `pkg/scheduler/routes/route_test.go` to verify that oversized payloads are correctly intercepted with an `EOF` error.

**Does this PR introduce a user-facing change?**:
No