### PR TITLE
feat: increase operations-per-run for stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -21,3 +21,4 @@ jobs:
           exempt-draft-pr: true
           enable-statistics: true
           ascending: true
+          operations-per-run: 300


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
The current `operations-per-run` for stale action is 30 by default, which is more enough for dealing all the issue and pull requests existing in the repo.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: