### PR TITLE
fix: prevent scheduler from dropping GPU nodes after 60s handshake piry

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -162,6 +162,8 @@ const (
 
 	// OnePodMultiContainerSplitSymbol this is when one pod having multi container and more than one container use device, use ; symbol to join device info.
 	OnePodMultiContainerSplitSymbol = ";"
+
+	handshakeExpiry = time.Second * 60
 )
 
 var (
@@ -506,28 +508,28 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (bool, bool) {
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
-		formertime, _ := time.ParseInLocation(time.DateTime, strings.Split(handshake, "_")[1], time.Local)
-		if time.Now().Before(formertime.Add(time.Second * 60)) {
+		parts := strings.SplitN(handshake, "_", 2)
+		if len(parts) < 2 {
+			return true, false
+		}
+		formerTime, err := time.ParseInLocation(time.DateTime, parts[1], time.Local)
+		if err != nil {
+			return true, false
+		}
+		if time.Now().Before(formerTime.Add(handshakeExpiry)) {
 			return true, false
 		}
 
 		qty := node.Status.Allocatable[corev1.ResourceName(resourceCountName)]
 		if qty.Value() > 0 {
-			klog.V(5).InfoS("Handshake expired but Allocatable still present, skipping NodeCleanUp", "nodeName", node.Name, "resource", resourceCountName)
-			return true, false
+			klog.V(5).InfoS("Handshake expired but Allocatable still present, refreshing handshake", "nodeName", node.Name, "resource", resourceCountName)
+			if !refreshHandshake(node.Name, devType) {
+				return true, false
+			}
+			return true, true
 		}
 		return false, false
 	} else if strings.Contains(handshake, "Deleted") {
-		// Mirror the timestamp logic used by the Requesting branch: a
-		// Deleted_<ts> older than 60s on a node whose devices are otherwise
-		// reporting healthy means the previous cleanup is stale and the
-		// scheduler should bring the node back into its cache. Stamp
-		// Requesting_<now> and return (true, true) so the caller re-adds
-		// node devices on the next reconcile.
-		//
-		// Bare "Deleted" without a timestamp (used in some unit tests) and
-		// any unparsable timestamp must keep the conservative (true, false)
-		// path so we never recover from a malformed value.
 		annoKey, ok := util.HandshakeAnnos[devType]
 		if !ok {
 			return true, false
@@ -540,44 +542,46 @@ func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (b
 		if err != nil {
 			return true, false
 		}
-		now := time.Now()
-		if now.Before(formerTime.Add(time.Second * 60)) {
+		if time.Now().Before(formerTime.Add(handshakeExpiry)) {
 			return true, false
 		}
-		newHandshake := "Requesting_" + now.Format(time.DateTime)
-		tmppat := map[string]string{annoKey: newHandshake}
-		klog.V(5).InfoS("Recovering stale Deleted_ handshake", "nodeName", node.Name, "annotationKey", annoKey, "annotationValue", newHandshake)
-		// Mirror the empty-annotation branch: GetNode also acts as a guard
-		// for an empty node.Name and an uninitialised client (PatchNodeAnnotations
-		// panics in unit tests without it). Worth a follow-up to dedupe with
-		// the else branch into a helper.
-		n, err := util.GetNode(node.Name)
-		if err != nil {
-			klog.ErrorS(err, "Failed to get node", "nodeName", node.Name)
+		klog.V(5).InfoS("Recovering stale Deleted_ handshake", "nodeName", node.Name, "annotationKey", annoKey)
+		if !refreshHandshake(node.Name, devType) {
 			return true, false
-		}
-		if err := util.PatchNodeAnnotations(n, tmppat); err != nil {
-			klog.ErrorS(err, "Failed to patch node annotations", "nodeName", node.Name)
 		}
 		return true, true
 	} else {
-		_, ok := util.HandshakeAnnos[devType]
-		if ok {
-			tmppat := make(map[string]string)
-			tmppat[util.HandshakeAnnos[devType]] = "Requesting_" + time.Now().Format(time.DateTime)
-			klog.V(5).InfoS("New timestamp for annotation", "nodeName", node.Name, "annotationKey", util.HandshakeAnnos[devType], "annotationValue", tmppat[util.HandshakeAnnos[devType]])
-			n, err := util.GetNode(node.Name)
-			if err != nil {
-				klog.ErrorS(err, "Failed to get node", "nodeName", node.Name)
-				return true, false
-			}
-			klog.V(5).InfoS("Patching node annotations", "nodeName", node.Name, "annotations", tmppat)
-			if err := util.PatchNodeAnnotations(n, tmppat); err != nil {
-				klog.ErrorS(err, "Failed to patch node annotations", "nodeName", node.Name)
-			}
+		if _, ok := util.HandshakeAnnos[devType]; !ok {
+			return true, true
+		}
+		if !refreshHandshake(node.Name, devType) {
+			return true, false
 		}
 		return true, true
 	}
+}
+
+// refreshHandshake writes a Requesting_<now> annotation to the node. Returns
+// false if the device type has no handshake key configured, the GetNode API
+// call failed, or the annotation patch failed.
+func refreshHandshake(nodeName, devType string) bool {
+	annoKey, ok := util.HandshakeAnnos[devType]
+	if !ok {
+		return false
+	}
+	annoPatch := map[string]string{
+		annoKey: "Requesting_" + time.Now().Format(time.DateTime),
+	}
+	n, err := util.GetNode(nodeName)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get node for handshake refresh", "nodeName", nodeName)
+		return false
+	}
+	if err := util.PatchNodeAnnotations(n, annoPatch); err != nil {
+		klog.ErrorS(err, "Failed to patch node annotations", "nodeName", nodeName)
+		return false
+	}
+	return true
 }
 
 // Enhanced ExtractMigTemplatesFromUUID with error handling.

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -840,8 +840,10 @@ func Test_CheckHealth(t *testing.T) {
 		},
 		{
 			// Expired Requesting_ but Allocatable still has the resource: the
-			// device-plugin gRPC stream is alive. Handshake is refreshed and the
-			// node stays healthy → (true, false).
+			// device-plugin gRPC stream is alive. Handshake refresh is attempted
+			// but fails in unit tests (no cluster), so the function returns
+			// (true, false). In production, refreshHandshake succeeds and the
+			// caller receives (true, true), repopulating the scheduler cache.
 			name: "Requesting state expired, allocatable present",
 			args: struct {
 				devType           string


### PR DESCRIPTION
When the Requesting_<ts> handshake annotation expires (>60s old) but the node still has allocatable GPU resources, CheckHealth() now refreshes the handshake and returns (true, true) instead of (true, false). This ensures the scheduler's register() loop calls addNode() periodically to keep the node cache fresh.

Previously, after 60s, CheckHealth() returned (healthy, needUpdate=false) causing addNode() to be skipped forever. The cache went stale, metrics dropped to zero, and no new GPU pods could be scheduled.

Also refactored for clarity:
- Extracted refreshHandshake() helper (deduplicating GetNode+PatchNodeAnnotations)
- Extracted handshakeExpiry constant
- Fixed formerTime naming inconsistency

Fixes: #1899

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1899

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: