### PR TITLE
test: add unit tests for nvinternal info, mig, and watch packages

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/info/version_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/info/version_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package info
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	original := version
+	defer func() { version = original }()
+
+	version = "v2.5.0"
+	if got := GetVersion(); got != "v2.5.0" {
+		t.Errorf("GetVersion() = %q, want %q", got, "v2.5.0")
+	}
+}
+
+func TestGetVersion_default(t *testing.T) {
+	original := version
+	defer func() { version = original }()
+
+	version = "unknown"
+	if got := GetVersion(); got != "unknown" {
+		t.Errorf("GetVersion() = %q, want %q", got, "unknown")
+	}
+}
+
+func TestGetVersionParts_withCommit(t *testing.T) {
+	origVersion := version
+	origCommit := gitCommit
+	defer func() {
+		version = origVersion
+		gitCommit = origCommit
+	}()
+
+	version = "v2.5.0"
+	gitCommit = "abc123"
+
+	parts := GetVersionParts()
+	if len(parts) != 2 {
+		t.Fatalf("GetVersionParts() returned %d parts, want 2", len(parts))
+	}
+	if parts[0] != "v2.5.0" {
+		t.Errorf("parts[0] = %q, want %q", parts[0], "v2.5.0")
+	}
+	if parts[1] != "commit: abc123" {
+		t.Errorf("parts[1] = %q, want %q", parts[1], "commit: abc123")
+	}
+}
+
+func TestGetVersionParts_noCommit(t *testing.T) {
+	origVersion := version
+	origCommit := gitCommit
+	defer func() {
+		version = origVersion
+		gitCommit = origCommit
+	}()
+
+	version = "v2.5.0"
+	gitCommit = ""
+
+	parts := GetVersionParts()
+	if len(parts) != 1 {
+		t.Fatalf("GetVersionParts() returned %d parts, want 1", len(parts))
+	}
+	if parts[0] != "v2.5.0" {
+		t.Errorf("parts[0] = %q, want %q", parts[0], "v2.5.0")
+	}
+}
+
+func TestGetVersionString_basic(t *testing.T) {
+	origVersion := version
+	origCommit := gitCommit
+	defer func() {
+		version = origVersion
+		gitCommit = origCommit
+	}()
+
+	version = "v2.5.0"
+	gitCommit = "abc123"
+
+	got := GetVersionString()
+	if !strings.Contains(got, "v2.5.0") {
+		t.Errorf("GetVersionString() missing version: %q", got)
+	}
+	if !strings.Contains(got, "abc123") {
+		t.Errorf("GetVersionString() missing commit: %q", got)
+	}
+}
+
+func TestGetVersionString_withExtra(t *testing.T) {
+	origVersion := version
+	origCommit := gitCommit
+	defer func() {
+		version = origVersion
+		gitCommit = origCommit
+	}()
+
+	version = "v2.5.0"
+	gitCommit = ""
+
+	got := GetVersionString("go1.25", "linux/amd64")
+	parts := strings.Split(got, "\n")
+	if len(parts) != 3 {
+		t.Fatalf("GetVersionString() returned %d lines, want 3, got: %q", len(parts), got)
+	}
+	if parts[0] != "v2.5.0" {
+		t.Errorf("parts[0] = %q, want %q", parts[0], "v2.5.0")
+	}
+	if parts[1] != "go1.25" {
+		t.Errorf("parts[1] = %q, want %q", parts[1], "go1.25")
+	}
+	if parts[2] != "linux/amd64" {
+		t.Errorf("parts[2] = %q, want %q", parts[2], "linux/amd64")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/info/version_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/info/version_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The HAMi Authors.
+Copyright 2026 The HAMi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package mig
 
 import (
+	"os"
 	"testing"
 )
 
 func TestGetMigCapabilityDevicePaths_noFile(t *testing.T) {
+	if _, err := os.Stat(nvcapsMigMinorsPath); err == nil {
+		t.Skipf("skipping: %s exists on this machine", nvcapsMigMinorsPath)
+	}
 	result, err := GetMigCapabilityDevicePaths()
 	if err != nil {
 		t.Fatalf("GetMigCapabilityDevicePaths() unexpected error: %v", err)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The HAMi Authors.
+Copyright 2026 The HAMi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/mig/mig_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mig
+
+import (
+	"testing"
+)
+
+func TestGetMigCapabilityDevicePaths_noFile(t *testing.T) {
+	result, err := GetMigCapabilityDevicePaths()
+	if err != nil {
+		t.Fatalf("GetMigCapabilityDevicePaths() unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("GetMigCapabilityDevicePaths() = %v, want nil on non-MIG machine", result)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFiles_valid(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "test.txt")
+	if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := Files(f)
+	if err != nil {
+		t.Fatalf("Files() error: %v", err)
+	}
+	defer w.Close()
+}
+
+func TestFiles_nonexistent(t *testing.T) {
+	_, err := Files("/tmp/hami-test-nonexistent-file-12345")
+	if err == nil {
+		t.Fatal("Files() expected error for nonexistent path, got nil")
+	}
+}
+
+func TestFiles_empty(t *testing.T) {
+	w, err := Files()
+	if err != nil {
+		t.Fatalf("Files() error on empty input: %v", err)
+	}
+	defer w.Close()
+}
+
+func TestSignals(t *testing.T) {
+	ch := Signals(os.Interrupt)
+	if ch == nil {
+		t.Fatal("Signals() returned nil channel")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The HAMi Authors.
+Copyright 2026 The HAMi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/watch/watchers_test.go
@@ -36,7 +36,7 @@ func TestFiles_valid(t *testing.T) {
 }
 
 func TestFiles_nonexistent(t *testing.T) {
-	_, err := Files("/tmp/hami-test-nonexistent-file-12345")
+	_, err := Files(filepath.Join(t.TempDir(), "nonexistent"))
 	if err == nil {
 		t.Fatal("Files() expected error for nonexistent path, got nil")
 	}


### PR DESCRIPTION
Adds unit tests for three packages under `pkg/device-plugin/nvidiadevice/nvinternal/` that had zero test coverage:

**info/version_test.go** (6 tests)
- `GetVersion` with custom and default values
- `GetVersionParts` with and without git commit
- `GetVersionString` basic and with extra args

**mig/mig_test.go** (1 test)
- `GetMigCapabilityDevicePaths` returns nil on non-MIG machines (covers the `os.IsNotExist` early-return path)

**watch/watchers_test.go** (4 tests)
- `Files` with valid path, nonexistent path, and empty input
- `Signals` channel creation

All tests pass locally. No production code changes.

Ref #569