### PR TITLE
vGPUmonitor: skip devices with invalid UTF-8 UUID during container init

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	dp "github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin"
@@ -500,6 +501,10 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			return fmt.Errorf("invalid UUID length for device %d", i)
 		}
 		uuid = uuid[0:40] // Ensure UUID is truncated to 40 characters
+		if !utf8.ValidString(uuid) {
+			klog.Warningf("Device %d in Pod %s/%s, Container %s has invalid UTF-8 UUID (shared memory not yet initialised); skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name)
+			continue
+		}
 
 		// Collect device metrics
 		memoryTotal := c.Info.DeviceMemoryTotal(i)


### PR DESCRIPTION
## Problem

`collectContainerMetrics` reads the GPU UUID from shared memory written by `libvgpu.so`
inside the container. Before CUDA has fully initialised, this memory is uninitialised/zeroed.
The raw bytes are sliced to 40 characters and passed directly as a Prometheus label value.
If the bytes are not valid UTF-8, `prometheus.NewConstMetric` returns an error and
per-container metrics are silently dropped for the entire scrape cycle.

Unlike the volcano-vgpu-device-plugin (which used `MustNewConstMetric` and panicked — see
Project-HAMi/volcano-vgpu-device-plugin#110), this code returns an error rather than
crashing, but metrics are still lost on every scrape until the container finishes initialising.

## Fix

After truncating the UUID to 40 characters, validate it is valid UTF-8 using
`unicode/utf8.ValidString`. If not, log a warning and `continue` to the next device.
On the next scrape cycle, once `libvgpu.so` has written the real UUID to shared memory,
the metric will be collected normally.

## Testing

- Reproduces during container initialisation on any node running HAMi-managed GPU workloads
- Fix prevents metric errors during init; device is retried automatically on the next scrape

Related: Project-HAMi/volcano-vgpu-device-plugin#110