### PR TITLE
fix(chart): add DRA resource RBAC for kube-scheduler on K8s 1.34+

### DIFF
--- a/charts/hami/templates/scheduler/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/clusterrole.yaml
@@ -22,6 +22,9 @@ rules:
   - apiGroups: [""]
     resources: ["resourcequotas"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["deviceclasses", "resourceclaims", "resourceclaimtemplates", "resourceslices"]
+    verbs: ["get", "list", "watch"]
 ---
 {{- if .Values.mockDevicePlugin.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

On Kubernetes 1.34+ (tested on ACK v1.35.2), the embedded kube-scheduler starts DRA informers for `resource.k8s.io` resources even when HAMi's own DRA feature is disabled (`dra.enabled=false`).

If the cluster's `system:kube-scheduler` ClusterRole does not include `resource.k8s.io` permissions (common on older/upgraded clusters), the scheduler container continuously emits reflector errors and the **hami-scheduler Pod will never become Ready**, causing the entire HAMi scheduling function to be unavailable:

```
I0527 13:06:16.352960       1 reflector.go:425] "Starting reflector" type="*v1.ResourceClaim" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0527 13:06:16.352996       1 reflector.go:472] "Listing and watching" type="*v1.ResourceClaim" reflector="k8s.io/client-go/informers/factory.go:177"
I0527 13:06:16.352949       1 reflector.go:425] "Starting reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:177"
I0527 13:06:16.353015       1 reflector.go:472] "Listing and watching" type="*v1.Node" reflector="k8s.io/client-go/informers/factory.go:177"
I0527 13:06:16.353501       1 reflector.go:490] "Data couldn't be fetched in watchlist mode. Falling back to regular list. This is expected if watchlist is not supported or disabled in kube-apiserver." err="deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:hami-system:hami-scheduler\" cannot watch resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope"
E0527 13:06:16.354925       1 reflector.go:227] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:hami-system:hami-scheduler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go/informers/factory.go:177" type="*v1.DeviceClass"
I0527 13:06:16.355585       1 reflector.go:490] "Data couldn't be fetched in watchlist mode. Falling back to regular list. This is expected if watchlist is not supported or disabled in kube-apiserver." err="resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:hami-system:hami-scheduler\" cannot watch resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope"
I0527 13:06:16.355682       1 reflector.go:490] "Data couldn't be fetched in watchlist mode. Falling back to regular list. This is expected if watchlist is not supported or disabled in kube-apiserver." err="resourceclaims.resource.k8s.io is forbidden: User \"system:serviceaccount:hami-system:hami-scheduler\" cannot watch resource \"resourceclaims\" in API group \"resource.k8s.io\" at the cluster scope"
```

This PR adds read-only RBAC rules for DRA resources to the chart's `hami-scheduler` ClusterRole:
- `deviceclasses`
- `resourceclaims`
- `resourceclaimtemplates`
- `resourceslices`

This does not enable HAMi DRA functionality; it only allows the embedded kube-scheduler to list/watch Kubernetes DRA API resources that it already attempts to watch on recent Kubernetes versions.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

No user-facing changes. The scheduler ClusterRole now includes additional read-only permissions for DRA resources, which prevents reflector errors on Kubernetes 1.34+ clusters.