### PR TITLE
fix: handle GetMemoryInfo ERROR_NOT_SUPPORTED for unified memory GPUs

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -22,6 +22,7 @@ data:
       defaultMemory: 0
       defaultCores: 0
       defaultGPUNum: 1
+      preConfiguredDeviceMemory: {{ .Values.devicePlugin.preConfiguredDeviceMemory | default 0 }}
       memoryFactor: 1
       deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
       deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -302,6 +302,10 @@ devicePlugin:
   deviceSplitCount: 10
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
+  # Pre-configured device memory in MB for GPUs that don't support memory query (e.g., unified memory architecture GPUs like NVIDIA GB10/DGX Spark).
+  # Set to 0 to use auto-detection (default). For unified memory GPUs, set to the total GPU memory (e.g., 131072 for 128GB).
+  # Can be overridden per-node via nodeConfiguration.config.
+  preConfiguredDeviceMemory: 0
   # Node configuration for device plugin, Priority: externalConfigName > config > default config
   nodeConfiguration:
     # If you want to use a custom config.json, you can set the content here.
@@ -314,6 +318,7 @@ devicePlugin:
             "operatingmode": "hami-core",
             "devicememoryscaling": 1,
             "devicesplitcount": 10,
+            "preconfigureddevicememory": 0,
             "migstrategy": "none",
             "filterdevices": {
               "uuid": [],

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -284,6 +284,10 @@ func (cc ClusterManagerCollector) collectGPUDeviceMetrics(ch chan<- prometheus.M
 
 func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
 	memory, ret := hdev.GetMemoryInfo()
+	if ret == nvml.ERROR_NOT_SUPPORTED {
+		klog.V(3).Infof("Memory metrics not supported for device %d (unified memory architecture), skipping", index)
+		return nil
+	}
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("nvml get memory error ret=%d", ret)
 	}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -124,9 +124,10 @@ type NvidiaConfig struct {
 
 // These configs can be specified for each node by using Nodeconfig.
 type NodeDefaultConfig struct {
-	DeviceSplitCount    *uint    `yaml:"deviceSplitCount" json:"devicesplitcount"`
-	DeviceMemoryScaling *float64 `yaml:"deviceMemoryScaling" json:"devicememoryscaling"`
-	DeviceCoreScaling   *float64 `yaml:"deviceCoreScaling" json:"devicecorescaling"`
+	DeviceSplitCount          *uint    `yaml:"deviceSplitCount" json:"devicesplitcount"`
+	DeviceMemoryScaling       *float64 `yaml:"deviceMemoryScaling" json:"devicememoryscaling"`
+	DeviceCoreScaling         *float64 `yaml:"deviceCoreScaling" json:"devicecorescaling"`
+	PreConfiguredDeviceMemory *int64   `yaml:"preConfiguredDeviceMemory" json:"preconfigureddevicememory"`
 	// LogLevel is LIBCUDA_LOG_LEVEL value
 	LogLevel *LibCudaLogLevel `yaml:"libCudaLogLevel" json:"libcudaloglevel"`
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

NVIDIA GB10 (DGX Spark) uses a unified memory architecture where CPU and GPU share the same physical memory. On these GPUs, `nvmlDeviceGetMemoryInfo()` returns `ERROR_NOT_SUPPORTED` instead of memory information. The current code treats any non-SUCCESS return as fatal and calls `panic(0)`, which crashes the entire device plugin daemonset and prevents the node from registering any GPU devices.

This PR handles `ERROR_NOT_SUPPORTED` gracefully by:
1. **Device registration** (`register.go`): Falls back to a new `defaultDeviceMemory` config value (in MiB). If not configured, the device is skipped with an error log instead of panicking.
2. **Metrics collection** (`metrics.go`): Skips memory metrics for unsupported devices instead of returning an error every scrape cycle.
3. **Config plumbing**: Adds `defaultDeviceMemory` field to `NvidiaConfig`, Helm chart configmap, and `values.yaml`.

**Which issue(s) this PR fixes**:

Fixes #1511

**Special notes for your reviewer**:

AI assistance disclosure: This PR was developed with Claude Code assisting in code analysis and review. The fix was designed, implemented, and validated by a human on real GB10 hardware.

Tested on real hardware: NVIDIA DGX Spark (GB10, ARM64, Driver 580.95.05, CUDA 13.0, Ubuntu 24.04, K8s v1.34.1).

| Scenario | Result |
|----------|--------|
| Unpatched v2.8.0 on GB10 | `panic: 0` at `register.go:115` ❌ |
| Patched with `defaultDeviceMemory: 131072` | Device registered, pod scheduled, vGPU isolation works ✅ |
| Patched without `defaultDeviceMemory` | Device skipped gracefully, no crash ✅ |

Usage — for unified memory GPUs, set `defaultDeviceMemory` to the total GPU memory in MiB:

```yaml
# values.yaml
devicePlugin:
  defaultDeviceMemory: 131072  # 128 GiB for GB10
```

Without this config, the device will be skipped (not registered) but the plugin won't crash.

**Does this PR introduce a user-facing change?**:

Yes. Adds a new optional Helm value `devicePlugin.defaultDeviceMemory` (default: `0`). Only needed for GPUs with unified memory architecture (e.g., NVIDIA GB10/DGX Spark) where `nvmlDeviceGetMemoryInfo()` is not supported. When set, the device plugin uses this value as the total device memory fallback instead of panicking.