### PR TITLE
fix A100-80G template

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -79,26 +79,26 @@ data:
           - 
             - name: 1g.10gb
               core: 14
-              memory: 10240
+              memory: 9728
               count: 7
           - 
             - name: 1g.10gb
               core: 14
-              memory: 10240
+              memory: 9728
               count: 1
             - name: 2g.20gb
               core: 28
-              memory: 20480
+              memory: 19968
               count: 3
           - 
             - name: 3g.40gb
               core: 42
-              memory: 40960
+              memory: 40192
               count: 2
           - 
             - name: 7g.80gb
               core: 98
-              memory: 81920
+              memory: 80896
               count: 1
       - models: [ "H100-PCIE-80GB", "H100-SXM5-80GB"]
         allowedGeometries:

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -96,9 +96,9 @@ data:
               memory: 40960
               count: 2
           - 
-            - name: 7g.79gb
-              core: 100
-              memory: 80896
+            - name: 7g.80gb
+              core: 98
+              memory: 81920
               count: 1
       - models: [ "H100-PCIE-80GB", "H100-SXM5-80GB"]
         allowedGeometries:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes # A100-SXM4-80GB MIG profile

Below is the result of `nvidia-smi mig -lgip` in my environment

```
nvidia-smi 
Fri May  8 19:04:43 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          On  |   00000000:3D:00.0 Off |                    0 |
| N/A   35C    P0             65W /  400W |       0MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA A100-SXM4-80GB          On  |   00000000:42:00.0 Off |                    0 |
| N/A   31C    P0             61W /  400W |       0MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
...

nvidia-smi mig -lgip
+-------------------------------------------------------------------------------+
| GPU instance profiles:                                                        |
| GPU   Name               ID    Instances   Memory     P2P    SM    DEC   ENC  |
|                                Free/Total   GiB              CE    JPEG  OFA  |
|===============================================================================|
|   0  MIG 1g.10gb         19     7/7        9.50       No     14     0     0   |
|                                                               1     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 1g.20gb         15     4/4        19.50      No     14     1     0   |
|                                                               1     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 2g.20gb         14     3/3        19.50      No     28     1     0   |
|                                                               2     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 3g.40gb          9     2/2        39.25      No     42     2     0   |
|                                                               3     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 4g.40gb          5     1/1        39.25      No     56     2     0   |
|                                                               4     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 7g.80gb          0     1/1        79.00      No     98     5     0   |
|                                                               7     0     1   |
+-------------------------------------------------------------------------------+

```

refer https://docs.nvidia.com/datacenter/tesla/mig-user-guide/latest/supported-mig-profiles.html#a100-mig-profiles 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: