### PR TITLE
scheduler: roll back quota usage when PatchPodAnnotations fails in Filter

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -786,7 +786,9 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	err = util.PatchPodAnnotations(args.Pod, annotations)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		s.podManager.DelPod(args.Pod)
+		if pi, ok := s.podManager.TakeAndDeletePod(args.Pod); ok {
+			s.quotaManager.RmUsage(args.Pod, pi.Devices)
+		}
 		return nil, err
 	}
 	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, nodeScores.NodeList)


### PR DESCRIPTION
## What this PR does

When `PatchPodAnnotations` fails in `Filter()`, `podManager.DelPod` was called but `quotaManager.AddUsage` was not rolled back. This leaves stale quota usage that causes later pods in the same namespace to be incorrectly rejected by quota checks.

Use `TakeAndDeletePod` (which returns the pod devices) and call `RmUsage` in the error path, matching the pattern in `onDelPod`.

Fixes #1896

Signed-off-by: pmady <pavan4devops@gmail.com>