### PR TITLE
fix(vGPUmonitor): prevent index out of bounds panic for priority above 1

### DIFF
--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -95,7 +95,7 @@ func CheckBlocking(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 		uuid := c.Info.DeviceUUID(i)
 		_, ok := utSwitchOn[uuid]
 		if ok {
-			for i := range p {
+			for i := range min(p, len(utSwitchOn[uuid])) {
 				if utSwitchOn[uuid][i] > 0 {
 					return true
 				}
@@ -112,12 +112,12 @@ func CheckPriority(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 		uuid := c.Info.DeviceUUID(i)
 		_, ok := utSwitchOn[uuid]
 		if ok {
-			for i := range p {
+			for i := range min(p, len(utSwitchOn[uuid])) {
 				if utSwitchOn[uuid][i] > 0 {
 					return true
 				}
 			}
-			if utSwitchOn[uuid][p] > 1 {
+			if p < len(utSwitchOn[uuid]) && utSwitchOn[uuid][p] > 1 {
 				return true
 			}
 		}
@@ -141,10 +141,11 @@ func Observe(lister *nvidia.ContainerLister) {
 						continue
 					}
 					uuid := c.Info.DeviceUUID(i)
-					if len(utSwitchOn[uuid]) == 0 {
-						utSwitchOn[uuid] = []int{0, 0}
+					p := c.Info.GetPriority()
+					for p >= len(utSwitchOn[uuid]) {
+						utSwitchOn[uuid] = append(utSwitchOn[uuid], 0)
 					}
-					utSwitchOn[uuid][c.Info.GetPriority()]++
+					utSwitchOn[uuid][p]++
 				}
 			}
 			c.Info.SetRecentKernel(recentKernel)

--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -117,7 +117,7 @@ func CheckPriority(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 					return true
 				}
 			}
-			if p < len(utSwitchOn[uuid]) && utSwitchOn[uuid][p] > 1 {
+			if p >= 0 && p < len(utSwitchOn[uuid]) && utSwitchOn[uuid][p] > 1 {
 				return true
 			}
 		}
@@ -142,6 +142,9 @@ func Observe(lister *nvidia.ContainerLister) {
 					}
 					uuid := c.Info.DeviceUUID(i)
 					p := c.Info.GetPriority()
+					if p < 0 {
+						continue
+					}
 					for p >= len(utSwitchOn[uuid]) {
 						utSwitchOn[uuid] = append(utSwitchOn[uuid], 0)
 					}

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+)
+
+type stubInfo struct{ priority int }
+
+func (s *stubInfo) DeviceMax() int                     { return 1 }
+func (s *stubInfo) DeviceNum() int                     { return 0 }
+func (s *stubInfo) DeviceUUID(int) string              { return "gpu-0" }
+func (s *stubInfo) DeviceMemoryContextSize(int) uint64 { return 0 }
+func (s *stubInfo) DeviceMemoryModuleSize(int) uint64  { return 0 }
+func (s *stubInfo) DeviceMemoryBufferSize(int) uint64  { return 0 }
+func (s *stubInfo) DeviceMemoryOffset(int) uint64      { return 0 }
+func (s *stubInfo) DeviceMemoryTotal(int) uint64       { return 0 }
+func (s *stubInfo) DeviceSmUtil(int) uint64            { return 0 }
+func (s *stubInfo) SetDeviceSmLimit(uint64)            {}
+func (s *stubInfo) IsValidUUID(int) bool               { return true }
+func (s *stubInfo) DeviceMemoryLimit(int) uint64       { return 0 }
+func (s *stubInfo) SetDeviceMemoryLimit(uint64)        {}
+func (s *stubInfo) LastKernelTime() int64              { return 0 }
+func (s *stubInfo) GetPriority() int                   { return s.priority }
+func (s *stubInfo) GetRecentKernel() int32             { return 1 }
+func (s *stubInfo) SetRecentKernel(int32)              {}
+func (s *stubInfo) GetUtilizationSwitch() int32        { return 0 }
+func (s *stubInfo) SetUtilizationSwitch(int32)         {}
+
+func TestCheckFunctionsHighPriority(t *testing.T) {
+	sw := map[string]UtilizationPerDevice{"gpu-0": {0, 1}}
+	c := &nvidia.ContainerUsage{Info: &stubInfo{priority: 3}}
+	if !CheckBlocking(sw, 3, c) {
+		t.Error("CheckBlocking: expected true")
+	}
+	if !CheckPriority(sw, 3, c) {
+		t.Error("CheckPriority: expected true")
+	}
+	sw2 := map[string]UtilizationPerDevice{"gpu-0": {0, 0}}
+	if CheckBlocking(sw2, 2, c) {
+		t.Error("CheckBlocking: expected false")
+	}
+}


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

utSwitchOn[uuid] was always initialized as a fixed two-element slice.

A container with CUDA_TASK_PRIORITY set to 2 or higher triggers a panic in 3 places.

Observe() writes utSwitchOn[uuid][priority] without growing the slice first.

CheckBlocking() and CheckPriority() loop up to the container priority and access utSwitchOn[uuid][p] without checking the slice length.

The bug was introduced in commit 54dc0de which replaced explicit for loops with range-over-int but kept the fixed two-element initialization.

The fix grows the slice in Observe() to fit any priority value and adds length guards in CheckBlocking() and CheckPriority().