### PR TITLE
fix(quota): enforce explicit zero limit in ResourceQuota

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -298,18 +298,22 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	)
 	for ns, val := range sher.GetQuotaManager().GetResourceQuota() {
 		for quotaname, q := range *val {
+			limitLabel := "unlimited"
+			if q.LimitSet {
+				limitLabel = fmt.Sprint(q.Limit)
+			}
 			ch <- prometheus.MustNewConstMetric(
 				quotaUsedDesc,
 				prometheus.GaugeValue,
 				float64(q.Used),
-				ns, quotaname, fmt.Sprint(q.Limit),
+				ns, quotaname, limitLabel,
 			)
 			if legacy {
 				ch <- prometheus.MustNewConstMetric(
 					legacyQuotaUsed,
 					prometheus.GaugeValue,
 					float64(q.Used),
-					ns, quotaname, fmt.Sprint(q.Limit),
+					ns, quotaname, limitLabel,
 				)
 			}
 		}

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -25,8 +25,9 @@ import (
 )
 
 type Quota struct {
-	Used  int64
-	Limit int64
+	Used     int64
+	Limit    int64
+	LimitSet bool
 }
 
 type DeviceQuota map[string]*Quota
@@ -69,19 +70,19 @@ func (q *QuotaManager) FitQuota(ns string, memreq int64, memoryFactor int32, cor
 		return true
 	}
 	memQuota, ok := (*dq)[memResourceName]
-	if ok {
+	if ok && memQuota.LimitSet {
 		klog.V(4).InfoS("resourceMem quota judging", "quota limit", memQuota.Limit, "used", memQuota.Used, "alloc", memreq, "memoryFactor", memoryFactor)
 		limit := memQuota.Limit
 		if memoryFactor > 1 {
 			limit = limit * int64(memoryFactor)
 		}
-		if limit != 0 && memQuota.Used+memreq > limit {
+		if memQuota.Used+memreq > limit {
 			klog.V(4).InfoS("resourceMem quota not fitted", "limit", limit, "used", memQuota.Used, "alloc", memreq)
 			return false
 		}
 	}
 	coreQuota, ok := (*dq)[coreResourceName]
-	if ok && coreQuota.Limit != 0 && coreQuota.Used+coresreq > coreQuota.Limit {
+	if ok && coreQuota.LimitSet && coreQuota.Used+coresreq > coreQuota.Limit {
 		klog.V(4).InfoS("resourceCores quota not fitted", "limit", coreQuota.Limit, "used", coreQuota.Used, "alloc", coresreq)
 		return false
 	}
@@ -206,6 +207,7 @@ func (q *QuotaManager) AddQuota(quota *corev1.ResourceQuota) {
 				}
 			}
 			(*dp)[dn].Limit = value
+			(*dp)[dn].LimitSet = true
 			klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
 		}
 	}
@@ -235,6 +237,7 @@ func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
 			if dq, ok := q.Quotas[quota.Namespace]; ok {
 				if quotaInfo, ok := (*dq)[dn]; ok {
 					quotaInfo.Limit = 0
+					quotaInfo.LimitSet = false
 				}
 			}
 		}

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -260,8 +260,9 @@ func (q *QuotaManager) GetResourceQuota() map[string]*DeviceQuota {
 		curDQ := &DeviceQuota{}
 		for name, quota := range *dq {
 			(*curDQ)[name] = &Quota{
-				Used:  quota.Used,
-				Limit: quota.Limit,
+				Used:     quota.Used,
+				Limit:    quota.Limit,
+				LimitSet: quota.LimitSet,
 			}
 		}
 		quotasCopy[ns] = curDQ

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -319,3 +319,28 @@ func TestAddQuotaExplicitZero(t *testing.T) {
 		t.Error("FitQuota should deny request when explicit zero limit is set")
 	}
 }
+
+func TestGetResourceQuotaPreservesLimitSet(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "copy-ns"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+
+	qm.Quotas[ns] = &DeviceQuota{
+		memName:  &Quota{Used: 100, Limit: 0, LimitSet: true},
+		coreName: &Quota{Used: 50, Limit: 200, LimitSet: false},
+	}
+
+	snapshot := qm.GetResourceQuota()
+	dq, ok := snapshot[ns]
+	if !ok {
+		t.Fatalf("GetResourceQuota: missing namespace %q", ns)
+	}
+	if !(*dq)[memName].LimitSet {
+		t.Error("GetResourceQuota: expected LimitSet=true to be preserved")
+	}
+	if (*dq)[coreName].LimitSet {
+		t.Error("GetResourceQuota: expected LimitSet=false to be preserved")
+	}
+}

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -126,8 +126,8 @@ func TestFitQuota(t *testing.T) {
 	coreName := "nvidia.com/gpucore"
 
 	qm.Quotas[ns] = &DeviceQuota{
-		memName:  &Quota{Used: 1000, Limit: 2000},
-		coreName: &Quota{Used: 200, Limit: 400},
+		memName:  &Quota{Used: 1000, Limit: 2000, LimitSet: true},
+		coreName: &Quota{Used: 200, Limit: 400, LimitSet: true},
 	}
 
 	// Should fit
@@ -157,6 +157,41 @@ func TestFitQuota(t *testing.T) {
 	// Should fit if device not present
 	if !qm.FitQuota(ns, 1000, 1, 100, "unknown-device") {
 		t.Error("FitQuota should return true if device not present")
+	}
+}
+
+func TestFitQuotaZeroLimitEnforced(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "zero-ns"
+	deviceName := "NVIDIA"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+
+	// Explicit zero limit must reject any non-zero request.
+	qm.Quotas[ns] = &DeviceQuota{
+		memName:  &Quota{Used: 0, Limit: 0, LimitSet: true},
+		coreName: &Quota{Used: 0, Limit: 0, LimitSet: true},
+	}
+	if qm.FitQuota(ns, 1, 1, 0, deviceName) {
+		t.Error("FitQuota should reject any memory when limit is explicitly 0")
+	}
+	if qm.FitQuota(ns, 0, 1, 1, deviceName) {
+		t.Error("FitQuota should reject any core when limit is explicitly 0")
+	}
+	// Zero request against zero limit is still allowed.
+	if !qm.FitQuota(ns, 0, 1, 0, deviceName) {
+		t.Error("FitQuota should allow zero request against zero limit")
+	}
+
+	// LimitSet=false (e.g. only AddUsage created the entry) means no limit configured.
+	nsUnset := "unset-ns"
+	qm.Quotas[nsUnset] = &DeviceQuota{
+		memName:  &Quota{Used: 0, Limit: 0, LimitSet: false},
+		coreName: &Quota{Used: 0, Limit: 0, LimitSet: false},
+	}
+	if !qm.FitQuota(nsUnset, 9999, 1, 9999, deviceName) {
+		t.Error("FitQuota should allow requests when no limit is configured")
 	}
 }
 
@@ -231,15 +266,56 @@ func TestAddQuotaAndDelQuota(t *testing.T) {
 	if (*qm.Quotas[ns])[memName].Limit != 100 {
 		t.Errorf("AddQuota: expected memory limit 100, got %d", (*qm.Quotas[ns])[memName].Limit)
 	}
+	if !(*qm.Quotas[ns])[memName].LimitSet {
+		t.Error("AddQuota: expected LimitSet=true for memory quota")
+	}
 	if (*qm.Quotas[ns])[coreName].Limit != 10 {
 		t.Errorf("AddQuota: expected core limit 10, got %d", (*qm.Quotas[ns])[coreName].Limit)
+	}
+	if !(*qm.Quotas[ns])[coreName].LimitSet {
+		t.Error("AddQuota: expected LimitSet=true for core quota")
 	}
 
 	qm.DelQuota(rq)
 	if (*qm.Quotas[ns])[memName].Limit != 0 {
 		t.Errorf("DelQuota: expected memory limit 0, got %d", (*qm.Quotas[ns])[memName].Limit)
 	}
+	if (*qm.Quotas[ns])[memName].LimitSet {
+		t.Error("DelQuota: expected LimitSet=false for memory quota")
+	}
 	if (*qm.Quotas[ns])[coreName].Limit != 0 {
 		t.Errorf("DelQuota: expected core limit 0, got %d", (*qm.Quotas[ns])[coreName].Limit)
+	}
+	if (*qm.Quotas[ns])[coreName].LimitSet {
+		t.Error("DelQuota: expected LimitSet=false for core quota")
+	}
+}
+
+func TestAddQuotaExplicitZero(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "zero-quota-ns"
+	memName := "nvidia.com/gpumem"
+
+	rq := &corev1.ResourceQuota{}
+	rq.Namespace = ns
+	rq.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName): *resource.NewQuantity(0, resource.DecimalSI),
+	}
+
+	qm.AddQuota(rq)
+	q := (*qm.Quotas[ns])[memName]
+	if q == nil {
+		t.Fatal("AddQuota: expected entry for explicit zero limit")
+	}
+	if q.Limit != 0 {
+		t.Errorf("AddQuota: expected limit 0, got %d", q.Limit)
+	}
+	if !q.LimitSet {
+		t.Error("AddQuota: expected LimitSet=true even when value is 0")
+	}
+	// Verify FitQuota now rejects any non-zero request.
+	if qm.FitQuota(ns, 1, 1, 0, "NVIDIA") {
+		t.Error("FitQuota should deny request when explicit zero limit is set")
 	}
 }

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -268,8 +268,8 @@ func TestFitResourceQuota(t *testing.T) {
 	coreName := "nvidia.com/gpucores"
 
 	qm.Quotas[ns] = &device.DeviceQuota{
-		memName:  &device.Quota{Used: 1000, Limit: 2000},
-		coreName: &device.Quota{Used: 200, Limit: 400},
+		memName:  &device.Quota{Used: 1000, Limit: 2000, LimitSet: true},
+		coreName: &device.Quota{Used: 200, Limit: 400, LimitSet: true},
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

QuotaManager used Limit != 0 to decide whether a quota was configured. As a result, setting limits.nvidia.com/gpumem: "0" (or gpucores: "0") was silently treated as "no limit" and every pod was allowed through, instead of blocking GPU usage in the namespace as the docs describe.

This PR adds a LimitSet flag on Quota to distinguish an explicitly-set zero from an auto-initialized entry. FitQuota now gates on LimitSet instead of Limit != 0, so an explicit zero is honored as a hard block.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- AddQuota sets LimitSet = true; DelQuota clears it.
- Entries auto-created by AddUsage keep LimitSet = false, so behavior when no quota is configured is unchanged.
- Existing NVIDIA-only / nvidia.com/gpu == 1 limitations in the webhook are untouched.
- New tests: TestFitQuotaZeroLimitEnforced, TestAddQuotaExplicitZero. Existing fixtures updated.

**Does this PR introduce a user-facing change?**:

Honor an explicit zero in `limits.nvidia.com/gpumem` / `limits.nvidia.com/gpucores` ResourceQuota as a hard block instead of silently treating it as "no limit".