### PR TITLE
fix: resolve cardinality explosion in Device_memory_desc_of_container

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -444,15 +444,15 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 		}
 
 		if err := sendMetric(ch, ctrDeviceMemoryContextDesc, prometheus.GaugeValue, float64(memoryContextSize), labels...); err != nil {
-			klog.Errorf("Failed to send context size metric: %v", err)
+			klog.Errorf("Failed to send Device Memory context size metric: %v", err)
 			return err
 		}
 		if err := sendMetric(ch, ctrDeviceMemoryModuleDesc, prometheus.GaugeValue, float64(memoryModuleSize), labels...); err != nil {
-			klog.Errorf("Failed to send module size metric: %v", err)
+			klog.Errorf("Failed to send Device Memory module size metric: %v", err)
 			return err
 		}
 		if err := sendMetric(ch, ctrDeviceMemoryBufferDesc, prometheus.GaugeValue, float64(memoryBufferSize), labels...); err != nil {
-			klog.Errorf("Failed to send buffer size metric: %v", err)
+			klog.Errorf("Failed to send Device Memory buffer size metric: %v", err)
 			return err
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a time series cardinality explosion in Prometheus. 
The metric `Device_memory_desc_of_container` was using dynamic memory values as labels. 
I have removed these labels and moved the memory data to the actual metric value.

**Which issue(s) this PR fixes**:
Fixes #1623

**Special notes for your reviewer**:
I removed the unused variables `memoryContextSize`, `memoryModuleSize`, `memoryBufferSize`, and `memoryOffset` to satisfy the Go compiler after removing them from the labels.

**Does this PR introduce a user-facing change?**:
No