### PR TITLE
fix(scheduler): clean up podManager on Bind failures to prevent resource leak

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -667,26 +667,37 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		Target:     corev1.ObjectReference{Kind: "Node", Name: args.Node},
 	}
 
+	// Clean up podManager and quotaManager entries added by Filter, on Bind failure.
+	// The pod may have been deleted between Filter and Bind; without
+	// this cleanup both internal bookkeepers leak permanently.
+	var podToDelete *corev1.Pod
+	defer func() {
+		if podToDelete == nil {
+			return
+		}
+		if pi, ok := s.podManager.TakeAndDeletePod(podToDelete); ok {
+			if len(pi.Devices) > 0 {
+				s.quotaManager.RmUsage(podToDelete, pi.Devices)
+			}
+		}
+	}()
+
 	current, err := s.podLister.Pods(args.PodNamespace).Get(args.PodName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod from cache", "pod", args.PodName, "namespace", args.PodNamespace)
-		// Clean up podManager and quotaManager entries added by Filter.
-		// The pod may have been deleted between Filter and Bind; without
-		// this cleanup both internal bookkeepers leak permanently.
-		podToDelete := &corev1.Pod{
+		// current is nil, construct a minimal pod object from args for
+		// TakeAndDeletePod to look up the podManager entry by UID.
+		podToDelete = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       args.PodUID,
 				Name:      args.PodName,
 				Namespace: args.PodNamespace,
 			},
 		}
-		if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(podToDelete); ok {
-			if len(podInfosToDelete.Devices) > 0 {
-				s.quotaManager.RmUsage(podToDelete, podInfosToDelete.Devices)
-			}
-		}
 		return &extenderv1.ExtenderBindingResult{Error: err.Error()}, err
 	}
+
+	podToDelete = current
 
 	klog.InfoS("Trying to get the target node for pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 
@@ -694,11 +705,6 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node from cache", "node", args.Node)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, fmt.Errorf("failed to get node %s", args.Node))
-		if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(current); ok {
-			if len(podInfosToDelete.Devices) > 0 {
-				s.quotaManager.RmUsage(current, podInfosToDelete.Devices)
-			}
-		}
 		res = &extenderv1.ExtenderBindingResult{Error: err.Error()}
 		return res, nil
 	}
@@ -728,6 +734,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		goto ReleaseNodeLocks
 	}
 
+	podToDelete = nil
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
 	klog.InfoS("Successfully bound pod to node", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 	return &extenderv1.ExtenderBindingResult{Error: ""}, nil
@@ -736,11 +743,6 @@ ReleaseNodeLocks:
 	klog.InfoS("Release node locks", "node", args.Node)
 	for _, val := range device.GetDevices() {
 		val.ReleaseNodeLock(node, current)
-	}
-	if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(current); ok {
-		if len(podInfosToDelete.Devices) > 0 {
-			s.quotaManager.RmUsage(current, podInfosToDelete.Devices)
-		}
 	}
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, err)
 	return &extenderv1.ExtenderBindingResult{Error: err.Error()}, nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -658,6 +658,12 @@ func (s *Scheduler) getPodUsage() (map[string]device.PodUseDeviceStat, error) {
 	return podUsageStat, nil
 }
 
+func cleanupStalePodAllocation(s *Scheduler, pod *corev1.Pod) {
+	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok && len(pi.Devices) > 0 {
+		s.quotaManager.RmUsage(pod, pi.Devices)
+	}
+}
+
 func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.ExtenderBindingResult, error) {
 	klog.InfoS("Attempting to bind pod to node", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 	var res *extenderv1.ExtenderBindingResult
@@ -667,37 +673,18 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		Target:     corev1.ObjectReference{Kind: "Node", Name: args.Node},
 	}
 
-	// Clean up podManager and quotaManager entries added by Filter, on Bind failure.
-	// The pod may have been deleted between Filter and Bind; without
-	// this cleanup both internal bookkeepers leak permanently.
-	var podToDelete *corev1.Pod
-	defer func() {
-		if podToDelete == nil {
-			return
-		}
-		if pi, ok := s.podManager.TakeAndDeletePod(podToDelete); ok {
-			if len(pi.Devices) > 0 {
-				s.quotaManager.RmUsage(podToDelete, pi.Devices)
-			}
-		}
-	}()
-
 	current, err := s.podLister.Pods(args.PodNamespace).Get(args.PodName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod from cache", "pod", args.PodName, "namespace", args.PodNamespace)
-		// current is nil, construct a minimal pod object from args for
-		// TakeAndDeletePod to look up the podManager entry by UID.
-		podToDelete = &corev1.Pod{
+		cleanupStalePodAllocation(s, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       args.PodUID,
 				Name:      args.PodName,
 				Namespace: args.PodNamespace,
 			},
-		}
+		})
 		return &extenderv1.ExtenderBindingResult{Error: err.Error()}, err
 	}
-
-	podToDelete = current
 
 	klog.InfoS("Trying to get the target node for pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 
@@ -705,6 +692,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node from cache", "node", args.Node)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, fmt.Errorf("failed to get node %s", args.Node))
+		cleanupStalePodAllocation(s, current)
 		res = &extenderv1.ExtenderBindingResult{Error: err.Error()}
 		return res, nil
 	}
@@ -734,7 +722,6 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		goto ReleaseNodeLocks
 	}
 
-	podToDelete = nil
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
 	klog.InfoS("Successfully bound pod to node", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 	return &extenderv1.ExtenderBindingResult{Error: ""}, nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -670,6 +670,13 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	current, err := s.podLister.Pods(args.PodNamespace).Get(args.PodName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod from cache", "pod", args.PodName, "namespace", args.PodNamespace)
+		// Clean up podManager entry added by Filter. The pod may have been
+		// deleted externally between Filter and Bind. Without this cleanup,
+		// the leaked entry causes getNodesUsage() to permanently overcount
+		// allocated resources, blocking future pod scheduling on the node.
+		s.podManager.DelPod(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: args.PodUID},
+		})
 		return &extenderv1.ExtenderBindingResult{Error: err.Error()}, err
 	}
 
@@ -679,6 +686,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node from cache", "node", args.Node)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, fmt.Errorf("failed to get node %s", args.Node))
+		s.podManager.DelPod(current)
 		res = &extenderv1.ExtenderBindingResult{Error: err.Error()}
 		return res, nil
 	}
@@ -717,6 +725,7 @@ ReleaseNodeLocks:
 	for _, val := range device.GetDevices() {
 		val.ReleaseNodeLock(node, current)
 	}
+	s.podManager.DelPod(current)
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, err)
 	return &extenderv1.ExtenderBindingResult{Error: err.Error()}, nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -670,13 +670,21 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	current, err := s.podLister.Pods(args.PodNamespace).Get(args.PodName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod from cache", "pod", args.PodName, "namespace", args.PodNamespace)
-		// Clean up podManager entry added by Filter. The pod may have been
-		// deleted externally between Filter and Bind. Without this cleanup,
-		// the leaked entry causes getNodesUsage() to permanently overcount
-		// allocated resources, blocking future pod scheduling on the node.
-		s.podManager.DelPod(&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{UID: args.PodUID},
-		})
+		// Clean up podManager and quotaManager entries added by Filter.
+		// The pod may have been deleted between Filter and Bind; without
+		// this cleanup both internal bookkeepers leak permanently.
+		podToDelete := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       args.PodUID,
+				Name:      args.PodName,
+				Namespace: args.PodNamespace,
+			},
+		}
+		if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(podToDelete); ok {
+			if len(podInfosToDelete.Devices) > 0 {
+				s.quotaManager.RmUsage(podToDelete, podInfosToDelete.Devices)
+			}
+		}
 		return &extenderv1.ExtenderBindingResult{Error: err.Error()}, err
 	}
 
@@ -686,7 +694,11 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node from cache", "node", args.Node)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, fmt.Errorf("failed to get node %s", args.Node))
-		s.podManager.DelPod(current)
+		if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(current); ok {
+			if len(podInfosToDelete.Devices) > 0 {
+				s.quotaManager.RmUsage(current, podInfosToDelete.Devices)
+			}
+		}
 		res = &extenderv1.ExtenderBindingResult{Error: err.Error()}
 		return res, nil
 	}
@@ -725,7 +737,11 @@ ReleaseNodeLocks:
 	for _, val := range device.GetDevices() {
 		val.ReleaseNodeLock(node, current)
 	}
-	s.podManager.DelPod(current)
+	if podInfosToDelete, ok := s.podManager.TakeAndDeletePod(current); ok {
+		if len(podInfosToDelete.Devices) > 0 {
+			s.quotaManager.RmUsage(current, podInfosToDelete.Devices)
+		}
+	}
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, err)
 	return &extenderv1.ExtenderBindingResult{Error: err.Error()}, nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -658,7 +658,7 @@ func (s *Scheduler) getPodUsage() (map[string]device.PodUseDeviceStat, error) {
 	return podUsageStat, nil
 }
 
-func cleanupStalePodAllocation(s *Scheduler, pod *corev1.Pod) {
+func (s *Scheduler) cleanupStalePodAllocation(pod *corev1.Pod) {
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok && len(pi.Devices) > 0 {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}
@@ -676,7 +676,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	current, err := s.podLister.Pods(args.PodNamespace).Get(args.PodName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get pod from cache", "pod", args.PodName, "namespace", args.PodNamespace)
-		cleanupStalePodAllocation(s, &corev1.Pod{
+		s.cleanupStalePodAllocation(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       args.PodUID,
 				Name:      args.PodName,
@@ -692,7 +692,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node from cache", "node", args.Node)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, fmt.Errorf("failed to get node %s", args.Node))
-		cleanupStalePodAllocation(s, current)
+		s.cleanupStalePodAllocation(current)
 		res = &extenderv1.ExtenderBindingResult{Error: err.Error()}
 		return res, nil
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -31,10 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
@@ -1489,4 +1492,121 @@ func Test_onAddPod_BadDeviceAnnotation(t *testing.T) {
 	s.onAddPod(pod)
 	_, ok := s.podManager.GetPod(pod)
 	assert.Equal(t, false, ok)
+}
+func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
+	t.Parallel()
+
+	podUID := types.UID("test-uid-1")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       podUID,
+		},
+	}
+
+	// Create scheduler with minimal setup — no device initialization needed
+	// because Bind returns early at Get(pod) failure before touching devices.
+	s := NewScheduler()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	s.eventRecorder = record.NewBroadcaster().NewRecorder(scheme, corev1.EventSource{})
+	client.KubeClient = fake.NewSimpleClientset()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour*1)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// Pre-populate podManager as Filter would have done
+	s.podManager.AddPod(pod, "node1", nil)
+
+	// Verify podManager has the entry before Bind
+	podsBefore, _ := s.podManager.ListPodsUID()
+	require.Len(t, podsBefore, 1)
+	require.Equal(t, podUID, podsBefore[0].UID)
+
+	// Bind with a non-existent pod (not in fake client)
+	args := extenderv1.ExtenderBindingArgs{
+		PodName:      pod.Name,
+		PodNamespace: pod.Namespace,
+		PodUID:       podUID,
+		Node:         "node1",
+	}
+	_, err := s.Bind(args)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// Verify podManager entry was cleaned up
+	podsAfter, _ := s.podManager.ListPodsUID()
+	require.Len(t, podsAfter, 0,
+		"Bind should clean up podManager entry when Get(pod) fails, "+
+			"otherwise Filter's addPod leaks resources permanently")
+}
+
+// Test_Bind_DelPodOnGetNodeFailure verifies that when Bind's nodeLister.Get
+// returns "not found", the podManager entry added by Filter is cleaned up.
+// This ensures every error path in Bind cleans up its podManager entry.
+func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
+	t.Parallel()
+
+	podUID := types.UID("test-uid-2")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-nodefail",
+			Namespace: "default",
+			UID:       podUID,
+		},
+	}
+
+	s := NewScheduler()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	s.eventRecorder = record.NewBroadcaster().NewRecorder(scheme, corev1.EventSource{})
+
+	// Use an independent fake client to avoid interference from other tests.
+	fakeClient := fake.NewSimpleClientset()
+	s.kubeClient = fakeClient
+
+	// Create the pod in fake client so podLister.Get succeeds,
+	// but leave the node uncreated so nodeLister.Get fails.
+	_, err := fakeClient.CoreV1().Pods(pod.Namespace).Create(
+		context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, time.Hour*1)
+
+	// Manually add the pod to the informer cache. In real environments,
+	// the reflector does this automatically, but fake client's informer
+	// does not reconcile already-created objects without this step.
+	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+	require.NoError(t, err)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// Pre-populate podManager as Filter would have done
+	s.podManager.AddPod(pod, "non-existent-node", nil)
+
+	podsBefore, _ := s.podManager.ListPodsUID()
+	require.Len(t, podsBefore, 1)
+	require.Equal(t, podUID, podsBefore[0].UID)
+
+	args := extenderv1.ExtenderBindingArgs{
+		PodName:      pod.Name,
+		PodNamespace: pod.Namespace,
+		PodUID:       podUID,
+		Node:         "non-existent-node",
+	}
+	res, err := s.Bind(args)
+	// nodeLister.Get failure returns (res, nil) — the error is
+	// embedded in result.Error, not as a Go error.
+	require.NoError(t, err, "node failure returns result-level error not Go error")
+	require.Contains(t, res.Error, "not found")
+
+	// Verify podManager entry was cleaned up
+	podsAfter, _ := s.podManager.ListPodsUID()
+	require.Len(t, podsAfter, 0,
+		"Bind should clean up podManager entry when Get(node) fails")
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1493,6 +1493,7 @@ func Test_onAddPod_BadDeviceAnnotation(t *testing.T) {
 	_, ok := s.podManager.GetPod(pod)
 	assert.Equal(t, false, ok)
 }
+
 func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
 	t.Parallel()
 
@@ -1505,8 +1506,6 @@ func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
 		},
 	}
 
-	// Create scheduler with minimal setup — no device initialization needed
-	// because Bind returns early at Get(pod) failure before touching devices.
 	s := NewScheduler()
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
@@ -1518,15 +1517,12 @@ func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
 	informerFactory.Start(s.stopCh)
 	informerFactory.WaitForCacheSync(s.stopCh)
 
-	// Pre-populate podManager as Filter would have done
 	s.podManager.AddPod(pod, "node1", nil)
 
-	// Verify podManager has the entry before Bind
 	podsBefore, _ := s.podManager.ListPodsUID()
 	require.Len(t, podsBefore, 1)
 	require.Equal(t, podUID, podsBefore[0].UID)
 
-	// Bind with a non-existent pod (not in fake client)
 	args := extenderv1.ExtenderBindingArgs{
 		PodName:      pod.Name,
 		PodNamespace: pod.Namespace,
@@ -1537,16 +1533,10 @@ func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 
-	// Verify podManager entry was cleaned up
 	podsAfter, _ := s.podManager.ListPodsUID()
-	require.Len(t, podsAfter, 0,
-		"Bind should clean up podManager entry when Get(pod) fails, "+
-			"otherwise Filter's addPod leaks resources permanently")
+	require.Len(t, podsAfter, 0)
 }
 
-// Test_Bind_DelPodOnGetNodeFailure verifies that when Bind's nodeLister.Get
-// returns "not found", the podManager entry added by Filter is cleaned up.
-// This ensures every error path in Bind cleans up its podManager entry.
 func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
 	t.Parallel()
 
@@ -1564,21 +1554,15 @@ func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 	s.eventRecorder = record.NewBroadcaster().NewRecorder(scheme, corev1.EventSource{})
 
-	// Use an independent fake client to avoid interference from other tests.
 	fakeClient := fake.NewSimpleClientset()
 	s.kubeClient = fakeClient
 
-	// Create the pod in fake client so podLister.Get succeeds,
-	// but leave the node uncreated so nodeLister.Get fails.
 	_, err := fakeClient.CoreV1().Pods(pod.Namespace).Create(
 		context.Background(), pod, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, time.Hour*1)
 
-	// Manually add the pod to the informer cache. In real environments,
-	// the reflector does this automatically, but fake client's informer
-	// does not reconcile already-created objects without this step.
 	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
 	require.NoError(t, err)
 	s.podLister = informerFactory.Core().V1().Pods().Lister()
@@ -1586,7 +1570,6 @@ func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
 	informerFactory.Start(s.stopCh)
 	informerFactory.WaitForCacheSync(s.stopCh)
 
-	// Pre-populate podManager as Filter would have done
 	s.podManager.AddPod(pod, "non-existent-node", nil)
 
 	podsBefore, _ := s.podManager.ListPodsUID()
@@ -1600,13 +1583,10 @@ func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
 		Node:         "non-existent-node",
 	}
 	res, err := s.Bind(args)
-	// nodeLister.Get failure returns (res, nil) — the error is
-	// embedded in result.Error, not as a Go error.
-	require.NoError(t, err, "node failure returns result-level error not Go error")
+
+	require.NoError(t, err)
 	require.Contains(t, res.Error, "not found")
 
-	// Verify podManager entry was cleaned up
 	podsAfter, _ := s.podManager.ListPodsUID()
-	require.Len(t, podsAfter, 0,
-		"Bind should clean up podManager entry when Get(node) fails")
+	require.Len(t, podsAfter, 0)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the HAMi scheduler acts as a kube-scheduler extender, the `Filter` function adds the pod's resource allocation to `podManager`. Later, `Bind` is called by the scheduler framework to perform the actual binding. However, if `Bind` fails (e.g., the pod was deleted externally between `Filter` and `Bind`), the old code returned immediately without cleaning up the `podManager` entry, causing a **permanent resource leak**.

The leaked entry makes `getNodesUsage()` permanently overcount allocated resources on the affected node, which blocks future pods from being scheduled there — even though the pod itself no longer exists.

This fix ensures every error path in `Bind` cleans up the `podManager` entry:

1. **`podLister.Get` failure**: the pod no longer exists in the API server → delete from `podManager` using `args.PodUID` (the UID key that `Filter` wrote).
2. **`nodeLister.Get` failure**: the target node was removed or not found → delete from `podManager`.
3. **`ReleaseNodeLocks` (catch-all)**: covers `LockNode` failure, `PatchPodAnnotations` failure, and `Bind` API failure — all now pass through a unified cleanup label that deletes from `podManager`.

**Which issue(s) this PR fixes**:

N/A — no issue filed yet. The bug was identified from production log analysis.

**Special notes for your reviewer**:

original log 

The bug was identified from production log analysis of a `csm-instance` pod that experienced three consecutive scheduling failures due to this exact leak. A detailed diagnosis report is available at . 

[诊断报告-csm-instance资源泄漏.html](https://github.com/user-attachments/files/28591286/-csm-instance.html)

Key logs after cleaning
[focus.log](https://github.com/user-attachments/files/28592680/focus.log)

Logs after restarting the scheduler
[new-focus.log](https://github.com/user-attachments/files/28592698/new-focus.log)

The root cause involves two interacting factors:
- **Control flow bug (primary)**: `Bind` returned on failure without `podManager` cleanup — a clear missing `defer`/cleanup pattern.
- **Informer unreliability (secondary)**: Even if `onDelPod` had fired (it didn't in this case because the Pod was never persisted in the API Server), a concurrent informer `onDelPod` + extender `Filter/addPod` race can still produce a window where the leak occurs. Therefore the fix in `Bind` is a necessary safety net regardless.

Two test cases are added to `scheduler_test.go` to cover the Get-pod-failure and Get-node-failure error paths, including proper `eventRecorder` initialization (which `NewScheduler()` does not set by default).

**Does this PR introduce a user-facing change?**:

No. This is a bug fix — it does not add or change any user-facing API, configuration, or behavior. It prevents an internal resource leak that could otherwise manifest as pods stuck in `Pending` state with `no enough resource` errors on nodes that still have free capacity.