### PR TITLE
fix: handle GetMemoryInfo NOT_SUPPORTED for unified memory GPUs (cherry-pick #1637 to release-v2.8)

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -22,6 +22,7 @@ data:
       defaultMemory: 0
       defaultCores: 0
       defaultGPUNum: 1
+      preConfiguredDeviceMemory: {{ .Values.devicePlugin.preConfiguredDeviceMemory | default 0 }}
       memoryFactor: 1
       deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
       deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -302,6 +302,10 @@ devicePlugin:
   deviceSplitCount: 10
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
+  # Pre-configured device memory in MB for GPUs that don't support memory query (e.g., unified memory architecture GPUs like NVIDIA GB10/DGX Spark).
+  # Set to 0 to use auto-detection (default). For unified memory GPUs, set to the total GPU memory (e.g., 131072 for 128GB).
+  # Can be overridden per-node via nodeConfiguration.config.
+  preConfiguredDeviceMemory: 0
   # Node configuration for device plugin, Priority: externalConfigName > config > default config
   nodeConfiguration:
     # If you want to use a custom config.json, you can set the content here.
@@ -314,6 +318,7 @@ devicePlugin:
             "operatingmode": "hami-core",
             "devicememoryscaling": 1,
             "devicesplitcount": 10,
+            "preconfigureddevicememory": 0,
             "migstrategy": "none",
             "filterdevices": {
               "uuid": [],

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -262,6 +262,10 @@ func (cc ClusterManagerCollector) collectGPUDeviceMetrics(ch chan<- prometheus.M
 
 func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
 	memory, ret := hdev.GetMemoryInfo()
+	if ret == nvml.ERROR_NOT_SUPPORTED {
+		klog.V(3).Infof("Memory metrics not supported for device %d (unified memory architecture), skipping", index)
+		return nil
+	}
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("nvml get memory error ret=%d", ret)
 	}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -124,9 +124,10 @@ type NvidiaConfig struct {
 
 // These configs can be specified for each node by using Nodeconfig.
 type NodeDefaultConfig struct {
-	DeviceSplitCount    *uint    `yaml:"deviceSplitCount" json:"devicesplitcount"`
-	DeviceMemoryScaling *float64 `yaml:"deviceMemoryScaling" json:"devicememoryscaling"`
-	DeviceCoreScaling   *float64 `yaml:"deviceCoreScaling" json:"devicecorescaling"`
+	DeviceSplitCount          *uint    `yaml:"deviceSplitCount" json:"devicesplitcount"`
+	DeviceMemoryScaling       *float64 `yaml:"deviceMemoryScaling" json:"devicememoryscaling"`
+	DeviceCoreScaling         *float64 `yaml:"deviceCoreScaling" json:"devicecorescaling"`
+	PreConfiguredDeviceMemory *int64   `yaml:"preConfiguredDeviceMemory" json:"preconfigureddevicememory"`
 	// LogLevel is LIBCUDA_LOG_LEVEL value
 	LogLevel *LibCudaLogLevel `yaml:"libCudaLogLevel" json:"libcudaloglevel"`
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Cherry-picks commit `13009aa` (PR #1637) onto the `release-v2.8` branch so that an eventual `v2.8.3` ships with the unified-memory fix for NVIDIA GB10 (DGX Spark) and other architectures whose GPUs return `ERROR_NOT_SUPPORTED` from `nvmlDeviceGetMemoryInfo`.

Without this backport, users on `v2.8.1` and `v2.8.2` continue to hit the device-plugin panic at `register.go:115` on GB10 hardware. See #1838 for the full reproduction and #1511 for the original bug report.

The cherry-pick applies cleanly to `release-v2.8` (no merge conflicts):

```
charts/hami/templates/scheduler/device-configmap.yaml  |  1 +
charts/hami/values.yaml                                |  5 +++++
cmd/vGPUmonitor/metrics.go                             |  4 ++++
.../nvidiadevice/nvinternal/plugin/register.go         | 18 ++++++++++++++++--
pkg/device/nvidia/device.go                            |  7 ++++---
5 files changed, 30 insertions(+), 5 deletions(-)
```

The diff is byte-identical to the upstream merge in master; commit author is preserved as @jsl9208.

**Which issue(s) this PR fixes**:

Fixes #1838

(Also indirectly resolves the v2.8.x portion of #1511; master is already covered by #1637.)

**Special notes for your reviewer**:

- Verified on a real DGX Spark (GB10, aarch64) that the post-fix code:
  - Logs `GetMemoryInfo not supported for device <UUID>, using configured PreConfiguredDeviceMemory: 131072 MB` instead of panicking.
  - Successfully registers `nvidia.com/gpu: 2` with the configured `deviceSplitCount`.
  - Allows two pods to share the GPU with HAMi's per-pod memory accounting.
- No new tests added: the fix's unit-test coverage is in the original PR #1637 and applies unchanged here.
- Submodule pointer (`libvgpu`) intentionally left untouched.

**Does this PR introduce a user-facing change?**:

Yes — a new chart value, `devicePlugin.preConfiguredDeviceMemory` (in MiB), which the device-plugin uses as the device's memory budget when NVML reports `ERROR_NOT_SUPPORTED`. Default `0` preserves the previous behaviour for non-unified-memory GPUs.

```release-note
NVIDIA device-plugin no longer panics on GB10 / unified memory architectures
when `nvmlDeviceGetMemoryInfo` returns ERROR_NOT_SUPPORTED. Set
`devicePlugin.preConfiguredDeviceMemory` (MiB) to enable scheduling on
those devices. (cherry-pick of #1637)
```

---

_AI assistance disclosure: this PR's body and the cherry-pick mechanics were drafted with Claude Code; the underlying code change is the unmodified content of #1637, authored by @jsl9208. End-to-end behaviour of the cherry-picked code was verified by me on a DGX Spark before submission._
