### PR TITLE
fix: suppress scheduler cleanup noise for unrelated vendors

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -393,6 +393,15 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 			klog.V(5).InfoS("Device health check result", "nodeName", val.Name, "deviceVendor", devhandsk, "health", health, "needUpdate", needUpdate)
 
 			if !health {
+				existingNode, getNodeErr := s.GetNode(val.Name)
+				if getNodeErr != nil {
+					klog.V(5).InfoS("Skipping device cleanup for node not present in scheduler cache", "nodeName", val.Name, "deviceVendor", devhandsk)
+					continue
+				}
+				if _, ok := existingNode.Devices[devhandsk]; !ok {
+					klog.V(5).InfoS("Skipping device cleanup for vendor not present in scheduler cache", "nodeName", val.Name, "deviceVendor", devhandsk)
+					continue
+				}
 				klog.Warning("Device is unhealthy, cleaning up node", "nodeName", val.Name, "deviceVendor", devhandsk)
 				err := devInstance.NodeCleanUp(val.Name)
 				if err != nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -913,6 +915,129 @@ func Test_RegisterFromNodeAnnotations_NIL(t *testing.T) {
 			}
 		})
 	}
+}
+
+type registerMockDevice struct {
+	nodeDevices   []*device.DeviceInfo
+	getNodeErr    error
+	health        bool
+	needUpdate    bool
+	nodeCleanedUp int
+}
+
+func (m *registerMockDevice) CommonWord() string { return "mock-vendor" }
+func (m *registerMockDevice) MutateAdmission(_ *corev1.Container, _ *corev1.Pod) (bool, error) {
+	return false, nil
+}
+func (m *registerMockDevice) CheckHealth(_ string, _ *corev1.Node) (bool, bool) {
+	return m.health, m.needUpdate
+}
+func (m *registerMockDevice) NodeCleanUp(_ string) error {
+	m.nodeCleanedUp++
+	return nil
+}
+func (m *registerMockDevice) GetResourceNames() device.ResourceNames { return device.ResourceNames{} }
+func (m *registerMockDevice) GetNodeDevices(_ corev1.Node) ([]*device.DeviceInfo, error) {
+	return m.nodeDevices, m.getNodeErr
+}
+func (m *registerMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error        { return nil }
+func (m *registerMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error { return nil }
+func (m *registerMockDevice) GenerateResourceRequests(_ *corev1.Container) device.ContainerDeviceRequest {
+	return device.ContainerDeviceRequest{}
+}
+func (m *registerMockDevice) PatchAnnotations(_ *corev1.Pod, _ *map[string]string, _ device.PodDevices) map[string]string {
+	return nil
+}
+func (m *registerMockDevice) ScoreNode(_ *corev1.Node, _ device.PodSingleDevice, _ []*device.DeviceUsage, _ string) float32 {
+	return 0
+}
+func (m *registerMockDevice) AddResourceUsage(_ *corev1.Pod, _ *device.DeviceUsage, _ *device.ContainerDevice) error {
+	return nil
+}
+func (m *registerMockDevice) Fit(_ []*device.DeviceUsage, _ device.ContainerDeviceRequest, _ *corev1.Pod, _ *device.NodeInfo, _ *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
+	return false, nil, ""
+}
+
+func TestRegisterSkipsCleanupForUntrackedVendor(t *testing.T) {
+	oldDevicesMap := device.DevicesMap
+	defer func() { device.DevicesMap = oldDevicesMap }()
+
+	mockDev := &registerMockDevice{
+		nodeDevices: []*device.DeviceInfo{},
+		health:      false,
+		needUpdate:  true,
+	}
+	device.DevicesMap = map[string]device.Devices{
+		"mock-vendor": mockDev,
+	}
+
+	s := NewScheduler()
+	s.stopCh = make(chan struct{})
+	client.KubeClient = fake.NewClientset()
+	s.kubeClient = client.KubeClient
+
+	t.Setenv("POD_NAMESPACE", "default")
+	t.Setenv("POD_NAME", "scheduler-0")
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+	}
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(node)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scheduler-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				util.HAMiComponentLabel: util.HAMiComponentScheduler,
+			},
+		},
+	}
+	_, err = client.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+	require.NoError(t, err)
+
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	s.addNode("node-1", &device.NodeInfo{
+		ID:   "node-1",
+		Node: node.DeepCopy(),
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID:           "GPU-0",
+				Index:        0,
+				Count:        1,
+				Devmem:       1024,
+				Devcore:      100,
+				Type:         nvidia.NvidiaGPUDevice,
+				Health:       true,
+				DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+
+	atomic.StoreUint32(&s.started, 1)
+	s.register(labels.Everything(), map[string]bool{})
+
+	assert.Equal(t, mockDev.nodeCleanedUp, 0)
+
+	nodeInfo, err := s.GetNode("node-1")
+	require.NoError(t, err)
+	_, ok := nodeInfo.Devices[nvidia.NvidiaGPUDevice]
+	assert.Equal(t, ok, true)
+	_, ok = nodeInfo.Devices["mock-vendor"]
+	assert.Equal(t, ok, false)
 }
 
 func Test_ResourceQuota(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Suppresses misleading scheduler cleanup noise for GPU vendors that are not actually tracked on a node.

Previously, if a device implementation reported `health=false` for a vendor that was not present in the scheduler cache, the scheduler could still emit noisy cleanup warnings for that unrelated vendor. This was confusing in single-vendor environments.

This change only runs the unhealthy-device cleanup path when that vendor is already tracked for the node in the scheduler cache.

**Which issue(s) this PR fixes**:
Fixes #1148

**Special notes for your reviewer**:
Adds a regression test covering the case where an unrelated vendor reports unhealthy while the node only has NVIDIA devices tracked.

Validation performed:
- `go test ./pkg/scheduler/...`
- `bash hack/verify-license.sh`
- `bash hack/verify-import-aliases.sh`

**Does this PR introduce a user-facing change?**:
No.
