### PR TITLE
fix: clean up stale node locks

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -65,6 +65,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 )
 
 // Constants for use by the 'volume-mounts' device list strategy
@@ -593,7 +594,9 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	nodename := os.Getenv(util.NodeNameEnvName)
 	current, err := getPendingPod(ctx, nodename)
 	if err != nil {
-		//nodelock.ReleaseNodeLock(nodename, NodeLockNvidia, current)
+		if _, releaseErr := nodelock.ReleaseStaleNodeLock(nodename, NodeLockNvidia); releaseErr != nil {
+			klog.ErrorS(releaseErr, "Failed to release stale node lock after pending pod lookup failed", "node", nodename)
+		}
 		return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
 	}
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
@@ -641,6 +644,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(alignedDevreq))
 			if err != nil {
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -481,7 +481,6 @@ func updatePodAnnotationsAndReleaseLock(nodeName string, pod *corev1.Pod, lockNa
 	newAnnos := map[string]string{util.DeviceBindPhase: deviceBindPhase}
 	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
 		klog.Errorf("Failed to patch pod annotations for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		return
 	}
 	if err := nodelock.ReleaseNodeLock(nodeName, lockName, pod, false); err != nil {
 		klog.Errorf("Failed to release node lock for node %s and lock %s: %v", nodeName, lockName, err)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 )
 
 func TestGenerateMigTemplate(t *testing.T) {
@@ -422,9 +423,10 @@ func Test_PodAllocationSuccess(t *testing.T) {
 
 	nodeName := "test-node"
 	lockName := "test-lock"
-
-	// Update pod annotations and release the lock as part of the setup for the test
-	updatePodAnnotationsAndReleaseLock(nodeName, pod, lockName, util.DeviceBindSuccess)
+	_, err = client.KubeClient.CoreV1().Nodes().Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(pod)}}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test node: %v", err)
+	}
 
 	// Call the function under test
 	PodAllocationSuccess(nodeName, pod, lockName)
@@ -439,7 +441,39 @@ func Test_PodAllocationSuccess(t *testing.T) {
 	if !ok || annos != util.DeviceBindSuccess {
 		t.Errorf("Expected DeviceBindPhase annotation to be '%s', got '%s'", util.DeviceBindSuccess, annos)
 	}
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get test node: %v", err)
+	}
+	if _, ok := node.Annotations[nodelock.NodeLockKey]; ok {
+		t.Error("Expected node lock to be released")
+	}
 }
+func TestUpdatePodAnnotationsAndReleaseLockReleasesWhenPodPatchFails(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-pod",
+			Namespace: "default",
+		},
+	}
+	nodeName := "test-node"
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(pod)}}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test node: %v", err)
+	}
+
+	updatePodAnnotationsAndReleaseLock(nodeName, pod, "test-lock", util.DeviceBindFailed)
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get test node: %v", err)
+	}
+	if _, ok := node.Annotations[nodelock.NodeLockKey]; ok {
+		t.Error("Expected node lock to be released even when pod patch fails")
+	}
+}
+
 func Test_PodAllocationFailed(t *testing.T) {
 
 	client.KubeClient = fake.NewClientset()
@@ -459,6 +493,10 @@ func Test_PodAllocationFailed(t *testing.T) {
 
 	nodeName := "test-node"
 	lockName := "test-lock"
+	_, err = client.KubeClient.CoreV1().Nodes().Create(context.Background(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(pod)}}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test node: %v", err)
+	}
 
 	// simulate a failed pod allocation
 	podAllocationFailed(nodeName, pod, lockName)
@@ -474,5 +512,12 @@ func Test_PodAllocationFailed(t *testing.T) {
 		t.Error("Expected DeviceBindPhase annotation to be present")
 	} else if annos != util.DeviceBindFailed {
 		t.Errorf("Expected DeviceBindPhase annotation to be '%s', got '%s'", util.DeviceBindFailed, annos)
+	}
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get test node: %v", err)
+	}
+	if _, ok := node.Annotations[nodelock.NodeLockKey]; ok {
+		t.Error("Expected node lock to be released")
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -187,9 +187,12 @@ func (s *Scheduler) onDelPod(obj any) {
 		return
 	}
 
-	_, ok = pod.Annotations[util.AssignedNodeAnnotations]
+	nodeID, ok := pod.Annotations[util.AssignedNodeAnnotations]
 	if !ok {
 		return
+	}
+	if err := nodelockutil.ReleaseNodeLock(nodeID, nodelockutil.NodeLockKey, pod, false); err != nil {
+		klog.ErrorS(err, "Failed to release node lock for deleted pod", "node", nodeID, "pod", klog.KObj(pod))
 	}
 	pi, ok := s.podManager.GetPod(pod)
 	if ok {
@@ -379,6 +382,9 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 	var nodeNames []string
 	for _, val := range rawNodes {
 		nodeNames = append(nodeNames, val.Name)
+		if _, err := nodelockutil.ReleaseStaleNodeLock(val.Name, nodelockutil.NodeLockKey); err != nil {
+			klog.ErrorS(err, "Failed to release stale node lock", "node", val.Name)
+		}
 		klog.V(5).InfoS("Processing node", "nodeName", val.Name)
 
 		for devhandsk, devInstance := range device.GetDevices() {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -626,6 +626,74 @@ func Test_Filter(t *testing.T) {
 	}
 }
 
+func TestSchedulerOnDelPodReleasesOwnedNodeLock(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+	s := NewScheduler()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deleted-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AssignedNodeAnnotations: "locked-node",
+			},
+		},
+	}
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "locked-node", Annotations: map[string]string{nodelockutil.NodeLockKey: nodelockutil.GenerateNodeLockKeyByPod(pod)}}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	s.onDelPod(pod)
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "locked-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok := node.Annotations[nodelockutil.NodeLockKey]
+	require.False(t, ok)
+}
+
+func TestSchedulerOnDelPodKeepsOtherPodNodeLock(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+	s := NewScheduler()
+	deletedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deleted-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AssignedNodeAnnotations: "locked-node",
+			},
+		},
+	}
+	ownerPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "owner-pod", Namespace: "default"}}
+	lockValue := nodelockutil.GenerateNodeLockKeyByPod(ownerPod)
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "locked-node", Annotations: map[string]string{nodelockutil.NodeLockKey: lockValue}}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	s.onDelPod(deletedPod)
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "locked-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, lockValue, node.Annotations[nodelockutil.NodeLockKey])
+}
+
+func TestSchedulerRegisterReleasesStaleNodeLock(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+	s := NewScheduler()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+	ownerPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "missing-owner", Namespace: "default"}}
+	lockValue := time.Now().Add(-10*time.Minute).Format(time.RFC3339) + nodelockutil.NodeLockSep + nodelockutil.GeneratePodNamespaceName(ownerPod, nodelockutil.NodeLockSep)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "stale-node", Annotations: map[string]string{nodelockutil.NodeLockKey: lockValue}}}
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(node))
+
+	s.register(labels.Everything(), map[string]bool{})
+
+	updated, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "stale-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok := updated.Annotations[nodelockutil.NodeLockKey]
+	require.False(t, ok)
+}
+
 func TestSchedulerOnDelNodeCleansLockDirectNode(t *testing.T) {
 	nodelockutil.ResetNodeLocksForTest()
 	t.Cleanup(nodelockutil.ResetNodeLocksForTest)

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -140,6 +140,9 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
 		}
+		if _, ok := node.Annotations[NodeLockKey]; ok {
+			return fmt.Errorf("node %s is locked", nodeName)
+		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
@@ -175,7 +178,7 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 	if !ok {
 		return nil
 	}
-	if !skipNodeLockOwnerCheck && !strings.HasSuffix(lockStr, fmt.Sprintf("%s%s", NodeLockSep, GeneratePodNamespaceName(pod, NodeLockSep))) {
+	if !skipNodeLockOwnerCheck && !isNodeLockOwnedByPod(lockStr, pod) {
 		klog.InfoS("NodeLock is not set by this pod", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
 		return nil
 	}
@@ -188,6 +191,14 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
+		}
+		lockStr, ok := node.Annotations[NodeLockKey]
+		if !ok {
+			return nil
+		}
+		if !skipNodeLockOwnerCheck && !isNodeLockOwnedByPod(lockStr, pod) {
+			klog.InfoS("NodeLock is no longer set by this pod", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
+			return nil
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
@@ -203,6 +214,50 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 
 	klog.InfoS("Node lock released", "node", nodeName, "podName", pod.Name)
 	return nil
+}
+
+func ReleaseStaleNodeLock(nodeName string, lockname string) (bool, error) {
+	// Acquire per-node lock instead of global lock
+	nodeLock := nodeLocks.getLock(nodeName)
+	nodeLock.Lock()
+	defer nodeLock.Unlock()
+
+	ctx := context.Background()
+	var released bool
+	err := retry.OnError(DefaultStrategy, func(err error) bool {
+		// Retry on any error
+		return true
+	}, func() error {
+		node, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			klog.ErrorS(err, "Failed to get node when retry to release stale lock", "node", nodeName)
+			return err
+		}
+		lockStr, ok := node.Annotations[NodeLockKey]
+		if !ok {
+			return nil
+		}
+		stale, reason, err := isNodeLockStale(ctx, lockStr)
+		if err != nil {
+			return err
+		}
+		if !stale {
+			return nil
+		}
+		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
+		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+		if err != nil {
+			klog.ErrorS(err, "Failed to patch node when retry to release stale lock", "node", nodeName)
+			return err
+		}
+		released = true
+		klog.InfoS("Stale node lock released", "node", nodeName, "nodeLock", lockStr, "reason", reason)
+		return nil
+	})
+	if err != nil {
+		return released, fmt.Errorf("failed to release stale node lock (node=%s, retry strategy=%+v): %w", nodeName, DefaultStrategy, err)
+	}
+	return released, nil
 }
 
 func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
@@ -246,6 +301,30 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 	}
 
 	return fmt.Errorf("node %s has been locked within %v", nodeName, NodeLockTimeout)
+}
+
+func isNodeLockStale(ctx context.Context, lockStr string) (bool, string, error) {
+	lockTime, ns, podName, err := ParseNodeLock(lockStr)
+	if err != nil {
+		return false, "", err
+	}
+	if time.Since(lockTime) > NodeLockTimeout {
+		return true, "expired", nil
+	}
+	if ns == "" || podName == "" {
+		return false, "", nil
+	}
+	if _, err := client.GetClient().CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, "owner pod not found", nil
+		}
+		return false, "", err
+	}
+	return false, "", nil
+}
+
+func isNodeLockOwnedByPod(lockStr string, pod *corev1.Pod) bool {
+	return strings.HasSuffix(lockStr, fmt.Sprintf("%s%s", NodeLockSep, GeneratePodNamespaceName(pod, NodeLockSep)))
 }
 
 func ParseNodeLock(value string) (lockTime time.Time, ns, name string, err error) {

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -443,6 +443,93 @@ func TestCleanupNodeLockOnNodeDelete(t *testing.T) {
 	}
 }
 
+func TestReleaseStaleNodeLock(t *testing.T) {
+	originalTimeout := NodeLockTimeout
+	NodeLockTimeout = time.Minute * 5
+	defer func() { NodeLockTimeout = originalTimeout }()
+
+	makeLock := func(lockTime time.Time, pod *corev1.Pod) string {
+		return lockTime.Format(time.RFC3339) + NodeLockSep + GeneratePodNamespaceName(pod, NodeLockSep)
+	}
+
+	t.Run("releases expired lock", func(t *testing.T) {
+		client.KubeClient = fake.NewSimpleClientset()
+		nodeName := "expired-node"
+		owner := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default"}}
+		_, err := client.KubeClient.CoreV1().Pods(owner.Namespace).Create(context.TODO(), owner, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create pod: %v", err)
+		}
+		_, err = client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{NodeLockKey: makeLock(time.Now().Add(-10*time.Minute), owner)}}}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+
+		released, err := ReleaseStaleNodeLock(nodeName, NodeLockKey)
+		if err != nil {
+			t.Fatalf("ReleaseStaleNodeLock returned error: %v", err)
+		}
+		if !released {
+			t.Fatal("expected stale lock to be released")
+		}
+		node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get node: %v", err)
+		}
+		if _, ok := node.Annotations[NodeLockKey]; ok {
+			t.Fatal("expected node lock annotation to be removed")
+		}
+	})
+
+	t.Run("releases dangling owner lock", func(t *testing.T) {
+		client.KubeClient = fake.NewSimpleClientset()
+		nodeName := "dangling-node"
+		owner := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"}}
+		_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{NodeLockKey: makeLock(time.Now(), owner)}}}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+
+		released, err := ReleaseStaleNodeLock(nodeName, NodeLockKey)
+		if err != nil {
+			t.Fatalf("ReleaseStaleNodeLock returned error: %v", err)
+		}
+		if !released {
+			t.Fatal("expected dangling lock to be released")
+		}
+	})
+
+	t.Run("keeps fresh owner lock", func(t *testing.T) {
+		client.KubeClient = fake.NewSimpleClientset()
+		nodeName := "fresh-node"
+		owner := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "default"}}
+		_, err := client.KubeClient.CoreV1().Pods(owner.Namespace).Create(context.TODO(), owner, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create pod: %v", err)
+		}
+		lockValue := makeLock(time.Now(), owner)
+		_, err = client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{NodeLockKey: lockValue}}}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+
+		released, err := ReleaseStaleNodeLock(nodeName, NodeLockKey)
+		if err != nil {
+			t.Fatalf("ReleaseStaleNodeLock returned error: %v", err)
+		}
+		if released {
+			t.Fatal("expected fresh lock to remain")
+		}
+		node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get node: %v", err)
+		}
+		if got := node.Annotations[NodeLockKey]; got != lockValue {
+			t.Fatalf("expected lock %q to remain, got %q", lockValue, got)
+		}
+	})
+}
+
 func TestGeneratePodNamespaceName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -71,7 +71,11 @@ func GetNode(nodename string) (*corev1.Node, error) {
 func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 	pod, err := GetAllocatePodByNode(ctx, node)
 	if err != nil {
-		return nil, err
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		klog.InfoS("Node lock owner pod not found, falling back to pending pod scan", "node", node)
+		pod = nil
 	}
 	if pod != nil {
 		return pod, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -196,8 +196,6 @@ func TestGetPendingPod(t *testing.T) {
 	}
 	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node1, metav1.CreateOptions{})
 
-	pendingPod := podList[0]
-
 	tests := []struct {
 		name    string
 		node    string
@@ -208,7 +206,7 @@ func TestGetPendingPod(t *testing.T) {
 			name:    "find pending pod",
 			node:    "test-node-0",
 			wantErr: false,
-			want:    pendingPod,
+			want:    podList[0],
 		},
 		{
 			name:    "find allocated pod",
@@ -229,6 +227,45 @@ func TestGetPendingPod(t *testing.T) {
 				assert.Equal(t, got.Name, tt.want.Name)
 			}
 		})
+	}
+}
+
+func TestGetPendingPodFallsBackWhenLockOwnerMissing(t *testing.T) {
+	client.KubeClient = fake.NewSimpleClientset()
+	missingOwner := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-owner",
+			Namespace: "default",
+		},
+	}
+	fallbackPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-pod-fallback",
+			Namespace: "default",
+			Annotations: map[string]string{
+				BindTimeAnnotations:     "2024-01-01T00:00:00Z",
+				DeviceBindPhase:         DeviceBindAllocating,
+				AssignedNodeAnnotations: "test-node-fallback",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-fallback"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	_, err := client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), fallbackPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create fallback pod: %v", err)
+	}
+	_, err = client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-fallback", Annotations: map[string]string{nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(missingOwner)}}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create fallback node: %v", err)
+	}
+
+	got, err := GetPendingPod(context.TODO(), "test-node-fallback")
+	if err != nil {
+		t.Fatalf("GetPendingPod returned error: %v", err)
+	}
+	if got.Name != fallbackPod.Name {
+		t.Fatalf("expected fallback pod %q, got %q", fallbackPod.Name, got.Name)
 	}
 }
 


### PR DESCRIPTION
Add safer node lock cleanup paths so stale scheduler locks can self-heal instead of requiring manual node annotation removal.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: