### PR TITLE
fix: install git in Docker build stages for libvgpu.so

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake
+RUN apt-get -y update; apt-get -y install cmake git
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake git
+RUN apt-get update && apt-get install -y --no-install-recommends cmake git && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -4,7 +4,7 @@ FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake
+RUN apt-get -y update; apt-get -y install cmake git
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -4,7 +4,7 @@ FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
 WORKDIR /libvgpu
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y install cmake git
+RUN apt-get update && apt-get install -y --no-install-recommends cmake git && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN bash ./build.sh
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04


### PR DESCRIPTION
## Summary
- The `nvbuild` stage in `Dockerfile` and `Dockerfile.hamicore` runs `build.sh` to compile `libvgpu.so`
- `build.sh` calls `git describe` to embed the commit hash into the build, but the Docker stages only installed `cmake`, not `git`
- This caused the build to fail with "git: command not found"
- Fix: add `git` to the `apt-get install` line in both Dockerfiles

Related: Project-HAMi/HAMi-core#184 (makes build.sh resilient to missing git as a fallback)

## Test plan
- [ ] Docker build completes without git-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)