### PR TITLE
Fix: Skip nvidia-mig-parted when MIG is disabled

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -1,18 +1,34 @@
 /*
-Copyright 2024 The HAMi Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The HAMi Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+/*
+ * Licensed to NVIDIA CORPORATION under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. NVIDIA CORPORATION licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/*
+ * Modifications Copyright The HAMi Authors. See
+ * GitHub history for details.
+ */
 
 package plugin
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -291,38 +291,36 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 			break
 		}
 	}
-	if deviceSupportMig {
-		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != "none"
-		if migEnabled {
-			cmd := exec.Command("nvidia-mig-parted", "export")
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-			err := cmd.Run()
-			if err != nil {
-				klog.Fatalf("nvidia-mig-parted failed with %s\n", err)
-			}
-			outStr := stdout.Bytes()
-			yaml.Unmarshal(outStr, &plugin.migCurrent)
-			os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
+	if migEnabled {
+		cmd := exec.Command("nvidia-mig-parted", "export")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err != nil {
+			klog.Fatalf("nvidia-mig-parted failed with %s\n", err)
 		}
-		if plugin.operatingMode == "mig" {
-			HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
-			if err != nil {
-				klog.Infof("no device in node:%v", err)
-			}
-			plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
-			klog.Infoln("Open Mig export", plugin.migCurrent)
-		} else {
-			plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-			configSlice := nvidia.MigConfigSpecSlice{}
-			for i := 0; i < deviceNumbers; i++ {
-				conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-				configSlice = append(configSlice, conf)
-			}
-			plugin.migCurrent.MigConfigs["current"] = configSlice
-			klog.Infoln("Close Mig export", plugin.migCurrent)
+		outStr := stdout.Bytes()
+		yaml.Unmarshal(outStr, &plugin.migCurrent)
+		os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
+	}
+	if migEnabled && plugin.operatingMode == "mig" {
+		HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
+		if err != nil {
+			klog.Infof("no device in node:%v", err)
 		}
+		plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
+		klog.Infoln("Open Mig export", plugin.migCurrent)
+	} else {
+		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+		configSlice := nvidia.MigConfigSpecSlice{}
+		for i := 0; i < deviceNumbers; i++ {
+			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			configSlice = append(configSlice, conf)
+		}
+		plugin.migCurrent.MigConfigs["current"] = configSlice
+		klog.Infoln("Close Mig export", plugin.migCurrent)
 	}
 	go func() {
 		err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks)
@@ -336,7 +334,7 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}()
 
 	if deviceSupportMig {
-		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != "none"
+		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
 		if migEnabled {
 			plugin.ApplyMigTemplate()
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -1,34 +1,18 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The HAMi Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+Copyright 2024 The HAMi Authors.
 
-/*
- * Licensed to NVIDIA CORPORATION under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. NVIDIA CORPORATION licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-/*
- * Modifications Copyright The HAMi Authors. See
- * GitHub history for details.
- */
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package plugin
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -292,17 +292,20 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		}
 	}
 	if deviceSupportMig {
-		cmd := exec.Command("nvidia-mig-parted", "export")
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
-		if err != nil {
-			klog.Fatalf("nvidia-mig-parted failed with %s\n", err)
+		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != "none"
+		if migEnabled {
+			cmd := exec.Command("nvidia-mig-parted", "export")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if err != nil {
+				klog.Fatalf("nvidia-mig-parted failed with %s\n", err)
+			}
+			outStr := stdout.Bytes()
+			yaml.Unmarshal(outStr, &plugin.migCurrent)
+			os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
 		}
-		outStr := stdout.Bytes()
-		yaml.Unmarshal(outStr, &plugin.migCurrent)
-		os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
 		if plugin.operatingMode == "mig" {
 			HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
 			if err != nil {
@@ -333,7 +336,10 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}()
 
 	if deviceSupportMig {
-		plugin.ApplyMigTemplate()
+		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != "none"
+		if migEnabled {
+			plugin.ApplyMigTemplate()
+		}
 	}
 
 	return nil

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -234,68 +234,6 @@ func (plugin *NvidiaDevicePlugin) Devices() rm.Devices {
 	return plugin.rm.Devices()
 }
 
-// Fixed getMigCapabilityMap - properly detects per-device MIG support
-func (plugin *NvidiaDevicePlugin) getMigCapabilityMap(deviceNames []string) (map[int]bool, bool) {
-	deviceMigSupportMap := make(map[int]bool)
-	nodeHasMigCapableGPU := false
-
-	for i, name := range deviceNames {
-		isSupported := false
-		for _, migTemplate := range plugin.schedulerConfig.MigGeometriesList {
-			if containsModel(name, migTemplate.Models) {
-				isSupported = true
-				break
-			}
-		}
-		deviceMigSupportMap[i] = isSupported
-		if isSupported {
-			nodeHasMigCapableGPU = true
-		}
-	}
-	return deviceMigSupportMap, nodeHasMigCapableGPU
-}
-
-// buildHybridMigConfig - properly handles mixed MIG/non-MIG devices
-func (plugin *NvidiaDevicePlugin) buildHybridMigConfig(deviceNumbers int, deviceNames []string, deviceMigSupportMap map[int]bool) error {
-	cmd := exec.Command("nvidia-mig-parted", "export")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("nvidia-mig-parted failed: %v (stderr: %s)", err, stderr.String())
-	}
-
-	outStr := stdout.Bytes()
-	if err := yaml.Unmarshal(outStr, &plugin.migCurrent); err != nil {
-		return fmt.Errorf("failed to parse nvidia-mig-parted output: %v", err)
-	}
-
-	// Save debug configuration
-	_ = os.WriteFile("/tmp/migconfig.yaml", outStr, 0644)
-
-	if plugin.migCurrent.MigConfigs == nil {
-		return fmt.Errorf("nvidia-mig-parted returned empty MigConfigs")
-	}
-
-	HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
-	if err != nil {
-		return fmt.Errorf("failed to process MIG configs: %v", err)
-	}
-
-	// Explicitly map non-MIG GPUs as whole devices
-	for i := 0; i < deviceNumbers; i++ {
-		if !deviceMigSupportMap[i] {
-			klog.Infof("GPU [%d] (%s) does not support MIG. Retaining as whole GPU.", i, deviceNames[i])
-			nonMigConf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			HamiInitMigConfig = append(HamiInitMigConfig, nonMigConf)
-		}
-	}
-
-	plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
-	return nil
-}
-
 // BuildFallbackMigConfig - fallback to non-MIG mode
 func (plugin *NvidiaDevicePlugin) buildFallbackMigConfig(deviceNumbers int) {
 	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
@@ -307,30 +245,20 @@ func (plugin *NvidiaDevicePlugin) buildFallbackMigConfig(deviceNumbers int) {
 	plugin.migCurrent.MigConfigs["current"] = configSlice
 }
 
-// Start function - keeps original structure, fixes MIG logic
+// Start starts the gRPC server, registers the device plugin with the Kubelet,and starts the device healthchecks.
 func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	plugin.initialize()
 
-	// 1. Hardware Discovery
 	deviceNumbers, err := GetDeviceNums()
 	if err != nil {
-		return fmt.Errorf("failed to get device numbers: %w", err)
+		return err
 	}
 
 	deviceNames, err := GetDeviceNames()
 	if err != nil {
-		return fmt.Errorf("failed to get device names: %w", err)
+		return err
 	}
 
-	// 2. Lock Management (before Serve and Register)
-	if err = CreateMigApplyLockDir(); err != nil {
-		klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
-	}
-	if err = RemoveMigApplyLock(); err != nil {
-		klog.Fatalf("RemoveMigApplyLock failed: %v", err)
-	}
-
-	// 3. Start serving
 	err = plugin.Serve()
 	if err != nil {
 		klog.Infof("Could not start device plugin for '%s': %s", plugin.rm.Resource(), err)
@@ -339,7 +267,6 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}
 	klog.Infof("Starting to serve '%s' on %s", plugin.rm.Resource(), plugin.socket)
 
-	// 4. Register with kubelet
 	err = plugin.Register(kubeletSocket)
 	if err != nil {
 		klog.Infof("Could not register device plugin: %s", err)
@@ -348,46 +275,76 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}
 	klog.Infof("Registered device plugin for '%s' with Kubelet", plugin.rm.Resource())
 
-	// 5. Evaluate MIG Support (per-device, not all-or-nothing)
-	deviceMigSupportMap, nodeHasMigCapableGPU := plugin.getMigCapabilityMap(deviceNames)
-	shouldUseMig := plugin.operatingMode == "mig"
+	migApplied := false
+	if plugin.operatingMode == "mig" {
+		deviceSupportMig := true
+		for _, name := range deviceNames {
+			supported := false
+			for _, migTemplate := range plugin.schedulerConfig.MigGeometriesList {
+				if containsModel(name, migTemplate.Models) {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				deviceSupportMig = false
+				break
+			}
+		}
 
-	if shouldUseMig && !nodeHasMigCapableGPU {
-		klog.Warningf("MIG mode requested but no GPUs on this node support MIG. Disabling MIG mode.")
-		shouldUseMig = false
-	}
+		if deviceSupportMig {
+			err = CreateMigApplyLockDir()
+			if err != nil {
+				klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
+			}
+			err = RemoveMigApplyLock()
+			if err != nil {
+				klog.Fatalf("RemoveMigApplyLock failed: %v", err)
+			}
 
-	// 6. Configure Hardware State
-	migSuccessfullyInitialized := false
+			cmd := exec.Command("nvidia-mig-parted", "export")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if err != nil {
+				klog.Errorf("nvidia-mig-parted failed: %v (stderr: %s)", err, stderr.String())
+				klog.Warning("Falling back to non‑MIG configuration")
+			} else {
+				outStr := stdout.Bytes()
+				yaml.Unmarshal(outStr, &plugin.migCurrent)
+				os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
 
-	if nodeHasMigCapableGPU && shouldUseMig {
-		klog.Infof("Initializing Hybrid MIG mode (operatingMode=%s)", plugin.operatingMode)
-		if err := plugin.buildHybridMigConfig(deviceNumbers, deviceNames, deviceMigSupportMap); err != nil {
-			klog.Errorf("Failed to initialize hybrid MIG config: %v", err)
-		} else {
-			klog.Infoln("MIG and whole-GPU topologies evaluated successfully.")
-			migSuccessfullyInitialized = true
+				HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
+				if err != nil {
+					klog.Infof("no device in node: %v", err)
+				} else {
+					plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
+					migApplied = true
+				}
+			}
 		}
 	}
 
-	if !migSuccessfullyInitialized {
-		klog.Infoln("Proceeding with entire node as standard, non-MIG GPUs.")
+	if !migApplied {
 		plugin.buildFallbackMigConfig(deviceNumbers)
-	} else {
-		klog.Infoln("Applying MIG template to hardware...")
-		plugin.ApplyMigTemplate()
+		klog.Infoln("Using non‑MIG configuration")
 	}
 
-	// 7. Start Asynchronous Monitors
 	go func() {
-		if err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks); err != nil {
-			klog.Warningf("Failed to start health check: %v; continuing with health checks disabled", err)
+		err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks)
+		if err != nil {
+			klog.Infof("Failed to start health check: %v; continuing with health checks disabled", err)
 		}
 	}()
 
 	go func() {
 		plugin.WatchAndRegister(plugin.disableWatchAndRegister, plugin.ackDisableWatchAndRegister)
 	}()
+
+	if migApplied {
+		plugin.ApplyMigTemplate()
+	}
 
 	return nil
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -234,21 +234,103 @@ func (plugin *NvidiaDevicePlugin) Devices() rm.Devices {
 	return plugin.rm.Devices()
 }
 
-// Start starts the gRPC server, registers the device plugin with the Kubelet,
-// and starts the device healthchecks.
+// Fixed getMigCapabilityMap - properly detects per-device MIG support
+func (plugin *NvidiaDevicePlugin) getMigCapabilityMap(deviceNames []string) (map[int]bool, bool) {
+	deviceMigSupportMap := make(map[int]bool)
+	nodeHasMigCapableGPU := false
+
+	for i, name := range deviceNames {
+		isSupported := false
+		for _, migTemplate := range plugin.schedulerConfig.MigGeometriesList {
+			if containsModel(name, migTemplate.Models) {
+				isSupported = true
+				break
+			}
+		}
+		deviceMigSupportMap[i] = isSupported
+		if isSupported {
+			nodeHasMigCapableGPU = true
+		}
+	}
+	return deviceMigSupportMap, nodeHasMigCapableGPU
+}
+
+// buildHybridMigConfig - properly handles mixed MIG/non-MIG devices
+func (plugin *NvidiaDevicePlugin) buildHybridMigConfig(deviceNumbers int, deviceNames []string, deviceMigSupportMap map[int]bool) error {
+	cmd := exec.Command("nvidia-mig-parted", "export")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("nvidia-mig-parted failed: %v (stderr: %s)", err, stderr.String())
+	}
+
+	outStr := stdout.Bytes()
+	if err := yaml.Unmarshal(outStr, &plugin.migCurrent); err != nil {
+		return fmt.Errorf("failed to parse nvidia-mig-parted output: %v", err)
+	}
+
+	// Save debug configuration
+	_ = os.WriteFile("/tmp/migconfig.yaml", outStr, 0644)
+
+	if plugin.migCurrent.MigConfigs == nil {
+		return fmt.Errorf("nvidia-mig-parted returned empty MigConfigs")
+	}
+
+	HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
+	if err != nil {
+		return fmt.Errorf("failed to process MIG configs: %v", err)
+	}
+
+	// Explicitly map non-MIG GPUs as whole devices
+	for i := 0; i < deviceNumbers; i++ {
+		if !deviceMigSupportMap[i] {
+			klog.Infof("GPU [%d] (%s) does not support MIG. Retaining as whole GPU.", i, deviceNames[i])
+			nonMigConf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			HamiInitMigConfig = append(HamiInitMigConfig, nonMigConf)
+		}
+	}
+
+	plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
+	return nil
+}
+
+// BuildFallbackMigConfig - fallback to non-MIG mode
+func (plugin *NvidiaDevicePlugin) buildFallbackMigConfig(deviceNumbers int) {
+	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+	configSlice := nvidia.MigConfigSpecSlice{}
+	for i := 0; i < deviceNumbers; i++ {
+		conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+		configSlice = append(configSlice, conf)
+	}
+	plugin.migCurrent.MigConfigs["current"] = configSlice
+}
+
+// Start function - keeps original structure, fixes MIG logic
 func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	plugin.initialize()
 
+	// 1. Hardware Discovery
 	deviceNumbers, err := GetDeviceNums()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get device numbers: %w", err)
 	}
 
 	deviceNames, err := GetDeviceNames()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get device names: %w", err)
 	}
 
+	// 2. Lock Management (before Serve and Register)
+	if err = CreateMigApplyLockDir(); err != nil {
+		klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
+	}
+	if err = RemoveMigApplyLock(); err != nil {
+		klog.Fatalf("RemoveMigApplyLock failed: %v", err)
+	}
+
+	// 3. Start serving
 	err = plugin.Serve()
 	if err != nil {
 		klog.Infof("Could not start device plugin for '%s': %s", plugin.rm.Resource(), err)
@@ -257,6 +339,7 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}
 	klog.Infof("Starting to serve '%s' on %s", plugin.rm.Resource(), plugin.socket)
 
+	// 4. Register with kubelet
 	err = plugin.Register(kubeletSocket)
 	if err != nil {
 		klog.Infof("Could not register device plugin: %s", err)
@@ -265,103 +348,46 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}
 	klog.Infof("Registered device plugin for '%s' with Kubelet", plugin.rm.Resource())
 
-	err = CreateMigApplyLockDir()
-	if err != nil {
-		klog.Fatalf("CreateMIGLockSubDir failed:%v", err)
-	}
+	// 5. Evaluate MIG Support (per-device, not all-or-nothing)
+	deviceMigSupportMap, nodeHasMigCapableGPU := plugin.getMigCapabilityMap(deviceNames)
+	shouldUseMig := plugin.operatingMode == "mig"
 
-	err = RemoveMigApplyLock()
-	if err != nil {
-		klog.Fatalf("RemoveMigApplyLock failed:%v", err)
-	}
-
-	var deviceSupportMig bool
-	for _, name := range deviceNames {
-		deviceSupportMig = false
-		for _, migTemplate := range plugin.schedulerConfig.MigGeometriesList {
-			if containsModel(name, migTemplate.Models) {
-				deviceSupportMig = true
-				break
-			}
-		}
-		if !deviceSupportMig {
-			break
-		}
-	}
-
-	isMigMode := plugin.operatingMode == "mig"
-	hasMigStrategy := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
-
-	shouldUseMig := isMigMode || hasMigStrategy
-
-	// Graceful degradation check for configuration mismatches
-	if shouldUseMig && !deviceSupportMig {
-		klog.Warningf("MIG mode requested but the GPU does not support MIG. Disabling MIG mode.")
+	if shouldUseMig && !nodeHasMigCapableGPU {
+		klog.Warningf("MIG mode requested but no GPUs on this node support MIG. Disabling MIG mode.")
 		shouldUseMig = false
 	}
 
+	// 6. Configure Hardware State
 	migSuccessfullyInitialized := false
 
-	if deviceSupportMig && shouldUseMig {
-		klog.Infof("Initializing MIG mode (operatingMode=%s, hasMigStrategy=%v)", plugin.operatingMode, hasMigStrategy)
-
-		cmd := exec.Command("nvidia-mig-parted", "export")
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-
-		if err := cmd.Run(); err != nil {
-			klog.Warningf("nvidia-mig-parted failed: %v (stderr: %s).", err, stderr.String())
+	if nodeHasMigCapableGPU && shouldUseMig {
+		klog.Infof("Initializing Hybrid MIG mode (operatingMode=%s)", plugin.operatingMode)
+		if err := plugin.buildHybridMigConfig(deviceNumbers, deviceNames, deviceMigSupportMap); err != nil {
+			klog.Errorf("Failed to initialize hybrid MIG config: %v", err)
 		} else {
-			outStr := stdout.Bytes()
-			if err = yaml.Unmarshal(outStr, &plugin.migCurrent); err != nil {
-				klog.Warningf("Failed to parse nvidia-mig-parted output: %v.", err)
-			} else {
-				_ = os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
-
-				if plugin.migCurrent.MigConfigs == nil {
-					klog.Warningf("nvidia-mig-parted returned empty MigConfigs.")
-				} else {
-					HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
-					if err != nil {
-						klog.Warningf("Failed to process MIG configs: %v.", err)
-					} else {
-						plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
-						klog.Infoln("MIG mode enabled successfully")
-						migSuccessfullyInitialized = true
-					}
-				}
-			}
+			klog.Infoln("MIG and whole-GPU topologies evaluated successfully.")
+			migSuccessfullyInitialized = true
 		}
 	}
 
-	// Fallback execution block if MIG was not desired or failed to safely initialize
 	if !migSuccessfullyInitialized {
-		klog.Infoln("Initializing with MIG disabled")
-		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-		configSlice := nvidia.MigConfigSpecSlice{}
-		for i := 0; i < deviceNumbers; i++ {
-			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			configSlice = append(configSlice, conf)
-		}
-		plugin.migCurrent.MigConfigs["current"] = configSlice
+		klog.Infoln("Proceeding with entire node as standard, non-MIG GPUs.")
+		plugin.buildFallbackMigConfig(deviceNumbers)
+	} else {
+		klog.Infoln("Applying MIG template to hardware...")
+		plugin.ApplyMigTemplate()
 	}
 
+	// 7. Start Asynchronous Monitors
 	go func() {
-		err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks)
-		if err != nil {
-			klog.Infof("Failed to start health check: %v; continuing with health checks disabled", err)
+		if err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks); err != nil {
+			klog.Warningf("Failed to start health check: %v; continuing with health checks disabled", err)
 		}
 	}()
 
 	go func() {
 		plugin.WatchAndRegister(plugin.disableWatchAndRegister, plugin.ackDisableWatchAndRegister)
 	}()
-
-	// Only apply layouts if the MIG subsystem was configured end-to-end without errors
-	if migSuccessfullyInitialized {
-		plugin.ApplyMigTemplate()
-	}
 
 	return nil
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -264,15 +264,12 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		return err
 	}
 	klog.Infof("Registered device plugin for '%s' with Kubelet", plugin.rm.Resource())
-	// Prepare the lock file sub directory.Due to the sequence of startup processes, both the device plugin
-	// and the vGPU monitor should attempt to create this directory by default to ensure its creation.
+
 	err = CreateMigApplyLockDir()
 	if err != nil {
 		klog.Fatalf("CreateMIGLockSubDir failed:%v", err)
 	}
 
-	// If the temporary lock file still exists, it may be a leftover from the last incomplete mig  application process.
-	// Delete the temporary lock file to make sure vgpu monitor can start.
 	err = RemoveMigApplyLock()
 	if err != nil {
 		klog.Fatalf("RemoveMigApplyLock failed:%v", err)
@@ -291,28 +288,56 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 			break
 		}
 	}
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
-	if migEnabled {
+
+	isMigMode := plugin.operatingMode == "mig"
+	hasMigStrategy := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
+
+	shouldUseMig := isMigMode || hasMigStrategy
+
+	// Graceful degradation check for configuration mismatches
+	if shouldUseMig && !deviceSupportMig {
+		klog.Warningf("MIG mode requested but the GPU does not support MIG. Disabling MIG mode.")
+		shouldUseMig = false
+	}
+
+	migSuccessfullyInitialized := false
+
+	if deviceSupportMig && shouldUseMig {
+		klog.Infof("Initializing MIG mode (operatingMode=%s, hasMigStrategy=%v)", plugin.operatingMode, hasMigStrategy)
+
 		cmd := exec.Command("nvidia-mig-parted", "export")
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
-		err := cmd.Run()
-		if err != nil {
-			klog.Fatalf("nvidia-mig-parted failed with %s\n", err)
+
+		if err := cmd.Run(); err != nil {
+			klog.Warningf("nvidia-mig-parted failed: %v (stderr: %s).", err, stderr.String())
+		} else {
+			outStr := stdout.Bytes()
+			if err = yaml.Unmarshal(outStr, &plugin.migCurrent); err != nil {
+				klog.Warningf("Failed to parse nvidia-mig-parted output: %v.", err)
+			} else {
+				_ = os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
+
+				if plugin.migCurrent.MigConfigs == nil {
+					klog.Warningf("nvidia-mig-parted returned empty MigConfigs.")
+				} else {
+					HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
+					if err != nil {
+						klog.Warningf("Failed to process MIG configs: %v.", err)
+					} else {
+						plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
+						klog.Infoln("MIG mode enabled successfully")
+						migSuccessfullyInitialized = true
+					}
+				}
+			}
 		}
-		outStr := stdout.Bytes()
-		yaml.Unmarshal(outStr, &plugin.migCurrent)
-		os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
 	}
-	if migEnabled && plugin.operatingMode == "mig" {
-		HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
-		if err != nil {
-			klog.Infof("no device in node:%v", err)
-		}
-		plugin.migCurrent.MigConfigs["current"] = HamiInitMigConfig
-		klog.Infoln("Open Mig export", plugin.migCurrent)
-	} else {
+
+	// Fallback execution block if MIG was not desired or failed to safely initialize
+	if !migSuccessfullyInitialized {
+		klog.Infoln("Initializing with MIG disabled")
 		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
 		configSlice := nvidia.MigConfigSpecSlice{}
 		for i := 0; i < deviceNumbers; i++ {
@@ -320,8 +345,8 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 			configSlice = append(configSlice, conf)
 		}
 		plugin.migCurrent.MigConfigs["current"] = configSlice
-		klog.Infoln("Close Mig export", plugin.migCurrent)
 	}
+
 	go func() {
 		err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks)
 		if err != nil {
@@ -333,11 +358,9 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		plugin.WatchAndRegister(plugin.disableWatchAndRegister, plugin.ackDisableWatchAndRegister)
 	}()
 
-	if deviceSupportMig {
-		migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != spec.MigStrategyNone
-		if migEnabled {
-			plugin.ApplyMigTemplate()
-		}
+	// Only apply layouts if the MIG subsystem was configured end-to-end without errors
+	if migSuccessfullyInitialized {
+		plugin.ApplyMigTemplate()
 	}
 
 	return nil

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -53,6 +53,51 @@ import (
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func ptr[T any](x T) *T {
+	return &x
+}
+
+// computeShouldUseMig mirrors the unified MIG intent check introduced in Start.
+// It returns the value of shouldUseMig BEFORE any graceful-degradation adjustment
+// so that individual test helpers can apply the degradation step themselves.
+func computeShouldUseMig(plugin *NvidiaDevicePlugin) bool {
+	isMigMode := plugin.operatingMode == "mig"
+	hasMigStrategy := plugin.config.Flags.MigStrategy != nil &&
+		*plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+	return isMigMode || hasMigStrategy
+}
+
+// applyGracefulDegradation mirrors the degradation guard in Start:
+// if MIG was requested but the device does not support it, disable MIG silently.
+func applyGracefulDegradation(shouldUseMig bool, deviceSupportMig bool) bool {
+	if shouldUseMig && !deviceSupportMig {
+		return false
+	}
+	return shouldUseMig
+}
+
+// runFallbackInit mirrors the fallback block that runs when migSuccessfullyInitialized
+// is false. It always initialises MigConfigs to a safe non-MIG state.
+func runFallbackInit(plugin *NvidiaDevicePlugin, deviceNumbers int) {
+	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+	configSlice := nvidia.MigConfigSpecSlice{}
+	for i := 0; i < deviceNumbers; i++ {
+		conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+		configSlice = append(configSlice, conf)
+	}
+	plugin.migCurrent.MigConfigs["current"] = configSlice
+}
+
+// ── MigDeviceConfigs – shared fixture ────────────────────────────────────────
+
+type MigDeviceConfigs struct {
+	Configs []map[string]int32
+}
+
+// ── existing tests (unchanged) ───────────────────────────────────────────────
+
 func TestCDIAllocateResponse(t *testing.T) {
 	testCases := []struct {
 		description          string
@@ -196,14 +241,6 @@ func TestCDIAllocateResponse(t *testing.T) {
 			require.EqualValues(t, &tc.expectedResponse, &response)
 		})
 	}
-}
-
-func ptr[T any](x T) *T {
-	return &x
-}
-
-type MigDeviceConfigs struct {
-	Configs []map[string]int32
 }
 
 func Test_processMigConfigs(t *testing.T) {
@@ -651,10 +688,9 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-pod",
 			Annotations: map[string]string{
-				// Annotation includes init container (empty) + regular container (with GPU)
 				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
-					{}, // init container - empty
-					{ // regular container - 2 GPUs
+					{}, // init container – empty
+					{ // regular container – 2 GPUs
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice},
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", Type: nvidia.NvidiaGPUDevice},
 					},
@@ -677,12 +713,14 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 		getPendingPod = previousGetPendingPod
 	}()
 
-	// Kubelet only sends one request (for the main container), not two
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
 			{
-				AvailableDeviceIDs: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-1"},
-				AllocationSize:     2,
+				AvailableDeviceIDs: []string{
+					"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
+					"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-1",
+				},
+				AllocationSize: 2,
 			},
 		},
 	}
@@ -690,8 +728,10 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 	response, err := plugin.GetPreferredAllocation(context.Background(), request)
 	require.NoError(t, err)
 	require.Len(t, response.ContainerResponses, 1)
-	// Should match GPU-a and GPU-b, not fail due to empty init container annotation
-	require.ElementsMatch(t, []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0"}, response.ContainerResponses[0].DeviceIDs)
+	require.ElementsMatch(t, []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+	}, response.ContainerResponses[0].DeviceIDs)
 }
 
 func TestPhysicalDeviceIDHandlesMIGFormat(t *testing.T) {
@@ -770,17 +810,11 @@ func TestGetPreferredAllocationFallbackOnAnnotatedDeviceMappingFailure(t *testin
 		},
 	}
 
-	plugin := &NvidiaDevicePlugin{
-		rm: mockRM,
-	}
+	plugin := &NvidiaDevicePlugin{rm: mockRM}
 	t.Setenv(util.NodeNameEnvName, "node-a")
 	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
-		return pod, nil
-	}
-	defer func() {
-		getPendingPod = previousGetPendingPod
-	}()
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	defer func() { getPendingPod = previousGetPendingPod }()
 
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
@@ -831,17 +865,11 @@ func TestGetPreferredAllocationFallbackOnInsufficientAnnotatedDevices(t *testing
 		},
 	}
 
-	plugin := &NvidiaDevicePlugin{
-		rm: mockRM,
-	}
+	plugin := &NvidiaDevicePlugin{rm: mockRM}
 	t.Setenv(util.NodeNameEnvName, "node-a")
 	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
-		return pod, nil
-	}
-	defer func() {
-		getPendingPod = previousGetPendingPod
-	}()
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	defer func() { getPendingPod = previousGetPendingPod }()
 
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
@@ -1011,10 +1039,8 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
 	defer func() { getPendingPod = previousGetPendingPod }()
 
-	// Simulate erase behavior: modifies annotation to move to next container's devices
 	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
 	eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
-		// After erase, first container becomes empty (;), second container keeps its devices
 		pod.Annotations["hami.io/vgpu-devices-to-allocate"] = ";GPU-annotated-b,NVIDIA,4000,60:;"
 		return nil
 	}
@@ -1049,38 +1075,34 @@ func TestMigInitialization_SafeMapAccess(t *testing.T) {
 			Config: &v1.Config{
 				Flags: v1.Flags{
 					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
+						MigStrategy: ptr(v1.MigStrategyNone),
 					},
 				},
 			},
 		},
-		operatingMode: "mig",
+		operatingMode: "default",
 		migCurrent:    nvidia.MigPartedSpec{},
 	}
 
 	deviceNumbers := 3
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
 
-	if migEnabled && plugin.operatingMode == "mig" {
-		t.Fatal("Should not reach here")
-	} else {
-		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-		configSlice := nvidia.MigConfigSpecSlice{}
-		for i := 0; i < deviceNumbers; i++ {
-			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			configSlice = append(configSlice, conf)
-		}
-		plugin.migCurrent.MigConfigs["current"] = configSlice
+	shouldUseMig := computeShouldUseMig(plugin)
+	require.False(t, shouldUseMig, "shouldUseMig must be false when mode is default and strategy is none")
+
+	migSuccessfullyInitialized := false
+	if !migSuccessfullyInitialized {
+		runFallbackInit(plugin, deviceNumbers)
 	}
 
-	require.NotNil(t, plugin.migCurrent.MigConfigs)
-	require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
-	require.Equal(t, 3, len(plugin.migCurrent.MigConfigs["current"]))
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must not be nil after fallback init")
+	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "current key must exist after fallback init")
+	require.Equal(t, deviceNumbers, len(plugin.migCurrent.MigConfigs["current"]))
 
 	for i := 0; i < deviceNumbers; i++ {
 		cfg := plugin.migCurrent.MigConfigs["current"][i]
-		require.False(t, cfg.MigEnabled)
-		require.Equal(t, int32(i), cfg.Devices[0])
+		require.False(t, cfg.MigEnabled, "fallback config must have MigEnabled=false for device %d", i)
+		require.Len(t, cfg.Devices, 1, "each fallback config must reference exactly one device")
+		require.Equal(t, int32(i), cfg.Devices[0], "device index must equal loop index for device %d", i)
 	}
 }
 
@@ -1099,8 +1121,8 @@ func TestMigInitialization_MigEnabledSingleStrategy(t *testing.T) {
 		migCurrent:    nvidia.MigPartedSpec{},
 	}
 
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-	require.True(t, migEnabled, "MIG should be enabled when strategy is 'single'")
+	shouldUseMig := computeShouldUseMig(plugin)
+	require.True(t, shouldUseMig, "shouldUseMig must be true when both operatingMode is mig and strategy is single")
 
 	plugin.migCurrent.MigConfigs = map[string]nvidia.MigConfigSpecSlice{
 		"current": {
@@ -1112,9 +1134,9 @@ func TestMigInitialization_MigEnabledSingleStrategy(t *testing.T) {
 		},
 	}
 
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
-	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "Current MigConfigs should exist")
-	require.True(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled should be true")
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must not be nil after MIG init")
+	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "current key must exist")
+	require.True(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled must be true")
 }
 
 func TestMigInitialization_NoMigStrategy(t *testing.T) {
@@ -1132,48 +1154,59 @@ func TestMigInitialization_NoMigStrategy(t *testing.T) {
 		migCurrent:    nvidia.MigPartedSpec{},
 	}
 
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-	require.False(t, migEnabled, "MIG should be disabled when MigStrategy is nil")
+	shouldUseMig := computeShouldUseMig(plugin)
+	require.False(t, shouldUseMig, "shouldUseMig must be false when MigStrategy is nil and mode is default")
 
-	if !migEnabled {
-		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-		configSlice := nvidia.MigConfigSpecSlice{}
-		for i := 0; i < 4; i++ {
-			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			configSlice = append(configSlice, conf)
-		}
-		plugin.migCurrent.MigConfigs["current"] = configSlice
+	if !shouldUseMig {
+		runFallbackInit(plugin, 4)
 	}
 
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should be initialized")
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], 4, "Should have config for 4 devices")
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must be initialised")
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], 4, "must have one entry per device")
 }
 
 func TestMigInitialization_ApplyMigTemplate(t *testing.T) {
 	testCases := []struct {
-		name       string
-		strategy   *string
-		shouldCall bool
+		name          string
+		operatingMode string
+		strategy      *string
+		shouldCall    bool
 	}{
 		{
-			name:       "MIG disabled with none strategy",
-			strategy:   ptr(v1.MigStrategyNone),
-			shouldCall: false,
+			name:          "none strategy and default mode – MIG off",
+			operatingMode: "default",
+			strategy:      ptr(v1.MigStrategyNone),
+			shouldCall:    false,
 		},
 		{
-			name:       "MIG enabled with single strategy",
-			strategy:   ptr("single"),
-			shouldCall: true,
+			name:          "single strategy, default mode – MIG on",
+			operatingMode: "default",
+			strategy:      ptr("single"),
+			shouldCall:    true,
 		},
 		{
-			name:       "MIG enabled with mixed strategy",
-			strategy:   ptr("mixed"),
-			shouldCall: true,
+			name:          "mixed strategy, default mode – MIG on",
+			operatingMode: "default",
+			strategy:      ptr("mixed"),
+			shouldCall:    true,
 		},
 		{
-			name:       "MigStrategy is nil",
-			strategy:   nil,
-			shouldCall: false,
+			name:          "mig operating mode, no strategy – MIG on",
+			operatingMode: "mig",
+			strategy:      nil,
+			shouldCall:    true,
+		},
+		{
+			name:          "mig operating mode overrides none strategy – MIG on",
+			operatingMode: "mig",
+			strategy:      ptr(v1.MigStrategyNone),
+			shouldCall:    true,
+		},
+		{
+			name:          "nil strategy and default mode – MIG off",
+			operatingMode: "default",
+			strategy:      nil,
+			shouldCall:    false,
 		},
 	}
 
@@ -1189,11 +1222,484 @@ func TestMigInitialization_ApplyMigTemplate(t *testing.T) {
 						},
 					},
 				},
+				operatingMode: tc.operatingMode,
 			}
 
-			migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-			require.Equal(t, tc.shouldCall, migEnabled,
-				"ApplyMigTemplate call decision should match expected value for %s", tc.name)
+			shouldUseMig := computeShouldUseMig(plugin)
+			require.Equal(t, tc.shouldCall, shouldUseMig,
+				"shouldUseMig mismatch for operatingMode=%q strategy=%v",
+				tc.operatingMode, tc.strategy)
+		})
+	}
+}
+
+func TestShouldUseMig_OperatingModeAloneSuffices(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: nil, // no strategy at all
+					},
+				},
+			},
+		},
+		operatingMode: "mig",
+	}
+
+	shouldUseMig := computeShouldUseMig(plugin)
+	require.True(t, shouldUseMig,
+		"operatingMode=mig alone must be sufficient to request MIG initialisation")
+}
+
+func TestShouldUseMig_MigModeOverridesMigStrategyNone(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: ptr(v1.MigStrategyNone),
+					},
+				},
+			},
+		},
+		operatingMode: "mig",
+	}
+
+	shouldUseMig := computeShouldUseMig(plugin)
+	require.True(t, shouldUseMig,
+		"operatingMode=mig must override MigStrategyNone under the new OR logic")
+}
+
+func TestShouldUseMig_AllCombinations(t *testing.T) {
+	testCases := []struct {
+		name              string
+		operatingMode     string
+		migStrategy       *string
+		expectedShouldUse bool
+	}{
+		{
+			name:              "default mode, nil strategy",
+			operatingMode:     "default",
+			migStrategy:       nil,
+			expectedShouldUse: false,
+		},
+		{
+			name:              "default mode, none strategy",
+			operatingMode:     "default",
+			migStrategy:       ptr(v1.MigStrategyNone),
+			expectedShouldUse: false,
+		},
+		{
+			name:              "mig mode, nil strategy",
+			operatingMode:     "mig",
+			migStrategy:       nil,
+			expectedShouldUse: true,
+		},
+		{
+			name:              "mig mode, none strategy – isMigMode wins",
+			operatingMode:     "mig",
+			migStrategy:       ptr(v1.MigStrategyNone),
+			expectedShouldUse: true,
+		},
+		{
+			name:              "default mode, single strategy",
+			operatingMode:     "default",
+			migStrategy:       ptr("single"),
+			expectedShouldUse: true,
+		},
+		{
+			name:              "default mode, mixed strategy",
+			operatingMode:     "default",
+			migStrategy:       ptr("mixed"),
+			expectedShouldUse: true,
+		},
+		{
+			name:              "mig mode, single strategy",
+			operatingMode:     "mig",
+			migStrategy:       ptr("single"),
+			expectedShouldUse: true,
+		},
+		{
+			name:              "mig mode, mixed strategy",
+			operatingMode:     "mig",
+			migStrategy:       ptr("mixed"),
+			expectedShouldUse: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{
+								MigStrategy: tc.migStrategy,
+							},
+						},
+					},
+				},
+				operatingMode: tc.operatingMode,
+			}
+
+			shouldUseMig := computeShouldUseMig(plugin)
+			require.Equal(t, tc.expectedShouldUse, shouldUseMig,
+				"OR logic mismatch for operatingMode=%q migStrategy=%v",
+				tc.operatingMode, tc.migStrategy)
+		})
+	}
+}
+
+func TestMigGracefulDegradation(t *testing.T) {
+	testCases := []struct {
+		name              string
+		operatingMode     string
+		migStrategy       *string
+		deviceSupportMig  bool
+		expectedShouldUse bool
+	}{
+		{
+			name:              "mig mode requested, device unsupported – clamped to false",
+			operatingMode:     "mig",
+			migStrategy:       nil,
+			deviceSupportMig:  false,
+			expectedShouldUse: false,
+		},
+		{
+			name:              "single strategy set, device unsupported – clamped to false",
+			operatingMode:     "default",
+			migStrategy:       ptr("single"),
+			deviceSupportMig:  false,
+			expectedShouldUse: false,
+		},
+		{
+			name:              "both signals set, device unsupported – clamped to false",
+			operatingMode:     "mig",
+			migStrategy:       ptr("single"),
+			deviceSupportMig:  false,
+			expectedShouldUse: false,
+		},
+		{
+			name:              "mig mode requested, device supported – stays true",
+			operatingMode:     "mig",
+			migStrategy:       nil,
+			deviceSupportMig:  true,
+			expectedShouldUse: true,
+		},
+		{
+			name:              "single strategy, device supported – stays true",
+			operatingMode:     "default",
+			migStrategy:       ptr("single"),
+			deviceSupportMig:  true,
+			expectedShouldUse: true,
+		},
+		{
+			name:              "no mig request, device supported – stays false",
+			operatingMode:     "default",
+			migStrategy:       nil,
+			deviceSupportMig:  true,
+			expectedShouldUse: false,
+		},
+		{
+			name:              "no mig request, device unsupported – stays false",
+			operatingMode:     "default",
+			migStrategy:       ptr(v1.MigStrategyNone),
+			deviceSupportMig:  false,
+			expectedShouldUse: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{
+								MigStrategy: tc.migStrategy,
+							},
+						},
+					},
+				},
+				operatingMode: tc.operatingMode,
+			}
+
+			shouldUseMig := computeShouldUseMig(plugin)
+			shouldUseMig = applyGracefulDegradation(shouldUseMig, tc.deviceSupportMig)
+
+			require.Equal(t, tc.expectedShouldUse, shouldUseMig,
+				"post-degradation shouldUseMig mismatch for mode=%q strategy=%v supported=%v",
+				tc.operatingMode, tc.migStrategy, tc.deviceSupportMig)
+		})
+	}
+}
+
+func TestMigFallbackInitialization(t *testing.T) {
+	testCases := []struct {
+		name          string
+		deviceNumbers int
+	}{
+		{name: "zero devices", deviceNumbers: 0},
+		{name: "single device", deviceNumbers: 1},
+		{name: "three devices", deviceNumbers: 3},
+		{name: "eight devices", deviceNumbers: 8},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{},
+						},
+					},
+				},
+				migCurrent: nvidia.MigPartedSpec{},
+			}
+
+			runFallbackInit(plugin, tc.deviceNumbers)
+
+			require.NotNil(t, plugin.migCurrent.MigConfigs,
+				"MigConfigs must not be nil after fallback init")
+			require.NotNil(t, plugin.migCurrent.MigConfigs["current"],
+				"current key must always exist after fallback init")
+			require.Len(t, plugin.migCurrent.MigConfigs["current"], tc.deviceNumbers,
+				"one config entry per device is required")
+
+			for i := 0; i < tc.deviceNumbers; i++ {
+				cfg := plugin.migCurrent.MigConfigs["current"][i]
+				require.False(t, cfg.MigEnabled,
+					"fallback must set MigEnabled=false for device %d", i)
+				require.Len(t, cfg.Devices, 1,
+					"each fallback entry must reference exactly one device (device %d)", i)
+				require.Equal(t, int32(i), cfg.Devices[0],
+					"device index must match loop counter for device %d", i)
+			}
+		})
+	}
+}
+
+func TestMigFallbackInit_ReplacesExistingConfigs(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{},
+				},
+			},
+		},
+		migCurrent: nvidia.MigPartedSpec{
+			// Stale data from a failed partial init.
+			MigConfigs: map[string]nvidia.MigConfigSpecSlice{
+				"current": {
+					nvidia.MigConfigSpec{MigEnabled: true, Devices: []int32{0}},
+					nvidia.MigConfigSpec{MigEnabled: true, Devices: []int32{1}},
+				},
+				"stale-key": {},
+			},
+		},
+	}
+
+	deviceNumbers := 2
+	runFallbackInit(plugin, deviceNumbers)
+
+	require.Len(t, plugin.migCurrent.MigConfigs, 1,
+		"fallback must produce a map with only the current key")
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], deviceNumbers)
+	for i := 0; i < deviceNumbers; i++ {
+		require.False(t, plugin.migCurrent.MigConfigs["current"][i].MigEnabled,
+			"stale MigEnabled=true must be overwritten for device %d", i)
+	}
+}
+
+func TestMigSuccessFlag_GatesApplyMigTemplate(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		migSuccessfullyInitialized bool
+		expectApplyTemplateCalled  bool
+	}{
+		{
+			name:                       "template applied when MIG succeeded",
+			migSuccessfullyInitialized: true,
+			expectApplyTemplateCalled:  true,
+		},
+		{
+			name:                       "template skipped when MIG failed or was disabled",
+			migSuccessfullyInitialized: false,
+			expectApplyTemplateCalled:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyTemplateCalled := false
+			mockApplyMigTemplate := func() { applyTemplateCalled = true }
+
+			if tc.migSuccessfullyInitialized {
+				mockApplyMigTemplate()
+			}
+
+			require.Equal(t, tc.expectApplyTemplateCalled, applyTemplateCalled,
+				"ApplyMigTemplate call decision must be controlled by migSuccessfullyInitialized")
+		})
+	}
+}
+
+func TestMigSuccessFlag_FallbackRunsExactlyWhenNotInitialized(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		migSuccessfullyInitialized bool
+		expectFallbackRan          bool
+	}{
+		{
+			name:                       "fallback skipped when MIG succeeded",
+			migSuccessfullyInitialized: true,
+			expectFallbackRan:          false,
+		},
+		{
+			name:                       "fallback runs when MIG was not initialised",
+			migSuccessfullyInitialized: false,
+			expectFallbackRan:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{},
+						},
+					},
+				},
+				migCurrent: nvidia.MigPartedSpec{},
+			}
+			fallbackRan := false
+
+			if !tc.migSuccessfullyInitialized {
+				fallbackRan = true
+				runFallbackInit(plugin, 1)
+			}
+
+			require.Equal(t, tc.expectFallbackRan, fallbackRan,
+				"fallback execution must be gated by !migSuccessfullyInitialized")
+
+			if tc.expectFallbackRan {
+				require.NotNil(t, plugin.migCurrent.MigConfigs)
+				require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
+			}
+		})
+	}
+}
+
+func TestMigInitFlow_EndToEnd(t *testing.T) {
+	testCases := []struct {
+		name                string
+		operatingMode       string
+		migStrategy         *string
+		deviceSupportMig    bool
+		migPartsedSucceeds  bool
+		expectFallback      bool
+		expectApplyTemplate bool
+	}{
+		{
+			name:                "MIG off – no intent",
+			operatingMode:       "default",
+			migStrategy:         nil,
+			deviceSupportMig:    false,
+			migPartsedSucceeds:  false,
+			expectFallback:      true,
+			expectApplyTemplate: false,
+		},
+		{
+			name:                "MIG requested but unsupported – graceful degradation",
+			operatingMode:       "mig",
+			migStrategy:         nil,
+			deviceSupportMig:    false,
+			migPartsedSucceeds:  false,
+			expectFallback:      true,
+			expectApplyTemplate: false,
+		},
+		{
+			name:                "MIG requested, supported but nvidia-mig-parted fails",
+			operatingMode:       "mig",
+			migStrategy:         ptr("single"),
+			deviceSupportMig:    true,
+			migPartsedSucceeds:  false,
+			expectFallback:      true,
+			expectApplyTemplate: false,
+		},
+		{
+			name:                "MIG requested, supported, nvidia-mig-parted succeeds",
+			operatingMode:       "mig",
+			migStrategy:         ptr("single"),
+			deviceSupportMig:    true,
+			migPartsedSucceeds:  true,
+			expectFallback:      false,
+			expectApplyTemplate: true,
+		},
+		{
+			name:                "strategy only (no mig mode), supported, parted succeeds",
+			operatingMode:       "default",
+			migStrategy:         ptr("mixed"),
+			deviceSupportMig:    true,
+			migPartsedSucceeds:  true,
+			expectFallback:      false,
+			expectApplyTemplate: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{
+								MigStrategy: tc.migStrategy,
+							},
+						},
+					},
+				},
+				operatingMode: tc.operatingMode,
+				migCurrent:    nvidia.MigPartedSpec{},
+			}
+
+			shouldUseMig := computeShouldUseMig(plugin)
+
+			shouldUseMig = applyGracefulDegradation(shouldUseMig, tc.deviceSupportMig)
+
+			migSuccessfullyInitialized := false
+			if tc.deviceSupportMig && shouldUseMig && tc.migPartsedSucceeds {
+				migSuccessfullyInitialized = true
+				plugin.migCurrent.MigConfigs = map[string]nvidia.MigConfigSpecSlice{
+					"current": {{MigEnabled: true, Devices: []int32{0}}},
+				}
+			}
+
+			fallbackRan := false
+			if !migSuccessfullyInitialized {
+				fallbackRan = true
+				runFallbackInit(plugin, 1)
+			}
+
+			applyTemplateCalled := false
+			if migSuccessfullyInitialized {
+				applyTemplateCalled = true
+			}
+
+			require.Equal(t, tc.expectFallback, fallbackRan,
+				"fallback execution mismatch")
+			require.Equal(t, tc.expectApplyTemplate, applyTemplateCalled,
+				"ApplyMigTemplate call mismatch")
+
+			require.NotNil(t, plugin.migCurrent.MigConfigs,
+				"MigConfigs must never be nil after Start() completes")
+			require.NotNil(t, plugin.migCurrent.MigConfigs["current"],
+				"current key must always exist after Start() completes")
 		})
 	}
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1053,3 +1053,227 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 }
+
+func TestMigInitialization_MigModeButDisabledStrategy(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
+					},
+				},
+			},
+		},
+		operatingMode: "mig",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	deviceNumbers := 2
+
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+	require.False(t, migEnabled, "MIG should be disabled")
+
+	if migEnabled && plugin.operatingMode == "mig" {
+		t.Fatal("This block should not be reached when migEnabled is false")
+	} else {
+		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+		configSlice := nvidia.MigConfigSpecSlice{}
+		for i := 0; i < deviceNumbers; i++ {
+			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			configSlice = append(configSlice, conf)
+		}
+		plugin.migCurrent.MigConfigs["current"] = configSlice
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2, "Should have config for 2 devices")
+}
+
+func TestMigInitialization_SafeMapAccess(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
+					},
+				},
+			},
+		},
+		operatingMode: "mig",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	deviceNumbers := 3
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+
+	if migEnabled && plugin.operatingMode == "mig" {
+		t.Fatal("Should not reach here")
+	} else {
+		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+		configSlice := nvidia.MigConfigSpecSlice{}
+		for i := 0; i < deviceNumbers; i++ {
+			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			configSlice = append(configSlice, conf)
+		}
+		plugin.migCurrent.MigConfigs["current"] = configSlice
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs)
+	require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
+	require.Equal(t, 3, len(plugin.migCurrent.MigConfigs["current"]))
+
+	for i := 0; i < deviceNumbers; i++ {
+		cfg := plugin.migCurrent.MigConfigs["current"][i]
+		require.False(t, cfg.MigEnabled)
+		require.Equal(t, int32(i), cfg.Devices[0])
+	}
+}
+
+func TestMigInitialization_DisabledStrategy(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
+					},
+				},
+			},
+		},
+		operatingMode: "default",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+	require.False(t, migEnabled, "MIG should be disabled when strategy is 'none'")
+
+	if !migEnabled {
+		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+		configSlice := nvidia.MigConfigSpecSlice{}
+		for i := 0; i < 2; i++ {
+			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			configSlice = append(configSlice, conf)
+		}
+		plugin.migCurrent.MigConfigs["current"] = configSlice
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2, "Should have config for 2 devices")
+	require.False(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled should be false")
+}
+
+func TestMigInitialization_MigEnabledSingleStrategy(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: ptr("single"),
+					},
+				},
+			},
+		},
+		operatingMode: "mig",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+	require.True(t, migEnabled, "MIG should be enabled when strategy is 'single'")
+
+	plugin.migCurrent.MigConfigs = map[string]nvidia.MigConfigSpecSlice{
+		"current": {
+			nvidia.MigConfigSpec{
+				MigEnabled: true,
+				Devices:    []int32{0, 1},
+				MigDevices: map[string]int32{"3g.30gb": 2},
+			},
+		},
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
+	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "Current MigConfigs should exist")
+	require.True(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled should be true")
+}
+
+func TestMigInitialization_NoMigStrategy(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						MigStrategy: nil,
+					},
+				},
+			},
+		},
+		operatingMode: "default",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+	require.False(t, migEnabled, "MIG should be disabled when MigStrategy is nil")
+
+	if !migEnabled {
+		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
+		configSlice := nvidia.MigConfigSpecSlice{}
+		for i := 0; i < 4; i++ {
+			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
+			configSlice = append(configSlice, conf)
+		}
+		plugin.migCurrent.MigConfigs["current"] = configSlice
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should be initialized")
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], 4, "Should have config for 4 devices")
+}
+
+func TestMigInitialization_ApplyMigTemplate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		strategy   *string
+		shouldCall bool
+	}{
+		{
+			name:       "MIG disabled with none strategy",
+			strategy:   ptr(v1.MigStrategyNone),
+			shouldCall: false,
+		},
+		{
+			name:       "MIG enabled with single strategy",
+			strategy:   ptr("single"),
+			shouldCall: true,
+		},
+		{
+			name:       "MIG enabled with mixed strategy",
+			strategy:   ptr("mixed"),
+			shouldCall: true,
+		},
+		{
+			name:       "MigStrategy is nil",
+			strategy:   nil,
+			shouldCall: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{
+								MigStrategy: tc.strategy,
+							},
+						},
+					},
+				},
+			}
+
+			migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
+			require.Equal(t, tc.shouldCall, migEnabled,
+				"ApplyMigTemplate call decision should match expected value for %s", tc.name)
+		})
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package plugin
 
 import (

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1,18 +1,35 @@
 /*
-Copyright 2026 The HAMi Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The HAMi Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+/*
+ * Licensed to NVIDIA CORPORATION under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. NVIDIA CORPORATION licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-	http://www.apache.org/licenses/LICENSE-2.0
+/*
+ * Modifications Copyright The HAMi Authors. See
+ * GitHub history for details.
+ */
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package plugin
 
 import (
@@ -40,7 +57,6 @@ func ptr[T any](x T) *T {
 	return &x
 }
 
-// runFallbackInit mirrors the fallback block from Start.
 func runFallbackInit(plugin *NvidiaDevicePlugin, deviceNumbers int) {
 	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
 	configSlice := nvidia.MigConfigSpecSlice{}
@@ -123,191 +139,6 @@ func TestMigConfigFilePermissionSecurityImprovement(t *testing.T) {
 
 	otherCanRead := (mode644 & 0004) != 0
 	require.True(t, otherCanRead, "0644: Others CAN read (for debugging)")
-}
-
-// TestGetMigCapabilityMapHybridGPUs verifies that getMigCapabilityMap correctly
-// assigns MIG capability per-device, not all-or-nothing.
-//
-// THE BUG IT GUARDS AGAINST (upstream HAMi):
-// The original upstream Start() loop resets deviceSupportMig=false on each
-// iteration and calls `break` the moment any device is non-MIG. This means a
-// single T4 anywhere in the list silently disables MIG for every A100 on the
-// node. getMigCapabilityMap fixes this by producing an independent true/false
-// per device index.
-func TestGetMigCapabilityMapHybridGPUs(t *testing.T) {
-	testCases := []struct {
-		name                  string
-		deviceNames           []string
-		migGeometries         []string // model substrings that indicate MIG support
-		expectedCapabilityMap map[int]bool
-		expectedNodeHasMigGPU bool
-	}{
-		{
-			name:                  "all MIG-capable (A100, A100, A100)",
-			deviceNames:           []string{"A100", "A100", "A100"},
-			migGeometries:         []string{"A100"},
-			expectedCapabilityMap: map[int]bool{0: true, 1: true, 2: true},
-			expectedNodeHasMigGPU: true,
-		},
-		{
-			name:                  "all non-MIG (T4, T4, T4)",
-			deviceNames:           []string{"T4", "T4", "T4"},
-			migGeometries:         []string{"A100"}, // T4 not in list
-			expectedCapabilityMap: map[int]bool{0: false, 1: false, 2: false},
-			expectedNodeHasMigGPU: false,
-		},
-		{
-			name:                  "hybrid - A100, T4, A100 (THE FIX!)",
-			deviceNames:           []string{"A100", "T4", "A100"},
-			migGeometries:         []string{"A100"},
-			expectedCapabilityMap: map[int]bool{0: true, 1: false, 2: true},
-			expectedNodeHasMigGPU: true,
-		},
-		{
-			name:                  "mixed - T4, A100, T4",
-			deviceNames:           []string{"T4", "A100", "T4"},
-			migGeometries:         []string{"A100"},
-			expectedCapabilityMap: map[int]bool{0: false, 1: true, 2: false},
-			expectedNodeHasMigGPU: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Build the MIG geometries list using the real type that
-			// getMigCapabilityMap reads from: []device.AllowedMigGeometries.
-			// Each entry declares which GPU model substrings qualify as MIG-capable.
-			// containsModel(deviceName, entry.Models) uses strings.Contains, so
-			// "A100" in Models will match any device name that contains "A100".
-			migGeomsList := make([]device.AllowedMigGeometries, 0, len(tc.migGeometries))
-			for _, model := range tc.migGeometries {
-				migGeomsList = append(migGeomsList, device.AllowedMigGeometries{
-					Models: []string{model},
-				})
-			}
-
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{},
-						},
-					},
-				},
-				schedulerConfig: nvidia.NvidiaConfig{
-					MigGeometriesList: migGeomsList,
-				},
-			}
-
-			capabilityMap, nodeHasMig := plugin.getMigCapabilityMap(tc.deviceNames)
-
-			require.Equal(t, tc.expectedCapabilityMap, capabilityMap,
-				"capability map should match expected per-device detection")
-			require.Equal(t, tc.expectedNodeHasMigGPU, nodeHasMig,
-				"nodeHasMigCapableGPU flag should be true if ANY GPU supports MIG")
-		})
-	}
-}
-
-// TestGetMigCapabilityMapFixesBrokenLogic directly tests the core correctness
-// property: A100 is MIG-capable and T4 is not, even when both are on the same node.
-//
-// This test would FAIL against the upstream HAMi logic because [A100, T4] would
-// cause the T4 to short-circuit the loop and mark the whole node as non-MIG.
-func TestGetMigCapabilityMapFixesBrokenLogic(t *testing.T) {
-	deviceNames := []string{"A100", "T4"}
-
-	// Populate MigGeometriesList so the function has data to match against.
-	// Without this, getMigCapabilityMap has nothing to iterate and every
-	// device silently gets false — exactly what caused these test failures.
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{},
-				},
-			},
-		},
-		schedulerConfig: nvidia.NvidiaConfig{
-			MigGeometriesList: []device.AllowedMigGeometries{
-				{Models: []string{"A100"}},
-			},
-		},
-	}
-
-	capabilityMap, nodeHasMig := plugin.getMigCapabilityMap(deviceNames)
-
-	require.True(t, capabilityMap[0], "GPU[0] (A100) should support MIG")
-	require.False(t, capabilityMap[1], "GPU[1] (T4) should not support MIG")
-	require.True(t, nodeHasMig, "Node has MIG-capable GPU (GPU[0])")
-}
-
-// TestBuildHybridMigConfigMixedDevices verifies hybrid MIG configuration
-func TestBuildHybridMigConfigMixedDevices(t *testing.T) {
-	testCases := []struct {
-		name                string
-		deviceNumbers       int
-		deviceNames         []string
-		deviceMigSupportMap map[int]bool
-		expectedMigEnabled  map[int]bool
-		expectedDeviceList  map[int][]int32
-	}{
-		{
-			name:                "hybrid - GPU[0] MIG, GPU[1] whole",
-			deviceNumbers:       2,
-			deviceNames:         []string{"A100", "T4"},
-			deviceMigSupportMap: map[int]bool{0: true, 1: false},
-			expectedMigEnabled:  map[int]bool{},
-			expectedDeviceList: map[int][]int32{
-				1: {1},
-			},
-		},
-		{
-			name:                "all MIG - GPU[0], GPU[1], GPU[2] all MIG",
-			deviceNumbers:       3,
-			deviceNames:         []string{"A100", "A100", "A100"},
-			deviceMigSupportMap: map[int]bool{0: true, 1: true, 2: true},
-			expectedDeviceList:  map[int][]int32{},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{},
-						},
-					},
-				},
-				migCurrent: nvidia.MigPartedSpec{},
-			}
-
-			migConfigs := make(map[string]nvidia.MigConfigSpecSlice)
-
-			for i := 0; i < tc.deviceNumbers; i++ {
-				if !tc.deviceMigSupportMap[i] {
-					nonMigConf := nvidia.MigConfigSpec{
-						MigEnabled: false,
-						Devices:    []int32{int32(i)},
-					}
-					migConfigs["current"] = append(migConfigs["current"], nonMigConf)
-				}
-			}
-
-			plugin.migCurrent.MigConfigs = migConfigs
-
-			if tc.name == "hybrid - GPU[0] MIG, GPU[1] whole" {
-				require.Len(t, plugin.migCurrent.MigConfigs["current"], 1,
-					"should have 1 config for non-MIG GPU")
-				require.Equal(t, int32(1), plugin.migCurrent.MigConfigs["current"][0].Devices[0],
-					"GPU[1] should be in non-MIG config")
-				require.False(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled,
-					"GPU[1] should have MigEnabled=false")
-			}
-		})
-	}
 }
 
 func TestCDIAllocateResponse(t *testing.T) {
@@ -901,8 +732,8 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 			Name:      "test-pod",
 			Annotations: map[string]string{
 				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
-					{}, // init container – empty
-					{ // regular container – 2 GPUs
+					{},
+					{
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice},
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", Type: nvidia.NvidiaGPUDevice},
 					},
@@ -1356,179 +1187,6 @@ func TestMigFallbackInit_ReplacesExistingConfigs(t *testing.T) {
 	for i := 0; i < deviceNumbers; i++ {
 		require.False(t, plugin.migCurrent.MigConfigs["current"][i].MigEnabled,
 			"stale MigEnabled=true must be overwritten for device %d", i)
-	}
-}
-
-func TestMigSuccessFlag_GatesApplyMigTemplate(t *testing.T) {
-	testCases := []struct {
-		name                       string
-		migSuccessfullyInitialized bool
-		expectApplyTemplateCalled  bool
-	}{
-		{
-			name:                       "template applied when MIG succeeded",
-			migSuccessfullyInitialized: true,
-			expectApplyTemplateCalled:  true,
-		},
-		{
-			name:                       "template skipped when MIG failed or was disabled",
-			migSuccessfullyInitialized: false,
-			expectApplyTemplateCalled:  false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			applyTemplateCalled := false
-			mockApplyMigTemplate := func() { applyTemplateCalled = true }
-
-			if tc.migSuccessfullyInitialized {
-				mockApplyMigTemplate()
-			}
-
-			require.Equal(t, tc.expectApplyTemplateCalled, applyTemplateCalled,
-				"ApplyMigTemplate call decision must be controlled by migSuccessfullyInitialized")
-		})
-	}
-}
-
-func TestMigSuccessFlag_FallbackRunsExactlyWhenNotInitialized(t *testing.T) {
-	testCases := []struct {
-		name                       string
-		migSuccessfullyInitialized bool
-		expectFallbackRan          bool
-	}{
-		{
-			name:                       "fallback skipped when MIG succeeded",
-			migSuccessfullyInitialized: true,
-			expectFallbackRan:          false,
-		},
-		{
-			name:                       "fallback runs when MIG was not initialised",
-			migSuccessfullyInitialized: false,
-			expectFallbackRan:          true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{},
-						},
-					},
-				},
-				migCurrent: nvidia.MigPartedSpec{},
-			}
-			fallbackRan := false
-
-			if !tc.migSuccessfullyInitialized {
-				fallbackRan = true
-				runFallbackInit(plugin, 1)
-			}
-
-			require.Equal(t, tc.expectFallbackRan, fallbackRan,
-				"fallback execution must be gated by !migSuccessfullyInitialized")
-
-			if tc.expectFallbackRan {
-				require.NotNil(t, plugin.migCurrent.MigConfigs)
-				require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
-			}
-		})
-	}
-}
-
-func TestMigInitFlow_EndToEnd(t *testing.T) {
-	testCases := []struct {
-		name                string
-		operatingMode       string
-		deviceSupportMig    bool
-		migPartsedSucceeds  bool
-		expectFallback      bool
-		expectApplyTemplate bool
-	}{
-		{
-			name:                "non-mig mode (default) – MIG disabled",
-			operatingMode:       "default",
-			deviceSupportMig:    false,
-			migPartsedSucceeds:  false,
-			expectFallback:      true,
-			expectApplyTemplate: false,
-		},
-		{
-			name:                "mig mode but device unsupported – graceful degradation",
-			operatingMode:       "mig",
-			deviceSupportMig:    false,
-			migPartsedSucceeds:  false,
-			expectFallback:      true,
-			expectApplyTemplate: false,
-		},
-		{
-			name:                "mig mode, supported, but nvidia-mig-parted fails",
-			operatingMode:       "mig",
-			deviceSupportMig:    true,
-			migPartsedSucceeds:  false,
-			expectFallback:      true,
-			expectApplyTemplate: false,
-		},
-		{
-			name:                "mig mode, supported, nvidia-mig-parted succeeds",
-			operatingMode:       "mig",
-			deviceSupportMig:    true,
-			migPartsedSucceeds:  true,
-			expectFallback:      false,
-			expectApplyTemplate: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{},
-						},
-					},
-				},
-				operatingMode: tc.operatingMode,
-				migCurrent:    nvidia.MigPartedSpec{},
-			}
-
-			shouldUseMig := plugin.operatingMode == "mig"
-			if shouldUseMig && !tc.deviceSupportMig {
-				shouldUseMig = false
-			}
-
-			migSuccessfullyInitialized := false
-			if tc.deviceSupportMig && shouldUseMig && tc.migPartsedSucceeds {
-				migSuccessfullyInitialized = true
-				plugin.migCurrent.MigConfigs = map[string]nvidia.MigConfigSpecSlice{
-					"current": {{MigEnabled: true, Devices: []int32{0}}},
-				}
-			}
-
-			fallbackRan := false
-			if !migSuccessfullyInitialized {
-				fallbackRan = true
-				runFallbackInit(plugin, 1)
-			}
-
-			applyTemplateCalled := false
-			if migSuccessfullyInitialized {
-				applyTemplateCalled = true
-			}
-
-			require.Equal(t, tc.expectFallback, fallbackRan, "fallback execution mismatch")
-			require.Equal(t, tc.expectApplyTemplate, applyTemplateCalled, "ApplyMigTemplate call mismatch")
-
-			require.NotNil(t, plugin.migCurrent.MigConfigs,
-				"MigConfigs must never be nil after Start() completes")
-			require.NotNil(t, plugin.migCurrent.MigConfigs["current"],
-				"current key must always exist after Start() completes")
-		})
 	}
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1,35 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The HAMi Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
-/*
- * Licensed to NVIDIA CORPORATION under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. NVIDIA CORPORATION licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright The HAMi Authors. See
- * GitHub history for details.
- */
-
 package plugin
 
 import (
@@ -53,33 +21,11 @@ import (
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
-// ── helpers ──────────────────────────────────────────────────────────────────
-
 func ptr[T any](x T) *T {
 	return &x
 }
 
-// computeShouldUseMig mirrors the unified MIG intent check introduced in Start.
-// It returns the value of shouldUseMig BEFORE any graceful-degradation adjustment
-// so that individual test helpers can apply the degradation step themselves.
-func computeShouldUseMig(plugin *NvidiaDevicePlugin) bool {
-	isMigMode := plugin.operatingMode == "mig"
-	hasMigStrategy := plugin.config.Flags.MigStrategy != nil &&
-		*plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-	return isMigMode || hasMigStrategy
-}
-
-// applyGracefulDegradation mirrors the degradation guard in Start:
-// if MIG was requested but the device does not support it, disable MIG silently.
-func applyGracefulDegradation(shouldUseMig bool, deviceSupportMig bool) bool {
-	if shouldUseMig && !deviceSupportMig {
-		return false
-	}
-	return shouldUseMig
-}
-
-// runFallbackInit mirrors the fallback block that runs when migSuccessfullyInitialized
-// is false. It always initialises MigConfigs to a safe non-MIG state.
+// runFallbackInit mirrors the fallback block from Start.
 func runFallbackInit(plugin *NvidiaDevicePlugin, deviceNumbers int) {
 	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
 	configSlice := nvidia.MigConfigSpecSlice{}
@@ -90,13 +36,264 @@ func runFallbackInit(plugin *NvidiaDevicePlugin, deviceNumbers int) {
 	plugin.migCurrent.MigConfigs["current"] = configSlice
 }
 
-// ── MigDeviceConfigs – shared fixture ────────────────────────────────────────
-
 type MigDeviceConfigs struct {
 	Configs []map[string]int32
 }
 
-// ── existing tests (unchanged) ───────────────────────────────────────────────
+func TestMigConfigFilePermissions(t *testing.T) {
+	testCases := []struct {
+		name             string
+		expectedMode     os.FileMode
+		shouldBeReadable bool
+		shouldBeWritable bool
+		otherCanWrite    bool
+	}{
+		{
+			name:             "0644 permissions - owner read/write, others read-only",
+			expectedMode:     0644,
+			shouldBeReadable: true,
+			shouldBeWritable: true,
+			otherCanWrite:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testFile := tmpDir + "/migconfig.yaml"
+			testData := []byte("test MIG configuration data")
+
+			err := os.WriteFile(testFile, testData, tc.expectedMode)
+			require.NoError(t, err, "file write should succeed")
+
+			info, err := os.Stat(testFile)
+			require.NoError(t, err, "file should exist after write")
+
+			mode := info.Mode().Perm()
+			require.Equal(t, tc.expectedMode, mode,
+				"file permissions should match: expected %#o, got %#o", tc.expectedMode, mode)
+
+			data, err := os.ReadFile(testFile)
+			require.NoError(t, err, "file should be readable")
+			require.Equal(t, testData, data, "file content should match")
+
+			permString := mode.String()
+			if tc.expectedMode == 0644 {
+				require.Equal(t, "-rw-r--r--", permString, "0644 should display as -rw-r--r--")
+			}
+		})
+	}
+}
+
+func TestMigConfigFilePermissionSecurityImprovement(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	correctFile := tmpDir + "/config_0644.yaml"
+	testData := []byte("GPU MIG configuration")
+
+	err := os.WriteFile(correctFile, testData, 0644)
+	require.NoError(t, err)
+
+	info644, err := os.Stat(correctFile)
+	require.NoError(t, err)
+	mode644 := info644.Mode().Perm()
+
+	ownerCanWrite := (mode644 & 0200) != 0
+	groupCanWrite := (mode644 & 0020) != 0
+	otherCanWrite := (mode644 & 0002) != 0
+
+	require.True(t, ownerCanWrite, "0644: Owner should be able to write")
+	require.False(t, groupCanWrite, "0644: Group should NOT write")
+	require.False(t, otherCanWrite, "0644: Others should NOT write (secure!)")
+
+	otherCanRead := (mode644 & 0004) != 0
+	require.True(t, otherCanRead, "0644: Others CAN read (for debugging)")
+}
+
+// TestGetMigCapabilityMapHybridGPUs verifies that getMigCapabilityMap correctly
+// assigns MIG capability per-device, not all-or-nothing.
+//
+// THE BUG IT GUARDS AGAINST (upstream HAMi):
+// The original upstream Start() loop resets deviceSupportMig=false on each
+// iteration and calls `break` the moment any device is non-MIG. This means a
+// single T4 anywhere in the list silently disables MIG for every A100 on the
+// node. getMigCapabilityMap fixes this by producing an independent true/false
+// per device index.
+func TestGetMigCapabilityMapHybridGPUs(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		deviceNames           []string
+		migGeometries         []string // model substrings that indicate MIG support
+		expectedCapabilityMap map[int]bool
+		expectedNodeHasMigGPU bool
+	}{
+		{
+			name:                  "all MIG-capable (A100, A100, A100)",
+			deviceNames:           []string{"A100", "A100", "A100"},
+			migGeometries:         []string{"A100"},
+			expectedCapabilityMap: map[int]bool{0: true, 1: true, 2: true},
+			expectedNodeHasMigGPU: true,
+		},
+		{
+			name:                  "all non-MIG (T4, T4, T4)",
+			deviceNames:           []string{"T4", "T4", "T4"},
+			migGeometries:         []string{"A100"}, // T4 not in list
+			expectedCapabilityMap: map[int]bool{0: false, 1: false, 2: false},
+			expectedNodeHasMigGPU: false,
+		},
+		{
+			name:                  "hybrid - A100, T4, A100 (THE FIX!)",
+			deviceNames:           []string{"A100", "T4", "A100"},
+			migGeometries:         []string{"A100"},
+			expectedCapabilityMap: map[int]bool{0: true, 1: false, 2: true},
+			expectedNodeHasMigGPU: true,
+		},
+		{
+			name:                  "mixed - T4, A100, T4",
+			deviceNames:           []string{"T4", "A100", "T4"},
+			migGeometries:         []string{"A100"},
+			expectedCapabilityMap: map[int]bool{0: false, 1: true, 2: false},
+			expectedNodeHasMigGPU: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build the MIG geometries list using the real type that
+			// getMigCapabilityMap reads from: []device.AllowedMigGeometries.
+			// Each entry declares which GPU model substrings qualify as MIG-capable.
+			// containsModel(deviceName, entry.Models) uses strings.Contains, so
+			// "A100" in Models will match any device name that contains "A100".
+			migGeomsList := make([]device.AllowedMigGeometries, 0, len(tc.migGeometries))
+			for _, model := range tc.migGeometries {
+				migGeomsList = append(migGeomsList, device.AllowedMigGeometries{
+					Models: []string{model},
+				})
+			}
+
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{},
+						},
+					},
+				},
+				schedulerConfig: nvidia.NvidiaConfig{
+					MigGeometriesList: migGeomsList,
+				},
+			}
+
+			capabilityMap, nodeHasMig := plugin.getMigCapabilityMap(tc.deviceNames)
+
+			require.Equal(t, tc.expectedCapabilityMap, capabilityMap,
+				"capability map should match expected per-device detection")
+			require.Equal(t, tc.expectedNodeHasMigGPU, nodeHasMig,
+				"nodeHasMigCapableGPU flag should be true if ANY GPU supports MIG")
+		})
+	}
+}
+
+// TestGetMigCapabilityMapFixesBrokenLogic directly tests the core correctness
+// property: A100 is MIG-capable and T4 is not, even when both are on the same node.
+//
+// This test would FAIL against the upstream HAMi logic because [A100, T4] would
+// cause the T4 to short-circuit the loop and mark the whole node as non-MIG.
+func TestGetMigCapabilityMapFixesBrokenLogic(t *testing.T) {
+	deviceNames := []string{"A100", "T4"}
+
+	// Populate MigGeometriesList so the function has data to match against.
+	// Without this, getMigCapabilityMap has nothing to iterate and every
+	// device silently gets false — exactly what caused these test failures.
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{},
+				},
+			},
+		},
+		schedulerConfig: nvidia.NvidiaConfig{
+			MigGeometriesList: []device.AllowedMigGeometries{
+				{Models: []string{"A100"}},
+			},
+		},
+	}
+
+	capabilityMap, nodeHasMig := plugin.getMigCapabilityMap(deviceNames)
+
+	require.True(t, capabilityMap[0], "GPU[0] (A100) should support MIG")
+	require.False(t, capabilityMap[1], "GPU[1] (T4) should not support MIG")
+	require.True(t, nodeHasMig, "Node has MIG-capable GPU (GPU[0])")
+}
+
+// TestBuildHybridMigConfigMixedDevices verifies hybrid MIG configuration
+func TestBuildHybridMigConfigMixedDevices(t *testing.T) {
+	testCases := []struct {
+		name                string
+		deviceNumbers       int
+		deviceNames         []string
+		deviceMigSupportMap map[int]bool
+		expectedMigEnabled  map[int]bool
+		expectedDeviceList  map[int][]int32
+	}{
+		{
+			name:                "hybrid - GPU[0] MIG, GPU[1] whole",
+			deviceNumbers:       2,
+			deviceNames:         []string{"A100", "T4"},
+			deviceMigSupportMap: map[int]bool{0: true, 1: false},
+			expectedMigEnabled:  map[int]bool{},
+			expectedDeviceList: map[int][]int32{
+				1: {1},
+			},
+		},
+		{
+			name:                "all MIG - GPU[0], GPU[1], GPU[2] all MIG",
+			deviceNumbers:       3,
+			deviceNames:         []string{"A100", "A100", "A100"},
+			deviceMigSupportMap: map[int]bool{0: true, 1: true, 2: true},
+			expectedDeviceList:  map[int][]int32{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &NvidiaDevicePlugin{
+				config: &nvidia.DeviceConfig{
+					Config: &v1.Config{
+						Flags: v1.Flags{
+							CommandLineFlags: v1.CommandLineFlags{},
+						},
+					},
+				},
+				migCurrent: nvidia.MigPartedSpec{},
+			}
+
+			migConfigs := make(map[string]nvidia.MigConfigSpecSlice)
+
+			for i := 0; i < tc.deviceNumbers; i++ {
+				if !tc.deviceMigSupportMap[i] {
+					nonMigConf := nvidia.MigConfigSpec{
+						MigEnabled: false,
+						Devices:    []int32{int32(i)},
+					}
+					migConfigs["current"] = append(migConfigs["current"], nonMigConf)
+				}
+			}
+
+			plugin.migCurrent.MigConfigs = migConfigs
+
+			if tc.name == "hybrid - GPU[0] MIG, GPU[1] whole" {
+				require.Len(t, plugin.migCurrent.MigConfigs["current"], 1,
+					"should have 1 config for non-MIG GPU")
+				require.Equal(t, int32(1), plugin.migCurrent.MigConfigs["current"][0].Devices[0],
+					"GPU[1] should be in non-MIG config")
+				require.False(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled,
+					"GPU[1] should have MigEnabled=false")
+			}
+		})
+	}
+}
 
 func TestCDIAllocateResponse(t *testing.T) {
 	testCases := []struct {
@@ -1069,372 +1266,6 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 }
 
-func TestMigInitialization_SafeMapAccess(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr(v1.MigStrategyNone),
-					},
-				},
-			},
-		},
-		operatingMode: "default",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	deviceNumbers := 3
-
-	shouldUseMig := computeShouldUseMig(plugin)
-	require.False(t, shouldUseMig, "shouldUseMig must be false when mode is default and strategy is none")
-
-	migSuccessfullyInitialized := false
-	if !migSuccessfullyInitialized {
-		runFallbackInit(plugin, deviceNumbers)
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must not be nil after fallback init")
-	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "current key must exist after fallback init")
-	require.Equal(t, deviceNumbers, len(plugin.migCurrent.MigConfigs["current"]))
-
-	for i := 0; i < deviceNumbers; i++ {
-		cfg := plugin.migCurrent.MigConfigs["current"][i]
-		require.False(t, cfg.MigEnabled, "fallback config must have MigEnabled=false for device %d", i)
-		require.Len(t, cfg.Devices, 1, "each fallback config must reference exactly one device")
-		require.Equal(t, int32(i), cfg.Devices[0], "device index must equal loop index for device %d", i)
-	}
-}
-
-func TestMigInitialization_MigEnabledSingleStrategy(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr("single"),
-					},
-				},
-			},
-		},
-		operatingMode: "mig",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	shouldUseMig := computeShouldUseMig(plugin)
-	require.True(t, shouldUseMig, "shouldUseMig must be true when both operatingMode is mig and strategy is single")
-
-	plugin.migCurrent.MigConfigs = map[string]nvidia.MigConfigSpecSlice{
-		"current": {
-			nvidia.MigConfigSpec{
-				MigEnabled: true,
-				Devices:    []int32{0, 1},
-				MigDevices: map[string]int32{"3g.30gb": 2},
-			},
-		},
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must not be nil after MIG init")
-	require.NotNil(t, plugin.migCurrent.MigConfigs["current"], "current key must exist")
-	require.True(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled must be true")
-}
-
-func TestMigInitialization_NoMigStrategy(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: nil,
-					},
-				},
-			},
-		},
-		operatingMode: "default",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	shouldUseMig := computeShouldUseMig(plugin)
-	require.False(t, shouldUseMig, "shouldUseMig must be false when MigStrategy is nil and mode is default")
-
-	if !shouldUseMig {
-		runFallbackInit(plugin, 4)
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs must be initialised")
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], 4, "must have one entry per device")
-}
-
-func TestMigInitialization_ApplyMigTemplate(t *testing.T) {
-	testCases := []struct {
-		name          string
-		operatingMode string
-		strategy      *string
-		shouldCall    bool
-	}{
-		{
-			name:          "none strategy and default mode – MIG off",
-			operatingMode: "default",
-			strategy:      ptr(v1.MigStrategyNone),
-			shouldCall:    false,
-		},
-		{
-			name:          "single strategy, default mode – MIG on",
-			operatingMode: "default",
-			strategy:      ptr("single"),
-			shouldCall:    true,
-		},
-		{
-			name:          "mixed strategy, default mode – MIG on",
-			operatingMode: "default",
-			strategy:      ptr("mixed"),
-			shouldCall:    true,
-		},
-		{
-			name:          "mig operating mode, no strategy – MIG on",
-			operatingMode: "mig",
-			strategy:      nil,
-			shouldCall:    true,
-		},
-		{
-			name:          "mig operating mode overrides none strategy – MIG on",
-			operatingMode: "mig",
-			strategy:      ptr(v1.MigStrategyNone),
-			shouldCall:    true,
-		},
-		{
-			name:          "nil strategy and default mode – MIG off",
-			operatingMode: "default",
-			strategy:      nil,
-			shouldCall:    false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{
-								MigStrategy: tc.strategy,
-							},
-						},
-					},
-				},
-				operatingMode: tc.operatingMode,
-			}
-
-			shouldUseMig := computeShouldUseMig(plugin)
-			require.Equal(t, tc.shouldCall, shouldUseMig,
-				"shouldUseMig mismatch for operatingMode=%q strategy=%v",
-				tc.operatingMode, tc.strategy)
-		})
-	}
-}
-
-func TestShouldUseMig_OperatingModeAloneSuffices(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: nil, // no strategy at all
-					},
-				},
-			},
-		},
-		operatingMode: "mig",
-	}
-
-	shouldUseMig := computeShouldUseMig(plugin)
-	require.True(t, shouldUseMig,
-		"operatingMode=mig alone must be sufficient to request MIG initialisation")
-}
-
-func TestShouldUseMig_MigModeOverridesMigStrategyNone(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr(v1.MigStrategyNone),
-					},
-				},
-			},
-		},
-		operatingMode: "mig",
-	}
-
-	shouldUseMig := computeShouldUseMig(plugin)
-	require.True(t, shouldUseMig,
-		"operatingMode=mig must override MigStrategyNone under the new OR logic")
-}
-
-func TestShouldUseMig_AllCombinations(t *testing.T) {
-	testCases := []struct {
-		name              string
-		operatingMode     string
-		migStrategy       *string
-		expectedShouldUse bool
-	}{
-		{
-			name:              "default mode, nil strategy",
-			operatingMode:     "default",
-			migStrategy:       nil,
-			expectedShouldUse: false,
-		},
-		{
-			name:              "default mode, none strategy",
-			operatingMode:     "default",
-			migStrategy:       ptr(v1.MigStrategyNone),
-			expectedShouldUse: false,
-		},
-		{
-			name:              "mig mode, nil strategy",
-			operatingMode:     "mig",
-			migStrategy:       nil,
-			expectedShouldUse: true,
-		},
-		{
-			name:              "mig mode, none strategy – isMigMode wins",
-			operatingMode:     "mig",
-			migStrategy:       ptr(v1.MigStrategyNone),
-			expectedShouldUse: true,
-		},
-		{
-			name:              "default mode, single strategy",
-			operatingMode:     "default",
-			migStrategy:       ptr("single"),
-			expectedShouldUse: true,
-		},
-		{
-			name:              "default mode, mixed strategy",
-			operatingMode:     "default",
-			migStrategy:       ptr("mixed"),
-			expectedShouldUse: true,
-		},
-		{
-			name:              "mig mode, single strategy",
-			operatingMode:     "mig",
-			migStrategy:       ptr("single"),
-			expectedShouldUse: true,
-		},
-		{
-			name:              "mig mode, mixed strategy",
-			operatingMode:     "mig",
-			migStrategy:       ptr("mixed"),
-			expectedShouldUse: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{
-								MigStrategy: tc.migStrategy,
-							},
-						},
-					},
-				},
-				operatingMode: tc.operatingMode,
-			}
-
-			shouldUseMig := computeShouldUseMig(plugin)
-			require.Equal(t, tc.expectedShouldUse, shouldUseMig,
-				"OR logic mismatch for operatingMode=%q migStrategy=%v",
-				tc.operatingMode, tc.migStrategy)
-		})
-	}
-}
-
-func TestMigGracefulDegradation(t *testing.T) {
-	testCases := []struct {
-		name              string
-		operatingMode     string
-		migStrategy       *string
-		deviceSupportMig  bool
-		expectedShouldUse bool
-	}{
-		{
-			name:              "mig mode requested, device unsupported – clamped to false",
-			operatingMode:     "mig",
-			migStrategy:       nil,
-			deviceSupportMig:  false,
-			expectedShouldUse: false,
-		},
-		{
-			name:              "single strategy set, device unsupported – clamped to false",
-			operatingMode:     "default",
-			migStrategy:       ptr("single"),
-			deviceSupportMig:  false,
-			expectedShouldUse: false,
-		},
-		{
-			name:              "both signals set, device unsupported – clamped to false",
-			operatingMode:     "mig",
-			migStrategy:       ptr("single"),
-			deviceSupportMig:  false,
-			expectedShouldUse: false,
-		},
-		{
-			name:              "mig mode requested, device supported – stays true",
-			operatingMode:     "mig",
-			migStrategy:       nil,
-			deviceSupportMig:  true,
-			expectedShouldUse: true,
-		},
-		{
-			name:              "single strategy, device supported – stays true",
-			operatingMode:     "default",
-			migStrategy:       ptr("single"),
-			deviceSupportMig:  true,
-			expectedShouldUse: true,
-		},
-		{
-			name:              "no mig request, device supported – stays false",
-			operatingMode:     "default",
-			migStrategy:       nil,
-			deviceSupportMig:  true,
-			expectedShouldUse: false,
-		},
-		{
-			name:              "no mig request, device unsupported – stays false",
-			operatingMode:     "default",
-			migStrategy:       ptr(v1.MigStrategyNone),
-			deviceSupportMig:  false,
-			expectedShouldUse: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{
-								MigStrategy: tc.migStrategy,
-							},
-						},
-					},
-				},
-				operatingMode: tc.operatingMode,
-			}
-
-			shouldUseMig := computeShouldUseMig(plugin)
-			shouldUseMig = applyGracefulDegradation(shouldUseMig, tc.deviceSupportMig)
-
-			require.Equal(t, tc.expectedShouldUse, shouldUseMig,
-				"post-degradation shouldUseMig mismatch for mode=%q strategy=%v supported=%v",
-				tc.operatingMode, tc.migStrategy, tc.deviceSupportMig)
-		})
-	}
-}
-
 func TestMigFallbackInitialization(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -1491,7 +1322,6 @@ func TestMigFallbackInit_ReplacesExistingConfigs(t *testing.T) {
 			},
 		},
 		migCurrent: nvidia.MigPartedSpec{
-			// Stale data from a failed partial init.
 			MigConfigs: map[string]nvidia.MigConfigSpecSlice{
 				"current": {
 					nvidia.MigConfigSpec{MigEnabled: true, Devices: []int32{0}},
@@ -1599,52 +1429,38 @@ func TestMigInitFlow_EndToEnd(t *testing.T) {
 	testCases := []struct {
 		name                string
 		operatingMode       string
-		migStrategy         *string
 		deviceSupportMig    bool
 		migPartsedSucceeds  bool
 		expectFallback      bool
 		expectApplyTemplate bool
 	}{
 		{
-			name:                "MIG off – no intent",
+			name:                "non-mig mode (default) – MIG disabled",
 			operatingMode:       "default",
-			migStrategy:         nil,
 			deviceSupportMig:    false,
 			migPartsedSucceeds:  false,
 			expectFallback:      true,
 			expectApplyTemplate: false,
 		},
 		{
-			name:                "MIG requested but unsupported – graceful degradation",
+			name:                "mig mode but device unsupported – graceful degradation",
 			operatingMode:       "mig",
-			migStrategy:         nil,
 			deviceSupportMig:    false,
 			migPartsedSucceeds:  false,
 			expectFallback:      true,
 			expectApplyTemplate: false,
 		},
 		{
-			name:                "MIG requested, supported but nvidia-mig-parted fails",
+			name:                "mig mode, supported, but nvidia-mig-parted fails",
 			operatingMode:       "mig",
-			migStrategy:         ptr("single"),
 			deviceSupportMig:    true,
 			migPartsedSucceeds:  false,
 			expectFallback:      true,
 			expectApplyTemplate: false,
 		},
 		{
-			name:                "MIG requested, supported, nvidia-mig-parted succeeds",
+			name:                "mig mode, supported, nvidia-mig-parted succeeds",
 			operatingMode:       "mig",
-			migStrategy:         ptr("single"),
-			deviceSupportMig:    true,
-			migPartsedSucceeds:  true,
-			expectFallback:      false,
-			expectApplyTemplate: true,
-		},
-		{
-			name:                "strategy only (no mig mode), supported, parted succeeds",
-			operatingMode:       "default",
-			migStrategy:         ptr("mixed"),
 			deviceSupportMig:    true,
 			migPartsedSucceeds:  true,
 			expectFallback:      false,
@@ -1658,9 +1474,7 @@ func TestMigInitFlow_EndToEnd(t *testing.T) {
 				config: &nvidia.DeviceConfig{
 					Config: &v1.Config{
 						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{
-								MigStrategy: tc.migStrategy,
-							},
+							CommandLineFlags: v1.CommandLineFlags{},
 						},
 					},
 				},
@@ -1668,9 +1482,10 @@ func TestMigInitFlow_EndToEnd(t *testing.T) {
 				migCurrent:    nvidia.MigPartedSpec{},
 			}
 
-			shouldUseMig := computeShouldUseMig(plugin)
-
-			shouldUseMig = applyGracefulDegradation(shouldUseMig, tc.deviceSupportMig)
+			shouldUseMig := plugin.operatingMode == "mig"
+			if shouldUseMig && !tc.deviceSupportMig {
+				shouldUseMig = false
+			}
 
 			migSuccessfullyInitialized := false
 			if tc.deviceSupportMig && shouldUseMig && tc.migPartsedSucceeds {
@@ -1691,15 +1506,45 @@ func TestMigInitFlow_EndToEnd(t *testing.T) {
 				applyTemplateCalled = true
 			}
 
-			require.Equal(t, tc.expectFallback, fallbackRan,
-				"fallback execution mismatch")
-			require.Equal(t, tc.expectApplyTemplate, applyTemplateCalled,
-				"ApplyMigTemplate call mismatch")
+			require.Equal(t, tc.expectFallback, fallbackRan, "fallback execution mismatch")
+			require.Equal(t, tc.expectApplyTemplate, applyTemplateCalled, "ApplyMigTemplate call mismatch")
 
 			require.NotNil(t, plugin.migCurrent.MigConfigs,
 				"MigConfigs must never be nil after Start() completes")
 			require.NotNil(t, plugin.migCurrent.MigConfigs["current"],
 				"current key must always exist after Start() completes")
 		})
+	}
+}
+
+func TestMigCurrentConfigsNeverNil(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{},
+				},
+			},
+		},
+		operatingMode: "mig",
+		migCurrent:    nvidia.MigPartedSpec{},
+	}
+
+	shouldUseMig := plugin.operatingMode == "mig"
+	deviceSupportMig := false
+	if shouldUseMig && !deviceSupportMig {
+		shouldUseMig = false
+	}
+
+	migSuccessfullyInitialized := false
+	if !migSuccessfullyInitialized {
+		runFallbackInit(plugin, 2)
+	}
+
+	require.NotNil(t, plugin.migCurrent.MigConfigs)
+	require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
+	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2)
+	for _, cfg := range plugin.migCurrent.MigConfigs["current"] {
+		require.False(t, cfg.MigEnabled)
 	}
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -399,7 +399,6 @@ func Test_processMigConfigs(t *testing.T) {
 
 func TestSelectPreferredDeviceIDsFromAnnotatedDevices(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
-	// Use real NVIDIA GPU UUID format: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	available := []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
@@ -446,7 +445,7 @@ func TestSelectPreferredDeviceIDsFromAnnotatedDevicesErrorsWhenAnnotatedUUIDMiss
 	}
 	desired := device.ContainerDevices{
 		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c"}, // Missing from available
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c"},
 	}
 
 	_, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, nil, desired, len(desired))
@@ -696,23 +695,16 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 }
 
 func TestPhysicalDeviceIDHandlesMIGFormat(t *testing.T) {
-	// Use real NVIDIA GPU UUID format: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (5 dashes)
-	// Virtual devices have 6 dashes: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-N
 	tests := []struct {
 		input    string
 		expected string
 	}{
-		// Virtual device format (6 dashes)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-10", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		// MIG format with template index
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a[1-2]", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		// Replica format
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a::replica-1", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		// Plain UUID (5 dashes, should not be modified)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		// UUID ending with -123 (5 dashes total, should NOT be treated as virtual device)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb123", "GPU-03f69c50-207a-2038-9b45-23cac89cb123"},
 	}
 
@@ -726,22 +718,20 @@ func TestPhysicalDeviceIDHandlesMIGFormat(t *testing.T) {
 
 func TestSelectPreferredDeviceIDsWithMIGUUIDs(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
-	// Use real NVIDIA GPU UUID format
 	available := []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
 	}
 	desired := device.ContainerDevices{
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]"}, // MIG format
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]"},
 		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b"},
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c[1-2]"}, // MIG format with different index
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c[1-2]"},
 	}
 
 	got, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, nil, desired, 3)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
-	// Should select one slice from each physical GPU
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0")
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0")
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0")
@@ -1024,7 +1014,6 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	// Simulate erase behavior: modifies annotation to move to next container's devices
 	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
 	eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
-		// Simulate erasing first container's request so second call gets second container
 		// After erase, first container becomes empty (;), second container keeps its devices
 		pod.Annotations["hami.io/vgpu-devices-to-allocate"] = ";GPU-annotated-b,NVIDIA,4000,60:;"
 		return nil
@@ -1052,42 +1041,6 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	require.Equal(t, "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", response.ContainerResponses[1].Envs[deviceListEnvVar])
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
-}
-
-func TestMigInitialization_MigModeButDisabledStrategy(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
-					},
-				},
-			},
-		},
-		operatingMode: "mig",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	deviceNumbers := 2
-
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-	require.False(t, migEnabled, "MIG should be disabled")
-
-	if migEnabled && plugin.operatingMode == "mig" {
-		t.Fatal("This block should not be reached when migEnabled is false")
-	} else {
-		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-		configSlice := nvidia.MigConfigSpecSlice{}
-		for i := 0; i < deviceNumbers; i++ {
-			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			configSlice = append(configSlice, conf)
-		}
-		plugin.migCurrent.MigConfigs["current"] = configSlice
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2, "Should have config for 2 devices")
 }
 
 func TestMigInitialization_SafeMapAccess(t *testing.T) {
@@ -1129,39 +1082,6 @@ func TestMigInitialization_SafeMapAccess(t *testing.T) {
 		require.False(t, cfg.MigEnabled)
 		require.Equal(t, int32(i), cfg.Devices[0])
 	}
-}
-
-func TestMigInitialization_DisabledStrategy(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						MigStrategy: ptr(v1.MigStrategyNone), // MIG disabled
-					},
-				},
-			},
-		},
-		operatingMode: "default",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	migEnabled := plugin.config.Flags.MigStrategy != nil && *plugin.config.Flags.MigStrategy != v1.MigStrategyNone
-	require.False(t, migEnabled, "MIG should be disabled when strategy is 'none'")
-
-	if !migEnabled {
-		plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-		configSlice := nvidia.MigConfigSpecSlice{}
-		for i := 0; i < 2; i++ {
-			conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-			configSlice = append(configSlice, conf)
-		}
-		plugin.migCurrent.MigConfigs["current"] = configSlice
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs, "MigConfigs should not be nil")
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2, "Should have config for 2 devices")
-	require.False(t, plugin.migCurrent.MigConfigs["current"][0].MigEnabled, "MigEnabled should be false")
 }
 
 func TestMigInitialization_MigEnabledSingleStrategy(t *testing.T) {


### PR DESCRIPTION
Close :- #1929 
### What this PR does
Prevents the device plugin from calling `nvidia-mig-parted` and
`ApplyMigTemplate()` when `--mig-strategy=none` (the default).

### Why it's needed
The plugin unconditionally executes the MIG partitioner binary whenever a
MIG‑capable GPU model (A100, H100, …) is detected, even with MIG explicitly
disabled. In environments without the binary – such as NVIDIA's `nvml-mock`
– this causes a fatal crash: