### PR TITLE
test(util): add coverage for GetGPUSchedulerPolicyByPod

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -652,6 +652,11 @@ func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
 	}{
 		{"nil pod", "binpack", nil, "binpack"},
 		{"no annotation", "binpack", &corev1.Pod{}, "binpack"},
+		{"other annotations", "binpack", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"other-annotation": "value"},
+			},
+		}, "binpack"},
 		{"with annotation", "binpack", &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{GPUSchedulerPolicyAnnotationKey: "spread"},
@@ -660,7 +665,7 @@ func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, GetGPUSchedulerPolicyByPod(tt.defaultPolicy, tt.pod))
+			assert.Equal(t, GetGPUSchedulerPolicyByPod(tt.defaultPolicy, tt.pod), tt.want)
 		})
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -642,3 +642,25 @@ func Test_IsPodTerminating(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultPolicy string
+		pod           *corev1.Pod
+		want          string
+	}{
+		{"nil pod", "binpack", nil, "binpack"},
+		{"no annotation", "binpack", &corev1.Pod{}, "binpack"},
+		{"with annotation", "binpack", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{GPUSchedulerPolicyAnnotationKey: "spread"},
+			},
+		}, "spread"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetGPUSchedulerPolicyByPod(tt.defaultPolicy, tt.pod))
+		})
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -665,7 +665,7 @@ func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, GetGPUSchedulerPolicyByPod(tt.defaultPolicy, tt.pod), tt.want)
+			assert.Equal(t, tt.want, GetGPUSchedulerPolicyByPod(tt.defaultPolicy, tt.pod))
 		})
 	}
 }


### PR DESCRIPTION
Add table-driven tests for `GetGPUSchedulerPolicyByPod` in `pkg/util/util.go`, which had 0% coverage.

Closes #569