### PR TITLE
test(util): add coverage for SchedulerPolicyName.String

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -669,3 +669,20 @@ func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
 		})
 	}
 }
+
+func TestSchedulerPolicyName_String(t *testing.T) {
+	tests := []struct {
+		policy SchedulerPolicyName
+		want   string
+	}{
+		{NodeSchedulerPolicyBinpack, "binpack"},
+		{NodeSchedulerPolicySpread, "spread"},
+		{GPUSchedulerPolicyTopology, "topology-aware"},
+		{SchedulerPolicyName("custom"), "custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.policy.String())
+		})
+	}
+}


### PR DESCRIPTION
Add table-driven tests for `SchedulerPolicyName.String()` in `pkg/util/types.go`, which had 0% coverage.

Closes #569