### PR TITLE
fix: git errors when building with latest hami-core

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,9 +13,11 @@ RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
+COPY .git/modules/libvgpu /libvgpu-git
+RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake
+RUN apt-get -y update; apt-get -y --no-install-recommends install cmake git && rm -rf /var/lib/apt/lists/*
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -2,9 +2,11 @@ ARG NVIDIA_IMAGE=nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
+COPY .git/modules/libvgpu /libvgpu-git
+RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake
+RUN apt-get -y update; apt-get -y --no-install-recommends install cmake git && rm -rf /var/lib/apt/lists/*
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
After the PR https://github.com/Project-HAMi/HAMi-core/pull/173 merged into HAMi-Core, `make docker` in this repo encountered some error about git command and `.git` path. This PR is here to fix it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The PR conflicts with the current hami-core and should be reviewed after hami-core being upgrade to this commit(b7a642e0d787c7af4730867673a48ad450345cdc) or later

**Does this PR introduce a user-facing change?**: