### PR TITLE
chore: using LeaderElectionConfiguration for kubernetes v1.23 and newer version

### DIFF
--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -19,7 +19,9 @@ data:
     {{- end }}
     kind: KubeSchedulerConfiguration
     leaderElection:
-      leaderElect: false
+      leaderElect: {{ .Values.scheduler.leaderElect }}
+      resourceName: {{ .Values.schedulerName }}
+      resourceNamespace: {{ include "hami-vgpu.namespace" . }}
     profiles:
     - schedulerName: {{ .Values.schedulerName }}
     extenders:

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -20,8 +20,8 @@ data:
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: {{ .Values.scheduler.leaderElect }}
-      resourceName: {{ .Values.schedulerName }}
-      resourceNamespace: {{ include "hami-vgpu.namespace" . }}
+      resourceName: {{ .Values.schedulerName | quote }}
+      resourceNamespace: {{ include "hami-vgpu.namespace" . | quote }}
     profiles:
     - schedulerName: {{ .Values.schedulerName }}
     extenders:

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -55,10 +55,10 @@ spec:
             {{- range .Values.scheduler.kubeScheduler.extraArgs }}
             - {{ . }}
             {{- end }}
-            {{- end }}
             - --leader-elect={{ .Values.scheduler.leaderElect }}
             - --leader-elect-resource-name={{ .Values.schedulerName }}
             - --leader-elect-resource-namespace={{ include "hami-vgpu.namespace" . }}
+            {{- end }}
           resources:
           {{- toYaml .Values.scheduler.kubeScheduler.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
**What type of PR is this?**
/cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
The `LeaderElection` field in `KubeSchedulerConfiguration` are conflict with the command line options for kube-scheduler. I remove the the command line options for kubernetes newer than v1.22.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: