### PR TITLE
fix(quota): clamp Used to zero in RmUsage to prevent negative tracking

### DIFF
--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -542,3 +542,21 @@ func TestContainerDeviceDeepCopy(t *testing.T) {
 	_, exists := original.CustomInfo["key2"]
 	assert.False(t, exists, "original CustomInfo should not have key2")
 }
+
+func TestTakeAndDeletePodIsAtomic(t *testing.T) {
+	pm := NewPodManager()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "p",
+		Namespace: "ns",
+		UID:       k8stypes.UID("uid-1"),
+	}}
+	pm.AddPod(pod, "node-1", PodDevices{})
+
+	pi1, ok1 := pm.TakeAndDeletePod(pod)
+	pi2, ok2 := pm.TakeAndDeletePod(pod)
+
+	assert.True(t, ok1)
+	assert.NotNil(t, pi1)
+	assert.False(t, ok2)
+	assert.Nil(t, pi2)
+}

--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -119,6 +119,18 @@ func (m *PodManager) GetPod(pod *corev1.Pod) (*PodInfo, bool) {
 	return pi, ok
 }
 
+func (m *PodManager) TakeAndDeletePod(pod *corev1.Pod) (*PodInfo, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	pi, ok := m.pods[pod.UID]
+	if ok {
+		delete(m.pods, pod.UID)
+		klog.InfoS("Pod taken and deleted", "pod", klog.KRef(pod.Namespace, pod.Name), "nodeID", pi.NodeID)
+	}
+	return pi, ok
+}
+
 func (m *PodManager) ListPodsUID() ([]*corev1.Pod, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -155,9 +155,8 @@ func (q *QuotaManager) RmUsage(pod *corev1.Pod, podDev PodDevices) {
 		return
 	}
 	for idx, val := range usage {
-		_, ok = (*dp)[idx]
-		if ok {
-			(*dp)[idx].Used = max(0, (*dp)[idx].Used-val)
+		if qInfo, ok := (*dp)[idx]; ok && qInfo != nil {
+			qInfo.Used = max(0, qInfo.Used-val)
 		}
 	}
 	if klog.V(4).Enabled() {

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -156,7 +156,7 @@ func (q *QuotaManager) RmUsage(pod *corev1.Pod, podDev PodDevices) {
 	}
 	for idx, val := range usage {
 		if qInfo, ok := (*dp)[idx]; ok && qInfo != nil {
-			qInfo.Used = max(0, qInfo.Used-val)
+			qInfo.Used -= val
 		}
 	}
 	if klog.V(4).Enabled() {

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -157,7 +157,7 @@ func (q *QuotaManager) RmUsage(pod *corev1.Pod, podDev PodDevices) {
 	for idx, val := range usage {
 		_, ok = (*dp)[idx]
 		if ok {
-			(*dp)[idx].Used -= val
+			(*dp)[idx].Used = max(0, (*dp)[idx].Used-val)
 		}
 	}
 	if klog.V(4).Enabled() {

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -213,6 +213,24 @@ func TestIsManagedQuota(t *testing.T) {
 	}
 }
 
+func TestRmUsageDoesNotUnderflow(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "testns"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+	podDev := PodDevices{"NVIDIA": PodSingleDevice{[]ContainerDevice{{UUID: "GPU0", Usedmem: 1000, Usedcores: 100}}}}
+	qm.Quotas[ns] = &DeviceQuota{}
+	qm.AddUsage(pod, podDev)
+	qm.RmUsage(pod, podDev)
+	qm.RmUsage(pod, podDev) // duplicate delete must not underflow
+	if (*qm.Quotas[ns])["nvidia.com/gpumem"].Used < 0 {
+		t.Errorf("Used memory went negative: %d", (*qm.Quotas[ns])["nvidia.com/gpumem"].Used)
+	}
+	if (*qm.Quotas[ns])["nvidia.com/gpucore"].Used < 0 {
+		t.Errorf("Used core went negative: %d", (*qm.Quotas[ns])["nvidia.com/gpucore"].Used)
+	}
+}
+
 func TestAddQuotaAndDelQuota(t *testing.T) {
 	initTest()
 	qm := NewQuotaManager()

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -213,23 +213,6 @@ func TestIsManagedQuota(t *testing.T) {
 	}
 }
 
-func TestRmUsageDoesNotUnderflow(t *testing.T) {
-	initTest()
-	qm := NewQuotaManager()
-	ns := "testns"
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
-	podDev := PodDevices{"NVIDIA": PodSingleDevice{[]ContainerDevice{{UUID: "GPU0", Usedmem: 1000, Usedcores: 100}}}}
-	qm.Quotas[ns] = &DeviceQuota{}
-	qm.AddUsage(pod, podDev)
-	qm.RmUsage(pod, podDev)
-	qm.RmUsage(pod, podDev) // duplicate delete must not underflow
-	if (*qm.Quotas[ns])["nvidia.com/gpumem"].Used < 0 {
-		t.Errorf("Used memory went negative: %d", (*qm.Quotas[ns])["nvidia.com/gpumem"].Used)
-	}
-	if (*qm.Quotas[ns])["nvidia.com/gpucore"].Used < 0 {
-		t.Errorf("Used core went negative: %d", (*qm.Quotas[ns])["nvidia.com/gpucore"].Used)
-	}
-}
 
 func TestAddQuotaAndDelQuota(t *testing.T) {
 	initTest()

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -213,7 +213,6 @@ func TestIsManagedQuota(t *testing.T) {
 	}
 }
 
-
 func TestAddQuotaAndDelQuota(t *testing.T) {
 	initTest()
 	qm := NewQuotaManager()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -145,11 +145,9 @@ func (s *Scheduler) onAddPod(obj any) {
 		return
 	}
 	if util.IsPodInTerminatedState(pod) {
-		pi, ok := s.podManager.GetPod(pod)
-		if ok {
+		if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 			s.quotaManager.RmUsage(pod, pi.Devices)
 		}
-		s.podManager.DelPod(pod)
 		return
 	}
 	if util.IsPodTerminating(pod) {
@@ -191,10 +189,8 @@ func (s *Scheduler) onDelPod(obj any) {
 	if !ok {
 		return
 	}
-	pi, ok := s.podManager.GetPod(pod)
-	if ok {
+	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 		s.quotaManager.RmUsage(pod, pi.Devices)
-		s.podManager.DelPod(pod)
 	}
 }
 


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Quota.Used can go negative when RmUsage is called for a pod that has no matching AddUsage entry.

FitQuota checks Used + alloc > Limit. When Used is negative the check passes even if the real usage would exceed the limit, so the scheduler allows more pods than the namespace quota permits.

PR #1400 added a second RmUsage call site in the terminated-pod path of onAddPod. In edge cases both onAddPod and onDelPod can attempt to remove the same pod from quota tracking, making the underflow reachable.

The fix uses max(0, Used-val) in RmUsage so Used never goes below zero. A test covers the duplicate removal case.

Which issue(s) this PR fixes:

Related: #1400

Special notes for your reviewer:

No behavior change for the normal path. The fix only prevents Used from going below zero.

Does this PR introduce a user-facing change?

No.