### PR TITLE
fix(scheduler): add missing return in ondelpod

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -180,6 +180,7 @@ func (s *Scheduler) onDelPod(obj any) {
 			klog.V(4).InfoS("Pod tombstone deleted, cleaning up cache", "pod", t.Key)
 		} else {
 			klog.Errorf("Received tombstone for non-pod object on pod delete")
+			return
 		}
 	default:
 		klog.Errorf("Received unknown object type on pod delete")

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -179,7 +179,7 @@ func (s *Scheduler) onDelPod(obj any) {
 		if pod, ok = t.Obj.(*corev1.Pod); ok {
 			klog.V(4).InfoS("Pod tombstone deleted, cleaning up cache", "pod", t.Key)
 		} else {
-			klog.Errorf("Received tombstone for non-pod object on pod delete")
+			klog.V(4).InfoS("Received tombstone for non-pod object on pod delete", "type", fmt.Sprintf("%T", t.Obj))
 			return
 		}
 	default:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Added the missing return to ensure the function exits correctly after handling the deletion.

**Which issue(s) this PR fixes**:
Fixes #1751

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No