### PR TITLE
fix: precedence bug in schedulerName check

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -61,7 +61,7 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Denied("pod has no containers")
 	}
 	if pod.Spec.SchedulerName != "" &&
-		pod.Spec.SchedulerName != corev1.DefaultSchedulerName || !config.ForceOverwriteDefaultScheduler &&
+		(pod.Spec.SchedulerName != corev1.DefaultSchedulerName || !config.ForceOverwriteDefaultScheduler) &&
 		(len(config.SchedulerName) == 0 || pod.Spec.SchedulerName != config.SchedulerName) {
 		klog.Infof(template+" - Pod already has different scheduler assigned", req.Namespace, req.Name, req.UID)
 		return admission.Allowed("pod already has different scheduler assigned")


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Fixes schedulerName check precedence in the admission webhook so pods with empty spec.schedulerName are not incorrectly treated as “already has different scheduler” when force-overwrite-default-scheduler=false.

Which issue(s) this PR fixes:
N/A

Special notes for your reviewer:
AI assistance disclosure: I used AI (Codex/GPT) to help analyze the code and build unit test; I reviewed and validated the final fix.

Does this PR introduce a user-facing change?:
Yes. It changes webhook behavior for pods without schedulerName when force-overwrite-default-scheduler=false.