### PR TITLE
fix(device): parse handshake annotation timestamp in local timezone

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -432,7 +432,7 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
-		formertime, _ := time.Parse(time.DateTime, strings.Split(handshake, "_")[1])
+		formertime, _ := time.ParseInLocation(time.DateTime, strings.Split(handshake, "_")[1], time.Local)
 		return time.Now().Before(formertime.Add(time.Second * 60)), false
 	} else if strings.Contains(handshake, "Deleted") {
 		return true, false


### PR DESCRIPTION
Fixes a timezone mismatch in `pkg/device/devices.go` `CheckHealth`.

The handshake annotation is written with `time.Now().Format(time.DateTime)` (local time),
but was read back with `time.Parse(time.DateTime, ...)` which returns UTC. On non-UTC hosts
this caused expired `Requesting_` annotations to appear still valid, so an unhealthy node
would pass the health check.

**Fix:** use `time.ParseInLocation(time.DateTime, str, time.Local)` to match the write side.

Found this while rebasing - the `TestCheckHealth` test added by #1810 fails consistently
on UTC+2 hosts because of this mismatch.

Tested locally with `go test ./pkg/device/nvidia/... -count=1`, all pass.