### PR TITLE
fix(scheduler): guard against zero-value division in ComputeScore (#1…

### DIFF
--- a/pkg/scheduler/policy/gpu_policy.go
+++ b/pkg/scheduler/policy/gpu_policy.go
@@ -57,6 +57,10 @@ func (l DeviceUsageList) Less(i, j int) bool {
 }
 
 func (ds *DeviceListsScore) ComputeScore(requests device.ContainerDeviceRequests) {
+	if ds.Device.Count == 0 || ds.Device.Totalcore == 0 || ds.Device.Totalmem == 0 {
+		ds.Score = 0
+		return
+	}
 	request, core, mem := int32(0), int32(0), int32(0)
 	// Here we are required to use the same type device
 	for _, container := range requests {

--- a/pkg/scheduler/policy/gpu_policy.go
+++ b/pkg/scheduler/policy/gpu_policy.go
@@ -57,7 +57,7 @@ func (l DeviceUsageList) Less(i, j int) bool {
 }
 
 func (ds *DeviceListsScore) ComputeScore(requests device.ContainerDeviceRequests) {
-	if ds.Device.Count == 0 || ds.Device.Totalcore == 0 || ds.Device.Totalmem == 0 {
+	if ds.Device == nil || ds.Device.Count == 0 || ds.Device.Totalcore == 0 || ds.Device.Totalmem == 0 {
 		ds.Score = 0
 		return
 	}

--- a/pkg/scheduler/policy/gpu_policy_test.go
+++ b/pkg/scheduler/policy/gpu_policy_test.go
@@ -204,6 +204,30 @@ func TestComputeScore(t *testing.T) {
 		expectedScore float32
 	}{
 		{
+			name: "Zero capacity device returns score 0 without panic",
+			device: &device.DeviceUsage{
+				ID:        "test-device",
+				Type:      "type1",
+				Count:     0,
+				Totalcore: 0,
+				Totalmem:  0,
+			},
+			requests:      make(device.ContainerDeviceRequests),
+			expectedScore: 0,
+		},
+		{
+			name: "Partial zero capacity (Count=0) returns score 0 without panic",
+			device: &device.DeviceUsage{
+				ID:        "test-device",
+				Type:      "type1",
+				Count:     0,
+				Totalcore: 8,
+				Totalmem:  4096,
+			},
+			requests:      make(device.ContainerDeviceRequests),
+			expectedScore: 0,
+		},
+		{
 			name: "ContainerDeviceRequests has no data",
 			device: &device.DeviceUsage{
 				ID:        "test-device",

--- a/pkg/scheduler/policy/node_policy.go
+++ b/pkg/scheduler/policy/node_policy.go
@@ -87,6 +87,10 @@ func (ns *NodeScore) ComputeDefaultScore(devices DeviceUsageList) {
 		totalCore += deviceLists.Device.Totalcore
 		totalMem += deviceLists.Device.Totalmem
 	}
+	if total == 0 || totalCore == 0 || totalMem == 0 {
+		ns.Score = 0
+		return
+	}
 	useScore := float32(used) / float32(total)
 	coreScore := float32(usedCore) / float32(totalCore)
 	memScore := float32(usedMem) / float32(totalMem)

--- a/pkg/scheduler/policy/node_policy_test.go
+++ b/pkg/scheduler/policy/node_policy_test.go
@@ -348,6 +348,33 @@ func TestComputeDefaultScore(t *testing.T) {
 		wantScore float32
 	}{
 		{
+			name: "Zero capacity devices returns score 0 without panic",
+			nodeScore: NodeScore{
+				NodeID: "node-zero",
+				Score:  0.0,
+			},
+			devices: DeviceUsageList{
+				DeviceLists: []*DeviceListsScore{
+					{Device: &device.DeviceUsage{
+						Count: 0, Totalcore: 0, Totalmem: 0,
+						Used: 0, Usedcores: 0, Usedmem: 0,
+					}, Score: 0},
+				},
+			},
+			wantScore: 0,
+		},
+		{
+			name: "Empty device list returns score 0 without panic",
+			nodeScore: NodeScore{
+				NodeID: "node-empty",
+				Score:  0.0,
+			},
+			devices: DeviceUsageList{
+				DeviceLists: []*DeviceListsScore{},
+			},
+			wantScore: 0,
+		},
+		{
 			name: "Test with no devices",
 			nodeScore: NodeScore{
 				NodeID: "node1",


### PR DESCRIPTION
**What type of PR is this?**

bug

**What this PR does / why we need it**:

`ComputeScore` (gpu_policy.go:78-80) and `ComputeDefaultScore`
(node_policy.go:90-92) divide by device capacity fields (`Count`,
`Totalcore`, `Totalmem`) without zero-checks. When any field is 0,
float32 division produces NaN/Inf, which breaks `sort.Sort`'s
total-ordering requirement — causing an index-out-of-range panic
that kills the entire scheduler extender process.

Since the offending pod stays Pending, kube-scheduler retries it on
every restart, creating a CrashLoopBackOff loop that halts all GPU
scheduling cluster-wide.

This PR adds zero-value guards to both functions so they return
score 0 instead of panicking, letting the scheduler gracefully
mark devices/nodes as unschedulable.

Note: `fitInDevices` already guards against "request more GPUs than
the node has" at score.go:65, but that check runs **after**
`ComputeScore`. The trigger is a device reporting zero-value
capacity, not an empty device list.

**Which issue(s) this PR fixes**:
Fixes #1780

**Special notes for your reviewer**:

- `ComputeDefaultScore` in node_policy.go has the same unguarded
  division pattern — fixed in this PR as well
- Unit tests added for both zero-capacity scenarios
- This PR was written with assistance from Claude Code

**Does this PR introduce a user-facing change?**:

Scheduler no longer panics when a device reports zero-value capacity
fields. Pods that cannot be satisfied are correctly marked as
unschedulable instead of crashing the scheduler.
