### PR TITLE
fix v2.8.1 monitor for new version of cache file

### DIFF
--- a/pkg/monitor/nvidia/api/api.go
+++ b/pkg/monitor/nvidia/api/api.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "sync"
+
+type Header struct {
+	InitializedFlag int32
+	MajorVersion    int32
+	MinorVersion    int32
+}
+
+type UsageInfo interface {
+	DeviceMax() int
+	DeviceNum() int
+	DeviceMemoryContextSize(idx int) uint64
+	DeviceMemoryModuleSize(idx int) uint64
+	DeviceMemoryBufferSize(idx int) uint64
+	DeviceMemoryOffset(idx int) uint64
+	DeviceMemoryTotal(idx int) uint64
+	DeviceSmUtil(idx int) uint64
+	SetDeviceSmLimit(l uint64)
+	IsValidUUID(idx int) bool
+	DeviceUUID(idx int) string
+	DeviceMemoryLimit(idx int) uint64
+	SetDeviceMemoryLimit(l uint64)
+	LastKernelTime() int64
+	GetPriority() int
+	GetRecentKernel() int32
+	SetRecentKernel(v int32)
+	GetUtilizationSwitch() int32
+	SetUtilizationSwitch(v int32)
+}
+
+type CacheFactory interface {
+	Match(header *Header, fileSize int64) bool
+	Cast(data []byte) UsageInfo
+	Name() string
+}
+
+var (
+	factories   []CacheFactory
+	factoriesMu sync.RWMutex
+)
+
+func RegisterFactory(f CacheFactory) {
+	factoriesMu.Lock()
+	defer factoriesMu.Unlock()
+	factories = append(factories, f)
+}
+
+func FindFactory(header *Header, fileSize int64) CacheFactory {
+	factoriesMu.RLock()
+	defer factoriesMu.RUnlock()
+	for _, f := range factories {
+		if f.Match(header, fileSize) {
+			return f
+		}
+	}
+	return nil
+}

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,34 +43,8 @@ import (
 
 const SharedRegionMagicFlag = 19920718
 
-type HeaderT struct {
-	InitializedFlag int32
-	MajorVersion    int32
-	MinorVersion    int32
-}
-
-type UsageInfo interface {
-	DeviceMax() int
-	DeviceNum() int
-	DeviceMemoryContextSize(idx int) uint64
-	DeviceMemoryModuleSize(idx int) uint64
-	DeviceMemoryBufferSize(idx int) uint64
-	DeviceMemoryOffset(idx int) uint64
-	DeviceMemoryTotal(idx int) uint64
-	DeviceSmUtil(idx int) uint64
-	SetDeviceSmLimit(l uint64)
-	IsValidUUID(idx int) bool
-	DeviceUUID(idx int) string
-	DeviceMemoryLimit(idx int) uint64
-	SetDeviceMemoryLimit(l uint64)
-	LastKernelTime() int64
-	//UsedMemory(idx int) (uint64, error)
-	GetPriority() int
-	GetRecentKernel() int32
-	SetRecentKernel(v int32)
-	GetUtilizationSwitch() int32
-	SetUtilizationSwitch(v int32)
-}
+type HeaderT = api.Header
+type UsageInfo = api.UsageInfo
 
 type ContainerUsage struct {
 	PodUID        string
@@ -93,7 +68,7 @@ type ContainerLister struct {
 	stopCh          chan struct{}
 }
 
-var resyncInterval time.Duration = 5 * time.Minute
+var resyncInterval = 5 * time.Minute
 
 func init() {
 	if os.Getenv("HAMI_RESYNC_INTERVAL") != "" {
@@ -107,6 +82,7 @@ func init() {
 }
 
 func NewContainerLister() (*ContainerLister, error) {
+	ensureBuiltinsRegistered()
 	hookPath, ok := os.LookupEnv("HOOK_PATH")
 	if !ok {
 		return nil, fmt.Errorf("HOOK_PATH not set")
@@ -274,8 +250,10 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	}
 	factory := findFactory(head, info.Size())
 	if factory == nil {
+		majorVersion := head.MajorVersion
+		minorVersion := head.MinorVersion
 		_ = syscall.Munmap(usage.data)
-		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), head.MajorVersion, head.MinorVersion)
+		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), majorVersion, minorVersion)
 	}
 	klog.Infof("casting......%s", factory.Name())
 	usage.Info = factory.Cast(usage.data)

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -27,8 +27,6 @@ import (
 	"time"
 	"unsafe"
 
-	v0 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v0"
-	v1 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v1"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,10 +42,10 @@ import (
 
 const SharedRegionMagicFlag = 19920718
 
-type headerT struct {
-	initializedFlag int32
-	majorVersion    int32
-	minorVersion    int32
+type HeaderT struct {
+	InitializedFlag int32
+	MajorVersion    int32
+	MinorVersion    int32
 }
 
 type UsageInfo interface {
@@ -252,7 +250,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		klog.Errorf("Failed to stat cache file: %s, error: %v", cacheFile, err)
 		return nil, err
 	}
-	if info.Size() < int64(unsafe.Sizeof(headerT{})) {
+	if info.Size() < int64(unsafe.Sizeof(HeaderT{})) {
 		return nil, fmt.Errorf("cache file size %d too small", info.Size())
 	}
 	f, err := os.OpenFile(cacheFile, os.O_RDWR, 0666)
@@ -269,21 +267,18 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		klog.Errorf("Failed to mmap cache file: %s, error: %v", cacheFile, err)
 		return nil, err
 	}
-	head := (*headerT)(unsafe.Pointer(&usage.data[0]))
-	if head.initializedFlag != SharedRegionMagicFlag {
+	head := (*HeaderT)(unsafe.Pointer(&usage.data[0]))
+	if head.InitializedFlag != SharedRegionMagicFlag {
 		_ = syscall.Munmap(usage.data)
 		return nil, fmt.Errorf("cache file magic flag not matched")
 	}
-	if info.Size() == 1197897 {
-		klog.Infoln("casting......v0")
-		usage.Info = v0.CastSpec(usage.data)
-	} else if head.majorVersion == 1 {
-		klog.Infoln("casting......v1")
-		usage.Info = v1.CastSpec(usage.data)
-	} else {
+	factory := findFactory(head, info.Size())
+	if factory == nil {
 		_ = syscall.Munmap(usage.data)
-		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), head.majorVersion, head.minorVersion)
+		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), head.MajorVersion, head.MinorVersion)
 	}
+	klog.Infof("casting......%s", factory.Name())
+	usage.Info = factory.Cast(usage.data)
 	return usage, nil
 }
 

--- a/pkg/monitor/nvidia/factory.go
+++ b/pkg/monitor/nvidia/factory.go
@@ -34,6 +34,5 @@ func ensureBuiltinsRegistered() {
 }
 
 func findFactory(header *HeaderT, fileSize int64) api.CacheFactory {
-	ensureBuiltinsRegistered()
 	return api.FindFactory(header, fileSize)
 }

--- a/pkg/monitor/nvidia/factory.go
+++ b/pkg/monitor/nvidia/factory.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"sync"
+)
+
+// CacheFactory abstracts version detection and binary casting for shared region cache files.
+// Each versioned sub-package (v0, v1, ...) registers its own factory implementations via init().
+type CacheFactory interface {
+	// Match returns true if this factory can handle the given cache file.
+	Match(header *HeaderT, fileSize int64) bool
+	// Cast interprets the raw mmap data as the version-specific shared region struct.
+	Cast(data []byte) UsageInfo
+	// Name returns a human-readable version identifier for logging.
+	Name() string
+}
+
+var (
+	factories []CacheFactory
+	factoriesMu sync.RWMutex
+)
+
+// RegisterFactory should be called from a sub-package's init() to register a version factory.
+func RegisterFactory(f CacheFactory) {
+	factoriesMu.Lock()
+	defer factoriesMu.Unlock()
+	factories = append(factories, f)
+}
+
+// findFactory iterates over registered factories and returns the first one that matches.
+func findFactory(header *HeaderT, fileSize int64) CacheFactory {
+	factoriesMu.RLock()
+	defer factoriesMu.RUnlock()
+	for _, f := range factories {
+		if f.Match(header, fileSize) {
+			return f
+		}
+	}
+	return nil
+}

--- a/pkg/monitor/nvidia/factory.go
+++ b/pkg/monitor/nvidia/factory.go
@@ -33,10 +33,6 @@ func ensureBuiltinsRegistered() {
 	})
 }
 
-func RegisterFactory(f api.CacheFactory) {
-	api.RegisterFactory(f)
-}
-
 func findFactory(header *HeaderT, fileSize int64) api.CacheFactory {
 	ensureBuiltinsRegistered()
 	return api.FindFactory(header, fileSize)

--- a/pkg/monitor/nvidia/factory.go
+++ b/pkg/monitor/nvidia/factory.go
@@ -18,39 +18,26 @@ package nvidia
 
 import (
 	"sync"
+
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
+	nvidiav0 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v0"
+	nvidiav1 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v1"
 )
 
-// CacheFactory abstracts version detection and binary casting for shared region cache files.
-// Each versioned sub-package (v0, v1, ...) registers its own factory implementations via init().
-type CacheFactory interface {
-	// Match returns true if this factory can handle the given cache file.
-	Match(header *HeaderT, fileSize int64) bool
-	// Cast interprets the raw mmap data as the version-specific shared region struct.
-	Cast(data []byte) UsageInfo
-	// Name returns a human-readable version identifier for logging.
-	Name() string
+var registerBuiltinsOnce sync.Once
+
+func ensureBuiltinsRegistered() {
+	registerBuiltinsOnce.Do(func() {
+		nvidiav0.Register()
+		nvidiav1.Register()
+	})
 }
 
-var (
-	factories   []CacheFactory
-	factoriesMu sync.RWMutex
-)
-
-// RegisterFactory should be called from a sub-package's init() to register a version factory.
-func RegisterFactory(f CacheFactory) {
-	factoriesMu.Lock()
-	defer factoriesMu.Unlock()
-	factories = append(factories, f)
+func RegisterFactory(f api.CacheFactory) {
+	api.RegisterFactory(f)
 }
 
-// findFactory iterates over registered factories and returns the first one that matches.
-func findFactory(header *HeaderT, fileSize int64) CacheFactory {
-	factoriesMu.RLock()
-	defer factoriesMu.RUnlock()
-	for _, f := range factories {
-		if f.Match(header, fileSize) {
-			return f
-		}
-	}
-	return nil
+func findFactory(header *HeaderT, fileSize int64) api.CacheFactory {
+	ensureBuiltinsRegistered()
+	return api.FindFactory(header, fileSize)
 }

--- a/pkg/monitor/nvidia/factory.go
+++ b/pkg/monitor/nvidia/factory.go
@@ -32,7 +32,7 @@ type CacheFactory interface {
 }
 
 var (
-	factories []CacheFactory
+	factories   []CacheFactory
 	factoriesMu sync.RWMutex
 )
 

--- a/pkg/monitor/nvidia/factory_test.go
+++ b/pkg/monitor/nvidia/factory_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import "testing"
+
+func TestFindFactory_RoutesByVersion(t *testing.T) {
+	ensureBuiltinsRegistered()
+
+	tests := []struct {
+		name     string
+		header   HeaderT
+		size     int64
+		expected string
+	}{
+		{
+			name:     "v0 matches by known cache size",
+			header:   HeaderT{MajorVersion: 0, MinorVersion: 0},
+			size:     1197897,
+			expected: "v0",
+		},
+		{
+			name:     "v1 base matches major 1 minor <= 1",
+			header:   HeaderT{MajorVersion: 1, MinorVersion: 1},
+			size:     1024,
+			expected: "v1",
+		},
+		{
+			name:     "v1 sem matches major 1 minor >= 2",
+			header:   HeaderT{MajorVersion: 1, MinorVersion: 2},
+			size:     1024,
+			expected: "v1-sem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := findFactory(&tt.header, tt.size)
+			if factory == nil {
+				t.Fatalf("expected factory %q, got nil", tt.expected)
+			}
+			if factory.Name() != tt.expected {
+				t.Fatalf("expected factory %q, got %q", tt.expected, factory.Name())
+			}
+		})
+	}
+}
+
+func TestFindFactory_UnknownVersionReturnsNil(t *testing.T) {
+	ensureBuiltinsRegistered()
+
+	factory := findFactory(&HeaderT{MajorVersion: 9, MinorVersion: 9}, 1)
+	if factory != nil {
+		t.Fatalf("expected nil factory for unknown version, got %q", factory.Name())
+	}
+}

--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package v0
 
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+)
 
 const maxDevices = 16
 
@@ -190,3 +194,13 @@ func (s Spec) GetUtilizationSwitch() int32 {
 func (s Spec) SetUtilizationSwitch(v int32) {
 	s.sr.utilizationSwitch = v
 }
+
+func init() {
+	nvidia.RegisterFactory(&v0Factory{})
+}
+
+type v0Factory struct{}
+
+func (v0Factory) Match(h *nvidia.HeaderT, size int64) bool { return size == 1197897 }
+func (v0Factory) Cast(data []byte) nvidia.UsageInfo        { return CastSpec(data) }
+func (v0Factory) Name() string                             { return "v0" }

--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v0
 
 import (
-	"sync"
 	"unsafe"
 
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
@@ -196,12 +195,8 @@ func (s Spec) SetUtilizationSwitch(v int32) {
 	s.sr.utilizationSwitch = v
 }
 
-var registerOnce sync.Once
-
 func Register() {
-	registerOnce.Do(func() {
-		api.RegisterFactory(&v0Factory{})
-	})
+	api.RegisterFactory(&v0Factory{})
 }
 
 type v0Factory struct{}

--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v0
 
 import (
+	"sync"
 	"unsafe"
 
-	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
 )
 
 const maxDevices = 16
@@ -195,12 +196,16 @@ func (s Spec) SetUtilizationSwitch(v int32) {
 	s.sr.utilizationSwitch = v
 }
 
-func init() {
-	nvidia.RegisterFactory(&v0Factory{})
+var registerOnce sync.Once
+
+func Register() {
+	registerOnce.Do(func() {
+		api.RegisterFactory(&v0Factory{})
+	})
 }
 
 type v0Factory struct{}
 
-func (v0Factory) Match(h *nvidia.HeaderT, size int64) bool { return size == 1197897 }
-func (v0Factory) Cast(data []byte) nvidia.UsageInfo        { return CastSpec(data) }
-func (v0Factory) Name() string                             { return "v0" }
+func (v0Factory) Match(h *api.Header, size int64) bool { return size == 1197897 }
+func (v0Factory) Cast(data []byte) api.UsageInfo       { return CastSpec(data) }
+func (v0Factory) Name() string                         { return "v0" }

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"sync"
 	"unsafe"
 
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
@@ -348,13 +347,9 @@ func CastSpecWithSemPostinit(data []byte) SpecWithSemPostinit {
 
 // --- Factory registrations ---
 
-var registerOnce sync.Once
-
 func Register() {
-	registerOnce.Do(func() {
-		api.RegisterFactory(&v1SemFactory{})  // major=1, minor=2
-		api.RegisterFactory(&v1BaseFactory{}) // major=1, minor=1
-	})
+	api.RegisterFactory(&v1SemFactory{})  // major=1, minor=2
+	api.RegisterFactory(&v1BaseFactory{}) // major=1, minor=1
 }
 
 type v1SemFactory struct{}

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -355,7 +355,7 @@ func init() {
 type v1SemFactory struct{}
 
 func (v1SemFactory) Match(h *nvidia.HeaderT, size int64) bool {
-	return h.MajorVersion == 1 && h.MinorVersion == 2
+	return h.MajorVersion == 1 && h.MinorVersion >= 2
 }
 func (v1SemFactory) Cast(data []byte) nvidia.UsageInfo { return CastSpecWithSemPostinit(data) }
 func (v1SemFactory) Name() string                      { return "v1-sem" }

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -141,10 +141,8 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := range min(int(s.sr.num), maxDevices) {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -161,10 +159,8 @@ func (s Spec) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := range min(int(s.sr.num), maxDevices) {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 
@@ -296,10 +292,8 @@ func (s SpecWithSemPostinit) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s SpecWithSemPostinit) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := range min(int(s.sr.num), maxDevices) {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -316,10 +310,8 @@ func (s SpecWithSemPostinit) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s SpecWithSemPostinit) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := range min(int(s.sr.num), maxDevices) {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -201,11 +201,172 @@ func (s Spec) GetUtilizationSwitch() int32 {
 func (s Spec) SetUtilizationSwitch(v int32) {
 	s.sr.utilizationSwitch = v
 }
+
+// --- sem_postinit variant (C major=1, minor>=2, e.g. hami-core) ---
+
+type shrregProcSlotTWithSeqlock struct {
+	pid         int32
+	hostpid     int32
+	used        [16]deviceMemory
+	monitorused [16]uint64
+	deviceUtil  [16]deviceUtilization
+	status      int32
+	seqlock     uint64
+	unused      [2]uint64
+}
+
+type sharedRegionTWithSemPostinit struct {
+	initializedFlag   int32
+	majorVersion      int32
+	minorVersion      int32
+	smInitFlag        int32
+	ownerPid          uint32
+	sem               semT
+	num               uint64
+	uuids             [16]uuid
+	limit             [16]uint64
+	smLimit           [16]uint64
+	procs             [1024]shrregProcSlotTWithSeqlock
+	procnum           int32
+	utilizationSwitch int32
+	recentKernel      int32
+	priority          int32
+	lastKernelTime    int64
+	semPostinit       semT
+}
+
+type SpecWithSemPostinit struct {
+	sr *sharedRegionTWithSemPostinit
+}
+
+func (s SpecWithSemPostinit) DeviceMax() int {
+	return maxDevices
+}
+
+func (s SpecWithSemPostinit) DeviceNum() int {
+	return int(s.sr.num)
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryContextSize(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.used[idx].contextSize
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryModuleSize(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.used[idx].moduleSize
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryBufferSize(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.used[idx].bufferSize
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryOffset(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.used[idx].offset
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryTotal(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.used[idx].total
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) DeviceSmUtil(idx int) uint64 {
+	v := uint64(0)
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+		v += p.deviceUtil[idx].smUtil
+	}
+	return v
+}
+
+func (s SpecWithSemPostinit) SetDeviceSmLimit(l uint64) {
+	idx := uint64(0)
+	for idx < s.sr.num {
+		s.sr.smLimit[idx] = l
+		idx += 1
+	}
+}
+
+func (s SpecWithSemPostinit) IsValidUUID(idx int) bool {
+	return s.sr.uuids[idx].uuid[0] != 0
+}
+
+func (s SpecWithSemPostinit) DeviceUUID(idx int) string {
+	return string(s.sr.uuids[idx].uuid[:])
+}
+
+func (s SpecWithSemPostinit) DeviceMemoryLimit(idx int) uint64 {
+	return s.sr.limit[idx]
+}
+
+func (s SpecWithSemPostinit) SetDeviceMemoryLimit(l uint64) {
+	idx := uint64(0)
+	for idx < s.sr.num {
+		s.sr.limit[idx] = l
+		idx += 1
+	}
+}
+
+func (s SpecWithSemPostinit) LastKernelTime() int64 {
+	return s.sr.lastKernelTime
+}
+
+func (s SpecWithSemPostinit) GetPriority() int {
+	return int(s.sr.priority)
+}
+
+func (s SpecWithSemPostinit) GetRecentKernel() int32 {
+	return s.sr.recentKernel
+}
+
+func (s SpecWithSemPostinit) SetRecentKernel(v int32) {
+	s.sr.recentKernel = v
+}
+
+func (s SpecWithSemPostinit) GetUtilizationSwitch() int32 {
+	return s.sr.utilizationSwitch
+}
+
+func (s SpecWithSemPostinit) SetUtilizationSwitch(v int32) {
+	s.sr.utilizationSwitch = v
+}
+
+func CastSpecWithSemPostinit(data []byte) SpecWithSemPostinit {
+	return SpecWithSemPostinit{
+		sr: (*sharedRegionTWithSemPostinit)(unsafe.Pointer(&data[0])),
+	}
+}
+
 // --- Factory registrations ---
 
 func init() {
-	nvidia.RegisterFactory(&v1BaseFactory{})  // major=1, minor=1
+	nvidia.RegisterFactory(&v1SemFactory{})  // major=1, minor=2
+	nvidia.RegisterFactory(&v1BaseFactory{}) // major=1, minor=1
 }
+
+type v1SemFactory struct{}
+
+func (v1SemFactory) Match(h *nvidia.HeaderT, size int64) bool {
+	return h.MajorVersion == 1 && h.MinorVersion == 2
+}
+func (v1SemFactory) Cast(data []byte) nvidia.UsageInfo { return CastSpecWithSemPostinit(data) }
+func (v1SemFactory) Name() string                      { return "v1-sem" }
 
 type v1BaseFactory struct{}
 

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package v1
 
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+)
 
 const maxDevices = 16
 
@@ -197,3 +201,16 @@ func (s Spec) GetUtilizationSwitch() int32 {
 func (s Spec) SetUtilizationSwitch(v int32) {
 	s.sr.utilizationSwitch = v
 }
+// --- Factory registrations ---
+
+func init() {
+	nvidia.RegisterFactory(&v1BaseFactory{})  // major=1, minor=1
+}
+
+type v1BaseFactory struct{}
+
+func (v1BaseFactory) Match(h *nvidia.HeaderT, size int64) bool {
+	return h.MajorVersion == 1 && h.MinorVersion <= 1
+}
+func (v1BaseFactory) Cast(data []byte) nvidia.UsageInfo { return CastSpec(data) }
+func (v1BaseFactory) Name() string                      { return "v1" }

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"sync"
 	"unsafe"
 
-	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/api"
 )
 
 const maxDevices = 16
@@ -347,23 +348,27 @@ func CastSpecWithSemPostinit(data []byte) SpecWithSemPostinit {
 
 // --- Factory registrations ---
 
-func init() {
-	nvidia.RegisterFactory(&v1SemFactory{})  // major=1, minor=2
-	nvidia.RegisterFactory(&v1BaseFactory{}) // major=1, minor=1
+var registerOnce sync.Once
+
+func Register() {
+	registerOnce.Do(func() {
+		api.RegisterFactory(&v1SemFactory{})  // major=1, minor=2
+		api.RegisterFactory(&v1BaseFactory{}) // major=1, minor=1
+	})
 }
 
 type v1SemFactory struct{}
 
-func (v1SemFactory) Match(h *nvidia.HeaderT, size int64) bool {
+func (v1SemFactory) Match(h *api.Header, size int64) bool {
 	return h.MajorVersion == 1 && h.MinorVersion >= 2
 }
-func (v1SemFactory) Cast(data []byte) nvidia.UsageInfo { return CastSpecWithSemPostinit(data) }
-func (v1SemFactory) Name() string                      { return "v1-sem" }
+func (v1SemFactory) Cast(data []byte) api.UsageInfo { return CastSpecWithSemPostinit(data) }
+func (v1SemFactory) Name() string                   { return "v1-sem" }
 
 type v1BaseFactory struct{}
 
-func (v1BaseFactory) Match(h *nvidia.HeaderT, size int64) bool {
+func (v1BaseFactory) Match(h *api.Header, size int64) bool {
 	return h.MajorVersion == 1 && h.MinorVersion <= 1
 }
-func (v1BaseFactory) Cast(data []byte) nvidia.UsageInfo { return CastSpec(data) }
-func (v1BaseFactory) Name() string                      { return "v1" }
+func (v1BaseFactory) Cast(data []byte) api.UsageInfo { return CastSpec(data) }
+func (v1BaseFactory) Name() string                   { return "v1" }

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -63,7 +63,7 @@ type sharedRegionT struct {
 	majorVersion    int32
 	minorVersion    int32
 	smInitFlag      int32
-	ownerPid        uint32
+	ownerPid        uint64
 	sem             semT
 	num             uint64
 	uuids           [16]uuid
@@ -220,7 +220,7 @@ type sharedRegionTWithSemPostinit struct {
 	majorVersion      int32
 	minorVersion      int32
 	smInitFlag        int32
-	ownerPid          uint32
+	ownerPid          uint64
 	sem               semT
 	num               uint64
 	uuids             [16]uuid


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug

**What this PR does / why we need it**:

v2.8.1 tag HAMi bump HAMi-core version which has added new fields for struct type `shared_region_t`. This make vgpu-monitor error on newly created workload with new libvgpu.so

<img width="1643" height="721" alt="截图_b840f5d9-1f61-4f3f-9b54-f24a10f57b8b" src="https://github.com/user-attachments/assets/beb6178b-71a3-4942-8fe8-f5d05316c616" />

提交 1988c5dadd3e0dd49dc7c6f97c8014401b9f0f55
```diff
diff --git a/src/multiprocess/multiprocess_memory_limit.h b/src/multiprocess/multiprocess_memory_limit.h
index 870e4da..4a66bb0 100755
--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -78,11 +78,12 @@ typedef struct {
 typedef struct {
     _Atomic int32_t pid;           // Atomic to detect slot allocation
     _Atomic int32_t hostpid;
+    _Atomic uint64_t seqlock;      // Sequence lock for consistent snapshots
     device_memory_t used[CUDA_DEVICE_MAX_COUNT];
     _Atomic uint64_t monitorused[CUDA_DEVICE_MAX_COUNT];
     device_util_t device_util[CUDA_DEVICE_MAX_COUNT];
     _Atomic int32_t status;
-    uint64_t unused[3];
+    uint64_t unused[2];
 } shrreg_proc_slot_t;
```

提交 e200da2c2ace17207accf106030715c787ce8e54
```diff
diff --git a/src/multiprocess/multiprocess_memory_limit.h b/src/multiprocess/multiprocess_memory_limit.h
index 10794a2..600375e 100755
--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -95,6 +95,7 @@ typedef struct {
     _Atomic int32_t sm_init_flag;
     _Atomic size_t owner_pid;
     sem_t sem;  // Only for process slot add/remove
+    sem_t sem_postinit;  // For serializing postInit() host PID detection
     uint64_t device_num;
     uuid uuids[CUDA_DEVICE_MAX_COUNT];
     uint64_t limit[CUDA_DEVICE_MAX_COUNT];
```

These newly added fields do not use the space reserved by `unused` but inserted before other fields. This cause the vgpu-monitor failed to parse new format cache file and read out wrong data. But if I change the  v1 spec directly, the old cache file will failed parsing too. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Also modify the field `ownerPid` from type `uint32` to `uint64` to match the declaration `size_t owner_pid` of struct  `shared_region_t` in HAMi-core `src/multiprocess/multiprocess_memory_limit.h`. 

Since we generally build HAMi and hami-core on platform amd64/arm64, the `size_t` should be 64-bit width. Previously, HAMi vgpu-monitor used `uint32` as the type for the `ownerPid` field, but it was still able to parse container cache files correctly to retrieve metrics because the `num uint64` field has an alignment guarantee of 8. (Refer to document: https://golang.google.cn/ref/spec#Size_and_alignment_guarantees), This compensates for the misalignment in the memory layout caused by using `uint32` rather than `uint64` for `ownerPid`. In fact, the values read from the fields between `ownerPid` and `num` are also incorrect, but this has no impact on the metric. All the fields required to parse the metric are located after `num`, so the metric appears to be perfectly normal.

The memory layout for `SharedRegionT` in package `HAMi/pkg/monitor/nvidia/v1` is shown in the table below. Notice that the  `OffsetOf(sem)+SizeOf(sem)=52`,  but `OffsetOf(num)` is 56. Because `num` has type `uint64`, which has an alignment of 8.
```shell
=== sharedRegionT ===
sizeof: 2008952

Field                 OffsetOf    Size        AlignOf   
----------------------------------------------------------------
initializedFlag       0           4           4         
majorVersion          4           4           4         
minorVersion          8           4           4         
smInitFlag            12          4           4         
ownerPid              16          4           4         
sem                   20          32          1         
num                   56          8           8         
uuids                 64          1536        1         
limit                 1600        128         8         
smLimit               1728        128         8         
procs                 1856        2007040     8         
procnum               2008896     4           4         
utilizationSwitch     2008900     4           4         
recentKernel          2008904     4           4         
priority              2008908     4           4         
lastKernelTime        2008912     8           8         
unused                2008920     32          8
```

**Does this PR introduce a user-facing change?**: No