### PR TITLE
refactor: filter device at nvml-manager

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/factory.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/factory.go
@@ -83,14 +83,14 @@ func New(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, de
 		o.cdiHandler = cdi.NewNullHandler()
 	}
 
-	resourceManagers, err := o.getResourceManagers()
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct resource managers: %w", err)
-	}
-
 	sConfig, mode, err := LoadNvidiaDevicePluginConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load nvidia plugin config: %v", err)
+	}
+
+	resourceManagers, err := o.getResourceManagers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct resource managers: %w", err)
 	}
 
 	var plugins []Interface

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -229,16 +229,7 @@ func (plugin *NvidiaDevicePlugin) cleanup() {
 
 // Devices returns the full set of devices associated with the plugin.
 func (plugin *NvidiaDevicePlugin) Devices() rm.Devices {
-	devs := plugin.rm.Devices()
-	ret := make(rm.Devices)
-	for id, dev := range devs {
-		if nvidia.FilterDeviceToRegister(dev.ID, dev.Index) {
-			klog.V(5).InfoS("Filtering device", "device", dev.ID)
-			continue
-		}
-		ret[id] = dev
-	}
-	return ret
+	return plugin.rm.Devices()
 }
 
 // Start starts the gRPC server, registers the device plugin with the Kubelet,

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -39,6 +39,7 @@ import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"k8s.io/klog/v2"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
@@ -73,6 +74,13 @@ func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, dev
 	for resourceName, devices := range deviceMap {
 		if len(devices) == 0 {
 			continue
+		}
+		for key, value := range devices {
+			if nvidia.FilterDeviceToRegister(value.ID, value.Index) {
+				klog.V(5).InfoS("Filtering device", "device", value.ID)
+				delete(devices, key)
+				continue
+			}
 		}
 		r := &nvmlResourceManager{
 			resourceManager: resourceManager{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -79,7 +79,6 @@ func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, dev
 			if nvidia.FilterDeviceToRegister(value.ID, value.Index) {
 				klog.V(5).InfoS("Filtering device", "device", value.ID)
 				delete(devices, key)
-				continue
 			}
 		}
 		r := &nvmlResourceManager{


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**What this PR does / why we need it**:

#1817 add filter in server.go before register.  This solution filters before registration. However, if the filtered-out devices are faulty cards, this may cause additional issues.  So we filter at the `nvml_manager` during device identification.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: