### PR TITLE
fix: fix gpu scheduler policy sort bug(#1806)

### DIFF
--- a/pkg/scheduler/policy/gpu_policy.go
+++ b/pkg/scheduler/policy/gpu_policy.go
@@ -19,8 +19,6 @@ package policy
 import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/util"
-
-	"k8s.io/klog/v2"
 )
 
 type DeviceListsScore struct {
@@ -43,17 +41,17 @@ func (l DeviceUsageList) Swap(i, j int) {
 }
 
 func (l DeviceUsageList) Less(i, j int) bool {
-	if l.Policy == util.GPUSchedulerPolicyBinpack.String() {
-		if l.DeviceLists[i].Device.Numa == l.DeviceLists[j].Device.Numa {
-			return l.DeviceLists[i].Score < l.DeviceLists[j].Score
-		}
-		return l.DeviceLists[i].Device.Numa > l.DeviceLists[j].Device.Numa
-	}
-	// default policy is spread
-	if l.DeviceLists[i].Device.Numa == l.DeviceLists[j].Device.Numa {
+	switch l.Policy {
+	case util.GPUSchedulerPolicyBinpack.String():
+		return l.DeviceLists[i].Score < l.DeviceLists[j].Score
+	case util.GPUSchedulerPolicySpread.String():
 		return l.DeviceLists[i].Score > l.DeviceLists[j].Score
+	default:
+		if l.DeviceLists[i].Device.Numa == l.DeviceLists[j].Device.Numa {
+			return l.DeviceLists[i].Score > l.DeviceLists[j].Score
+		}
+		return l.DeviceLists[i].Device.Numa < l.DeviceLists[j].Device.Numa
 	}
-	return l.DeviceLists[i].Device.Numa < l.DeviceLists[j].Device.Numa
 }
 
 func (ds *DeviceListsScore) ComputeScore(requests device.ContainerDeviceRequests) {

--- a/pkg/scheduler/policy/gpu_policy_test.go
+++ b/pkg/scheduler/policy/gpu_policy_test.go
@@ -150,7 +150,7 @@ func TestDeviceUsageList_Less(t *testing.T) {
 				{Device: &device.DeviceUsage{Numa: 0, Used: 10}, Score: 10},
 				{Device: &device.DeviceUsage{Numa: 1, Used: 20}, Score: 20},
 			},
-			expectedLess: false,
+			expectedLess: true,
 		},
 		{
 			name:   "Spread policy with same Numa",
@@ -177,7 +177,7 @@ func TestDeviceUsageList_Less(t *testing.T) {
 				{Device: &device.DeviceUsage{Numa: 0, Used: 10}, Score: 10},
 				{Device: &device.DeviceUsage{Numa: 1, Used: 20}, Score: 20},
 			},
-			expectedLess: true,
+			expectedLess: false,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Update the gpu policy Less function. If the gpu scheduler policy is binpack or spread, it will not compare numa as sort key

**Which issue(s) this PR fixes**:
Fixes #1806

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: