### PR TITLE
fix(quota): roll back usage when Filter evicts a stale pod entry

### DIFF
--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -545,16 +545,10 @@ func TestContainerDeviceDeepCopy(t *testing.T) {
 
 func TestTakeAndDeletePodIsAtomic(t *testing.T) {
 	pm := NewPodManager()
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-		Name:      "p",
-		Namespace: "ns",
-		UID:       k8stypes.UID("uid-1"),
-	}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "p", Namespace: "ns"}}
 	pm.AddPod(pod, "node-1", PodDevices{})
-
 	pi1, ok1 := pm.TakeAndDeletePod(pod)
 	pi2, ok2 := pm.TakeAndDeletePod(pod)
-
 	assert.True(t, ok1)
 	assert.NotNil(t, pi1)
 	assert.False(t, ok2)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -740,7 +740,9 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 			Error:       "",
 		}, nil
 	}
-	s.podManager.DelPod(args.Pod)
+	if pi, ok := s.podManager.TakeAndDeletePod(args.Pod); ok {
+		s.quotaManager.RmUsage(args.Pod, pi.Devices)
+	}
 	nodeUsage, failedNodes, err := s.getNodesUsage(args.NodeNames, args.Pod)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1392,6 +1392,37 @@ func Test_ListNodes_Concurrent(t *testing.T) {
 	<-done
 }
 
+func Test_Filter_EvictsStaleEntry(t *testing.T) {
+	require.NoError(t, config.InitDevicesWithConfig(&config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName: "hami.io/gpu", ResourceMemoryName: "hami.io/gpumem",
+			ResourceCoreName: "hami.io/gpucores", DefaultGPUNum: 1,
+		},
+	}))
+	s := NewScheduler()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-s2", Name: "stale", Namespace: "ns-evict"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "c",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"hami.io/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+				"hami.io/gpumem": *resource.NewQuantity(500, resource.BinarySI),
+			}},
+		}}},
+	}
+	devs := device.PodDevices{
+		nvidia.NvidiaGPUDevice: device.PodSingleDevice{{device.ContainerDevice{Usedmem: 500, Usedcores: 10}}},
+	}
+	s.podManager.AddPod(pod, "node1", devs)
+	s.quotaManager.AddUsage(pod, devs)
+	s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &[]string{}})
+	_, inCache := s.podManager.GetPod(pod)
+	assert.Equal(t, false, inCache)
+	for _, v := range *s.quotaManager.GetResourceQuota()[pod.Namespace] {
+		assert.Equal(t, int64(0), v.Used)
+	}
+}
+
 func Test_Scheduler_Issue1368_TerminatingPodRetainsCache(t *testing.T) {
 	s := NewScheduler()
 


### PR DESCRIPTION
`Filter()` calls `TakeAndDeletePod` at the start to clear any leftover
cache entry from a previous scheduling attempt. 

The old `DelPod` call
removed the pod from the cache but did not call `RmUsage`, 
so the
namespace quota stayed inflated until scheduler restart.

This PR switches to `TakeAndDeletePod + RmUsage` 
so the quota is rolled
back in the same step.

Identified during code review of the quota tracking changes on this branch.

Not covered by #1896 / #1898, which fix the `PatchPodAnnotations` error
path only.
