### PR TITLE
fix: recover scheduling on nodes with stale Deleted_ handshake

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -510,7 +510,7 @@ func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
 		if len(parts) < 2 {
 			return true, false
 		}
-		formerTime, err := time.Parse(time.DateTime, parts[1])
+		formerTime, err := time.ParseInLocation(time.DateTime, parts[1], time.Local)
 		if err != nil {
 			return true, false
 		}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -502,6 +502,10 @@ func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
 		// Bare "Deleted" without a timestamp (used in some unit tests) and
 		// any unparsable timestamp must keep the conservative (true, false)
 		// path so we never recover from a malformed value.
+		annoKey, ok := util.HandshakeAnnos[devType]
+		if !ok {
+			return true, false
+		}
 		parts := strings.SplitN(handshake, "_", 2)
 		if len(parts) < 2 {
 			return true, false
@@ -510,12 +514,17 @@ func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
 		if err != nil {
 			return true, false
 		}
-		if time.Now().Before(formerTime.Add(time.Second * 60)) {
+		now := time.Now()
+		if now.Before(formerTime.Add(time.Second * 60)) {
 			return true, false
 		}
-		tmppat := make(map[string]string)
-		tmppat[util.HandshakeAnnos[devType]] = "Requesting_" + time.Now().Format(time.DateTime)
-		klog.V(5).InfoS("Recovering stale Deleted_ handshake", "nodeName", node.Name, "annotationKey", util.HandshakeAnnos[devType], "annotationValue", tmppat[util.HandshakeAnnos[devType]])
+		newHandshake := "Requesting_" + now.Format(time.DateTime)
+		tmppat := map[string]string{annoKey: newHandshake}
+		klog.V(5).InfoS("Recovering stale Deleted_ handshake", "nodeName", node.Name, "annotationKey", annoKey, "annotationValue", newHandshake)
+		// Mirror the empty-annotation branch: GetNode also acts as a guard
+		// for an empty node.Name and an uninitialised client (PatchNodeAnnotations
+		// panics in unit tests without it). Worth a follow-up to dedupe with
+		// the else branch into a helper.
 		n, err := util.GetNode(node.Name)
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node", "nodeName", node.Name)

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -492,7 +492,39 @@ func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
 		formertime, _ := time.ParseInLocation(time.DateTime, strings.Split(handshake, "_")[1], time.Local)
 		return time.Now().Before(formertime.Add(time.Second * 60)), false
 	} else if strings.Contains(handshake, "Deleted") {
-		return true, false
+		// Mirror the timestamp logic used by the Requesting branch: a
+		// Deleted_<ts> older than 60s on a node whose devices are otherwise
+		// reporting healthy means the previous cleanup is stale and the
+		// scheduler should bring the node back into its cache. Stamp
+		// Requesting_<now> and return (true, true) so the caller re-adds
+		// node devices on the next reconcile.
+		//
+		// Bare "Deleted" without a timestamp (used in some unit tests) and
+		// any unparsable timestamp must keep the conservative (true, false)
+		// path so we never recover from a malformed value.
+		parts := strings.SplitN(handshake, "_", 2)
+		if len(parts) < 2 {
+			return true, false
+		}
+		formerTime, err := time.Parse(time.DateTime, parts[1])
+		if err != nil {
+			return true, false
+		}
+		if time.Now().Before(formerTime.Add(time.Second * 60)) {
+			return true, false
+		}
+		tmppat := make(map[string]string)
+		tmppat[util.HandshakeAnnos[devType]] = "Requesting_" + time.Now().Format(time.DateTime)
+		klog.V(5).InfoS("Recovering stale Deleted_ handshake", "nodeName", node.Name, "annotationKey", util.HandshakeAnnos[devType], "annotationValue", tmppat[util.HandshakeAnnos[devType]])
+		n, err := util.GetNode(node.Name)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get node", "nodeName", node.Name)
+			return true, false
+		}
+		if err := util.PatchNodeAnnotations(n, tmppat); err != nil {
+			klog.ErrorS(err, "Failed to patch node annotations", "nodeName", node.Name)
+		}
+		return true, true
 	} else {
 		_, ok := util.HandshakeAnnos[devType]
 		if ok {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -622,6 +622,68 @@ func Test_CheckHealth(t *testing.T) {
 			want2: false,
 		},
 		{
+			// Inside the 60s cooldown window — keep the conservative path,
+			// scheduler should not yet re-add the node to its cache.
+			name: "Deleted state within cooldown",
+			args: struct {
+				devType string
+				n       corev1.Node
+			}{
+				devType: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Deleted_2128-12-02 00:00:00",
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			// Stale Deleted_ — the recovery path is taken but util.GetNode
+			// fails outside a real cluster, so the function falls back to
+			// (true, false). Behaviour matches the existing "Unknown state"
+			// case which exercises the same util.GetNode failure path.
+			name: "Deleted state stale",
+			args: struct {
+				devType string
+				n       corev1.Node
+			}{
+				devType: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Deleted_2024-01-02 00:00:00",
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			// Unparsable timestamp must keep the conservative (true, false)
+			// path — never recover from a malformed value.
+			name: "Deleted state with unparsable timestamp",
+			args: struct {
+				devType string
+				n       corev1.Node
+			}{
+				devType: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Deleted_not-a-timestamp",
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
 			name: "Unknown state",
 			args: struct {
 				devType string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`CheckHealth` in `pkg/device/devices.go` previously returned `(true, false)` for any handshake annotation containing `Deleted`, which is what the scheduler's reconcile loop interprets as *"node is healthy AND no cache update needed"* — so it skips re-adding the node to its cache. After `NodeCleanUp` writes `Deleted_<ts>` and `s.rmNodeDevices(...)` removes the node from `s.nodes` (e.g. after a transient health failure during a node reboot), the node never gets re-added even after the device-plugin reports devices healthy again. Every subsequent GPU pod fails to schedule with:

```
0/N nodes are available: N node unregistered. no new claims to deallocate
```

This PR mirrors the timestamp logic that the `Requesting` branch already uses: if `Deleted_<ts>` is older than the same 60s cooldown window, stamp `Requesting_<now>` and return `(true, true)` so the scheduler re-adds the node's devices on its next reconcile. Inside the cooldown, behaviour is unchanged. Bare `"Deleted"` without a timestamp (used in some unit tests) and any unparsable timestamp also keep `(true, false)` so we never accidentally recover from a malformed value.

This is a single-file change in shared code, so it covers every vendor that uses `CheckHealth` (NVIDIA, Hygon, Ascend, Vastai, Kunlun, Iluvatar, Enflame, Mthreads, Metax) — all of them are stuck unconditionally today once the annotation is in `Deleted_<ts>` state.

**Which issue(s) this PR fixes**:

Fixes #1839

**Special notes for your reviewer**:

The shape of the fix follows the discussion on #1839, where @mesutoezdil pointed out that:

- Constraining `MarkAnnotationsToDelete` only prevents *new* stuck states.
- Re-stamping `Requesting_` from the device-plugin doesn't help: scheduler still takes the `(true, false)` exit (within the 60s window) and skips cache rebuild. Recovery requires `(true, true)` to fire the re-add.
- Mirroring the `Requesting_` time-window logic for `Deleted_<ts>` in `CheckHealth` is the right shape — single-file change, no device-plugin changes, covers all vendors.

The implementation also follows the maintainer's note that *"bare `Deleted` without a timestamp appears in some tests, make sure the parse-error path stays at `return true, false` rather than accidentally recovering."* Every parse and patch failure in the new branch returns the conservative `(true, false)`.

Local verification:

- `go test ./pkg/device/ -run Test_CheckHealth -v` — all 7 cases pass (4 existing + 3 new)
- `gofmt` clean, `go vet` clean
- The new test "Deleted state stale" returns `(true, false)` in unit-test env because `util.GetNode` fails outside a real cluster — matching the existing `"Unknown state"` case which exercises the same path.

The diff is small (`+95/-1` across `pkg/device/devices.go` and `pkg/device/devices_test.go`) and intentionally does not refactor the empty-annotation `else` branch even though the new branch is structurally similar — keeping the change minimal. Happy to factor out a shared helper in a follow-up if maintainers prefer.

**Marking as draft** while we get formal direction from an OWNERS approver on #1839; the code is ready to review but the discussion thread should ideally land first.

**Does this PR introduce a user-facing change?**:

```release-note
Fix scheduling on GPU nodes that recover after a transient health
failure: the scheduler now re-adds nodes whose `hami.io/node-handshake`
annotation is `Deleted_<ts>` older than the 60s cooldown, instead of
leaving them permanently outside the scheduler cache.
```

---

_AI assistance disclosure: this PR was drafted with Claude Code, based on the maintainer-led discussion in #1839 and on direct verification of `pkg/device/devices.go` and the existing `Test_CheckHealth` patterns. Code authored by me; tests pass locally before submission._
