### PR TITLE
charts: make device plugin security context configurable via Helm values

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -40,8 +40,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
-      hostPID: true
-      hostNetwork: false
+      hostPID: {{ .Values.devicePlugin.hostPID }}
+      hostNetwork: {{ .Values.devicePlugin.hostNetwork }}
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}
       initContainers:
@@ -49,8 +49,7 @@ spec:
           image: {{ include "hami.devicePlugin.image" . }}
           imagePullPolicy: {{ .Values.devicePlugin.image.pullPolicy }}
           securityContext:
-            privileged: true
-            runAsUser: 0
+          {{- toYaml .Values.devicePlugin.initContainerSecurityContext | nindent 12 }}
           command: ["sh", "-c"]
           args:
             - |
@@ -125,11 +124,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           securityContext:
-            privileged: true
-            allowPrivilegeEscalation: true
-            capabilities:
-              drop: ["ALL"]
-              add: ["SYS_ADMIN"]
+          {{- toYaml .Values.devicePlugin.securityContext | nindent 12 }}
           resources:
           {{- toYaml .Values.devicePlugin.resources | nindent 12 }}
           volumeMounts:
@@ -171,10 +166,7 @@ spec:
             - {{ . }}
             {{- end }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-              add: ["SYS_ADMIN"]
+          {{- toYaml .Values.devicePlugin.monitor.securityContext | nindent 12 }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -40,16 +40,18 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "hami-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
-      hostPID: {{ .Values.devicePlugin.hostPID }}
-      hostNetwork: {{ .Values.devicePlugin.hostNetwork }}
+      hostPID: {{ ne (toString .Values.devicePlugin.hostPID) "false" }}
+      hostNetwork: {{ eq (toString .Values.devicePlugin.hostNetwork) "true" }}
       {{- include "hami.devicePlugin.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.devicePlugin.gpuOperatorToolkitReady.enabled }}
       initContainers:
         - name: toolkit-validation
           image: {{ include "hami.devicePlugin.image" . }}
           imagePullPolicy: {{ .Values.devicePlugin.image.pullPolicy }}
+          {{- if .Values.devicePlugin.initContainerSecurityContext }}
           securityContext:
-          {{- toYaml .Values.devicePlugin.initContainerSecurityContext | nindent 12 }}
+            {{- toYaml .Values.devicePlugin.initContainerSecurityContext | nindent 12 }}
+          {{- end }}
           command: ["sh", "-c"]
           args:
             - |
@@ -123,8 +125,10 @@ spec:
             {{- with .Values.devicePlugin.extraEnvs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- if .Values.devicePlugin.securityContext }}
           securityContext:
-          {{- toYaml .Values.devicePlugin.securityContext | nindent 12 }}
+            {{- toYaml .Values.devicePlugin.securityContext | nindent 12 }}
+          {{- end }}
           resources:
           {{- toYaml .Values.devicePlugin.resources | nindent 12 }}
           volumeMounts:
@@ -165,8 +169,10 @@ spec:
             {{- range .Values.devicePlugin.monitor.extraArgs }}
             - {{ . }}
             {{- end }}
+          {{- if .Values.devicePlugin.monitor.securityContext }}
           securityContext:
-          {{- toYaml .Values.devicePlugin.monitor.securityContext | nindent 12 }}
+            {{- toYaml .Values.devicePlugin.monitor.securityContext | nindent 12 }}
+          {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -318,6 +318,11 @@ devicePlugin:
     extraArgs:
       - -v=4
     extraEnvs: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+        add: ["SYS_ADMIN"]
     resources: {}
       # If you do want to specify resources, uncomment the following lines, adjust them as necessary.
       # and remove the curly braces after 'resources:'.
@@ -382,6 +387,20 @@ devicePlugin:
     httpPort: 31992
     labels: {}
     annotations: {}
+
+  hostPID: true
+  hostNetwork: false
+
+  securityContext:
+    privileged: true
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["SYS_ADMIN"]
+
+  initContainerSecurityContext:
+    privileged: true
+    runAsUser: 0
 
   pluginPath: /var/lib/kubelet/device-plugins
   libPath: /usr/local/vgpu


### PR DESCRIPTION
## What this PR does

Exposes the hardcoded security context fields in the device plugin DaemonSet as configurable Helm values. Current settings are kept as defaults so this is non-breaking.

Configurable fields:
- `devicePlugin.hostPID` (default: `true`)
- `devicePlugin.hostNetwork` (default: `false`)
- `devicePlugin.securityContext` — main device-plugin container
- `devicePlugin.monitor.securityContext` — vgpu-monitor container
- `devicePlugin.initContainerSecurityContext` — toolkit-validation init container

This lets operators running under strict Pod Security Admission or least-privilege policies adjust these settings without patching templates.

Fixes #1888

Signed-off-by: pmady <pavan4devops@gmail.com>