### PR TITLE
fix(nvidia): add explicit check for gpumem when determining exclusive…

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -416,11 +416,17 @@ func (dev *NvidiaGPUDevices) defaultExclusiveCoreIfNeeded(ctr *corev1.Container)
 	}
 
 	exclusive := false
+	// gpumem-percentage explicitly set
 	if pct, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryPercentageName)); ok {
 		exclusive = pct == 100
+	} else if _, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryName)); ok {
+		// gpumem is explicitly set to a specific value (NOT exclusive)
+		exclusive = false
 	} else if dev.config.ResourceMemoryName == "" {
+		// ResourceMemoryName is disabled in config (treat as exclusive)
 		exclusive = true
-	} else if _, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryName)); !ok {
+	} else {
+		// Neither gpumem-percentage nor gpumem is set  (default to exclusive (100%))
 		exclusive = true
 	}
 

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -415,19 +415,11 @@ func (dev *NvidiaGPUDevices) defaultExclusiveCoreIfNeeded(ctr *corev1.Container)
 		return false
 	}
 
-	exclusive := false
-	// gpumem-percentage explicitly set
+	exclusive := true // Default to exclusive
 	if pct, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryPercentageName)); ok {
 		exclusive = pct == 100
 	} else if _, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryName)); ok {
-		// gpumem is explicitly set to a specific value (NOT exclusive)
-		exclusive = false
-	} else if dev.config.ResourceMemoryName == "" {
-		// ResourceMemoryName is disabled in config (treat as exclusive)
-		exclusive = true
-	} else {
-		// Neither gpumem-percentage nor gpumem is set  (default to exclusive (100%))
-		exclusive = true
+		exclusive = false // ✅ Same explicit check, but cleaner
 	}
 
 	if !exclusive {


### PR DESCRIPTION
Fixes #1863 
## Problem
`nvidia.com/gpucores` is incorrectly auto-set to 100 when only `nvidia.com/gpumem` 
is requested with a specific value.

## Solution
Add explicit check in defaultExclusiveCoreIfNeeded() if gpumem is present 
with a specific value, treat as shareable memory (not exclusive).