### PR TITLE
Fix: Handle Kernel 6.17 handshake edge cases in NVIDIA health checks

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -231,12 +231,14 @@ func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, 
 	reported := dev.ReportedGPUNum[n.Name]
 	klog.V(3).InfoS("checking device health for node", "nodeName", n.Name, "deviceType", devType, "currentDevices", current, "reportedDevices", reported)
 
+	handshakeHealthy, handshakeChanged := device.CheckHealth(devType, n)
+
 	if current == 0 {
 		if reported == 0 {
-			return true, false
+			return handshakeHealthy, handshakeChanged
 		}
 		dev.ReportedGPUNum[n.Name] = current
-		return false, false
+		return false, handshakeChanged
 	}
 
 	if reported != current {
@@ -244,7 +246,7 @@ func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, 
 		return true, true
 	}
 
-	return true, false
+	return handshakeHealthy, handshakeChanged
 }
 
 func (dev *NvidiaGPUDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1561,8 +1561,11 @@ func TestAssertNuma(t *testing.T) {
 func TestCheckHealth(t *testing.T) {
 	config := NvidiaConfig{ResourceCountName: "nvidia.com/gpu"}
 
+	oldHandshakeAnnos := util.HandshakeAnnos
+	defer func() { util.HandshakeAnnos = oldHandshakeAnnos }()
+
 	util.HandshakeAnnos = make(map[string]string)
-	util.HandshakeAnnos[NvidiaGPUDevice] = "hami.io/node-handshake" // Adjust annotation key if different
+	util.HandshakeAnnos[NvidiaGPUDevice] = "hami.io/node-handshake"
 
 	pastTime := time.Now().Add(-2 * time.Hour).Format(time.DateTime)
 

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -1560,60 +1561,95 @@ func TestAssertNuma(t *testing.T) {
 func TestCheckHealth(t *testing.T) {
 	config := NvidiaConfig{ResourceCountName: "nvidia.com/gpu"}
 
+	util.HandshakeAnnos = make(map[string]string)
+	util.HandshakeAnnos[NvidiaGPUDevice] = "hami.io/node-handshake" // Adjust annotation key if different
+
+	pastTime := time.Now().Add(-2 * time.Hour).Format(time.DateTime)
+
 	tests := []struct {
-		name          string
-		current       int64
-		reported      int64
-		wantHealthy   bool
-		wantNeedReset bool
+		name                string
+		current             int64
+		reported            int64
+		handshakeAnnotation string
+		wantHealthy         bool
+		wantNeedReset       bool
 	}{
 		{
-			name:          "current=0 reported=0: no devices registered yet",
-			current:       0,
-			reported:      0,
-			wantHealthy:   true,
-			wantNeedReset: false,
+			name:                "current=0 reported=0: no devices registered yet",
+			current:             0,
+			reported:            0,
+			handshakeAnnotation: "Deleted_",
+			wantHealthy:         true,
+			wantNeedReset:       false,
 		},
 		{
-			name:          "current=0 reported>0: devices disappeared",
-			current:       0,
-			reported:      2,
-			wantHealthy:   false,
-			wantNeedReset: false,
+			name:                "current=0 reported>0: devices disappeared",
+			current:             0,
+			reported:            2,
+			handshakeAnnotation: "Deleted_",
+			wantHealthy:         false,
+			wantNeedReset:       false,
 		},
 		{
-			name:          "current>0 reported differs: count changed",
-			current:       4,
-			reported:      2,
-			wantHealthy:   true,
-			wantNeedReset: true,
+			name:                "current>0 reported differs: count changed",
+			current:             4,
+			reported:            2,
+			handshakeAnnotation: "Deleted_",
+			wantHealthy:         true,
+			wantNeedReset:       true,
 		},
 		{
-			name:          "current>0 reported same: stable",
-			current:       4,
-			reported:      4,
-			wantHealthy:   true,
-			wantNeedReset: false,
+			name:                "current>0 reported same: stable",
+			current:             4,
+			reported:            4,
+			handshakeAnnotation: "Deleted_",
+			wantHealthy:         true,
+			wantNeedReset:       false,
+		},
+		{
+			name:                "Kernel 6.17 Bug: current=0 reported=0 but handshake pending",
+			current:             0,
+			reported:            0,
+			handshakeAnnotation: "Requesting_" + time.Now().Format(time.DateTime),
+			wantHealthy:         true,
+			wantNeedReset:       false,
+		},
+		{
+			name:                "Kernel 6.17 Bug: current=0 reported=0 but handshake expired",
+			current:             0,
+			reported:            0,
+			handshakeAnnotation: "Requesting_" + pastTime,
+			wantHealthy:         false,
+			wantNeedReset:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dev := InitNvidiaDevice(config)
+
 			allocatable := corev1.ResourceList{}
 			if tt.current > 0 {
 				allocatable[corev1.ResourceName(config.ResourceCountName)] = *resource.NewQuantity(tt.current, resource.DecimalSI)
 			}
+
 			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
-				Status:     corev1.NodeStatus{Allocatable: allocatable},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						util.HandshakeAnnos[NvidiaGPUDevice]: tt.handshakeAnnotation,
+					},
+				},
+				Status: corev1.NodeStatus{Allocatable: allocatable},
 			}
+
 			if tt.reported > 0 {
 				dev.ReportedGPUNum["test-node"] = tt.reported
 			}
+
 			healthy, needReset := dev.CheckHealth("NVIDIA", node)
-			assert.Equal(t, healthy, tt.wantHealthy)
-			assert.Equal(t, needReset, tt.wantNeedReset)
+			assert.Equal(t, tt.wantHealthy, healthy, "Healthy status mismatch")
+			assert.Equal(t, tt.wantNeedReset, needReset, "Reset status mismatch")
 		})
 	}
 }


### PR DESCRIPTION
Description:
This PR fixes #1800  an edge case caused by a Kernel 6.17 bug where the NVIDIA device health check fails or hangs when device counts are current=0 and reported=0, but a handshake is either pending or expired.

Changes Made:

Updated device.go to properly bypass or resolve the handshake pending/expired states without breaking normal device tracking.

Added specific unit tests for the Kernel 6.17 edge cases to prevent future regressions.