### PR TITLE
fix(charts): change scheduler anti-affinity to preferred for rolling …

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -195,7 +195,7 @@ spec:
       {{- if .Values.scheduler.leaderElect }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app.kubernetes.io/component

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -196,13 +196,15 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - hami-scheduler
-            topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - hami-scheduler
+              topologyKey: "kubernetes.io/hostname"
       {{- end }}
       volumes:
         {{- if .Values.scheduler.admissionWebhook.enabled }}


### PR DESCRIPTION
## PR type
/kind/bug

## Problem
In single-node clusters, the scheduler's `podAntiAffinity` is set to `requiredDuringSchedulingIgnoredDuringExecution`, which prevents rolling updates. When updating the scheduler deployment, the new pod cannot be scheduled because the existing pod already occupies the node, causing a deadlock.

## Solution
Change the scheduler affinity configuration in Helm charts from hard anti-affinity to preferred (or remove the hard constraint), allowing the scheduler pod to be rescheduled on the same node during rolling updates.

## Changes
- Modified `charts/hami/templates/scheduler/deployment.yaml` (or relevant affinity config)

## Testing
- Verified rolling update succeeds on single-node cluster
- Multi-node clusters still benefit from preferred spread

Fixes #1933 