### PR TITLE
fix: rollback quota usage when filter annotation patch fails

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -780,14 +780,19 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		val.PatchAnnotations(args.Pod, &annotations, m.Devices)
 	}
 
-	if s.podManager.AddPod(args.Pod, m.NodeID, m.Devices) {
-		s.quotaManager.AddUsage(args.Pod, m.Devices)
+	added := s.podManager.AddPod(args.Pod, m.NodeID, m.Devices)
+	if added {
+	    s.quotaManager.AddUsage(args.Pod, m.Devices)
 	}
+	
 	err = util.PatchPodAnnotations(args.Pod, annotations)
 	if err != nil {
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		s.podManager.DelPod(args.Pod)
-		return nil, err
+	    s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+	    if added {
+	        s.quotaManager.RmUsage(args.Pod, m.Devices)
+	    }
+	    s.podManager.DelPod(args.Pod)
+	    return nil, err
 	}
 	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, nodeScores.NodeList)
 	s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringSucceed, successMsg, nil)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR attempts to fix a possible local quota usage consistency issue in `Scheduler.Filter()`.

Currently, `Filter()` calls `podManager.AddPod()` and `quotaManager.AddUsage()` before patching pod annotations. If `PatchPodAnnotations()` fails, HAMi removes the pod from `podManager`, but the quota usage added before the patch is not rolled back.

This PR stores the return value of `podManager.AddPod()` in an `added` variable. If `added` is true and `PatchPodAnnotations()` fails, it calls `quotaManager.RmUsage()` before deleting the pod from `podManager`.

This keeps `AddUsage()` and `RmUsage()` symmetric in the patch failure path.

**Which issue(s) this PR fixes**:

Related to #1896

**Special notes for your reviewer**:

The `added` flag is used because `quotaManager.AddUsage()` is only called when `podManager.AddPod()` returns true. Therefore, `quotaManager.RmUsage()` should also only be called when `AddUsage()` has actually been executed.

I am not sure whether there is another later reconciliation path that corrects this quota usage automatically. If such a mechanism exists, please correct me.

**Does this PR introduce a user-facing change?**:

```release-note
NONE