### PR TITLE
docs: complete tasklist.md migration - add hardware entries, resource…

### DIFF
--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -1,14 +1,15 @@
 # roadmap
 | Production | manufactor   | Type       | MemoryIsolation  | CoreIsolation | MultiCard support |
+| -----------| -------------| -----------| --------- -------| --------------| ------------------|
 | GPU        | NVIDIA       | All        | ✅               | ✅           | ✅ |
 | MLU        | Cambricon    | 370, 590   | ✅               | ✅           | ❌ |
 | GCU        |  Enflame     | S60        | ✅               | ✅           | ❌ |
 | DCU        | Hygon        | Z100, Z100L| ✅               | ✅           | ❌ |
 | Ascend     | Huawei       | 910B       | ✅               | ✅           | ❌ |
 | GPU        | iluvatar     | All        | ✅               | ✅           | ❌ |
-| DPU        | Teco         | Checking   | In progress      | In progress  | ❌ |
-| GPU        |Moore Threads | MTT S4000  | In progress      | In progress  | ❌ |
-| GPU        | Birentech    | Model 110  | In progress      | In progress | ❌ |
+| DPU        | Teco         | Checking   | In progress      | In progress   | ❌ |
+| GPU        |Moore Threads | MTT S4000  | In progress      | In progress   | ❌ |
+| GPU        | Birentech    | Model 110  | In progress      | In progress   | ❌ |
 
 
 - [ ] Support video codec processing

--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -1,15 +1,18 @@
 # roadmap
-| Production | manufactor   | Type       | MemoryIsolation  | CoreIsolation | MultiCard support |
-| -----------| -------------| -----------| --------- -------| --------------| ------------------|
-| GPU        | NVIDIA       | All        | ✅               | ✅           | ✅ |
-| MLU        | Cambricon    | 370, 590   | ✅               | ✅           | ❌ |
-| GCU        |  Enflame     | S60        | ✅               | ✅           | ❌ |
-| DCU        | Hygon        | Z100, Z100L| ✅               | ✅           | ❌ |
-| Ascend     | Huawei       | 910B       | ✅               | ✅           | ❌ |
-| GPU        | iluvatar     | All        | ✅               | ✅           | ❌ |
-| DPU        | Teco         | Checking   | In progress      | In progress   | ❌ |
-| GPU        |Moore Threads | MTT S4000  | In progress      | In progress   | ❌ |
-| GPU        | Birentech    | Model 110  | In progress      | In progress   | ❌ |
+| Production | Manufactor    | Type             | MemoryIsolation | CoreIsolation | MultiCard support |
+|------------|---------------|------------------|-----------------|---------------|-------------------|
+| GPU        | NVIDIA        | All              | ✅              | ✅            | ✅                |
+| MLU        | Cambricon     | 370, 590         | ✅              | ✅            | ❌                |
+| GCU        | Enflame       | S60              | ✅              | ✅            | ❌                |
+| DCU        | Hygon         | Z100, Z100L      | ✅              | ✅            | ❌                |
+| NPU        | Ascend        | 310P, 910B, 910B3| ✅              | ✅            | ❌                |
+| GPU        | iluvatar      | All              | ✅              | ✅            | ❌                |
+| DPU        | Teco          | Checking         | In progress     | In progress   | ❌                |
+| GPU        | Moore Threads | MTT S4000        | ✅              | ✅            | ❌                |
+| GPU        | Birentech     | Model 110        | In progress     | In progress   | ❌                |
+| GPU        | MetaX         | MXC500           | ✅              | ✅            | ❌                |
+| XPU        | Kunlunxin     | P800             | ✅              | ✅            | ❌                |
+| GPU        | Vastai        | VA16             | ✅              | ✅            | ❌              |      
 
 
 - [ ] Support video codec processing

--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -1,16 +1,14 @@
 # roadmap
-
-Heterogeneous AI Computing device to support
-
-| Production  | manufactor | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
-|-------------|------------|-------------|-----------|---------------|-------------------|
-| GPU         | NVIDIA     | All         | ✅              | ✅            | ✅                |
-| MLU         | Cambricon  | 370, 590    | ✅              | ✅            | ❌                |
-| GCU         | Enflame    | S60         | ✅              | ✅            | ❌                |
-| DCU         | Hygon      | Z100, Z100L | ✅              | ✅            | ❌                |
-| Ascend      | Huawei     | 910B        | ✅              | ✅            | ❌                |
-| GPU         | iluvatar   | All         | ✅              | ✅            | ❌                |
-| DPU         | Teco       | Checking    | In progress     | In progress   | ❌                |
+| Production | manufactor   | Type       | MemoryIsolation  | CoreIsolation | MultiCard support |
+| GPU        | NVIDIA       | All        | ✅               | ✅           | ✅ |
+| MLU        | Cambricon    | 370, 590   | ✅               | ✅           | ❌ |
+| GCU        |  Enflame     | S60        | ✅               | ✅           | ❌ |
+| DCU        | Hygon        | Z100, Z100L| ✅               | ✅           | ❌ |
+| Ascend     | Huawei       | 910B       | ✅               | ✅           | ❌ |
+| GPU        | iluvatar     | All        | ✅               | ✅           | ❌ |
+| DPU        | Teco         | Checking   | In progress      | In progress  | ❌ |
+| GPU        |Moore Threads | MTT S4000  | In progress      | In progress  | ❌ |
+| GPU        | Birentech    | Model 110  | In progress      | In progress | ❌ |
 
 
 - [ ] Support video codec processing

--- a/docs/resource-quota.md
+++ b/docs/resource-quota.md
@@ -1,0 +1,58 @@
+# ResourceQuota Support
+
+HAMi supports Kubernetes [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+to limit GPU memory usage per namespace.
+
+## Why This Is Needed
+
+The number of virtual devices in a namespace does not directly represent
+actual GPU memory consumption. HAMi solves this by supporting memory-based
+quota limits, so cluster administrators can cap how much device memory a
+namespace is allowed to use.
+
+## How It Works
+
+HAMi exposes `requests.nvidia.com/gpu-memory` as a quota resource.
+When a ResourceQuota is applied to a namespace, HAMi enforces that the
+total device memory requested by all pods in that namespace does not exceed
+the configured limit.
+
+## Example
+
+**Step 1:** Create the ResourceQuota definition:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi
+    requests.nvidia.com/gpu-memory: 30000
+```
+
+**Step 2:** Apply it to your namespace:
+
+```bash
+kubectl create -f ./compute-resources.yaml --namespace=myspace
+```
+
+This limits the total GPU memory that can be requested across all pods
+in namespace `myspace` to 30,000 MiB (approximately 30GB).
+
+## Verify the Quota
+
+```bash
+kubectl describe resourcequota compute-resources --namespace=myspace
+```
+
+## Notes
+
+- The quota unit for `requests.nvidia.com/gpu-memory` is MiB.
+- This quota applies to the sum of all pod requests in the namespace,
+  not per individual pod.
+- Pods that would exceed the quota will be rejected at admission time.

--- a/docs/resource-quota.md
+++ b/docs/resource-quota.md
@@ -32,7 +32,7 @@ spec:
     requests.memory: 1Gi
     limits.cpu: "2"
     limits.memory: 2Gi
-    requests.nvidia.com/gpu-memory: 30000
+    limits.nvidia.com/gpumem: 30000
 ```
 
 **Step 2:** Apply it to your namespace:
@@ -52,7 +52,7 @@ kubectl describe resourcequota compute-resources --namespace=myspace
 
 ## Notes
 
-- The quota unit for `requests.nvidia.com/gpu-memory` is MiB.
+- The quota unit for `limits.nvidia.com/gpumem` is MiB.
 - This quota applies to the sum of all pod requests in the namespace,
   not per individual pod.
 - Pods that would exceed the quota will be rejected at admission time.

--- a/docs/scheduling-policy.md
+++ b/docs/scheduling-policy.md
@@ -1,0 +1,75 @@
+# Scheduling Policies
+
+HAMi supports multiple GPU scheduling policies to handle complex workload
+scenarios. A pod can select a scheduling policy using pod annotations.
+
+## Available Policies
+
+| Policy      | Scope | Effect |
+| `binpack`   | Node  | Tries to allocate tasks to the **same GPU node** as much as possible |
+| `spread`    | Node  | Tries to allocate tasks to **different GPU nodes** as much as possible |
+| `numa-first`| GPU   | For multi-GPU allocations, prefers GPUs on the **same NUMA node** |
+
+## Default Policy
+
+The default node scheduling policy is `binpack` and the default GPU
+scheduling policy is `spread`. These can be changed globally via Helm:
+
+```bash
+helm install hami hami-charts/hami \
+  --set scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy=binpack \
+  --set scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy=spread
+```
+
+## Per-Pod Policy via Annotations
+
+Individual pods can override the default by specifying a scheduling policy
+in `.metadata.annotations`.
+
+### Example: binpack policy
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    hami.io/node-scheduler-policy: "binpack"
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:22.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          nvidia.com/gpu: 2
+          nvidia.com/gpumem: 4000
+```
+
+### Example: spread policy
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    hami.io/node-scheduler-policy: "spread"
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:22.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          nvidia.com/gpu: 2
+          nvidia.com/gpumem: 4000
+```
+
+## Notes
+
+- The annotation `hami.io/node-scheduler-policy` controls **which node**
+  the pod is placed on.
+- For GPU-level policy (which GPU card within a node), configure
+  `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy` globally.
+- See [config.md](./config.md) for the full list of scheduler configuration options.

--- a/docs/scheduling-policy.md
+++ b/docs/scheduling-policy.md
@@ -6,6 +6,7 @@ scenarios. A pod can select a scheduling policy using pod annotations.
 ## Available Policies
 
 | Policy      | Scope | Effect |
+| ---------   | ----- | ------ |
 | `binpack`   | Node  | Tries to allocate tasks to the **same GPU node** as much as possible |
 | `spread`    | Node  | Tries to allocate tasks to **different GPU nodes** as much as possible |
 | `numa-first`| GPU   | For multi-GPU allocations, prefers GPUs on the **same NUMA node** |
@@ -70,6 +71,9 @@ spec:
 
 - The annotation `hami.io/node-scheduler-policy` controls **which node**
   the pod is placed on.
-- For GPU-level policy (which GPU card within a node), configure
-  `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy` globally.
+- Only node-level policies (`binpack`, `spread`) can be overridden per-pod
+  via annotations. GPU-level policy within a node is configured globally
+  via `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy`.
+- `numa-first` (NUMA affinity) is not yet implemented and is tracked
+  as an open item in [roadmap.md](./develop/roadmap.md).
 - See [config.md](./config.md) for the full list of scheduler configuration options.


### PR DESCRIPTION
## What type of PR is this?
/kind documentation
/kind cleanup

## What this PR does / why we need it
Completes the content migration from the deleted `docs/develop/tasklist.md` (#1801).
Four tracking issues were left open with no documentation changes. This PR resolves all of them:

- `docs/develop/roadmap.md`: Added Moore Threads MTT S4000 and Birentech Model 110 to the supported hardware table
- `docs/resource-quota.md`: New doc covering ResourceQuota support with examples
- `docs/scheduling-policy.md`: New doc covering scheduling policies (binpack, spread, numa-first) with per-pod annotation examples

## Which issue(s) this PR fixes
Closes #1796
Closes #1797
Closes #1798
Closes #1799

## Does this PR introduce a user-facing change?
Yes — adds two new documentation pages for ResourceQuota and scheduling policies.

## AI disclosure
Used Claude as a reference. Final decisions and PR done by me.