### PR TITLE
Fix time-out logic incorrectly triggered 

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -300,7 +300,7 @@ func (dev *Devices) checkType(annos map[string]string, d device.DeviceUsage, n d
 }
 
 func (dev *Devices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	return device.CheckHealth(devType, n)
+	return device.CheckHealth(devType, dev.GetResourceNames().ResourceCountName, n)
 }
 
 func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -510,7 +510,7 @@ func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (b
 		if time.Now().Before(formertime.Add(time.Second * 60)) {
 			return true, false
 		}
-	
+
 		qty := node.Status.Allocatable[corev1.ResourceName(resourceCountName)]
 		if qty.Value() > 0 {
 			klog.V(5).InfoS("Handshake expired but Allocatable still present, skipping NodeCleanUp", "nodeName", node.Name, "resource", resourceCountName)

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -503,9 +503,6 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 	return uuids
 }
 
-// CheckHealth checks whether the device-plugin for devType is still alive on node.
-// resourceCountName is the Kubernetes resource name (e.g. "nvidia.com/gpu") used to
-// verify liveness via node.Status.Allocatable when the handshake timestamp expires.
 func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (bool, bool) {
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
@@ -513,11 +510,7 @@ func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (b
 		if time.Now().Before(formertime.Add(time.Second * 60)) {
 			return true, false
 		}
-		// Handshake timestamp has expired. Before triggering NodeCleanUp, check
-		// whether the device-plugin is still reporting via node Allocatable. Kubelet
-		// maintains Allocatable directly from the device-plugin gRPC stream, so a
-		// non-zero quantity is a reliable liveness signal regardless of vendor.
-		// No annotation patch is issued here to avoid unnecessary API server writes.
+	
 		qty := node.Status.Allocatable[corev1.ResourceName(resourceCountName)]
 		if qty.Value() > 0 {
 			klog.V(5).InfoS("Handshake expired but Allocatable still present, skipping NodeCleanUp", "nodeName", node.Name, "resource", resourceCountName)

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -503,11 +503,27 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 	return uuids
 }
 
-func CheckHealth(devType string, node *corev1.Node) (bool, bool) {
+// CheckHealth checks whether the device-plugin for devType is still alive on node.
+// resourceCountName is the Kubernetes resource name (e.g. "nvidia.com/gpu") used to
+// verify liveness via node.Status.Allocatable when the handshake timestamp expires.
+func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (bool, bool) {
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
 		formertime, _ := time.ParseInLocation(time.DateTime, strings.Split(handshake, "_")[1], time.Local)
-		return time.Now().Before(formertime.Add(time.Second * 60)), false
+		if time.Now().Before(formertime.Add(time.Second * 60)) {
+			return true, false
+		}
+		// Handshake timestamp has expired. Before triggering NodeCleanUp, check
+		// whether the device-plugin is still reporting via node Allocatable. Kubelet
+		// maintains Allocatable directly from the device-plugin gRPC stream, so a
+		// non-zero quantity is a reliable liveness signal regardless of vendor.
+		// No annotation patch is issued here to avoid unnecessary API server writes.
+		qty := node.Status.Allocatable[corev1.ResourceName(resourceCountName)]
+		if qty.Value() > 0 {
+			klog.V(5).InfoS("Handshake expired but Allocatable still present, skipping NodeCleanUp", "nodeName", node.Name, "resource", resourceCountName)
+			return true, false
+		}
+		return false, false
 	} else if strings.Contains(handshake, "Deleted") {
 		// Mirror the timestamp logic used by the Requesting branch: a
 		// Deleted_<ts> older than 60s on a node whose devices are otherwise

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -45,15 +45,6 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 	assert.DeepEqual(t, cd1, cd2)
 }
 
-func TestDecodeContainerDevices_InvalidFields(t *testing.T) {
-	_, err := DecodeContainerDevices("uuid,type,100:")
-	assert.Assert(t, err != nil)
-	_, err = DecodeContainerDevices("uuid,type,notanumber,3:")
-	assert.Assert(t, err != nil)
-	_, err = DecodeContainerDevices("uuid,type,100,notanumber:")
-	assert.Assert(t, err != nil)
-}
-
 func TestEmptyPodDeviceCoding(t *testing.T) {
 	pd1 := PodDevices{}
 	s := EncodePodDevices(inRequestDevices, pd1)
@@ -694,8 +685,9 @@ func Test_CheckHealth(t *testing.T) {
 	tests := []struct {
 		name string
 		args struct {
-			devType string
-			n       corev1.Node
+			devType           string
+			resourceCountName string
+			n                 corev1.Node
 		}
 		want1 bool
 		want2 bool
@@ -703,8 +695,9 @@ func Test_CheckHealth(t *testing.T) {
 		{
 			name: "Requesting state",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -721,8 +714,9 @@ func Test_CheckHealth(t *testing.T) {
 		{
 			name: "Deleted state",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -737,12 +731,15 @@ func Test_CheckHealth(t *testing.T) {
 			want2: false,
 		},
 		{
-			// Inside the 60s cooldown window — keep the conservative path,
-			// scheduler should not yet re-add the node to its cache.
+			// Inside the 60-second deletedCooldown window — keep the conservative
+			// path; the scheduler should not yet re-add the node to its cache.
+			// The far-future timestamp (year 2128) ensures the cooldown has not
+			// elapsed regardless of when the test runs.
 			name: "Deleted state within cooldown",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -763,8 +760,9 @@ func Test_CheckHealth(t *testing.T) {
 			// case which exercises the same util.GetNode failure path.
 			name: "Deleted state stale",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -783,8 +781,9 @@ func Test_CheckHealth(t *testing.T) {
 			// path — never recover from a malformed value.
 			name: "Deleted state with unparsable timestamp",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -801,8 +800,9 @@ func Test_CheckHealth(t *testing.T) {
 		{
 			name: "Unknown state",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
 				devType: "huawei.com/Ascend910",
 				n: corev1.Node{
@@ -817,12 +817,16 @@ func Test_CheckHealth(t *testing.T) {
 			want2: false,
 		},
 		{
-			name: "Requesting state expired",
+			// Expired Requesting_ and no Allocatable resources: the device-plugin
+			// is truly gone, so NodeCleanUp should be triggered → (false, false).
+			name: "Requesting state expired, no allocatable",
 			args: struct {
-				devType string
-				n       corev1.Node
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
 			}{
-				devType: "huawei.com/Ascend910",
+				devType:           "huawei.com/Ascend910",
+				resourceCountName: "huawei.com/Ascend910",
 				n: corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
@@ -834,10 +838,38 @@ func Test_CheckHealth(t *testing.T) {
 			want1: false,
 			want2: false,
 		},
+		{
+			// Expired Requesting_ but Allocatable still has the resource: the
+			// device-plugin gRPC stream is alive. Handshake is refreshed and the
+			// node stays healthy → (true, false).
+			name: "Requesting state expired, allocatable present",
+			args: struct {
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
+			}{
+				devType:           "huawei.com/Ascend910",
+				resourceCountName: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_2024-01-02 00:00:00",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							"huawei.com/Ascend910": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result1, result2 := CheckHealth(test.args.devType, &test.args.n)
+			result1, result2 := CheckHealth(test.args.devType, test.args.resourceCountName, &test.args.n)
 			assert.Equal(t, result1, test.want1)
 			assert.Equal(t, result2, test.want2)
 		})

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -181,7 +181,7 @@ func (dev *DCUDevices) NodeCleanUp(nn string) error {
 }
 
 func (dev *DCUDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	return device.CheckHealth(devType, n)
+	return device.CheckHealth(devType, dev.GetResourceNames().ResourceCountName, n)
 }
 
 func (dev *DCUDevices) checkType(annos map[string]string, d device.DeviceUsage, n device.ContainerDeviceRequest) (bool, bool, bool) {

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -189,7 +189,7 @@ func (dev *IluvatarDevices) checkType(annos map[string]string, d device.DeviceUs
 }
 
 func (dev *IluvatarDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	return device.CheckHealth(devType, n)
+	return device.CheckHealth(devType, dev.GetResourceNames().ResourceCountName, n)
 }
 
 func (dev *IluvatarDevices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -90,7 +90,7 @@ func (dev *KunlunVDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod)
 }
 
 func (dev *KunlunVDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	return device.CheckHealth(devType, n)
+	return device.CheckHealth(devType, dev.GetResourceNames().ResourceCountName, n)
 }
 
 func (dev *KunlunVDevices) NodeCleanUp(nn string) error {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -232,7 +232,7 @@ func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, 
 	reported := dev.ReportedGPUNum[n.Name]
 	klog.V(3).InfoS("checking device health for node", "nodeName", n.Name, "deviceType", devType, "currentDevices", current, "reportedDevices", reported)
 
-	handshakeHealthy, handshakeChanged := device.CheckHealth(devType, n)
+	handshakeHealthy, handshakeChanged := device.CheckHealth(devType, dev.config.ResourceCountName, n)
 
 	if current == 0 {
 		if reported == 0 {

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -137,7 +137,7 @@ func (dev *VastaiDevices) checkType(annos map[string]string, d device.DeviceUsag
 }
 
 func (dev *VastaiDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
-	return device.CheckHealth(devType, n)
+	return device.CheckHealth(devType, dev.GetResourceNames().ResourceCountName, n)
 }
 
 func (dev *VastaiDevices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,8 +48,13 @@ func GetNode(nodename string) (*corev1.Node, error) {
 		return nil, fmt.Errorf("nodename is empty")
 	}
 
+	c := client.GetClient()
+	if c == nil {
+		return nil, fmt.Errorf("kubernetes client is not initialized")
+	}
+
 	klog.V(5).InfoS("Fetching node", "nodeName", nodename)
-	n, err := client.GetClient().CoreV1().Nodes().Get(context.Background(), nodename, metav1.GetOptions{})
+	n, err := c.CoreV1().Nodes().Get(context.Background(), nodename, metav1.GetOptions{})
 	if err != nil {
 		switch {
 		case apierrors.IsNotFound(err):


### PR DESCRIPTION
/kind bug

In v2.9.0, we use 'node.allocatible' to track the health of devices. So newest NVIDIA-hami-device-plugin doesn't refresh handshake annotations when devices are healthy to reduce api-server  preassure, but the time-out logic on scheduler side may incorrectly triggered because handshake timestamp may expire. It results in pod stuck in pending state until handshake refreshment.

This is a quick-fix, i think we need to ultimately eliminate the handshake annos, i'll add it to the roadmap in v2.10