### PR TITLE
fix(chart): sanitize managedNodeSelector keys for environment variables

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           {{- end }}
           {{- if .Values.global.managedNodeSelectorEnable }}
           {{- range $key, $value := .Values.global.managedNodeSelector }}
-            - name: NODE_SELECTOR_{{ $key | upper | replace "-" "_" }}
+            - name: NODE_SELECTOR_{{ $key | upper | replace "-" "_" | replace "/" "_" | replace "." "_" }}
               value: "{{ $value }}"
           {{- end }}
           {{- end }}


### PR DESCRIPTION
The current implementation fails when node selector keys contain characters  unsupported by Kubernetes environment variable naming rules (e.g., '/').

This fix adds a transformation to replace '/' and '-' with underscores  to ensure valid naming conventions while keeping the generated env names  compatible with shell environments.

Error encountered: 
Invalid value: "NODE_SELECTOR_COMPANY.COM/HAMI": a valid environment variable name  must consist of alphabetic characters, digits, '_', '-', or '.', and must  not start with a digit.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: