### PR TITLE
Disable host network for device plugin

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
-      hostNetwork: true
+      hostNetwork: false
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}
       initContainers:


### PR DESCRIPTION
## Summary
- Disable hostNetwork for the NVIDIA device plugin DaemonSet.

## Motivation
In security-isolated environments, the host port exposure range is strictly controlled. Running the device plugin pod with hostNetwork makes the monitor endpoint bind to the host network, so ServiceMonitor cannot collect metrics from the expected pod/service network path.

## Testing
- Not run. The change only flips the hard-coded hostNetwork value in the Helm template.