### PR TITLE
fix: failing readiness probe when replica > 1

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -85,6 +85,14 @@ spec:
           image: {{ include "hami.scheduler.extender.image" . }}
           imagePullPolicy: {{ .Values.scheduler.extender.image.pullPolicy }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           {{- if .Values.scheduler.nodeLockExpire }}
             - name: HAMI_NODELOCK_EXPIRE
               value: "{{ .Values.scheduler.nodeLockExpire }}"

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -32,5 +32,6 @@ spec:
       protocol: TCP
   selector:
     app.kubernetes.io/component: hami-scheduler
+    hami.io/scheduler-role: leader
     {{- include "hami-vgpu.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -147,14 +147,11 @@ func ReadyzRoute(s *scheduler.Scheduler) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		klog.Infoln("Readiness check endpoint hit")
 
-		ok := s.GetLeaderManager().IsLeader()
-		if !ok {
-			klog.Infoln("Not leader yet")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
+		if s.GetLeaderManager().IsLeader() {
+			klog.Infoln("This scheduler extender replica is the leader")
+		} else {
+			klog.Infoln("This scheduler extender replica has not become the leader yet")
 		}
-
-		klog.Infoln("Scheduler extender is leader")
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -353,11 +354,45 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 	// 2. lost leadership during or after register: synced will set to true after finishing register, and callback will set it to false again after lock is acquired by callback
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	// Only do registration when we are leader
-	if !s.leaderManager.IsLeader() {
+
+	isLeader := s.leaderManager.IsLeader()
+	pod, err := s.podLister.Pods(os.Getenv("POD_NAMESPACE")).Get(os.Getenv("POD_NAME"))
+	if err != nil {
+		klog.Fatal(err, "Failed to get hami scheduler pod from lister", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
+	}
+	if isLeader {
+		// Current pod is leader, add or change the role label to leader
+		if pod.Labels == nil || pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueLeader {
+			err := util.PatchPodLabels(
+				os.Getenv("POD_NAMESPACE"),
+				os.Getenv("POD_NAME"),
+				map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueLeader},
+			)
+			if err != nil {
+				klog.ErrorS(err, "Failed to patch leader label to pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
+			} else {
+				klog.V(4).InfoS("Successfully patched leader label to hami scheduler pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
+			}
+		}
+	} else {
+		// Current pod is not leader, add or change the role label to follower
+		if pod.Labels != nil && pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueFollower {
+			err := util.PatchPodLabels(
+				os.Getenv("POD_NAMESPACE"),
+				os.Getenv("POD_NAME"),
+				map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueFollower},
+			)
+			if err != nil {
+				klog.ErrorS(err, "Failed to patch leader label from pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
+			} else {
+				klog.V(4).InfoS("Successfully add follower label to hami scheduler pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
+			}
+		}
+		// Only do registration when we are leader
 		klog.V(5).InfoS("Scheduler is not leader yet, skipping ...")
 		return
 	}
+
 	rawNodes, err := s.nodeLister.List(labelSelector)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list nodes with selector", "selector", labelSelector.String())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -355,40 +355,11 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	// Only do registration when we are leader.
 	isLeader := s.leaderManager.IsLeader()
-	pod, err := s.podLister.Pods(os.Getenv("POD_NAMESPACE")).Get(os.Getenv("POD_NAME"))
-	if err != nil {
-		klog.Fatal(err, "Failed to get hami scheduler pod from lister", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
-	}
 	if isLeader {
-		// Current pod is leader, add or change the role label to leader
-		if pod.Labels == nil || pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueLeader {
-			err := util.PatchPodLabels(
-				os.Getenv("POD_NAMESPACE"),
-				os.Getenv("POD_NAME"),
-				map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueLeader},
-			)
-			if err != nil {
-				klog.ErrorS(err, "Failed to patch leader label to pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
-			} else {
-				klog.V(4).InfoS("Successfully patched leader label to hami scheduler pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
-			}
-		}
+		s.updateSchedulerLabel()
 	} else {
-		// Current pod is not leader, add or change the role label to follower
-		if pod.Labels != nil && pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueFollower {
-			err := util.PatchPodLabels(
-				os.Getenv("POD_NAMESPACE"),
-				os.Getenv("POD_NAME"),
-				map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueFollower},
-			)
-			if err != nil {
-				klog.ErrorS(err, "Failed to patch leader label from pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
-			} else {
-				klog.V(4).InfoS("Successfully add follower label to hami scheduler pod", "namespace", os.Getenv("POD_NAMESPACE"), "pod", os.Getenv("POD_NAME"))
-			}
-		}
-		// Only do registration when we are leader
 		klog.V(5).InfoS("Scheduler is not leader yet, skipping ...")
 		return
 	}
@@ -457,6 +428,62 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 
 	// Set synced to true only after getNodeUsage() succeeds
 	s.synced = true
+}
+
+func (s *Scheduler) updateSchedulerLabel() {
+	schedulerSelector := labels.Set(map[string]string{util.HAMiComponentLabel: util.HAMiComponentScheduler}).AsSelector()
+	schedulerPods, err := s.podLister.Pods(os.Getenv("POD_NAMESPACE")).List(schedulerSelector)
+	if err != nil {
+		klog.Fatalf("Failed to list hami scheduler pods from lister: namespace %s selector %s",
+			os.Getenv("POD_NAMESPACE"),
+			schedulerSelector.String(),
+		)
+	}
+
+	for idx := range schedulerPods {
+		pod := schedulerPods[idx]
+		if pod.Name == os.Getenv("POD_NAME") {
+			// The pod is leader, apply the leader role label to it.
+			if pod.Labels == nil || pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueLeader {
+				err := util.PatchPodLabels(
+					pod.Namespace,
+					pod.Name,
+					map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueLeader},
+				)
+				if err != nil {
+					klog.Fatalf("Failed to patch the leader label to hami scheduler pod: namespace %s pod %s",
+						pod.Namespace,
+						pod.Name,
+					)
+				} else {
+					klog.V(4).InfoS("Successfully patched leader label to hami scheduler pod",
+						"namespace", pod.Namespace,
+						"pod", pod.Name,
+					)
+				}
+			}
+		} else {
+			// The pod is not the leader, apply the follower role label to it.
+			if pod.Labels == nil || pod.Labels[util.HAMiRoleLabel] != util.HAMiRoleLabelValueFollower {
+				err := util.PatchPodLabels(
+					pod.Namespace,
+					pod.Name,
+					map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueFollower},
+				)
+				if err != nil {
+					klog.ErrorS(err, "Failed to patch leader label from pod",
+						"namespace", pod.Namespace,
+						"pod", pod.Name,
+					)
+				} else {
+					klog.V(4).InfoS("Successfully patched follower label to hami scheduler pod",
+						"namespace", pod.Namespace,
+						"pod", pod.Name,
+					)
+				}
+			}
+		}
+	}
 }
 
 func (s *Scheduler) WaitForCacheSync(ctx context.Context) bool {

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -45,6 +45,11 @@ const (
 	HAMiRoleLabelValueLeader = "leader"
 	// LeaderRoleLabelValueFollower is the label value used to identify the follower pod.
 	HAMiRoleLabelValueFollower = "follower"
+
+	// HAMiSchedulerLabelValue is the label key to identify the component of HAMi in Kubernetes.
+	HAMiComponentLabel = "app.kubernetes.io/component"
+	// HAMiComponentScheduler the label value for hami-scheduler.
+	HAMiComponentScheduler = "hami-scheduler"
 )
 
 var (

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -38,6 +38,13 @@ const (
 	NodeNameEnvName = "NODE_NAME"
 	TaskPriority    = "CUDA_TASK_PRIORITY"
 	CoreLimitSwitch = "GPU_CORE_UTILIZATION_POLICY"
+
+	// LeaderRoleLabel is the label key used to identify the leader pod.
+	HAMiRoleLabel = "hami.io/scheduler-role"
+	// LeaderRoleLabelValueLeader is the label value used to identify the leader pod.
+	HAMiRoleLabelValueLeader = "leader"
+	// LeaderRoleLabelValueFollower is the label value used to identify the follower pod.
+	HAMiRoleLabelValueFollower = "follower"
 )
 
 var (

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -183,6 +183,33 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	return err
 }
 
+func PatchPodLabels(namespace, name string, labels map[string]string) error {
+	type patchMetadata struct {
+		Labels map[string]string `json:"labels,omitempty"`
+	}
+	type patchPod struct {
+		Metadata patchMetadata `json:"metadata"`
+	}
+
+	p := patchPod{
+		Metadata: patchMetadata{
+			Labels: labels,
+		},
+	}
+
+	bytes, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	klog.V(5).InfoS("Patching pod labels", "namespace", namespace, "name", name, "labels", labels)
+	_, err = client.GetClient().CoreV1().Pods(namespace).
+		Patch(context.Background(), name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to patch pod labels", "namespace", namespace, "name", name)
+	}
+	return err
+}
+
 func InitKlogFlags() *flag.FlagSet {
 	// Init log flags
 	flagset := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -517,3 +517,95 @@ func Test_AllContainersCreated(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchPodLabels(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+
+	// Create test pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{},
+		},
+	}
+
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+
+	tests := []struct {
+		name      string
+		namespace string
+		podName   string
+		labels    map[string]string
+		wantErr   bool
+	}{
+		{
+			name:      "patch with valid labels",
+			namespace: "default",
+			podName:   "test-pod",
+			labels: map[string]string{
+				HAMiRoleLabel: HAMiRoleLabelValueLeader,
+			},
+			wantErr: false,
+		},
+		{
+			name:      "update existing label",
+			namespace: "default",
+			podName:   "test-pod",
+			labels: map[string]string{
+				HAMiRoleLabel: HAMiRoleLabelValueFollower,
+			},
+			wantErr: false,
+		},
+		{
+			name:      "add multiple labels",
+			namespace: "default",
+			podName:   "test-pod",
+			labels: map[string]string{
+				"test-key1": "test-value1",
+				"test-key2": "test-value2",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "patch non-existent pod",
+			namespace: "default",
+			podName:   "non-existent",
+			labels: map[string]string{
+				HAMiRoleLabel: HAMiRoleLabelValueLeader,
+			},
+			wantErr: true,
+		},
+		{
+			name:      "patch non-existent namespace",
+			namespace: "non-existent",
+			podName:   "test-pod",
+			labels: map[string]string{
+				HAMiRoleLabel: HAMiRoleLabelValueLeader,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := PatchPodLabels(tt.namespace, tt.podName, tt.labels)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchPodLabels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// If success, verify the labels were patched
+			if err == nil {
+				updatedPod, getErr := client.KubeClient.CoreV1().Pods(tt.namespace).Get(context.TODO(), tt.podName, metav1.GetOptions{})
+				if getErr != nil {
+					t.Errorf("Failed to get updated pod: %v", getErr)
+					return
+				}
+				for k, v := range tt.labels {
+					if updatedPod.Labels[k] != v {
+						t.Errorf("Label %s = %s, want %s", k, updatedPod.Labels[k], v)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
As described in #1617, the PR #1553 brings the readinessProbe check for vgpu-scheduler-extender container in hami-scheduler Pod, however it the current implementation don't work well with the rolling update strategy of deployment.

So in this PR, A new label is introduced to make sure that only the leader is selected by the service

**Which issue(s) this PR fixes**:
Fixes #1617

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**AI Assistant disclosure**:
I used kimi-cli to generate the testing code