### PR TITLE
chore(e2e): no longer delete namespace when clean up

### DIFF
--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -80,7 +80,6 @@ jobs:
           helm uninstall hami -n hami-system --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
           kubectl wait --for=delete pod --all -n hami-system \
             --timeout=120s --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
-          kubectl delete ns hami-system --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
           kubectl annotate node --all \
             hami.io/mutex.lock- hami.io/node-handshake- \
             hami.io/node-nvidia-register- hami.io/nvidia-license- \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Deleting namespace without check resources is not safe and helm uninstall is enough for cleanup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: