### PR TITLE
feat: add local-deploy target for deploying to minikube/kind clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ docker:
 	--build-arg DEST_DIR=${DEST_DIR} \
 	--build-arg VERSION=${VERSION} \
 	--build-arg GOPROXY=https://goproxy.cn,direct \
-	. -f=docker/Dockerfile -t ${IMG_TAG}
+	. -f=docker/Dockerfile -t ${IMG_NAME}:${IMG_TAG}
 
 dockerwithlib:
 	docker build \
@@ -39,7 +39,7 @@ dockerwithlib:
 	--build-arg DEST_DIR=${DEST_DIR} \
 	--build-arg VERSION=${VERSION} \
 	--build-arg GOPROXY=https://goproxy.cn,direct \
-	. -f=docker/Dockerfile.withlib -t ${IMG_TAG}
+	. -f=docker/Dockerfile.withlib -t ${IMG_NAME}:${IMG_TAG}
 
 tidy:
 	$(GO) mod tidy
@@ -100,6 +100,10 @@ e2e-env-setup:
 .PHONY: helm-deploy
 helm-deploy:
 	./hack/deploy-helm.sh "${E2E_TYPE}" "${KUBE_CONF}" "${HAMI_VERSION}"
+
+.PHONY: local-deploy
+local-deploy: docker
+	IMG_NAME="${IMG_NAME}" IMG_TAG="${IMG_TAG}" ./hack/deploy-helm.sh "local" "${KUBE_CONF}"
 
 .PHONY: e2e-test
 e2e-test:

--- a/hack/deploy-helm.sh
+++ b/hack/deploy-helm.sh
@@ -56,6 +56,32 @@ if [ "${E2E_TYPE}" == "pullrequest" ]; then
 elif [ "${E2E_TYPE}" == "release" ]; then
   HELM_SOURCE="${HELM_NAME}/${HAMI_ALIAS}"
   echo "Using remote chart: ${HELM_SOURCE}"
+elif [ "${E2E_TYPE}" == "local" ]; then
+  # Package the chart from source and derive image settings from the VERSION file.
+  helm dependency update charts/hami
+  helm package charts/hami -d charts/
+  HELM_SOURCE=$(ls -t charts/hami-*.tgz | head -1)
+
+  echo "Using local chart: ${HELM_SOURCE}"
+  echo "Using local image: ${IMG_NAME}:${IMG_TAG}"
+
+  # Load image into the cluster based on the current context.
+  KUBE_CONTEXT=$(kubectl --kubeconfig "${KUBE_CONF}" config current-context 2>/dev/null || echo "")
+  if echo "${KUBE_CONTEXT}" | grep -q "minikube"; then
+    minikube image load "${IMG_NAME}:${IMG_TAG}"
+  elif echo "${KUBE_CONTEXT}" | grep -q "^kind-"; then
+    kind load docker-image "${IMG_NAME}:${IMG_TAG}" --name "${KUBE_CONTEXT#kind-}"
+  else
+    echo "Warning: context '${KUBE_CONTEXT}' is not minikube or kind, skipping image load."
+  fi
+
+  # Detect the kube-scheduler version from the live cluster.
+  KUBE_SCHEDULER_TAG=$(kubectl version -o json 2>/dev/null | jq --raw-output '.serverVersion.gitVersion')
+  if [ -z "${KUBE_SCHEDULER_TAG}" ]; then
+    echo "Error: Could not detect Kubernetes server version."
+    exit 1
+  fi
+  echo "Detected kube-scheduler tag: ${KUBE_SCHEDULER_TAG}"
 else
   echo "Invalid E2E Type: ${E2E_TYPE}"
   exit 1
@@ -81,16 +107,35 @@ fi
 # Deploy or upgrade Helm Chart.
 echo "Deploying/Upgrading HAMI Helm Chart..."
 echo "Helm Source: ${HELM_SOURCE}"
-echo "Helm Version: ${HELM_VER}"
 echo "Namespace: ${TARGET_NS}"
 echo "Kubeconfig: ${KUBE_CONF}"
 
-if ! helm --debug upgrade --install --create-namespace --cleanup-on-fail \
-  "${HAMI_ALIAS}" "${HELM_SOURCE}" -n "${TARGET_NS}" \
-  --set devicePlugin.passDeviceSpecsEnabled=false \
-  --version "${HELM_VER}" --set global.imageTag="${HELM_VER}" --wait --timeout 10m --kubeconfig "${KUBE_CONF}"; then
-  echo "Error: Failed to deploy/upgrade Helm Chart. Please check the Helm logs above for more details."
-  exit 1
+if [ "${E2E_TYPE}" == "local" ]; then
+  if ! helm --debug upgrade --install --create-namespace --cleanup-on-fail \
+    "${HAMI_ALIAS}" "${HELM_SOURCE}" -n "${TARGET_NS}" \
+    --set global.imageTag="${IMG_TAG}" \
+    --set scheduler.extender.image.registry="" \
+    --set scheduler.extender.image.repository="${IMG_NAME}" \
+    --set devicePlugin.image.registry="" \
+    --set devicePlugin.image.repository="${IMG_NAME}" \
+    --set devicePlugin.monitor.image.registry="" \
+    --set devicePlugin.monitor.image.repository="${IMG_NAME}" \
+    --set scheduler.kubeScheduler.image.registry="registry.k8s.io" \
+    --set scheduler.kubeScheduler.image.repository="kube-scheduler" \
+    --set scheduler.kubeScheduler.image.tag="${KUBE_SCHEDULER_TAG}" \
+    --set scheduler.leaderElect=false \
+    --wait --timeout 10m --kubeconfig "${KUBE_CONF}"; then
+    echo "Error: Failed to deploy/upgrade Helm Chart. Please check the Helm logs above for more details."
+    exit 1
+  fi
+else
+  if ! helm --debug upgrade --install --create-namespace --cleanup-on-fail \
+    "${HAMI_ALIAS}" "${HELM_SOURCE}" -n "${TARGET_NS}" \
+    --set devicePlugin.passDeviceSpecsEnabled=false \
+    --version "${HELM_VER}" --set global.imageTag="${HELM_VER}" --wait --timeout 10m --kubeconfig "${KUBE_CONF}"; then
+    echo "Error: Failed to deploy/upgrade Helm Chart. Please check the Helm logs above for more details."
+    exit 1
+  fi
 fi
 
 # Check Pod status.

--- a/version.mk
+++ b/version.mk
@@ -10,4 +10,4 @@ DEST_DIR=/usr/local/vgpu/
 
 VERSION = v0.0.1
 IMG_NAME =hami
-IMG_TAG="${IMG_NAME}:${VERSION}"
+IMG_TAG=${VERSION}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a local-deploy Make target that builds the HAMi docker image and helm charts and deploys it to a local Kubernetes cluster (minikube or kind) without requiring a remote image registry. It auto-detects the cluster type from the kubeconfig context to load the image correctly, and derives the kube-scheduler version from the live cluster. This makes the local development and testing workflow significantly faster.

**Which issue(s) this PR fixes**:
This PR doesn't fix any issues but adds an enhancement to make local development easier.

**Special notes for your reviewer**:
This PR adds the local-deploy target without altering the behavior of existing targets. The local-deploy target requires jq and either minikube or kind to be installed. It is not wired into CI and is intended for local developer use only.
I have used assistance from ChatGPT and Claude code for implementing this PR, however the code is entirely written by myself.

**Does this PR introduce a user-facing change?**:
No. Only developer facing enhacement.