### PR TITLE
fix: return error from DecodePodDevices on decode failure

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -584,7 +584,8 @@ func (cc ClusterManagerCollector) collectPodAndContainerMigInfo(ch chan<- promet
 	for _, pod := range pods {
 		pdevices, err := device.DecodePodDevices(device.SupportDevices, pod.Annotations)
 		if err != nil {
-			return fmt.Errorf("failed to decode pod devices: %w", err)
+			klog.Errorf("failed to decode pod devices for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
 		}
 		for ctrIdx, container := range pod.Spec.Containers {
 			for ctrDevIdx, ctrDevices := range pdevices[nv.NvidiaGPUDevice] {

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -444,7 +444,7 @@ func DecodePodDevices(checklist map[string]string, annos map[string]string) (Pod
 		for s := range strings.SplitSeq(str, OnePodMultiContainerSplitSymbol) {
 			cd, err := DecodeContainerDevices(s)
 			if err != nil {
-				return PodDevices{}, nil
+				return PodDevices{}, err
 			}
 			// IMPORTANT: Do NOT skip empty ContainerDevices!
 			// We must preserve the index mapping between annotation entries and pod containers.

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -293,6 +293,13 @@ func Test_DecodePodDevices(t *testing.T) {
 	}
 }
 
+func TestDecodePodDevices_BadAnnotation(t *testing.T) {
+	checklist := map[string]string{"NVIDIA": "hami.io/vgpu-devices-to-allocate"}
+	annos := map[string]string{"hami.io/vgpu-devices-to-allocate": "uuid,type,100:;"}
+	_, err := DecodePodDevices(checklist, annos)
+	assert.Assert(t, err != nil)
+}
+
 func TestMarshalNodeDevices(t *testing.T) {
 	type args struct {
 		dlist []*DeviceInfo

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -157,7 +157,10 @@ func (s *Scheduler) onAddPod(obj any) {
 		s.podManager.UpdatePod(pod)
 		return
 	}
-	podDev, _ := device.DecodePodDevices(device.SupportDevices, pod.Annotations)
+	podDev, err := device.DecodePodDevices(device.SupportDevices, pod.Annotations)
+	if err != nil {
+		klog.Errorf("failed to decode pod devices for %s: %v", pod.Name, err)
+	}
 	if s.podManager.AddPod(pod, nodeID, podDev) {
 		s.quotaManager.AddUsage(pod, podDev)
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -160,6 +160,7 @@ func (s *Scheduler) onAddPod(obj any) {
 	podDev, err := device.DecodePodDevices(device.SupportDevices, pod.Annotations)
 	if err != nil {
 		klog.Errorf("failed to decode pod devices for %s: %v", pod.Name, err)
+		return
 	}
 	if s.podManager.AddPod(pod, nodeID, podDev) {
 		s.quotaManager.AddUsage(pod, podDev)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -159,7 +159,7 @@ func (s *Scheduler) onAddPod(obj any) {
 	}
 	podDev, err := device.DecodePodDevices(device.SupportDevices, pod.Annotations)
 	if err != nil {
-		klog.Errorf("failed to decode pod devices for %s: %v", pod.Name, err)
+		klog.ErrorS(err, "failed to decode pod devices", "pod", klog.KObj(pod))
 		return
 	}
 	if s.podManager.AddPod(pod, nodeID, podDev) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1439,3 +1439,23 @@ func Test_Scheduler_Issue1368_TerminatingPodRetainsCache(t *testing.T) {
 	_, ok = s.podManager.GetPod(terminatedPod)
 	assert.Equal(t, false, ok, "Pod should be removed from cache after reaching a terminal phase (Succeeded/Failed)")
 }
+
+func Test_onAddPod_BadDeviceAnnotation(t *testing.T) {
+	device.SupportDevices["TEST"] = "hami.io/test-allocated"
+	s := NewScheduler()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "bad-anno-uid",
+			Name:      "bad-anno-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AssignedNodeAnnotations:  "node1",
+				"hami.io/test-allocated":      "uuid,type,100:;",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	s.onAddPod(pod)
+	_, ok := s.podManager.GetPod(pod)
+	assert.Equal(t, true, ok)
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1449,8 +1449,8 @@ func Test_onAddPod_BadDeviceAnnotation(t *testing.T) {
 			Name:      "bad-anno-pod",
 			Namespace: "default",
 			Annotations: map[string]string{
-				util.AssignedNodeAnnotations:  "node1",
-				"hami.io/test-allocated":      "uuid,type,100:;",
+				util.AssignedNodeAnnotations: "node1",
+				"hami.io/test-allocated":     "uuid,type,100:;",
 			},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1457,5 +1457,5 @@ func Test_onAddPod_BadDeviceAnnotation(t *testing.T) {
 	}
 	s.onAddPod(pod)
 	_, ok := s.podManager.GetPod(pod)
-	assert.Equal(t, true, ok)
+	assert.Equal(t, false, ok)
 }


### PR DESCRIPTION
DecodePodDevices was returning nil error when DecodeContainerDevices failed, hiding the problem from all callers. onAddPod in the scheduler was discarding the error with blank identifier, so failures were never visible in logs.

DecodePodDevices now passes back the error. onAddPod logs it and continues tracking the pod with an empty device map.