### PR TITLE
fix: propagate parse errors in DecodeNodeDevices

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -18,7 +18,6 @@ package device
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -240,7 +239,7 @@ func GetDevices() map[string]Devices {
 
 func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 	if !strings.Contains(str, OneContainerMultiDeviceSplitSymbol) {
-		return []*DeviceInfo{}, errors.New("node annotations not decode successfully")
+		return nil, fmt.Errorf("node annotation missing device separator")
 	}
 	tmp := strings.Split(str, OneContainerMultiDeviceSplitSymbol)
 	var retval []*DeviceInfo
@@ -248,34 +247,40 @@ func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 		if strings.Contains(val, ",") {
 			items := strings.Split(val, ",")
 			if len(items) == 7 || len(items) == 9 {
-				count, _ := strconv.ParseInt(items[1], 10, 32)
-				devmem, _ := strconv.ParseInt(items[2], 10, 32)
-				devcore, _ := strconv.ParseInt(items[3], 10, 32)
-				health, _ := strconv.ParseBool(items[6])
-				numa, _ := strconv.Atoi(items[5])
+				count, err := strconv.ParseInt(items[1], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid count field: %w", err)
+				}
+				devmem, err := strconv.ParseInt(items[2], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid memory field: %w", err)
+				}
+				devcore, err := strconv.ParseInt(items[3], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid core field: %w", err)
+				}
+				health, err := strconv.ParseBool(items[6])
+				if err != nil {
+					return nil, fmt.Errorf("invalid health field: %w", err)
+				}
+				numa, err := strconv.Atoi(items[5])
+				if err != nil {
+					return nil, fmt.Errorf("invalid numa field: %w", err)
+				}
 				mode := "hami-core"
 				index := 0
 				if len(items) == 9 {
-					index, _ = strconv.Atoi(items[7])
+					index, err = strconv.Atoi(items[7])
+					if err != nil {
+						return nil, fmt.Errorf("invalid index field: %w", err)
+					}
 					mode = items[8]
-				}
-				count32, err := safecast.Convert[int32](count)
-				if err != nil {
-					return []*DeviceInfo{}, errors.New("node annotations not decode successfully")
-				}
-				devmem32, err := safecast.Convert[int32](devmem)
-				if err != nil {
-					return []*DeviceInfo{}, errors.New("node annotations not decode successfully")
-				}
-				devcore32, err := safecast.Convert[int32](devcore)
-				if err != nil {
-					return []*DeviceInfo{}, errors.New("node annotations not decode successfully")
 				}
 				i := DeviceInfo{
 					ID:      items[0],
-					Count:   count32,
-					Devmem:  devmem32,
-					Devcore: devcore32,
+					Count:   int32(count),
+					Devmem:  int32(devmem),
+					Devcore: int32(devcore),
 					Type:    items[4],
 					Numa:    numa,
 					Health:  health,
@@ -284,7 +289,7 @@ func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 				}
 				retval = append(retval, &i)
 			} else {
-				return []*DeviceInfo{}, errors.New("node annotations not decode successfully")
+				return nil, fmt.Errorf("unexpected field count %d in node annotation", len(items))
 			}
 		}
 	}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -274,6 +274,9 @@ func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 					if err != nil {
 						return nil, fmt.Errorf("invalid index field: %w", err)
 					}
+					if index < 0 {
+						return nil, fmt.Errorf("index field must not be negative: %d", index)
+					}
 					mode = items[8]
 				}
 				i := DeviceInfo{

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -244,56 +244,60 @@ func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 	tmp := strings.Split(str, OneContainerMultiDeviceSplitSymbol)
 	var retval []*DeviceInfo
 	for _, val := range tmp {
-		if strings.Contains(val, ",") {
-			items := strings.Split(val, ",")
-			if len(items) == 7 || len(items) == 9 {
-				count, err := strconv.ParseInt(items[1], 10, 32)
-				if err != nil {
-					return nil, fmt.Errorf("invalid count field: %w", err)
-				}
-				devmem, err := strconv.ParseInt(items[2], 10, 32)
-				if err != nil {
-					return nil, fmt.Errorf("invalid memory field: %w", err)
-				}
-				devcore, err := strconv.ParseInt(items[3], 10, 32)
-				if err != nil {
-					return nil, fmt.Errorf("invalid core field: %w", err)
-				}
-				health, err := strconv.ParseBool(items[6])
-				if err != nil {
-					return nil, fmt.Errorf("invalid health field: %w", err)
-				}
-				numa, err := strconv.Atoi(items[5])
-				if err != nil {
-					return nil, fmt.Errorf("invalid numa field: %w", err)
-				}
-				mode := "hami-core"
-				index := 0
-				if len(items) == 9 {
-					index, err = strconv.Atoi(items[7])
-					if err != nil {
-						return nil, fmt.Errorf("invalid index field: %w", err)
-					}
-					if index < 0 {
-						return nil, fmt.Errorf("index field must not be negative: %d", index)
-					}
-					mode = items[8]
-				}
-				i := DeviceInfo{
-					ID:      items[0],
-					Count:   int32(count),
-					Devmem:  int32(devmem),
-					Devcore: int32(devcore),
-					Type:    items[4],
-					Numa:    numa,
-					Health:  health,
-					Mode:    mode,
-					Index:   uint(index),
-				}
-				retval = append(retval, &i)
-			} else {
-				return nil, fmt.Errorf("unexpected field count %d in node annotation", len(items))
+		if val == "" {
+			continue
+		}
+		if !strings.Contains(val, ",") {
+			return nil, fmt.Errorf("malformed node annotation segment: %q", val)
+		}
+		items := strings.Split(val, ",")
+		if len(items) == 7 || len(items) == 9 {
+			count, err := strconv.ParseInt(items[1], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid count field: %w", err)
 			}
+			devmem, err := strconv.ParseInt(items[2], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid memory field: %w", err)
+			}
+			devcore, err := strconv.ParseInt(items[3], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid core field: %w", err)
+			}
+			health, err := strconv.ParseBool(items[6])
+			if err != nil {
+				return nil, fmt.Errorf("invalid health field: %w", err)
+			}
+			numa, err := strconv.Atoi(items[5])
+			if err != nil {
+				return nil, fmt.Errorf("invalid numa field: %w", err)
+			}
+			mode := "hami-core"
+			index := 0
+			if len(items) == 9 {
+				index, err = strconv.Atoi(items[7])
+				if err != nil {
+					return nil, fmt.Errorf("invalid index field: %w", err)
+				}
+				if index < 0 {
+					return nil, fmt.Errorf("index field must not be negative: %d", index)
+				}
+				mode = items[8]
+			}
+			i := DeviceInfo{
+				ID:      items[0],
+				Count:   int32(count),
+				Devmem:  int32(devmem),
+				Devcore: int32(devcore),
+				Type:    items[4],
+				Numa:    numa,
+				Health:  health,
+				Mode:    mode,
+				Index:   uint(index),
+			}
+			retval = append(retval, &i)
+		} else {
+			return nil, fmt.Errorf("unexpected field count %d in node annotation", len(items))
 		}
 	}
 	return retval, nil

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -461,8 +461,8 @@ func Test_DecodeNodeDevices(t *testing.T) {
 				di  []*DeviceInfo
 				err error
 			}{
-				di:  []*DeviceInfo{},
-				err: errors.New("node annotations not decode successfully"),
+				di:  nil,
+				err: errors.New("node annotation missing device separator"),
 			},
 		},
 		{

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -512,6 +512,17 @@ func Test_DecodeNodeDevices(t *testing.T) {
 			},
 		},
 		{
+			name: "malformed segment without comma",
+			args: "garbage:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`malformed node annotation segment: "garbage"`),
+			},
+		},
+		{
 			name: "invalid count field",
 			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,notanint,7680,100,NVIDIA-Tesla P4,0,true:",
 			want: struct {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -511,6 +511,94 @@ func Test_DecodeNodeDevices(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "invalid count field",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,notanint,7680,100,NVIDIA-Tesla P4,0,true:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid count field: strconv.ParseInt: parsing "notanint": invalid syntax`),
+			},
+		},
+		{
+			name: "invalid memory field",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,notanint,100,NVIDIA-Tesla P4,0,true:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid memory field: strconv.ParseInt: parsing "notanint": invalid syntax`),
+			},
+		},
+		{
+			name: "invalid core field",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,notanint,NVIDIA-Tesla P4,0,true:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid core field: strconv.ParseInt: parsing "notanint": invalid syntax`),
+			},
+		},
+		{
+			name: "invalid numa field",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,100,NVIDIA-Tesla P4,notanint,true:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid numa field: strconv.Atoi: parsing "notanint": invalid syntax`),
+			},
+		},
+		{
+			name: "invalid health field",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,100,NVIDIA-Tesla P4,0,notabool:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid health field: strconv.ParseBool: parsing "notabool": invalid syntax`),
+			},
+		},
+		{
+			name: "unexpected field count",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,100,NVIDIA-Tesla P4:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New("unexpected field count 5 in node annotation"),
+			},
+		},
+		{
+			name: "invalid index field in new format",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,100,NVIDIA-Tesla P4,0,true,notanint,hami-core:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New(`invalid index field: strconv.Atoi: parsing "notanint": invalid syntax`),
+			},
+		},
+		{
+			name: "negative index field in new format",
+			args: "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4,10,7680,100,NVIDIA-Tesla P4,0,true,-1,hami-core:",
+			want: struct {
+				di  []*DeviceInfo
+				err error
+			}{
+				di:  nil,
+				err: errors.New("index field must not be negative: -1"),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
DecodeNodeDevices was ignoring parse errors from strconv.ParseInt, strconv.ParseBool, and strconv.Atoi. A bad annotation value would silently become zero, leading to incorrect device allocation.

Each field now returns a wrapped error on parse failure. The safecast calls were removed because ParseInt with bitSize 32 already covers the int32 range check. Generic error messages are replaced with field-specific context. The test is updated to match.