### PR TITLE
Helm - Render nvidia.overwriteEnv from values with a default of false.

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -18,7 +18,7 @@ data:
       resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
       resourceCoreName: {{ .Values.resourceCores }}
       resourcePriorityName: {{ .Values.resourcePriority }}
-      overwriteEnv: false
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       defaultMemory: 0
       defaultCores: 0
       defaultGPUNum: 1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a Helm chart bug where scheduler.overwriteEnv was effectively ignored because templates/scheduler/device-configmap.yaml hardcoded nvidia.overwriteEnv: false. In mixed-GPU nodes, that caused HAMi scheduler allocation metadata (e.g. a 3060 UUID selected via nvidia.com/use-gputype) to diverge from the GPU actually exposed in-container (NVIDIA_VISIBLE_DEVICES/nvidia-smi, often a different model like 3090). This change makes overwriteEnv value-driven from chart values, so operators can set scheduler.overwriteEnv: "true" and ensure runtime GPU visibility matches scheduler allocation, enabling reliable model-based scheduling without UUID pinning.

**Which issue(s) this PR fixes**:
Fixes #1705

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No