### PR TITLE
docs: mark benchmark.md as outdated

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **This document is outdated and no longer reflects current HAMi performance.**
+> It was written for Kubernetes v1.12.9 + Tesla V100 (2018). Current baselines are A100/H100 on Kubernetes v1.28+.
+> Do not use these numbers for evaluation. A replacement benchmark is tracked in [GitHub Issues](https://github.com/Project-HAMi/HAMi/issues).
+
 ## Benchmarks
 
 Three instances from ai-benchmark have been used to evaluate vGPU-device-plugin performance as follows:


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

The benchmark.md document references Kubernetes v1.12.9 and Tesla V100 (2018).
Current GPU baselines are A100/H100 on Kubernetes v1.28+. Users evaluating HAMi
may rely on these numbers and form incorrect expectations.

This PR adds a visible warning at the top of the file. No content is removed.
A replacement benchmark with current hardware should be tracked as a follow-up issue.

Special notes for your reviewer: One file changed, 5 lines added. No existing content modified.