### PR TITLE
feat: Support enflame drs

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -54,8 +54,9 @@ This document provides detailed descriptions of all configurable values paramete
 ### Enflame GCU Resources
 | Parameter | Description | Default Value |
 |-----------|-------------|---------------|
-| `enflameResourceNameVGCU` | vGCU resource name | `"enflame.com/vgcu"` |
-| `enflameResourceNameVGCUPercentage` | vGCU percentage resource name | `"enflame.com/vgcu-percentage"` |
+| `enflameResourceNameDRSGCU` | DRS GCU resource name | `"enflame.com/drs-gcu"` |
+| `enflameResourceNameGCUMemory` | GCU memory request resource name | `"enflame.com/gcu-memory"` |
+| `enflameResourceNameGCUCore` | GCU core request resource name | `"enflame.com/gcu-core"` |
 
 ### Kunlunxin XPU Resources
 | Parameter | Description | Default Value |

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -247,8 +247,9 @@ data:
       sgpuTopologyAware: {{ .Values.metaxsGPUTopologyAware }}
     enflame:
       resourceNameGCU: "enflame.com/gcu"
-      resourceNameVGCU: {{ .Values.enflameResourceNameVGCU }}
-      resourceNameVGCUPercentage: {{ .Values.enflameResourceNameVGCUPercentage }}
+      resourceNameDRSGCU: {{ .Values.enflameResourceNameDRSGCU }}
+      resourceNameGCUMemory: {{ .Values.enflameResourceNameGCUMemory }}
+      resourceNameGCUCore: {{ .Values.enflameResourceNameGCUCore }}
     mthreads:
       resourceCountName: "mthreads.com/vgpu"
       resourceMemoryName: "mthreads.com/sgpu-memory"

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -44,9 +44,10 @@ metaxResourceCore: "metax-tech.com/vcore"
 metaxResourceMem: "metax-tech.com/vmemory"
 metaxsGPUTopologyAware: "false"
 
-#Enflame VGCU Parameters
-enflameResourceNameVGCU: "enflame.com/vgcu"
-enflameResourceNameVGCUPercentage: "enflame.com/vgcu-percentage"
+#Enflame DRS Parameters
+enflameResourceNameDRSGCU: "enflame.com/drs-gcu"
+enflameResourceNameGCUMemory: "enflame.com/gcu-memory"
+enflameResourceNameGCUCore: "enflame.com/gcu-core"
 
 #Kunlun XPU Parameters
 kunlunResourceName: "kunlunxin.com/xpu"
@@ -458,8 +459,9 @@ devices:
   enflame:
     enabled: true
     customresources:
-      - enflame.com/vgcu
-      - enflame.com/vgcu-percentage
+      - enflame.com/drs-gcu
+      - enflame.com/gcu-memory
+      - enflame.com/gcu-core
       - enflame.com/gcu
   mthreads:
     enabled: true

--- a/docs/enflame-vgcu-support.md
+++ b/docs/enflame-vgcu-support.md
@@ -1,61 +1,45 @@
 ## Introduction
 
-**We now support sharing on enflame.com/gcu(i.e S60) by implementing most device-sharing features as nvidia-GPU**, including:
+HAMi now supports Enflame **DRS** hard partition scheduling, aligned with Enflame native scheduler behavior.
 
-***GCU sharing***: Each task can allocate a portion of GCU instead of a whole GCU card, thus GCU can be shared among multiple tasks.
-
-***Device Memory and Core Control***: GCUs can be allocated with certain percentage of device memory and core, we make sure that it does not exceed the boundary.
-
-***Device UUID Selection***: You can specify which GCU devices to use or exclude using annotations.
-
-***Very Easy to use***: You don't need to modify your task yaml to use our scheduler. All your GPU jobs will be automatically supported after installation.
+DRS is a hard-slice mode similar to NVIDIA MIG and Ascend VNPU templates.
 
 ## Prerequisites
 
-* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, we only need gcushare-device-plugin here )
-* driver version >= 1.2.3.14
+* Enflame gcushare-device-plugin >= 2.2.14
+* driver version >= 1.8.7
 * kubernetes >= 1.24
-* enflame-container-toolkit >=2.0.50
+* enflame-container-toolkit >= 2.0.50
 
-## Enabling GCU-sharing Support
+## Enable Enflame DRS scheduling
 
-* Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
+* Deploy `gcushare-device-plugin` on Enflame nodes.
+* Enable Enflame support in HAMi:
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
-
-> **NOTE:** The default resource names are:
-> - `enflame.com/vgcu` for GCU count, only support 1 now.
-> - `enflame.com/vgcu-percentage` for the percentage of memory and cores in a gcu slice.
->
-> You can customize these names by modifying `hami-scheduler-device` configMap above.
-
-* Set 'devices.enflame.enabled=true' when deploy HAMi
-
-```
+```bash
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system
 ```
 
-## Device Granularity
+Default DRS resource:
 
-HAMi divides each Enflame GCU into 100 units for resource allocation. When you request a portion of a GPU, you're actually requesting a certain number of these units.
+* `enflame.com/drs-gcu`
+* `enflame.com/gcu-memory`
+* `enflame.com/gcu-core`
 
-### GCU Slice Allocation
+## Run DRS workloads
 
-- Each unit of `enflame.com/vgcu-percentage` represents 1% device memory and 1% core
-- If you don't specify a memory request, the system will default to using 100% of the available memory
-- Memory allocation is enforced with hard limits to ensure tasks don't exceed their allocated memory
-- Core allocation is enforced with hard limits to ensure tasks don't exceed their allocated cores
+HAMi supports two request styles:
 
-## Running Enflame jobs
+1. Direct DRS slice request (`enflame.com/drs-gcu`)
+2. Unified memory/core request (`enflame.com/gcu-memory` + `enflame.com/gcu-core`), HAMi converts it to DRS profile internally.
 
-Enflame GCUs can now be requested by a container
-using the `enflame.com/vgcu` and `enflame.com/vgcu-percentage`  resource type:
+### 1) Direct DRS slice request
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: gcushare-pod-2
+  name: gcushare-pod-drs
   namespace: kube-system
 spec:
   terminationGracePeriodSeconds: 0
@@ -63,58 +47,46 @@ spec:
     - name: pod-gcu-example1
       image: ubuntu:18.04
       imagePullPolicy: IfNotPresent
-      command:
-        - sleep
-      args:
-        - '100000'
+      command: ["sleep"]
+      args: ["100000"]
       resources:
         limits:
-          enflame.com/vgcu: 1
-          enflame.com/vgcu-percentage: 22
+          enflame.com/drs-gcu: 3
+        requests:
+          enflame.com/drs-gcu: 3
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](../examples/enflame/)*
-
-## Device UUID Selection
-
-You can specify which GPU devices to use or exclude using annotations:
+### 2) Request by memory/core (recommended unified API)
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
-  annotations:
-    # Use specific GPU devices (comma-separated list)
-    enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
-    enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
+  name: gcushare-pod-by-spec
+  namespace: kube-system
 spec:
-  # ... rest of pod spec
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: pod-gcu-example1
+      image: ubuntu:18.04
+      imagePullPolicy: IfNotPresent
+      command: ["sleep"]
+      args: ["100000"]
+      resources:
+        limits:
+          enflame.com/gcu-memory: 20480 # MiB
+          enflame.com/gcu-core: 40      # percent
+        requests:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40
 ```
 
-> **NOTE:** The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+During scheduling HAMi writes DRS-compatible annotations such as:
 
-### Finding Device UUIDs
+* `assigned-containers`
+* `enflame.com/gcu-assigned`
+* `enflame.com/gcu-assigned-index`
+* `enflame.com/gcu-assigned-minor`
+* `enflame.com/gcu-request-size`
 
-You can find the UUIDs of Enflame GCUs on a node using the following command:
-
-```bash
-kubectl get pod <pod-name> -o yaml | grep -A 10 "hami.io/<card-type>-devices-allocated"
-```
-
-Or by examining the node annotations:
-
-```bash
-kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-type>"
-```
-
-Look for annotations containing device information in the node status.
-
-## Notes
-
-1. GCUshare takes effect only for containers that apply for one GCU(i.e enflame.com/vgcu=1 ).
-
-2. Multiple GCU allocation in one container is not supported yet
-
-3. `efsmi` inside container shows the total device memory, which is NOT a bug, device memory will be properly limited when running tasks.
+These annotations are then consumed by Enflame device-plugin allocate flow.

--- a/docs/enflame-vgcu-support_cn.md
+++ b/docs/enflame-vgcu-support_cn.md
@@ -1,26 +1,19 @@
 ## 简介
 
-本组件支持复用燧原GCU设备(S60)，并为此提供以下几种与vGPU类似的复用功能，包括：
+HAMi 现已支持燧原 **DRS 硬切分**调度，并对齐燧原原生调度器链路。
 
-***GPU 共享***: 每个任务可以只占用一部分显卡，多个任务可以共享一张显卡
-
-***百分比切片能力***: 你现在可以用百分比来申请一个GCU切片（例如20%），本组件会确保任务使用的显存和算力不会超过这个百分比对应的数值
-
-***设备 UUID 选择***: 你可以通过注解指定使用或排除特定的GCU设备
-
-***方便易用***:  部署本组件后，只需要部署厂家提供的gcushare-device-plugin即可使用
-
+DRS 是类似 NVIDIA MIG / Ascend VNPU 的硬切分方案。
 
 ## 节点需求
 
-* Enflame gcushare-device-plugin >= 2.1.6
-* driver version >= 1.2.3.14
+* Enflame gcushare-device-plugin >= 2.2.14
+* driver version >= 1.8.7
 * kubernetes >= 1.24
 * enflame-container-toolkit >=2.0.50
 
 ## 开启GCU复用
 
-* 部署'gcushare-device-plugin'，燧原的GCU共享需要配合厂家提供的'gcushare-device-plugin'一起使用，请联系设备提供方获取
+* 部署 `gcushare-device-plugin`，并确保版本支持 DRS。
 
 > **注意:** *只需要安装gcushare-device-plugin，不要安装gcushare-scheduler-plugin.*
 
@@ -30,29 +23,25 @@
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system
 ```
 
-> **说明:** 默认资源名称如下：
-> - `enflame.com/vgcu` 用于GCU数量，这里只能为1
-> - `enflame.com/vgcu-percentage` 用于生成共享GCU切片
->
-> 你可以通过修改`hami-scheduler-device`配置，来修改这些资源名称
-
-## 设备粒度切分
-
-HAMi 将每个燧原 GCU 划分为 100 个单元进行资源分配。当你请求一部分 GPU 时，实际上是在请求这些单元中的一定数量。
-
-### 内存和核心分配
-
-- 每个 `enflame.com/vgcu-percentage` 单位代表1%的算力和1%的显存
-- 如果不指定内存请求，系统将默认使用 100% 的可用内存
-- 内存与核心的分配通过硬限制强制执行，确保任务不会超过其分配的内存与核心
+> **说明:** 默认资源名称包括：
+> - `enflame.com/drs-gcu`（直接 DRS 切片请求）
+> - `enflame.com/gcu-memory`（按显存请求，单位 MiB）
+> - `enflame.com/gcu-core`（按算力百分比请求）
 
 ## 运行GCU任务
+
+HAMi 支持两种申请方式：
+
+1. 直接申请 DRS 切片数（`enflame.com/drs-gcu`）
+2. 按显存/算力申请（`enflame.com/gcu-memory` + `enflame.com/gcu-core`），由 HAMi 在调度内部换算为 DRS profile。
+
+### 1）直接申请 DRS 切片
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: gcushare-pod-2
+  name: gcushare-pod-drs
   namespace: kube-system
 spec:
   terminationGracePeriodSeconds: 0
@@ -66,52 +55,47 @@ spec:
         - '100000'
       resources:
         limits:
-          enflame.com/vgcu: 1
-          enflame.com/vgcu-percentage: 22
+          enflame.com/drs-gcu: 3
+        requests:
+          enflame.com/drs-gcu: 3
 ```
 > **注意:** *查看更多的[用例](../examples/enflame/).*
 
-## 设备 UUID 选择
-
-你可以通过 Pod 注解来指定要使用或排除特定的 GPU 设备：
+### 2）按显存/算力申请（统一 API）
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
-  annotations:
-    # Use specific GPU devices (comma-separated list)
-    enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
-    enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
+  name: gcushare-pod-by-spec
+  namespace: kube-system
 spec:
-  # ... rest of pod spec
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: pod-gcu-example1
+      image: ubuntu:18.04
+      imagePullPolicy: IfNotPresent
+      command:
+        - sleep
+      args:
+        - '100000'
+      resources:
+        limits:
+          enflame.com/gcu-memory: 20480 # MiB
+          enflame.com/gcu-core: 40      # 百分比
+        requests:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40
 ```
-
-> **说明:** 设备 ID 格式为 `{节点名称}-enflame-{索引}`。你可以在节点状态中找到可用的设备 ID。
-
-### 查找设备 UUID
-
-你可以使用以下命令查找节点上的燧原 GCU 设备 UUID：
-
-```bash
-kubectl get pod <pod-name> -o yaml | grep -A 10 "hami.io/<card-type>-devices-allocated"
-```
-
-或者通过检查节点注解：
-
-```bash
-kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-type>"
-```
-
-在节点注解中查找包含设备信息的注解。
-
 
 ## 注意事项
 
-1. 共享模式只对申请一张GPU的容器生效（enflame.com/vgcu=1）。
+HAMi 在调度阶段会写入与 DRS 兼容的注解，包括：
 
-2. 目前暂时不支持一个容器中申请多个GCU设备。
+* `assigned-containers`
+* `enflame.com/gcu-assigned`
+* `enflame.com/gcu-assigned-index`
+* `enflame.com/gcu-assigned-minor`
+* `enflame.com/gcu-request-size`
 
-3. 任务中使用`efsmi`可以看到全部的显存，但这并非异常，显存会在任务使用过程中被正确限制。
+这些注解将由燧原 device-plugin 在 Allocate 阶段继续处理并完成 DRS instance 绑定。

--- a/examples/enflame/vgcu_use.yaml
+++ b/examples/enflame/vgcu_use.yaml
@@ -1,4 +1,4 @@
-# request 1 vgcu device
+# request 1g DRS profile
 apiVersion: v1
 kind: Pod
 metadata:
@@ -16,9 +16,11 @@ spec:
         - '100000'
       resources:
         limits:
-          enflame.com/vgcu: 1
+          enflame.com/drs-gcu: 1
+        requests:
+          enflame.com/drs-gcu: 1
 ---
-# request 22% vgcu devices
+# request 3g DRS profile
 apiVersion: v1
 kind: Pod
 metadata:
@@ -36,5 +38,30 @@ spec:
         - '100000'
       resources:
         limits:
-          enflame.com/vgcu: 1
-          enflame.com/vgcu-percentage: 22 # The GCU is divided into N portions, each as a percentage tier, and the requested percentage is rounded up to the nearest tier.
+          enflame.com/drs-gcu: 3
+        requests:
+          enflame.com/drs-gcu: 3
+---
+# request by memory/core, HAMi converts to DRS profile automatically
+apiVersion: v1
+kind: Pod
+metadata:
+  name: drs-pod-by-spec
+  namespace: kube-system
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: pod-gcu-example1
+      image: ubuntu:18.04
+      imagePullPolicy: IfNotPresent
+      command:
+        - sleep
+      args:
+        - '100000'
+      resources:
+        limits:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40
+        requests:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40

--- a/pkg/device/enflame/config.go
+++ b/pkg/device/enflame/config.go
@@ -20,6 +20,9 @@ import "flag"
 
 var (
 	EnflameResourceNameGCU            string
+	EnflameResourceNameDRSGCU         string
+	EnflameResourceNameGCUMemory      string
+	EnflameResourceNameGCUCore        string
 	EnflameResourceNameVGCU           string
 	EnflameResourceNameVGCUPercentage string
 )
@@ -28,7 +31,12 @@ type EnflameConfig struct {
 	// GCU
 	ResourceNameGCU string `yaml:"resourceNameGCU"`
 
-	// Shared-GCU
+	// DRS-GCU (new hard-partition mode)
+	ResourceNameDRSGCU string `yaml:"resourceNameDRSGCU"`
+	ResourceNameMemory string `yaml:"resourceNameGCUMemory"`
+	ResourceNameCore   string `yaml:"resourceNameGCUCore"`
+
+	// Legacy shared-GCU key kept for compatibility.
 	ResourceNameVGCU           string `yaml:"resourceNameVGCU"`
 	ResourceNameVGCUPercentage string `yaml:"resourceNameVGCUPercentage"`
 }
@@ -37,7 +45,13 @@ func ParseConfig(fs *flag.FlagSet) {
 	// GCU
 	fs.StringVar(&EnflameResourceNameGCU, "enflame-gcu-resource-name", "enflame.com/gcu", "enflame gcu resource name")
 
-	// Shared-GCU
-	fs.StringVar(&EnflameResourceNameVGCU, "enflame-vgcu-resource-name", "enflame.com/vgcu", "enflame shared gcu count resource name")
+	// DRS-GCU.
+	fs.StringVar(&EnflameResourceNameDRSGCU, "enflame-drs-gcu-resource-name", "enflame.com/drs-gcu", "enflame drs gcu resource name")
+	fs.StringVar(&EnflameResourceNameGCUMemory, "enflame-gcu-memory-resource-name", "enflame.com/gcu-memory", "enflame gcu memory request resource name")
+	fs.StringVar(&EnflameResourceNameGCUCore, "enflame-gcu-core-resource-name", "enflame.com/gcu-core", "enflame gcu core request resource name")
+	// Legacy flag alias for backward compatibility.
+	fs.StringVar(&EnflameResourceNameDRSGCU, "enflame-vgcu-resource-name", "enflame.com/drs-gcu", "legacy enflame vgcu resource name, now maps to drs-gcu")
+	// Legacy shared-GCU related flags.
+	fs.StringVar(&EnflameResourceNameVGCU, "enflame-vgcu-legacy-resource-name", "enflame.com/vgcu", "legacy enflame shared gcu count resource name")
 	fs.StringVar(&EnflameResourceNameVGCUPercentage, "enflame-vgcu-percentage-resource-name", "enflame.com/vgcu-percentage", "enflame shared gcu percentage resource name")
 }

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -17,7 +17,11 @@ limitations under the License.
 package enflame
 
 import (
+	"encoding/json"
 	"fmt"
+	"maps"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,13 +30,10 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device/common"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 )
 
-type EnflameDevices struct {
-	factor int
-}
+type EnflameDevices struct{}
 
 const (
 	EnflameVGCUDevice     = "Enflame"
@@ -44,23 +45,63 @@ const (
 	PodRequestGCUSize  = "enflame.com/gcu-request-size"
 	PodAssignedGCUID   = "enflame.com/gcu-assigned-id"
 	PodHasAssignedGCU  = "enflame.com/gcu-assigned"
+	PodAssignedGCUIdx  = "enflame.com/gcu-assigned-index"
+	PodAssignedGCUMin  = "enflame.com/gcu-assigned-minor"
 	PodAssignedGCUTime = "enflame.com/gcu-assigned-time"
-	GCUSharedCapacity  = "enflame.com/gcu-shared-capacity"
+	AssignedContainers = "assigned-containers"
+	GCUDrsCapacity     = "enflame.com/gcu-drs-capacity"
 
 	SharedResourceName = "enflame.com/shared-gcu"
 	CountNoSharedName  = "enflame.com/gcu-count"
+
+	enflameRequestModeDirect  int32 = 0
+	enflameRequestModeBySpec  int32 = -1
+	enflameUnknownCoreRequest int32 = 0
 )
 
+type drsCapacitySpec struct {
+	Devices  []drsDeviceSpec   `json:"devices"`
+	Profiles map[string]string `json:"profiles"`
+}
+
+type drsDeviceSpec struct {
+	Index    string `json:"index"`
+	Minor    string `json:"minor"`
+	Capacity any    `json:"capacity"`
+}
+
+type assignedContainerInfo struct {
+	Allocated    bool   `json:"allocated"`
+	Request      int32  `json:"request"`
+	ProfileID    string `json:"profileID,omitempty"`
+	ProfileName  string `json:"profileName,omitempty"`
+	InstanceID   string `json:"instanceID,omitempty"`
+	InstanceUUID string `json:"instanceUUID,omitempty"`
+}
+
 func InitEnflameDevice(config EnflameConfig) *EnflameDevices {
+	EnflameResourceNameDRSGCU = config.ResourceNameDRSGCU
+	if EnflameResourceNameDRSGCU == "" {
+		EnflameResourceNameDRSGCU = config.ResourceNameVGCU
+	}
+	if EnflameResourceNameDRSGCU == "" {
+		EnflameResourceNameDRSGCU = "enflame.com/drs-gcu"
+	}
+	EnflameResourceNameGCUMemory = config.ResourceNameMemory
+	if EnflameResourceNameGCUMemory == "" {
+		EnflameResourceNameGCUMemory = "enflame.com/gcu-memory"
+	}
+	EnflameResourceNameGCUCore = config.ResourceNameCore
+	if EnflameResourceNameGCUCore == "" {
+		EnflameResourceNameGCUCore = "enflame.com/gcu-core"
+	}
 	EnflameResourceNameVGCU = config.ResourceNameVGCU
 	EnflameResourceNameVGCUPercentage = config.ResourceNameVGCUPercentage
 	_, ok := device.SupportDevices[EnflameVGCUDevice]
 	if !ok {
 		device.SupportDevices[EnflameVGCUDevice] = "hami.io/enflame-vgpu-devices-allocated"
 	}
-	return &EnflameDevices{
-		factor: 0,
-	}
+	return &EnflameDevices{}
 }
 
 func (dev *EnflameDevices) CommonWord() string {
@@ -68,58 +109,133 @@ func (dev *EnflameDevices) CommonWord() string {
 }
 
 func (dev *EnflameDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	count, ok := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameVGCU)]
+	resourceCount := corev1.ResourceName(EnflameResourceNameDRSGCU)
+	count, ok := ctr.Resources.Limits[resourceCount]
+	if !ok {
+		count, ok = ctr.Resources.Requests[resourceCount]
+	}
+	if ctr.Resources.Limits == nil {
+		ctr.Resources.Limits = corev1.ResourceList{}
+	}
+	if ctr.Resources.Requests == nil {
+		ctr.Resources.Requests = corev1.ResourceList{}
+	}
+
+	// Direct DRS API: enflame.com/drs-gcu
 	if ok {
-		if count.Value() > 1 {
-			ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameVGCUPercentage)] = *resource.NewQuantity(int64(100), resource.DecimalSI)
-			ctr.Resources.Limits[corev1.ResourceName(SharedResourceName)] = *resource.NewQuantity(int64(dev.factor*int(count.Value())), resource.DecimalSI)
-		} else {
-			percentageResource, ok := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameVGCUPercentage)]
-			percentage := percentageResource.Value()
-			if !ok {
-				percentage = 100
-			}
-			if percentage < 1 {
-				percentage = 1
-			}
-			slice := float64(100) / float64(dev.factor)
-			for i := 0; i < dev.factor; i++ {
-				if slice*float64(i) < float64(percentage) && float64(percentage) <= slice*float64((i+1)) {
-					percentage = int64(slice * float64(i+1))
-					ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameVGCUPercentage)] = *resource.NewQuantity(percentage, resource.DecimalSI)
-					ctr.Resources.Limits[corev1.ResourceName(SharedResourceName)] = *resource.NewQuantity(int64(i+1), resource.DecimalSI)
-					ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameVGCUPercentage)] = *resource.NewQuantity(percentage, resource.DecimalSI)
-					ctr.Resources.Requests[corev1.ResourceName(SharedResourceName)] = *resource.NewQuantity(int64(i+1), resource.DecimalSI)
-					break
-				}
-			}
+		if count.Value() <= 0 {
+			return false, fmt.Errorf("%s must be greater than 0", EnflameResourceNameDRSGCU)
+		}
+		if _, exists := ctr.Resources.Limits[resourceCount]; !exists {
+			ctr.Resources.Limits[resourceCount] = count
+		}
+		if _, exists := ctr.Resources.Requests[resourceCount]; !exists {
+			ctr.Resources.Requests[resourceCount] = count
+		}
+		return true, nil
+	}
+
+	// Unified API: request by memory/core, then convert profile in Fit().
+	memReq, hasMem := getContainerResourceRequest(ctr, corev1.ResourceName(EnflameResourceNameGCUMemory))
+	coreReq, hasCore := getContainerResourceRequest(ctr, corev1.ResourceName(EnflameResourceNameGCUCore))
+	if !hasMem && !hasCore {
+		return false, nil
+	}
+	if hasMem && memReq <= 0 {
+		return false, fmt.Errorf("%s must be greater than 0", EnflameResourceNameGCUMemory)
+	}
+	if hasCore && (coreReq <= 0 || coreReq > 100) {
+		return false, fmt.Errorf("%s must be in range (0,100]", EnflameResourceNameGCUCore)
+	}
+	if hasMem {
+		memQty := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUMemory)]
+		if memQty.IsZero() {
+			memQty = ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUMemory)]
+		}
+		if _, exists := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUMemory)]; !exists {
+			ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUMemory)] = memQty
+		}
+		if _, exists := ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUMemory)]; !exists {
+			ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUMemory)] = memQty
 		}
 	}
-	return ok, nil
+	if hasCore {
+		coreQty := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUCore)]
+		if coreQty.IsZero() {
+			coreQty = ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUCore)]
+		}
+		if _, exists := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUCore)]; !exists {
+			ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCUCore)] = coreQty
+		}
+		if _, exists := ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUCore)]; !exists {
+			ctr.Resources.Requests[corev1.ResourceName(EnflameResourceNameGCUCore)] = coreQty
+		}
+	}
+	return true, nil
 }
 
 func (dev *EnflameDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
-	nodedevices := []*device.DeviceInfo{}
-	i := 0
-	cards, ok := n.Status.Capacity.Name(corev1.ResourceName(CountNoSharedName), resource.DecimalSI).AsInt64()
-	if !ok || cards == 0 {
-		return []*device.DeviceInfo{}, fmt.Errorf("device not found %s", CountNoSharedName)
+	capacityRaw, ok := n.Annotations[GCUDrsCapacity]
+	if !ok {
+		return []*device.DeviceInfo{}, fmt.Errorf("annotation not found %s", GCUDrsCapacity)
 	}
-	shared, _ := n.Status.Capacity.Name(corev1.ResourceName(SharedResourceName), resource.DecimalSI).AsInt64()
-	dev.factor = int(shared / cards)
-	for i < int(cards) {
+	spec := drsCapacitySpec{}
+	if err := json.Unmarshal([]byte(capacityRaw), &spec); err != nil {
+		return []*device.DeviceInfo{}, fmt.Errorf("failed to parse %s: %w", GCUDrsCapacity, err)
+	}
+	maxSlice := 0
+	maxMemGB := 0
+	for profileName := range spec.Profiles {
+		slice, memGB := parseProfile(profileName)
+		if slice > maxSlice {
+			maxSlice = slice
+		}
+		if memGB > maxMemGB {
+			maxMemGB = memGB
+		}
+	}
+	if maxSlice <= 0 {
+		return []*device.DeviceInfo{}, fmt.Errorf("no valid drs profiles found on node %s", n.Name)
+	}
+	if maxMemGB <= 0 {
+		maxMemGB = maxSlice
+	}
+	nodedevices := make([]*device.DeviceInfo, 0, len(spec.Devices))
+	for idx, d := range spec.Devices {
+		devIndex, err := strconv.Atoi(d.Index)
+		if err != nil {
+			devIndex = idx
+		}
+		capacity, err := parseDRSCapacity(d.Capacity)
+		if err != nil || capacity <= 0 {
+			return []*device.DeviceInfo{}, fmt.Errorf("invalid drs capacity on node %s", n.Name)
+		}
+		minor := strings.TrimSpace(d.Minor)
+		if minor == "" {
+			minor = strconv.Itoa(devIndex)
+		}
+		profiles := map[string]string{}
+		maps.Copy(profiles, spec.Profiles)
 		nodedevices = append(nodedevices, &device.DeviceInfo{
-			Index:        uint(i),
-			ID:           n.Name + "-enflame-" + fmt.Sprint(i),
-			Count:        100,
-			Devmem:       100,
+			Index:        uint(devIndex),
+			ID:           fmt.Sprintf("%s-enflame-drs-%d", n.Name, devIndex),
+			Count:        capacity,
+			Devmem:       int32(maxMemGB * 1024),
 			Devcore:      100,
 			Type:         EnflameVGCUDevice,
 			Numa:         0,
 			Health:       true,
 			DeviceVendor: EnflameVGCUCommonWord,
+			CustomInfo: map[string]any{
+				"minor":    minor,
+				"index":    strconv.Itoa(devIndex),
+				"profiles": profiles,
+				"maxSlice": maxSlice,
+			},
 		})
-		i++
+	}
+	if len(nodedevices) == 0 {
+		return []*device.DeviceInfo{}, fmt.Errorf("no drs devices found on node %s", n.Name)
 	}
 	return nodedevices, nil
 }
@@ -130,13 +246,48 @@ func (dev *EnflameDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[stri
 		(*annoinput)[device.SupportDevices[EnflameVGCUDevice]] = device.EncodePodSingleDevice(devlist)
 		(*annoinput)[PodHasAssignedGCU] = "false"
 		(*annoinput)[PodAssignedGCUTime] = strconv.FormatInt(time.Now().UnixNano(), 10)
-		annoKey := PodAssignedGCUID
-		value := ""
-		for _, val := range devlist[0] {
-			value = value + fmt.Sprint(val.Idx) + ","
+
+		assigned := map[string]assignedContainerInfo{}
+		for ctridx, ctrDevices := range devlist {
+			if len(ctrDevices) == 0 {
+				continue
+			}
+			chosen := ctrDevices[0]
+			slice := int32(readCustomInfoInt(chosen.CustomInfo, "drsSlice"))
+			if slice <= 0 {
+				slice = 1
+			}
+			ctrName := containerNameByIndex(pod, ctridx)
+			profileName := readCustomInfoString(chosen.CustomInfo, "profileName")
+			profileID := readCustomInfoString(chosen.CustomInfo, "profileID")
+			assigned[ctrName] = assignedContainerInfo{
+				Allocated:   false,
+				Request:     slice,
+				ProfileID:   profileID,
+				ProfileName: profileName,
+			}
+
+			if _, exists := (*annoinput)[PodAssignedGCUIdx]; !exists {
+				if index := readCustomInfoString(chosen.CustomInfo, "index"); index != "" {
+					(*annoinput)[PodAssignedGCUIdx] = index
+					(*annoinput)[PodAssignedGCUID] = index
+				}
+			}
+			if _, exists := (*annoinput)[PodAssignedGCUMin]; !exists {
+				if minor := readCustomInfoString(chosen.CustomInfo, "minor"); minor != "" {
+					(*annoinput)[PodAssignedGCUMin] = minor
+				}
+			}
+			if _, exists := (*annoinput)[PodRequestGCUSize]; !exists && slice > 0 {
+				(*annoinput)[PodRequestGCUSize] = strconv.FormatInt(int64(slice), 10)
+			}
 		}
-		if len(value) > 0 {
-			(*annoinput)[annoKey] = strings.TrimRight(value, ",")
+		if len(assigned) > 0 {
+			if payload, err := json.Marshal(assigned); err != nil {
+				klog.ErrorS(err, "failed to marshal assigned containers", "pod", klog.KObj(pod))
+			} else {
+				(*annoinput)[AssignedContainers] = string(payload)
+			}
 		}
 	}
 	return *annoinput
@@ -167,33 +318,48 @@ func (dev *EnflameDevices) CheckHealth(devType string, n *corev1.Node) (bool, bo
 
 func (dev *EnflameDevices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {
 	klog.Info("Start to count enflame devices for container ", ctr.Name)
-	resourceCount := corev1.ResourceName(EnflameResourceNameVGCU)
-	resourcePercentage := corev1.ResourceName(EnflameResourceNameVGCUPercentage)
+	resourceCount := corev1.ResourceName(EnflameResourceNameDRSGCU)
 	v, ok := ctr.Resources.Limits[resourceCount]
 	if !ok {
 		v, ok = ctr.Resources.Requests[resourceCount]
 	}
 	if ok {
-		if n, ok := v.AsInt64(); ok {
+		if n, ok := v.AsInt64(); ok && n > 0 {
 			klog.Info("Found enflame devices")
-			memnum := 100
-			mem, ok := ctr.Resources.Limits[resourcePercentage]
-			if !ok {
-				mem, ok = ctr.Resources.Requests[resourcePercentage]
-			}
-			if ok {
-				memnum = int(mem.Value())
+			if n > math.MaxInt32 {
+				klog.ErrorS(nil, "drs request is too large", "container", ctr.Name, "request", n)
+				return device.ContainerDeviceRequest{}
 			}
 			return device.ContainerDeviceRequest{
-				Nums:             int32(n),
+				Nums:             1,
 				Type:             EnflameVGCUDevice,
-				Memreq:           int32(memnum),
-				MemPercentagereq: 0,
-				Coresreq:         0,
+				Memreq:           int32(n),
+				MemPercentagereq: enflameRequestModeDirect,
+				Coresreq:         enflameUnknownCoreRequest,
 			}
 		}
 	}
-	return device.ContainerDeviceRequest{}
+	memReq, hasMem := getContainerResourceRequest(ctr, corev1.ResourceName(EnflameResourceNameGCUMemory))
+	coreReq, hasCore := getContainerResourceRequest(ctr, corev1.ResourceName(EnflameResourceNameGCUCore))
+	if !hasMem && !hasCore {
+		return device.ContainerDeviceRequest{}
+	}
+	if hasMem && memReq > math.MaxInt32 {
+		klog.ErrorS(nil, "gcu memory request is too large", "container", ctr.Name, "request", memReq)
+		return device.ContainerDeviceRequest{}
+	}
+	if hasCore && coreReq > math.MaxInt32 {
+		klog.ErrorS(nil, "gcu core request is too large", "container", ctr.Name, "request", coreReq)
+		return device.ContainerDeviceRequest{}
+	}
+	klog.Info("Found enflame memory/core based request")
+	return device.ContainerDeviceRequest{
+		Nums:             1,
+		Type:             EnflameVGCUDevice,
+		Memreq:           int32(memReq),
+		MemPercentagereq: enflameRequestModeBySpec,
+		Coresreq:         int32(coreReq),
+	}
 }
 
 func (dev *EnflameDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
@@ -201,7 +367,11 @@ func (dev *EnflameDevices) ScoreNode(node *corev1.Node, podDevices device.PodSin
 }
 
 func (dev *EnflameDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
-	n.Used++
+	slice := int32(readCustomInfoInt(ctr.CustomInfo, "drsSlice"))
+	if slice <= 0 {
+		slice = 1
+	}
+	n.Used += slice
 	n.Usedcores += ctr.Usedcores
 	n.Usedmem += ctr.Usedmem
 	return nil
@@ -210,29 +380,37 @@ func (dev *EnflameDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsa
 func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
-	prevnuma := -1
 	klog.InfoS("Allocating device for container request", "pod", klog.KObj(pod), "card request", k)
-	var tmpDevs map[string]device.ContainerDevices
-	tmpDevs = make(map[string]device.ContainerDevices)
+	tmpDevs := make(map[string]device.ContainerDevices)
 	reason := make(map[string]int)
+	profile, profileMatch := enf.selectProfileByRequest(devices, k)
+	if !profileMatch {
+		reason[common.ModeNotFit]++
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
+	requiredSlice := int32(profile.Size)
+	if requiredSlice <= 0 {
+		reason[common.ModeNotFit]++
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
+	profileMemoryMiB := int32(profile.MemoryGB * 1024)
+	if profileMemoryMiB <= 0 {
+		reason[common.ModeNotFit]++
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
+	profileCorePercent := int32(profile.CorePercent)
+	if profileCorePercent <= 0 {
+		profileCorePercent = 1
+	}
 	for i := len(devices) - 1; i >= 0; i-- {
 		dev := devices[i]
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 
-		_, found, numa := enf.checkType(pod.GetAnnotations(), *dev, k)
+		_, found, _ := enf.checkType(pod.GetAnnotations(), *dev, k)
 		if !found {
 			reason[common.CardTypeMismatch]++
 			klog.V(5).InfoS(common.CardTypeMismatch, "pod", klog.KObj(pod), "device", dev.ID, dev.Type, k.Type)
 			continue
-		}
-		if numa && prevnuma != dev.Numa {
-			if k.Nums != originReq {
-				reason[common.NumaNotFit] += len(tmpDevs)
-				klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", dev.ID, "k.nums", k.Nums, "numa", numa, "prevnuma", prevnuma, "device numa", dev.Numa)
-			}
-			k.Nums = originReq
-			prevnuma = dev.Numa
-			tmpDevs = make(map[string]device.ContainerDevices)
 		}
 		if !device.CheckUUID(pod.GetAnnotations(), dev.ID, EnflameUseUUID, EnflameNoUseUUID, enf.CommonWord()) {
 			reason[common.CardUUIDMismatch]++
@@ -240,47 +418,21 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			continue
 		}
 
-		memreq := int32(0)
 		if dev.Count <= dev.Used {
 			reason[common.CardTimeSlicingExhausted]++
 			klog.V(5).InfoS(common.CardTimeSlicingExhausted, "pod", klog.KObj(pod), "device", dev.ID, "count", dev.Count, "used", dev.Used)
 			continue
 		}
-		if k.Coresreq > 100 {
-			klog.ErrorS(nil, "core limit can't exceed 100", "pod", klog.KObj(pod), "device", dev.ID)
-			k.Coresreq = 100
-			//return false, tmpDevs
-		}
-		if k.Memreq > 0 {
-			memreq = k.Memreq
-		}
-		if k.MemPercentagereq != 101 && k.Memreq == 0 {
-			//This incurs an issue
-			memreq = dev.Totalmem * k.MemPercentagereq / 100
-		}
-		if dev.Totalmem-dev.Usedmem < memreq {
+		if dev.Totalmem-dev.Usedmem < profileMemoryMiB {
 			reason[common.CardInsufficientMemory]++
-			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)
+			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", profileMemoryMiB)
 			continue
 		}
-		if dev.Totalcore-dev.Usedcores < k.Coresreq {
+		if dev.Totalcore > 0 && dev.Totalcore-dev.Usedcores < profileCorePercent {
 			reason[common.CardInsufficientCore]++
-			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", dev.Totalcore, "device used core", dev.Usedcores, "request cores", k.Coresreq)
+			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", dev.Totalcore, "device used core", dev.Usedcores, "request cores", profileCorePercent)
 			continue
 		}
-		// Coresreq=100 indicates it want this card exclusively
-		if dev.Totalcore == 100 && k.Coresreq == 100 && dev.Used > 0 {
-			reason[common.ExclusiveDeviceAllocateConflict]++
-			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
-			continue
-		}
-		// You can't allocate core=0 job to an already full GPU
-		if dev.Totalcore != 0 && dev.Usedcores == dev.Totalcore && k.Coresreq == 0 {
-			reason[common.CardComputeUnitsExhausted]++
-			klog.V(5).InfoS(common.CardComputeUnitsExhausted, "pod", klog.KObj(pod), "device", dev.ID, "device index", i)
-			continue
-		}
-
 		if k.Nums > 0 {
 			klog.V(5).InfoS("find fit device", "pod", klog.KObj(pod), "device", dev.ID)
 			k.Nums--
@@ -288,8 +440,17 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 				Idx:       int(dev.Index),
 				UUID:      dev.ID,
 				Type:      k.Type,
-				Usedmem:   memreq,
-				Usedcores: k.Coresreq,
+				Usedmem:   profileMemoryMiB,
+				Usedcores: profileCorePercent,
+				CustomInfo: map[string]any{
+					"profileName": profile.Name,
+					"profileID":   profile.ID,
+					"minor":       readCustomInfoString(dev.CustomInfo, "minor"),
+					"index":       readCustomInfoString(dev.CustomInfo, "index"),
+					"drsSlice":    profile.Size,
+					"requestMem":  profile.RequestMemoryGB,
+					"requestCore": profile.RequestCorePercent,
+				},
 			})
 		}
 		if k.Nums == 0 {
@@ -298,8 +459,8 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		}
 
 	}
-	if len(tmpDevs) > 0 {
-		reason[common.AllocatedCardsInsufficientRequest] = len(tmpDevs)
+	if len(tmpDevs[k.Type]) > 0 {
+		reason[common.AllocatedCardsInsufficientRequest] = len(tmpDevs[k.Type])
 		klog.V(5).InfoS(common.AllocatedCardsInsufficientRequest, "pod", klog.KObj(pod), "request", originReq, "allocated", len(tmpDevs))
 	}
 	return false, tmpDevs, common.GenReason(reason, len(devices))
@@ -307,8 +468,263 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 
 func (dev *EnflameDevices) GetResourceNames() device.ResourceNames {
 	return device.ResourceNames{
-		ResourceCountName:  EnflameResourceNameVGCU,
-		ResourceMemoryName: EnflameResourceNameVGCUPercentage,
-		ResourceCoreName:   "",
+		ResourceCountName:  EnflameResourceNameDRSGCU,
+		ResourceMemoryName: EnflameResourceNameGCUMemory,
+		ResourceCoreName:   EnflameResourceNameGCUCore,
 	}
+}
+
+type drsProfileCandidate struct {
+	Name               string
+	ID                 string
+	Size               int
+	MemoryGB           int
+	CorePercent        int
+	RequestMemoryGB    int
+	RequestCorePercent int
+}
+
+func (dev *EnflameDevices) selectProfileByRequest(devices []*device.DeviceUsage, request device.ContainerDeviceRequest) (drsProfileCandidate, bool) {
+	candidates := collectDRSProfiles(devices)
+	if len(candidates) == 0 {
+		return drsProfileCandidate{}, false
+	}
+	if request.MemPercentagereq == enflameRequestModeDirect {
+		for _, c := range candidates {
+			if c.Size == int(request.Memreq) {
+				return c, true
+			}
+		}
+		return drsProfileCandidate{}, false
+	}
+
+	maxMemGB := candidates[len(candidates)-1].MemoryGB
+	requestMemGB := normalizeMemoryRequestToGB(request.Memreq, maxMemGB)
+	requestCorePercent := int(request.Coresreq)
+
+	for _, c := range candidates {
+		if requestMemGB > 0 && c.MemoryGB < requestMemGB {
+			continue
+		}
+		if requestCorePercent > 0 && c.CorePercent < requestCorePercent {
+			continue
+		}
+		c.RequestMemoryGB = requestMemGB
+		c.RequestCorePercent = requestCorePercent
+		return c, true
+	}
+	return drsProfileCandidate{}, false
+}
+
+func parseProfilesFromCustomInfo(customInfo map[string]any) map[string]string {
+	if customInfo == nil {
+		return map[string]string{}
+	}
+	rawProfiles, ok := customInfo["profiles"]
+	if !ok {
+		return map[string]string{}
+	}
+	switch typed := rawProfiles.(type) {
+	case map[string]string:
+		return typed
+	case map[string]any:
+		res := map[string]string{}
+		for name, profileID := range typed {
+			profileIDStr, ok := profileID.(string)
+			if !ok {
+				continue
+			}
+			res[name] = profileIDStr
+		}
+		return res
+	default:
+		return map[string]string{}
+	}
+}
+
+func collectDRSProfiles(devices []*device.DeviceUsage) []drsProfileCandidate {
+	maxSlice := 0
+	for _, devUsage := range devices {
+		if candidateMaxSlice := readCustomInfoInt(devUsage.CustomInfo, "maxSlice"); candidateMaxSlice > maxSlice {
+			maxSlice = candidateMaxSlice
+		}
+	}
+	if maxSlice <= 0 {
+		for _, devUsage := range devices {
+			for profileName := range parseProfilesFromCustomInfo(devUsage.CustomInfo) {
+				size, _ := parseProfile(profileName)
+				if size > maxSlice {
+					maxSlice = size
+				}
+			}
+		}
+	}
+	if maxSlice <= 0 {
+		return []drsProfileCandidate{}
+	}
+
+	seen := map[string]drsProfileCandidate{}
+	for _, devUsage := range devices {
+		for profileName, profileID := range parseProfilesFromCustomInfo(devUsage.CustomInfo) {
+			size, memGB := parseProfile(profileName)
+			if size <= 0 || memGB <= 0 {
+				continue
+			}
+			corePercent := int(math.Ceil(float64(size) * 100 / float64(maxSlice)))
+			seen[profileName] = drsProfileCandidate{
+				Name:        profileName,
+				ID:          profileID,
+				Size:        size,
+				MemoryGB:    memGB,
+				CorePercent: corePercent,
+			}
+		}
+	}
+	candidates := make([]drsProfileCandidate, 0, len(seen))
+	for _, c := range seen {
+		candidates = append(candidates, c)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Size == candidates[j].Size {
+			return candidates[i].MemoryGB < candidates[j].MemoryGB
+		}
+		return candidates[i].Size < candidates[j].Size
+	})
+	return candidates
+}
+
+func parseProfile(profileName string) (int, int) {
+	normalized := strings.ToLower(strings.TrimSpace(profileName))
+	parts := strings.Split(normalized, ".")
+	if len(parts) < 2 {
+		return 0, 0
+	}
+	sizePart := strings.TrimSpace(parts[0])
+	sizePart = strings.TrimSuffix(sizePart, "g")
+	size, err := strconv.Atoi(sizePart)
+	if err != nil {
+		return 0, 0
+	}
+	memPart := strings.TrimSpace(parts[1])
+	memPart = strings.TrimSuffix(memPart, "gb")
+	memGB, err := strconv.Atoi(memPart)
+	if err != nil {
+		return size, 0
+	}
+	return size, memGB
+}
+
+func normalizeMemoryRequestToGB(rawMemory int32, maxProfileMemoryGB int) int {
+	if rawMemory <= 0 {
+		return 0
+	}
+	if maxProfileMemoryGB <= 0 {
+		return int(rawMemory)
+	}
+	// If the request value is much larger than profile-GB units, treat it as MiB.
+	if int(rawMemory) > maxProfileMemoryGB*2 {
+		return int(math.Ceil(float64(rawMemory) / 1024.0))
+	}
+	return int(rawMemory)
+}
+
+func parseDRSCapacity(raw any) (int32, error) {
+	switch typed := raw.(type) {
+	case float64:
+		return int32(typed), nil
+	case int:
+		return int32(typed), nil
+	case int32:
+		return typed, nil
+	case int64:
+		return int32(typed), nil
+	case string:
+		capacity, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err != nil {
+			return 0, err
+		}
+		return int32(capacity), nil
+	default:
+		return 0, fmt.Errorf("unknown capacity type: %T", raw)
+	}
+}
+
+func containerNameByIndex(pod *corev1.Pod, index int) string {
+	if pod == nil {
+		return fmt.Sprintf("container-%d", index)
+	}
+	initCount := len(pod.Spec.InitContainers)
+	if index < initCount {
+		return pod.Spec.InitContainers[index].Name
+	}
+	containerIdx := index - initCount
+	if containerIdx >= 0 && containerIdx < len(pod.Spec.Containers) {
+		return pod.Spec.Containers[containerIdx].Name
+	}
+	return fmt.Sprintf("container-%d", index)
+}
+
+func readCustomInfoString(customInfo map[string]any, key string) string {
+	if customInfo == nil {
+		return ""
+	}
+	raw, ok := customInfo[key]
+	if !ok {
+		return ""
+	}
+	switch typed := raw.(type) {
+	case string:
+		return typed
+	case int:
+		return strconv.Itoa(typed)
+	case int32:
+		return strconv.Itoa(int(typed))
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case float64:
+		return strconv.FormatInt(int64(typed), 10)
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func readCustomInfoInt(customInfo map[string]any, key string) int {
+	if customInfo == nil {
+		return 0
+	}
+	raw, ok := customInfo[key]
+	if !ok {
+		return 0
+	}
+	switch typed := raw.(type) {
+	case int:
+		return typed
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case string:
+		v, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err != nil {
+			return 0
+		}
+		return v
+	default:
+		return 0
+	}
+}
+
+func getContainerResourceRequest(ctr *corev1.Container, resourceName corev1.ResourceName) (int64, bool) {
+	if ctr == nil || resourceName == "" {
+		return 0, false
+	}
+	if qty, ok := ctr.Resources.Limits[resourceName]; ok {
+		return qty.Value(), true
+	}
+	if qty, ok := ctr.Resources.Requests[resourceName]; ok {
+		return qty.Value(), true
+	}
+	return 0, false
 }

--- a/pkg/device/enflame/device_test.go
+++ b/pkg/device/enflame/device_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package enflame
 
 import (
-	"flag"
-	"maps"
-	"strconv"
+	"encoding/json"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 
@@ -31,190 +29,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGetNodeDevices(t *testing.T) {
-
-	tests := []struct {
-		name     string
-		node     corev1.Node
-		expected []*device.DeviceInfo
-		err      error
-	}{
-		{
-			name: "Test with valid node",
-			node: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Status: corev1.NodeStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceName(CountNoSharedName):  *resource.NewQuantity(1, resource.DecimalSI),
-						corev1.ResourceName(SharedResourceName): *resource.NewQuantity(6, resource.DecimalSI),
-					},
-				},
-			},
-			expected: []*device.DeviceInfo{
-				{
-					Index:        0,
-					ID:           "test-enflame-0",
-					Count:        100,
-					Devmem:       100,
-					Devcore:      100,
-					Type:         EnflameVGCUDevice,
-					Numa:         0,
-					Health:       true,
-					DeviceVendor: EnflameVGCUCommonWord,
-				},
-			},
-			err: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dev := &EnflameDevices{}
-			got, err := dev.GetNodeDevices(tt.node)
-			if (err != nil) != (tt.err != nil) {
-				t.Errorf("GetNodeDevices() error = %v, expected %v", err, tt.err)
-				return
-			}
-
-			if len(got) != len(tt.expected) {
-				t.Errorf("GetNodeDevices() got %d devices, expected %d", len(got), len(tt.expected))
-				return
-			}
-
-			for i, device := range got {
-				if device.Index != tt.expected[i].Index {
-					t.Errorf("Expected index %d, got %d", tt.expected[i].Index, device.Index)
-				}
-				if device.ID != tt.expected[i].ID {
-					t.Errorf("Expected id %s, got %s", tt.expected[i].ID, device.ID)
-				}
-				if device.Devcore != tt.expected[i].Devcore {
-					t.Errorf("Expected devcore %d, got %d", tt.expected[i].Devcore, device.Devcore)
-				}
-				if device.Devmem != tt.expected[i].Devmem {
-					t.Errorf("Expected cevmem %d, got %d", tt.expected[i].Devmem, device.Devmem)
-				}
-			}
-		})
-	}
-}
-
-func TestPatchAnnotations(t *testing.T) {
-	InitEnflameDevice(EnflameConfig{})
-
-	tests := []struct {
-		name       string
-		annoInput  map[string]string
-		podDevices device.PodDevices
-		expected   map[string]string
-	}{
-		{
-			name:       "No devices",
-			annoInput:  map[string]string{},
-			podDevices: device.PodDevices{},
-			expected:   map[string]string{},
-		},
-		{
-			name:      "With devices",
-			annoInput: map[string]string{},
-			podDevices: device.PodDevices{
-				EnflameVGCUDevice: device.PodSingleDevice{
-					[]device.ContainerDevice{
-						{
-							Idx:  0,
-							UUID: "k8s-gpu-enflame-0",
-							Type: "Enflame",
-						},
-					},
-				},
-			},
-			expected: map[string]string{
-				device.SupportDevices[EnflameVGCUDevice]: "k8s-gpu-enflame-0,Enflame,0,0:;",
-				PodHasAssignedGCU:                        "false",
-				PodAssignedGCUTime:                       strconv.FormatInt(time.Now().UnixNano(), 10),
-				PodAssignedGCUID:                         "0",
+func TestGetNodeDevices_DRSAnnotation(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	dev := &EnflameDevices{}
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-a",
+			Annotations: map[string]string{
+				GCUDrsCapacity: `{"devices":[{"index":"0","minor":"0","capacity":6}],"profiles":{"1g.6gb":"0","3g.20gb":"1","6g.40gb":"2"}}`,
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			annoInputCopy := make(map[string]string)
-			maps.Copy(annoInputCopy, tt.annoInput)
-
-			dev := &EnflameDevices{}
-			got := dev.PatchAnnotations(&corev1.Pod{}, &annoInputCopy, tt.podDevices)
-
-			if len(got) != len(tt.expected) {
-				t.Errorf("PatchAnnotations() got %d annotations, expected %d", len(got), len(tt.expected))
-				return
-			}
-
-			for k, v := range tt.expected {
-				if k == PodAssignedGCUTime {
-					if len(got[k]) != len(v) {
-						t.Errorf("Expected %s %s, got %s", k, v, got[k])
-					}
-					continue
-				}
-
-				if got[k] != v {
-					t.Errorf("Expected %s %s, got %s", k, v, got[k])
-				}
-			}
-		})
-	}
-}
-
-func Test_MutateAdmission(t *testing.T) {
-	tests := []struct {
-		name string
-		args struct {
-			ctr *corev1.Container
-			p   *corev1.Pod
-		}
-		want bool
-		err  error
-	}{
-		{
-			name: "EnflameResourceCount and EnflameResourcePercentage set to limits",
-			args: struct {
-				ctr *corev1.Container
-				p   *corev1.Pod
-			}{
-				ctr: &corev1.Container{
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"enflame.com/vgcu":            *resource.NewQuantity(1, resource.DecimalSI),
-							"enflame.com/vgcu-percentage": *resource.NewQuantity(15, resource.DecimalSI),
-						},
-						Requests: corev1.ResourceList{},
-					},
-				},
-				p: &corev1.Pod{},
-			},
-			want: true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			config := EnflameConfig{
-				ResourceNameVGCU:           "enflame.com/vgcu",
-				ResourceNameVGCUPercentage: "enflame.com/vgcu-percentage",
-			}
-			InitEnflameDevice(config)
-			dev := EnflameDevices{
-				factor: 4,
-			}
-			result, _ := dev.MutateAdmission(test.args.ctr, test.args.p)
-			assert.Equal(t, result, test.want)
-			limits := test.args.ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameVGCUPercentage)]
-			number, _ := limits.AsInt64()
-			assert.Equal(t, number, int64(25))
-		})
-	}
+	got, err := dev.GetNodeDevices(node)
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got[0].Type, EnflameVGCUDevice)
+	assert.Equal(t, got[0].Devmem, int32(40960))
+	assert.Equal(t, got[0].Count, int32(6))
+	assert.Equal(t, got[0].CustomInfo["minor"], "0")
 }
 
 func Test_checkType(t *testing.T) {
@@ -275,523 +108,221 @@ func Test_checkType(t *testing.T) {
 	}
 }
 
-func Test_GenerateResourceRequests(t *testing.T) {
-	tests := []struct {
-		name string
-		args *corev1.Container
-		want device.ContainerDeviceRequest
-	}{
-		{
-			name: "all resources set to limits and requests",
-			args: &corev1.Container{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						"enflame.com/vgcu":            resource.MustParse("1"),
-						"enflame.com/vgcu-percentage": resource.MustParse("15"),
-					},
-					Requests: corev1.ResourceList{
-						"enflame.com/vgcu":            resource.MustParse("1"),
-						"enflame.com/vgcu-percentage": resource.MustParse("15"),
-					},
-				},
-			},
-			want: device.ContainerDeviceRequest{
-				Nums:             int32(1),
-				Type:             EnflameVGCUDevice,
-				Memreq:           int32(15),
-				MemPercentagereq: int32(0),
-				Coresreq:         int32(0),
-			},
-		},
-		{
-			name: "all resources don't set to limits and requests",
-			args: &corev1.Container{
-				Resources: corev1.ResourceRequirements{
-					Limits:   corev1.ResourceList{},
-					Requests: corev1.ResourceList{},
-				},
-			},
-			want: device.ContainerDeviceRequest{},
-		},
-		{
-			name: "resourcemem don't set to limits and requests",
-			args: &corev1.Container{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						"enflame.com/vgcu": resource.MustParse("1"),
-					},
-					Requests: corev1.ResourceList{
-						"enflame.com/vgcu": resource.MustParse("1"),
-					},
-				},
-			},
-			want: device.ContainerDeviceRequest{
-				Nums:             int32(1),
-				Type:             EnflameVGCUDevice,
-				Memreq:           int32(100),
-				MemPercentagereq: int32(0),
-				Coresreq:         int32(0),
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			dev := EnflameDevices{factor: 4}
-			fs := flag.FlagSet{}
-			ParseConfig(&fs)
-			result := dev.GenerateResourceRequests(test.args)
-			assert.DeepEqual(t, result, test.want)
-		})
-	}
-}
-
-func TestDevices_Fit(t *testing.T) {
+func TestGenerateResourceRequests(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{
+		ResourceNameDRSGCU: "enflame.com/drs-gcu",
+		ResourceNameMemory: "enflame.com/gcu-memory",
+		ResourceNameCore:   "enflame.com/gcu-core",
+	})
 	config := EnflameConfig{
-		ResourceNameVGCU:           "enflame.com/vgcu",
-		ResourceNameVGCUPercentage: "enflame.com/vgcu-percentage",
+		ResourceNameDRSGCU: "enflame.com/drs-gcu",
+		ResourceNameMemory: "enflame.com/gcu-memory",
+		ResourceNameCore:   "enflame.com/gcu-core",
 	}
 	dev := InitEnflameDevice(config)
-
-	tests := []struct {
-		name       string
-		devices    []*device.DeviceUsage
-		request    device.ContainerDeviceRequest
-		annos      map[string]string
-		wantFit    bool
-		wantLen    int
-		wantDevIDs []string
-		wantReason string
-	}{
-		{
-			name: "fit success",
-			devices: []*device.DeviceUsage{
-				{
-					ID:        "dev-0",
-					Index:     0,
-					Used:      0,
-					Count:     100,
-					Usedmem:   0,
-					Totalmem:  128,
-					Totalcore: 100,
-					Usedcores: 0,
-					Numa:      0,
-					Type:      EnflameVGCUDevice,
-					Health:    true,
-				},
-				{
-					ID:        "dev-1",
-					Index:     0,
-					Used:      0,
-					Count:     100,
-					Usedmem:   0,
-					Totalmem:  128,
-					Totalcore: 100,
-					Usedcores: 0,
-					Numa:      0,
-					Type:      EnflameVGCUDevice,
-					Health:    true,
-				},
+	container := &corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"enflame.com/drs-gcu": resource.MustParse("3"),
 			},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           64,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    true,
-			wantLen:    1,
-			wantDevIDs: []string{"dev-1"},
-			wantReason: "",
-		},
-		{
-			name: "fit fail: memory not enough",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  128,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardInsufficientMemory",
-		},
-		{
-			name: "fit fail: core not enough",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1024,
-				Totalcore: 100,
-				Usedcores: 100,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardInsufficientCore",
-		},
-		{
-			name: "fit fail: type mismatch",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  128,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Health:    true,
-				Type:      EnflameVGCUDevice,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Type:             "OtherType",
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardTypeMismatch",
-		},
-		{
-			name: "fit fail: user assign use uuid mismatch",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-1",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             2,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{EnflameUseUUID: "dev-0"},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardUuidMismatch",
-		},
-		{
-			name: "fit fail: user assign no use uuid match",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             2,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{EnflameNoUseUUID: "dev-0"},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardUuidMismatch",
-		},
-		{
-			name: "fit fail: card overused",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      100,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         50,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardTimeSlicingExhausted",
-		},
-		{
-			name: "fit success: but core limit can't exceed 100",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      0,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         120,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    true,
-			wantLen:    1,
-			wantDevIDs: []string{"dev-0"},
-			wantReason: "",
-		},
-		{
-			name: "fit fail:  card exclusively",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      20,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 0,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         100,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 ExclusiveDeviceAllocateConflict",
-		},
-		{
-			name: "fit fail:  CardComputeUnitsExhausted",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      20,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 100,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         0,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 CardComputeUnitsExhausted",
-		},
-		{
-			name: "fit fail:  AllocatedCardsInsufficientRequest",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      20,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 10,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             2,
-				Memreq:           512,
-				MemPercentagereq: 0,
-				Coresreq:         20,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    false,
-			wantLen:    0,
-			wantDevIDs: []string{},
-			wantReason: "1/1 AllocatedCardsInsufficientRequest",
-		},
-		{
-			name: "fit success:  memory percentage",
-			devices: []*device.DeviceUsage{{
-				ID:        "dev-0",
-				Index:     0,
-				Used:      20,
-				Count:     100,
-				Usedmem:   0,
-				Totalmem:  1280,
-				Totalcore: 100,
-				Usedcores: 10,
-				Numa:      0,
-				Type:      EnflameVGCUDevice,
-				Health:    true,
-			}},
-			request: device.ContainerDeviceRequest{
-				Nums:             1,
-				Memreq:           0,
-				MemPercentagereq: 10,
-				Coresreq:         20,
-				Type:             EnflameVGCUDevice,
-			},
-			annos:      map[string]string{},
-			wantFit:    true,
-			wantLen:    1,
-			wantDevIDs: []string{"dev-0"},
-			wantReason: "",
 		},
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			allocated := &device.PodDevices{}
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: test.annos,
-				},
-			}
-			fit, result, reason := dev.Fit(test.devices, test.request, pod, &device.NodeInfo{}, allocated)
-			if fit != test.wantFit {
-				t.Errorf("Fit: got %v, want %v", fit, test.wantFit)
-			}
-			if test.wantFit {
-				if len(result[EnflameVGCUDevice]) != test.wantLen {
-					t.Errorf("expected len: %d, got len %d", test.wantLen, len(result[EnflameVGCUDevice]))
-				}
-				for idx, id := range test.wantDevIDs {
-					if id != result[EnflameVGCUDevice][idx].UUID {
-						t.Errorf("expected device id: %s, got device id %s", id, result[EnflameVGCUDevice][idx].UUID)
-					}
-				}
-			}
-
-			if reason != test.wantReason {
-				t.Errorf("expected reason: %s, got reason: %s", test.wantReason, reason)
-			}
-		})
-	}
+	req := dev.GenerateResourceRequests(container)
+	assert.Equal(t, req.Nums, int32(1))
+	assert.Equal(t, req.Memreq, int32(3))
+	assert.Equal(t, req.MemPercentagereq, enflameRequestModeDirect)
+	assert.Equal(t, req.Type, EnflameVGCUDevice)
 }
 
-func TestDevices_AddResourceUsage(t *testing.T) {
-	tests := []struct {
-		name        string
-		deviceUsage *device.DeviceUsage
-		ctr         *device.ContainerDevice
-		wantErr     bool
-		wantUsage   *device.DeviceUsage
-	}{
-		{
-			name: "test add resource usage",
-			deviceUsage: &device.DeviceUsage{
-				ID:        "dev-0",
-				Used:      0,
-				Usedcores: 15,
-				Usedmem:   2000,
+func TestGenerateResourceRequests_ByMemoryCore(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{
+		ResourceNameDRSGCU: "enflame.com/drs-gcu",
+		ResourceNameMemory: "enflame.com/gcu-memory",
+		ResourceNameCore:   "enflame.com/gcu-core",
+	})
+	container := &corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"enflame.com/gcu-memory": resource.MustParse("20480"),
+				"enflame.com/gcu-core":   resource.MustParse("40"),
 			},
-			ctr: &device.ContainerDevice{
-				UUID:      "dev-0",
-				Usedcores: 50,
-				Usedmem:   1024,
-			},
-			wantUsage: &device.DeviceUsage{
-				ID:        "dev-0",
-				Used:      1,
-				Usedcores: 65,
-				Usedmem:   3024,
-			},
-			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dev := &EnflameDevices{}
-			if err := dev.AddResourceUsage(&corev1.Pod{}, tt.deviceUsage, tt.ctr); (err != nil) != tt.wantErr {
-				t.Errorf("AddResourceUsage() error=%v, wantErr %v", err, tt.wantErr)
-			}
-			if !tt.wantErr {
-				if tt.deviceUsage.Usedcores != tt.wantUsage.Usedcores {
-					t.Errorf("expected used cores: %d, got used cores %d", tt.wantUsage.Usedcores, tt.deviceUsage.Usedcores)
-				}
-				if tt.deviceUsage.Usedmem != tt.wantUsage.Usedmem {
-					t.Errorf("expected used mem: %d, got used mem %d", tt.wantUsage.Usedmem, tt.deviceUsage.Usedmem)
-				}
-				if tt.deviceUsage.Used != tt.wantUsage.Used {
-					t.Errorf("expected used: %d, got used %d", tt.wantUsage.Used, tt.deviceUsage.Used)
-				}
-			}
-		})
+	req := dev.GenerateResourceRequests(container)
+	assert.Equal(t, req.Nums, int32(1))
+	assert.Equal(t, req.Type, EnflameVGCUDevice)
+	assert.Equal(t, req.Memreq, int32(20480))
+	assert.Equal(t, req.Coresreq, int32(40))
+	assert.Equal(t, req.MemPercentagereq, enflameRequestModeBySpec)
+}
+
+func TestFit_SelectProfileByRequest(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	devices := []*device.DeviceUsage{
+		{
+			ID:       "node-a-enflame-drs-0",
+			Index:    0,
+			Count:    6,
+			Used:     0,
+			Totalmem: 40960,
+			Type:     EnflameVGCUDevice,
+			CustomInfo: map[string]any{
+				"minor": "0",
+				"index": "0",
+				"profiles": map[string]string{
+					"1g.6gb":  "0",
+					"3g.20gb": "1",
+					"6g.40gb": "2",
+				},
+			},
+		},
 	}
+	req := device.ContainerDeviceRequest{
+		Nums:   1,
+		Type:   EnflameVGCUDevice,
+		Memreq: 3,
+	}
+	fit, result, reason := dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, reason, "")
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 1)
+	assert.Equal(t, result[EnflameVGCUDevice][0].Usedmem, int32(20480))
+	assert.Equal(t, result[EnflameVGCUDevice][0].Usedcores, int32(50))
+	assert.Equal(t, result[EnflameVGCUDevice][0].CustomInfo["profileName"], "3g.20gb")
+	assert.Equal(t, result[EnflameVGCUDevice][0].CustomInfo["profileID"], "1")
+}
+
+func TestFit_SelectProfileByMemoryCoreRequest(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	devices := []*device.DeviceUsage{
+		{
+			ID:       "node-a-enflame-drs-0",
+			Index:    0,
+			Count:    6,
+			Used:     0,
+			Totalmem: 40960,
+			Type:     EnflameVGCUDevice,
+			CustomInfo: map[string]any{
+				"minor": "0",
+				"index": "0",
+				"profiles": map[string]string{
+					"1g.6gb":  "0",
+					"3g.20gb": "1",
+					"6g.40gb": "2",
+				},
+			},
+		},
+	}
+	req := device.ContainerDeviceRequest{
+		Nums:             1,
+		Type:             EnflameVGCUDevice,
+		Memreq:           20480, // MiB -> 20GB
+		Coresreq:         40,    // 40% core requirement
+		MemPercentagereq: enflameRequestModeBySpec,
+	}
+	fit, result, reason := dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, reason, "")
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 1)
+	assert.Equal(t, result[EnflameVGCUDevice][0].Usedmem, int32(20480))
+	assert.Equal(t, result[EnflameVGCUDevice][0].Usedcores, int32(50))
+	assert.Equal(t, result[EnflameVGCUDevice][0].CustomInfo["profileName"], "3g.20gb")
+	assert.Equal(t, result[EnflameVGCUDevice][0].CustomInfo["profileID"], "1")
+}
+
+func TestMutateAdmission_ByMemoryCoreAPI(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{
+		ResourceNameDRSGCU: "enflame.com/drs-gcu",
+		ResourceNameMemory: "enflame.com/gcu-memory",
+		ResourceNameCore:   "enflame.com/gcu-core",
+	})
+	container := &corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"enflame.com/gcu-memory": resource.MustParse("20480"),
+				"enflame.com/gcu-core":   resource.MustParse("50"),
+			},
+		},
+	}
+	found, err := dev.MutateAdmission(container, &corev1.Pod{})
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+}
+
+func TestFit_ProfileNotFound(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	devices := []*device.DeviceUsage{
+		{
+			ID:       "node-a-enflame-drs-0",
+			Index:    0,
+			Count:    6,
+			Used:     0,
+			Totalmem: 40960,
+			Type:     EnflameVGCUDevice,
+			CustomInfo: map[string]any{
+				"minor": "0",
+				"index": "0",
+				"profiles": map[string]string{
+					"1g.6gb": "0",
+				},
+			},
+		},
+	}
+	req := device.ContainerDeviceRequest{
+		Nums:   1,
+		Type:   EnflameVGCUDevice,
+		Memreq: 3,
+	}
+	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, "ModeNotFit"))
+}
+
+func TestPatchAnnotations_DRSFields(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "pod-gcu-example1"},
+			},
+		},
+	}
+	annoInput := map[string]string{}
+	podDevices := device.PodDevices{
+		EnflameVGCUDevice: {
+			{
+				{
+					Idx:       0,
+					UUID:      "node-a-enflame-drs-0",
+					Type:      EnflameVGCUDevice,
+					Usedmem:   20480,
+					Usedcores: 50,
+					CustomInfo: map[string]any{
+						"minor":       "0",
+						"index":       "0",
+						"profileName": "3g.20gb",
+						"profileID":   "1",
+						"drsSlice":    3,
+					},
+				},
+			},
+		},
+	}
+
+	got := dev.PatchAnnotations(pod, &annoInput, podDevices)
+	assert.Assert(t, strings.Contains(got[device.SupportDevices[EnflameVGCUDevice]], ",20480,50"))
+	assert.Equal(t, got[PodHasAssignedGCU], "false")
+	assert.Equal(t, got[PodAssignedGCUIdx], "0")
+	assert.Equal(t, got[PodAssignedGCUMin], "0")
+	assert.Equal(t, got[PodRequestGCUSize], "3")
+	assert.Assert(t, got[PodAssignedGCUTime] != "")
+	assert.Assert(t, got[AssignedContainers] != "")
+
+	assigned := map[string]assignedContainerInfo{}
+	err := json.Unmarshal([]byte(got[AssignedContainers]), &assigned)
+	assert.NilError(t, err)
+	assert.Equal(t, assigned["pod-gcu-example1"].Allocated, false)
+	assert.Equal(t, assigned["pod-gcu-example1"].Request, int32(3))
+	assert.Equal(t, assigned["pod-gcu-example1"].ProfileName, "3g.20gb")
+	assert.Equal(t, assigned["pod-gcu-example1"].ProfileID, "1")
 }

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -66,8 +66,9 @@ metax:
   resourceCountName: "metax-tech.com/gpu"
 enflame:
   resourceNameGCU: "enflame.com/gcu"
-  resourceNameVGCU: "enflame.com/vgcu"
-  resourceNameVGCUPercentage: "enflame.com/vgcu-percentage"
+  resourceNameDRSGCU: "enflame.com/drs-gcu"
+  resourceNameGCUMemory: "enflame.com/gcu-memory"
+  resourceNameGCUCore: "enflame.com/gcu-core"
 mthreads:
   resourceCountName: "mthreads.com/vgpu"
   resourceMemoryName: "mthreads.com/sgpu-memory"
@@ -281,9 +282,10 @@ func createMetaxConfig() metax.MetaxConfig {
 
 func createEnflameConfig() enflame.EnflameConfig {
 	return enflame.EnflameConfig{
-		ResourceNameGCU:            "enflame.com/gcu",
-		ResourceNameVGCU:           "enflame.com/vgcu",
-		ResourceNameVGCUPercentage: "enflame.com/vgcu-percentage",
+		ResourceNameGCU:    "enflame.com/gcu",
+		ResourceNameDRSGCU: "enflame.com/drs-gcu",
+		ResourceNameMemory: "enflame.com/gcu-memory",
+		ResourceNameCore:   "enflame.com/gcu-core",
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds Enflame DRS hard-partition scheduling support in HAMi and replaces the previous Enflame shared-vGCU scheduling path.

Key changes:
- Switch Enflame scheduling resource to `enflame.com/drs-gcu`.
- Parse node annotation `enflame.com/gcu-drs-capacity` (devices + profiles) for capacity/profile-aware scheduling.
- Add a unified Enflame request API:
  - `enflame.com/gcu-memory`
  - `enflame.com/gcu-core`
  HAMi now converts memory/core requests into DRS profile slices internally.
- Keep direct DRS request API (`enflame.com/drs-gcu`) for compatibility.
- Match requested DRS/profile in scheduler `Fit` and write DRS-compatible annotations:
  - `assigned-containers`
  - `enflame.com/gcu-assigned`
  - `enflame.com/gcu-assigned-index`
  - `enflame.com/gcu-assigned-minor`
  - `enflame.com/gcu-request-size`
- Change `hami.io/enflame-vgpu-devices-allocated` payload to memory/core units (MiB/%), so Enflame exported allocation/usage forms are aligned with other vendors.
- Keep DRS slice identity in custom metadata for internal conversion while exposing memory/core-form accounting externally.
- Update Helm defaults/custom resources to include the new memory/core APIs.
- Update Enflame docs/examples for direct DRS and memory/core-based requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- DRS profile matching is derived from profile names in node annotation (e.g. `3g.20gb` => size=3, memory=20GB).
- For memory/core API, memory values are treated as MiB when they are larger than profile-GB scale.
- Legacy Enflame config keys/flags are kept as compatibility aliases where reasonable.

**Does this PR introduce a user-facing change?**:

As Legacy Enflame vgcu is not supported by the vendor currently the Enflame DRS (`enflame.com/drs-gcu`) is the default path which is consistent with Enflame scheduler, and users can also request Enflame slices using a HAMi style memory/core API (`enflame.com/gcu-memory`, `enflame.com/gcu-core`).

**AI assistance disclosure**:
This PR was prepared with AI coding assistance. Manually tested at enflame s60.
