### PR TITLE
Configure ASCEND_VISIBLE_DEVICES env for container and RuntimeClassName for pods

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -294,6 +294,8 @@ data:
       memoryCapacity: 32768
       memoryFactor: 1
       aiCore: 30
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         - name: vir02
           memory: 2184
@@ -316,6 +318,8 @@ data:
       memoryFactor: 1
       aiCore: 24
       aiCPU: 6
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         - name: vir03_1c_8g
           memory: 8192
@@ -338,6 +342,8 @@ data:
       memoryFactor: 1
       aiCore: 20
       aiCPU: 7
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         - name: vir05_1c_16g
           memory: 16384
@@ -356,6 +362,8 @@ data:
       memoryFactor: 1
       aiCore: 20
       aiCPU: 7
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         # NOTE: Names of vnpu template for 910B4-1 are fixed by Ascend runtime and must not be changed.
         # The memory is used for scheduling so the correct values must be set.
@@ -378,6 +386,8 @@ data:
       memoryFactor: 1
       aiCore: 20
       aiCPU: 7
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         - name: vir05_1c_8g
           memory: 8192
@@ -396,6 +406,8 @@ data:
       memoryFactor: 1
       aiCore: 8
       aiCPU: 7
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
       templates:
         - name: vir01
           memory: 3072
@@ -417,5 +429,7 @@ data:
       memoryCapacity: 65536
       aiCore: 20
       aiCPU: 7
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
   {{ end }}
 {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -483,6 +483,7 @@ devices:
     nodeSelector:
       ascend: "on"
     tolerations: []
+    runtimeClassName: ""  # Name of the runtime class to set the Pod .spec.runtimeClassName utilizing Ascend NPU
     customresources:
       - huawei.com/Ascend910A
       - huawei.com/Ascend910A-memory

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -155,6 +155,11 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
+
+	// Set runtime class name if it is not set by user and the runtime class name is configured
+	if p.Spec.RuntimeClassName == nil && dev.config.RuntimeClassName != "" {
+		p.Spec.RuntimeClassName = &dev.config.RuntimeClassName
+	}
 	return true, nil
 }
 

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -113,6 +113,12 @@ func (dev *Devices) CommonWord() string {
 func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceName)]
 	if !ok {
+		if dev.config.OverwriteEnv {
+			ctr.Env = append(ctr.Env, corev1.EnvVar{
+				Name:  "ASCEND_VISIBLE_DEVICES",
+				Value: "",
+			})
+		}
 		return false, nil
 	}
 

--- a/pkg/device/ascend/vnpu.go
+++ b/pkg/device/ascend/vnpu.go
@@ -33,6 +33,7 @@ type VNPUConfig struct {
 	MemoryFactor       int32      `yaml:"memoryFactor"`
 	AICore             int32      `yaml:"aiCore"`
 	AICPU              int32      `yaml:"aiCPU"`
+	RuntimeClassName   string     `yaml:"runtimeClassName"`
 	OverwriteEnv       bool       `yaml:"overwriteEnv"`
 	Templates          []Template `yaml:"templates"`
 }

--- a/pkg/device/ascend/vnpu.go
+++ b/pkg/device/ascend/vnpu.go
@@ -33,5 +33,6 @@ type VNPUConfig struct {
 	MemoryFactor       int32      `yaml:"memoryFactor"`
 	AICore             int32      `yaml:"aiCore"`
 	AICPU              int32      `yaml:"aiCPU"`
+	OverwriteEnv       bool       `yaml:"overwriteEnv"`
 	Templates          []Template `yaml:"templates"`
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind feature

**What this PR does / why we need it**:

In certain scenarios—such as building images from Ascend base images or running `docker commit` on containers in Docker-based Kubernetes clusters—the resulting image may **inadvertently inherit Ascend-related environment variables**, such as `ASCEND_VISIBLE_DEVICES`. If such an image is later used to create a Pod on a node where the default container runtime is configured as `ascend-docker-runtime`, the container may gain access to unexpected Ascend NPU devices—even if the Pod **did not request any Ascend resources**.

To improve security and resource isolation, this PR introduces two key enhancements:

1. **Explicitly set `RuntimeClassName` for Pods that request Ascend resources**  
   The hami-scheduler webhook now automatically injects `runtimeClassName: ascend-docker-runtime` into Pods that declare Ascend resource requests. This ensures that only Pods genuinely requiring Ascend devices use the `ascend-docker-runtime`, while all other Pods continue using the default `runc` runtime—preventing non-Ascend workloads from accidentally mounting NPU devices.

2. **Forcefully override `ASCEND_VISIBLE_DEVICES` for containers that do *not* request Ascend resources**  
   For any container that **does not request Ascend resources** (regardless of whether its image contains `ASCEND_VISIBLE_DEVICES`), this PR injects the environment variable `ASCEND_VISIBLE_DEVICES=""`. Since `ascend-docker-runtime` parses this variable **from the end of the list backward**, this override effectively hides all NPU devices from the container—even if it mistakenly uses `ascend-docker-runtime`.

> ⚠️ Note: This PR **does NOT address the `ASCEND_VNPU_SPECS` inheritance issue**, which can cause incorrect VNPU specifications to be applied. That remains a known limitation and must be mitigated through operational practices (see details below).

**Which issue(s) this PR fixes**:

(Insert linked issue number(s) here)

**Special notes for your reviewer**:

### Background: Why Ascend Environment Variable Pollution Matters

In real-world usage, users may run `docker commit` on a running Ascend container to create a new image. If that container was allocated a VNPU (e.g., `vir05_1c_8g`), its runtime environment variables—particularly `ASCEND_VNPU_SPECS` and `ASCEND_VISIBLE_DEVICES`—get persisted into the image configuration. When this image is later used to launch a new Pod, even if the new Pod requests a different VNPU template (e.g., `vir10_3c_16g`) or no VNPU at all (e.g., requesting a full physical card), device assignment may still reflect the old specification due to environment variable inheritance.

#### Reproduction steps:
1. Cluster uses Docker as the container runtime;
2. A container is scheduled with an Ascend VNPU (e.g., `vir05_1c_8g`);
3. The user runs `docker commit` on this container to produce a new image;
4. A new Pod is created from this image, requesting either:
   - A different VNPU template (e.g., `vir10_3c_16g`), or
   - No VNPU slicing at all (full-card allocation).

**Observed behavior**: The new container sees a VNPU with spec `vir05_1c_8g`, not the requested one.

#### Root cause:
- Step 2 causes the container to have `ASCEND_VNPU_SPECS=vir05_1c_8g`;
- Steps 1 + 3 persist this variable into the committed image’s `Config.Env`;
- In step 4, although the device plugin and scheduler inject a new `ASCEND_VNPU_SPECS` value (appended to the end of the environment list), `ascend-docker-runtime` **parses `ASCEND_VNPU_SPECS` from front to back**, so it uses the stale value from the image.

> 📌 Additional note: `ascend-docker-runtime` treats `ASCEND_VNPU_SPECS` in three states:
> - **Undefined**: no VNPU is created;
> - **Valid value** (e.g., `vir05_1c_8g`): creates VNPU per template;
> - **Invalid value** (including empty string `""`): fails with `cannot parse param`.
>
> Therefore, users **cannot "unset" the VNPU spec by overriding it with an empty string**—only true absence (undefined) disables VNPU creation. Since Kubernetes only supports *appending* environment variables (not removing existing ones from the image), this issue **cannot be resolved via runtime injection alone**.

#### Scope of this PR
- ✅ **Addresses `ASCEND_VISIBLE_DEVICES` pollution**: By forcing it to `""`, non-Ascend containers cannot see any NPU devices.
- ✅ **Prevents non-Ascend Pods from using `ascend-docker-runtime`**: Explicit `RuntimeClassName` ensures correct runtime binding.
- ❌ **Does NOT fix `ASCEND_VNPU_SPECS` inheritance**: This requires operational guardrails (e.g., prohibiting `commit` on Ascend containers) or future runtime enhancements.

### Environment Variable Parsing Behavior

When Kubernetes starts a container, environment variables are appended to the `Config.Env` list in this order:
1. Original variables from the image;
2. Variables injected by the device plugin via kubelet;
3. Variables defined in the Pod’s `container.env`.

However, `ascend-docker-runtime` interprets them as follows:
- `ASCEND_VISIBLE_DEVICES`: parsed **from back to front** → later values override earlier ones (this PR leverages this);
- All other variables (including `ASCEND_VNPU_SPECS`): parsed **from front to back** → image-defined values take precedence.

Thus, this PR safely mitigates visibility risks for `ASCEND_VISIBLE_DEVICES`, but cannot resolve `ASCEND_VNPU_SPECS` misconfiguration.

**Does this PR introduce a user-facing change?**: No