### PR TITLE
feat: add enableGetPreferredAllocation flag

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -352,6 +352,7 @@ devicePlugin:
               "uuid": [],
               "index": []
             }
+            "enablegetpreferredallocation": false
           }
         ]
       }

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -351,7 +351,7 @@ devicePlugin:
             "filterdevices": {
               "uuid": [],
               "index": []
-            }
+            },
             "enablegetpreferredallocation": false
           }
         ]

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,7 @@ kubectl -n kube-system edit cm hami-device-plugin
   * `uuid`: UUIDs of devices to ignore
   * `index`: Indexes of devices to ignore.
   * A device is ignored by HAMi if it's in `uuid` or `index` list.
+* `enablegetpreferredallocation`: Indicates whether GetPreferredAllocation is enabled.
 
 ## Chart Configs: parameters
 

--- a/docs/config_cn.md
+++ b/docs/config_cn.md
@@ -60,6 +60,7 @@ kubectl -n <namespace> edit cm hami-device-plugin
   * `uuid`: 所要排除设备的 UUID。
   * `index`: 所要排除设备的索引。
   * 一个设备只要在 `uuid` 或者 `index` 列表中，就不会被 HAMi 管理。
+* `enablegetpreferredallocation`: 是否开启 GetPreferredAllocation。
 
 ## Chart 参数
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -77,9 +77,10 @@ const (
 )
 
 var (
-	hostHookPath  string
-	ConfigFile    *string
-	getPendingPod = util.GetPendingPod
+	hostHookPath                 string
+	ConfigFile                   *string
+	getPendingPod                = util.GetPendingPod
+	enableGetPreferredAllocation bool
 )
 
 func init() {
@@ -142,6 +143,7 @@ func readFromConfigFile(sConfig *nvidia.NvidiaConfig, path string) (string, erro
 			if len(val.OperatingMode) > 0 {
 				mode = val.OperatingMode
 			}
+			enableGetPreferredAllocation = val.EnableGetPreferredAllocation
 			klog.Infof("FilterDevice: %v", val.FilterDevice)
 		}
 	}
@@ -430,7 +432,7 @@ func (plugin *NvidiaDevicePlugin) Register(kubeletSocket string) error {
 		Endpoint:     path.Base(plugin.socket),
 		ResourceName: string(plugin.rm.Resource()),
 		Options: &kubeletdevicepluginv1beta1.DevicePluginOptions{
-			GetPreferredAllocationAvailable: true,
+			GetPreferredAllocationAvailable: enableGetPreferredAllocation,
 		},
 	}
 
@@ -492,26 +494,17 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 	}
 
 	for idx, req := range r.ContainerRequests {
-		var (
-			devices []string
-			err     error
-		)
-
 		if idx < len(nonEmptyAnnotations) {
-			devices, err = plugin.selectPreferredDeviceIDsFromAnnotatedDevices(req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, nonEmptyAnnotations[idx], int(req.AllocationSize))
-			if err != nil {
-				devices, err = plugin.rm.GetPreferredAllocation(req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, int(req.AllocationSize))
+			devices, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, nonEmptyAnnotations[idx], int(req.AllocationSize))
+			if err == nil {
+				klog.V(5).Infof("selectPreferredDevice: %v", devices)
+				response.ContainerResponses = append(response.ContainerResponses, &kubeletdevicepluginv1beta1.ContainerPreferredAllocationResponse{
+					DeviceIDs: devices,
+				})
+			} else {
+				klog.Warningf("err: %v", err)
 			}
-		} else {
-			devices, err = plugin.rm.GetPreferredAllocation(req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, int(req.AllocationSize))
 		}
-		if err != nil {
-			return nil, fmt.Errorf("error getting list of preferred allocation devices: %v", err)
-		}
-
-		response.ContainerResponses = append(response.ContainerResponses, &kubeletdevicepluginv1beta1.ContainerPreferredAllocationResponse{
-			DeviceIDs: devices,
-		})
 	}
 	return response, nil
 }
@@ -643,12 +636,15 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				podAllocationFailed(nodename, current, NodeLockNvidia)
 				return &kubeletdevicepluginv1beta1.AllocateResponse{}, errors.New("device number not matched")
 			}
-			alignedDevreq, err := plugin.alignContainerDevicesWithAllocatedIDs(devreq, reqs.ContainerRequests[idx].DevicesIds)
-			if err != nil {
-				podAllocationFailed(nodename, current, NodeLockNvidia)
-				return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+			if enableGetPreferredAllocation {
+				alignedDevreq, err := plugin.alignContainerDevicesWithAllocatedIDs(devreq, reqs.ContainerRequests[idx].DevicesIds)
+				if err != nil {
+					podAllocationFailed(nodename, current, NodeLockNvidia)
+					return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+				}
+				devreq = alignedDevreq
 			}
-			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(alignedDevreq))
+			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(devreq))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}
@@ -660,11 +656,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 
 			if plugin.operatingMode != "mig" {
-				for i, dev := range alignedDevreq {
+				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
 				}
-				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(alignedDevreq[0].Usedcores)
+				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
 				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
 				if *plugin.schedulerConfig.DeviceMemoryScaling > 1 {
 					response.Envs["CUDA_OVERSUBSCRIBE"] = "true"

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -563,11 +563,12 @@ func Test_configOverride(t *testing.T) {
 
 	config := nvidia.DevicePluginConfigs{
 		Nodeconfig: []struct {
-			nvidia.NodeDefaultConfig `json:",inline"`
-			Name                     string               `json:"name"`
-			OperatingMode            string               `json:"operatingmode"`
-			Migstrategy              string               `json:"migstrategy"`
-			FilterDevice             *nvidia.FilterDevice `json:"filterdevices"`
+			nvidia.NodeDefaultConfig     `json:",inline"`
+			Name                         string               `json:"name"`
+			OperatingMode                string               `json:"operatingmode"`
+			Migstrategy                  string               `json:"migstrategy"`
+			FilterDevice                 *nvidia.FilterDevice `json:"filterdevices"`
+			EnableGetPreferredAllocation bool                 `json:"enablegetpreferredallocation"`
 		}{
 			{
 				NodeDefaultConfig: nvidia.NodeDefaultConfig{
@@ -576,10 +577,11 @@ func Test_configOverride(t *testing.T) {
 					DeviceCoreScaling:   &coreScale1,
 					LogLevel:            &logLevel1,
 				},
-				Name:          "node-1",
-				OperatingMode: "default",
-				Migstrategy:   "single",
-				FilterDevice:  nil,
+				Name:                         "node-1",
+				OperatingMode:                "default",
+				Migstrategy:                  "single",
+				FilterDevice:                 nil,
+				EnableGetPreferredAllocation: true,
 			},
 			{
 				NodeDefaultConfig: nvidia.NodeDefaultConfig{
@@ -588,10 +590,11 @@ func Test_configOverride(t *testing.T) {
 					DeviceCoreScaling:   &coreScale2,
 					LogLevel:            &logLevel2,
 				},
-				Name:          "testnode",
-				OperatingMode: "custom",
-				Migstrategy:   "mixed",
-				FilterDevice:  nil,
+				Name:                         "testnode",
+				OperatingMode:                "custom",
+				Migstrategy:                  "mixed",
+				FilterDevice:                 nil,
+				EnableGetPreferredAllocation: true,
 			},
 		},
 	}
@@ -803,12 +806,7 @@ func TestGetPreferredAllocationFallbackOnAnnotatedDeviceMappingFailure(t *testin
 
 	response, err := plugin.GetPreferredAllocation(context.Background(), request)
 	require.NoError(t, err)
-	require.Len(t, response.ContainerResponses, 1)
-	require.ElementsMatch(t, []string{
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
-	}, response.ContainerResponses[0].DeviceIDs)
-	require.Equal(t, 1, rmCallCount)
+	require.Len(t, response.ContainerResponses, 0)
 }
 
 func TestGetPreferredAllocationFallbackOnInsufficientAnnotatedDevices(t *testing.T) {
@@ -869,68 +867,7 @@ func TestGetPreferredAllocationFallbackOnInsufficientAnnotatedDevices(t *testing
 
 	response, err := plugin.GetPreferredAllocation(context.Background(), request)
 	require.NoError(t, err)
-	require.Len(t, response.ContainerResponses, 1)
-	require.ElementsMatch(t, []string{
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
-	}, response.ContainerResponses[0].DeviceIDs)
-	require.Equal(t, 1, rmCallCount)
-}
-
-func TestGetPreferredAllocationPropagatesRMErrors(t *testing.T) {
-	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
-	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
-	defer func() {
-		device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice
-	}()
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "test-pod",
-			Annotations: map[string]string{
-				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
-					{
-						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67z", Type: nvidia.NvidiaGPUDevice},
-					},
-				}),
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "main"}},
-		},
-	}
-
-	mockRM := &rm.ResourceManagerMock{
-		GetPreferredAllocationFunc: func(available []string, required []string, size int) ([]string, error) {
-			return nil, fmt.Errorf("rm allocation failed")
-		},
-	}
-
-	plugin := &NvidiaDevicePlugin{
-		rm: mockRM,
-	}
-	t.Setenv(util.NodeNameEnvName, "node-a")
-	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
-		return pod, nil
-	}
-	defer func() {
-		getPendingPod = previousGetPendingPod
-	}()
-
-	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
-		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
-			{
-				AvailableDeviceIDs: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0"},
-				AllocationSize:     1,
-			},
-		},
-	}
-
-	_, err := plugin.GetPreferredAllocation(context.Background(), request)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "rm allocation failed")
+	require.Len(t, response.ContainerResponses, 0)
 }
 
 func TestAlignContainerDevicesWithAllocatedIDsPreservesMetadata(t *testing.T) {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -142,11 +142,12 @@ type FilterDevice struct {
 type DevicePluginConfigs struct {
 	Nodeconfig []struct {
 		// These configs is shared and will overwrite those in NvidiaConfig.
-		NodeDefaultConfig `json:",inline"`
-		Name              string        `json:"name"`
-		OperatingMode     string        `json:"operatingmode"`
-		Migstrategy       string        `json:"migstrategy"`
-		FilterDevice      *FilterDevice `json:"filterdevices"`
+		NodeDefaultConfig            `json:",inline"`
+		Name                         string        `json:"name"`
+		OperatingMode                string        `json:"operatingmode"`
+		Migstrategy                  string        `json:"migstrategy"`
+		FilterDevice                 *FilterDevice `json:"filterdevices"`
+		EnableGetPreferredAllocation bool          `json:"enablegetpreferredallocation"`
 	} `json:"nodeconfig"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:
#1743 will enable `GetPreferredAllocation` by default and rename DeviceIDs. 
We discussed this feature in the weekly meeting, and the final conclusion was to add a switch that is disabled by default.

Additionally, using the default fallback may cause the following error, so  it has been changed to return an empty response in this pr.

<img width="1763" height="115" alt="ScreenShot_2026-04-30_130603_447" src="https://github.com/user-attachments/assets/a88ad04f-f9dd-4940-8d8b-479504323e1b" />



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: