### PR TITLE
fix(ascend): check unmarshal error before iterating node devices

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -203,12 +203,12 @@ func (dev *Devices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) 
 		return []*device.DeviceInfo{}, fmt.Errorf("annos not found %s", dev.nodeRegisterAnno)
 	}
 	nodeDevices, err := device.UnMarshalNodeDevices(anno)
-	for idx := range nodeDevices {
-		nodeDevices[idx].DeviceVendor = dev.config.CommonWord
-	}
 	if err != nil {
 		klog.ErrorS(err, "failed to unmarshal node devices", "node", n.Name, "device annotation", anno)
 		return []*device.DeviceInfo{}, err
+	}
+	for idx := range nodeDevices {
+		nodeDevices[idx].DeviceVendor = dev.config.CommonWord
 	}
 	if len(nodeDevices) == 0 {
 		klog.InfoS("no gpu device found", "node", n.Name, "device annotation", anno)


### PR DESCRIPTION
/kind bug

The GetNodeDevices function in the Ascend device implementation was iterating over nodeDevices before checking the error returned by UnMarshalNodeDevices. If the unmarshal fails and returns a partial result alongside an error, the loop would mutate that partial data before the error is caught and returned.

The NVIDIA and Hygon implementations both check the error first. This aligns the Ascend implementation with the same pattern.