### PR TITLE
feat(helm): make device plugin security context configurable via values

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
-      hostPID: {{ .Values.devicePlugin.hostPID | default true }}
+      hostPID: {{ .Values.devicePlugin.hostPID }}
       hostNetwork: {{ .Values.devicePlugin.hostNetwork | default false }}
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -40,17 +40,18 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
-      hostPID: true
-      hostNetwork: false
+      hostPID: {{ .Values.devicePlugin.hostPID }}
+      hostNetwork: {{ .Values.devicePlugin.hostNetwork }}
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}
       initContainers:
         - name: toolkit-validation
           image: {{ include "hami.devicePlugin.image" . }}
           imagePullPolicy: {{ .Values.devicePlugin.image.pullPolicy }}
+          {{- with .Values.devicePlugin.initContainerSecurityContext }}
           securityContext:
-            privileged: true
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["sh", "-c"]
           args:
             - |
@@ -124,12 +125,10 @@ spec:
             {{- with .Values.devicePlugin.extraEnvs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- with .Values.devicePlugin.securityContext }}
           securityContext:
-            privileged: true
-            allowPrivilegeEscalation: true
-            capabilities:
-              drop: ["ALL"]
-              add: ["SYS_ADMIN"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
           {{- toYaml .Values.devicePlugin.resources | nindent 12 }}
           volumeMounts:
@@ -170,11 +169,10 @@ spec:
             {{- range .Values.devicePlugin.monitor.extraArgs }}
             - {{ . }}
             {{- end }}
+          {{- with .Values.devicePlugin.monitor.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-              add: ["SYS_ADMIN"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -48,7 +48,7 @@ spec:
         - name: toolkit-validation
           image: {{ include "hami.devicePlugin.image" . }}
           imagePullPolicy: {{ .Values.devicePlugin.image.pullPolicy }}
-          {{- with .Values.devicePlugin.initContainerSecurityContext }}
+          {{- with .Values.devicePlugin.gpuOperatorToolkitReady.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -40,8 +40,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
-      hostPID: {{ .Values.devicePlugin.hostPID }}
-      hostNetwork: {{ .Values.devicePlugin.hostNetwork }}
+      hostPID: {{ .Values.devicePlugin.hostPID | default true }}
+      hostNetwork: {{ .Values.devicePlugin.hostNetwork | default false }}
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}
       initContainers:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -317,6 +317,11 @@ devicePlugin:
     extraArgs:
       - -v=4
     extraEnvs: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+        add: ["SYS_ADMIN"]
     resources: {}
       # If you do want to specify resources, uncomment the following lines, adjust them as necessary.
       # and remove the curly braces after 'resources:'.
@@ -386,6 +391,17 @@ devicePlugin:
   libPath: /usr/local/vgpu
 
   podAnnotations: {}
+  hostPID: true
+  hostNetwork: false
+  initContainerSecurityContext:
+    privileged: true
+    runAsUser: 0
+  securityContext:
+    privileged: true
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["SYS_ADMIN"]
   nvidiaNodeSelector:
     gpu: "on"
   tolerations: []

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -269,6 +269,9 @@ devicePlugin:
   gpuOperatorToolkitReady:
     enabled: false
     hostPath: "/run/nvidia/validations"
+    securityContext:
+      privileged: true
+      runAsUser: 0
   ## @param image.registry devicePlugin image registry
   ## @param image.repository devicePlugin image repository
   ## @param image.tag devicePlugin image tag (immutable tags are recommended)
@@ -393,9 +396,6 @@ devicePlugin:
   podAnnotations: {}
   hostPID: true
   hostNetwork: false
-  initContainerSecurityContext:
-    privileged: true
-    runAsUser: 0
   securityContext:
     privileged: true
     allowPrivilegeEscalation: true


### PR DESCRIPTION
## Summary

- `hostPID` and `hostNetwork` on the device plugin DaemonSet pod spec are now values-configurable (defaults: `true` / `false` — unchanged from current behaviour)
- `securityContext` for the main `device-plugin` container is now values-configurable (default: `privileged: true`, `allowPrivilegeEscalation: true`, `SYS_ADMIN`)
- `securityContext` for the `vgpu-monitor` container is now values-configurable (default: `allowPrivilegeEscalation: false`, `SYS_ADMIN`)
- `gpuOperatorToolkitReady.securityContext` for the toolkit-validation init container is now values-configurable (default: `privileged: true`, `runAsUser: 0`)

All defaults preserve the existing hardcoded values — this is a non-breaking change.

## Motivation

Users deploying HAMi in environments with custom Pod Security Admission policies or restricted node configurations need to be able to tune these settings without patching the chart templates.

Through testing we found that not all security defaults — such as `privileged: true` and `hostPID: true` — are required for every use case. Making these configurable allows users to apply a least-privilege posture where their environment permits.

Closes #1888
Related: #1143

> AI assistance used in drafting this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new configuration options to control whether the device plugin uses host PID and host networking.
  * Introduced configurable security settings for the device plugin, its monitoring component, and the toolkit validation step.

* **Bug Fixes**
  * Replaced previously hardcoded privilege and container security settings with deployment-driven controls, improving compatibility and flexibility across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->