### PR TITLE
fix: propagate parse errors in DecodeContainerDevices

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -413,7 +413,7 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 		if strings.Contains(val, ",") {
 			tmpstr := strings.Split(val, ",")
 			if len(tmpstr) < 4 {
-				return ContainerDevices{}, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
+				return nil, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
 			}
 			tmpdev.UUID = tmpstr[0]
 			tmpdev.Type = tmpstr[1]

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -411,16 +411,21 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 	klog.V(5).Infof("Start to decode container device %s", str)
 	for _, val := range cd {
 		if strings.Contains(val, ",") {
-			//fmt.Println("cd is ", val)
 			tmpstr := strings.Split(val, ",")
 			if len(tmpstr) < 4 {
 				return ContainerDevices{}, fmt.Errorf("pod annotation format error; information missing, please do not use nodeName field in task")
 			}
 			tmpdev.UUID = tmpstr[0]
 			tmpdev.Type = tmpstr[1]
-			devmem, _ := strconv.ParseInt(tmpstr[2], 10, 32)
+			devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid memory field: %w", err)
+			}
 			tmpdev.Usedmem = int32(devmem)
-			devcores, _ := strconv.ParseInt(tmpstr[3], 10, 32)
+			devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid core field: %w", err)
+			}
 			tmpdev.Usedcores = int32(devcores)
 			contdev = append(contdev, tmpdev)
 		}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -449,7 +449,7 @@ func DecodePodDevices(checklist map[string]string, annos map[string]string) (Pod
 		for s := range strings.SplitSeq(str, OnePodMultiContainerSplitSymbol) {
 			cd, err := DecodeContainerDevices(s)
 			if err != nil {
-				return PodDevices{}, nil
+				return PodDevices{}, err
 			}
 			// IMPORTANT: Do NOT skip empty ContainerDevices!
 			// We must preserve the index mapping between annotation entries and pod containers.

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -413,7 +413,7 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 		if strings.Contains(val, ",") {
 			tmpstr := strings.Split(val, ",")
 			if len(tmpstr) < 4 {
-				return ContainerDevices{}, fmt.Errorf("pod annotation format error; information missing, please do not use nodeName field in task")
+				return ContainerDevices{}, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
 			}
 			tmpdev.UUID = tmpstr[0]
 			tmpdev.Type = tmpstr[1]

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -45,6 +45,13 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 	assert.DeepEqual(t, cd1, cd2)
 }
 
+func TestDecodeContainerDevices_InvalidFields(t *testing.T) {
+	_, err := DecodeContainerDevices("uuid,type,notanumber,3:")
+	assert.Assert(t, err != nil)
+	_, err = DecodeContainerDevices("uuid,type,100,notanumber:")
+	assert.Assert(t, err != nil)
+}
+
 func TestEmptyPodDeviceCoding(t *testing.T) {
 	pd1 := PodDevices{}
 	s := EncodePodDevices(inRequestDevices, pd1)

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -46,7 +46,9 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 }
 
 func TestDecodeContainerDevices_InvalidFields(t *testing.T) {
-	_, err := DecodeContainerDevices("uuid,type,notanumber,3:")
+	_, err := DecodeContainerDevices("uuid,type,100:")
+	assert.Assert(t, err != nil)
+	_, err = DecodeContainerDevices("uuid,type,notanumber,3:")
 	assert.Assert(t, err != nil)
 	_, err = DecodeContainerDevices("uuid,type,100,notanumber:")
 	assert.Assert(t, err != nil)


### PR DESCRIPTION
DecodeContainerDevices was ignoring errors from strconv.ParseInt when reading device memory and core count. A malformed annotation would silently produce a zero-value device with no error returned.

Each field now returns a wrapped error on parse failure. A dead debug comment was also removed. A pre-existing semicolon in an error message was cleaned up.