### PR TITLE
fix_leaderNotify Block

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -100,7 +100,10 @@ func NewScheduler() *Scheduler {
 	if config.LeaderElect {
 		callbacks := leaderelection.LeaderCallbacks{
 			OnStartedLeading: func() {
-				s.leaderNotify <- struct{}{}
+				select {
+				case s.leaderNotify <- struct{}{}:
+				default:
+				}
 			},
 			OnStoppedLeading: func() {
 				s.lock.Lock()

--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -112,12 +112,17 @@ func (m *leaderManager) onAdd(obj any) {
 	}
 
 	m.leaseLock.Lock()
-	defer m.leaseLock.Unlock()
-
 	m.setObservedRecord(lease)
-	// Notify if we are the leader from the very begging
-	if m.isHolderOf(lease) && m.callbacks.OnStartedLeading != nil {
-		m.callbacks.OnStartedLeading()
+	// Determine callback while holding the lock, then release before invoking
+	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
+	var callback func()
+	if m.isHolderOf(lease) {
+		callback = m.callbacks.OnStartedLeading
+	}
+	m.leaseLock.Unlock()
+
+	if callback != nil {
+		callback()
 	}
 }
 
@@ -133,29 +138,32 @@ func (m *leaderManager) onUpdate(oldObj, newObj any) {
 	}
 
 	m.leaseLock.Lock()
-	defer m.leaseLock.Unlock()
 	m.setObservedRecord(newLease)
-
-	// Notify if we have been elected to become the leader
+	// Determine callback while holding the lock, then release before invoking
+	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
+	var callback func()
 	if !m.isHolderOf(oldLease) && m.isHolderOf(newLease) {
-		if m.callbacks.OnStartedLeading != nil {
-			m.callbacks.OnStartedLeading()
-		}
+		callback = m.callbacks.OnStartedLeading
 	} else if m.isHolderOf(oldLease) && !m.isHolderOf(newLease) {
-		if m.callbacks.OnStoppedLeading != nil {
-			m.callbacks.OnStoppedLeading()
-		}
+		callback = m.callbacks.OnStoppedLeading
+	}
+	m.leaseLock.Unlock()
+
+	if callback != nil {
+		callback()
 	}
 }
 
 func (m *leaderManager) onDelete(obj any) {
-	// Do nothing on delete
 	m.leaseLock.Lock()
-	defer m.leaseLock.Unlock()
-
 	m.setObservedRecord(nil)
-	if m.callbacks.OnStoppedLeading != nil {
-		m.callbacks.OnStoppedLeading()
+	// Determine callback while holding the lock, then release before invoking
+	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
+	callback := m.callbacks.OnStoppedLeading
+	m.leaseLock.Unlock()
+
+	if callback != nil {
+		callback()
 	}
 }
 

--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -113,8 +113,6 @@ func (m *leaderManager) onAdd(obj any) {
 
 	m.leaseLock.Lock()
 	m.setObservedRecord(lease)
-	// Determine callback while holding the lock, then release before invoking
-	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
 	var callback func()
 	if m.isHolderOf(lease) {
 		callback = m.callbacks.OnStartedLeading
@@ -139,8 +137,6 @@ func (m *leaderManager) onUpdate(oldObj, newObj any) {
 
 	m.leaseLock.Lock()
 	m.setObservedRecord(newLease)
-	// Determine callback while holding the lock, then release before invoking
-	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
 	var callback func()
 	if !m.isHolderOf(oldLease) && m.isHolderOf(newLease) {
 		callback = m.callbacks.OnStartedLeading
@@ -157,8 +153,6 @@ func (m *leaderManager) onUpdate(oldObj, newObj any) {
 func (m *leaderManager) onDelete(obj any) {
 	m.leaseLock.Lock()
 	m.setObservedRecord(nil)
-	// Determine callback while holding the lock, then release before invoking
-	// to avoid AB-BA deadlock with callers that hold an external lock and call IsLeader().
 	callback := m.callbacks.OnStoppedLeading
 	m.leaseLock.Unlock()
 


### PR DESCRIPTION

/kind bug

fix: https://github.com/Project-HAMi/HAMi/issues/1954

When --leader-elect is enabled and multiple scheduler replicas are running, the OnStartedLeading callback used a blocking channel send (s.leaderNotify <- struct{}{}). If the RegisterFromNodeAnnotations goroutine was busy executing register() at the moment of a leader transition, the channel buffer would be full and the send would block indefinitely, hanging the informer event handler goroutine.

With the informer goroutine stuck, no further Lease events could be processed. As a result, IsLeader() would eventually return false (due to isLeaseValid expiring without new events), causing every subsequent call to register() to be skipped. The synced flag would never be set back to true, making WaitForCacheSync block all incoming /filter requests until the kube-scheduler extender timeout fired. The only recovery was a manual pod restart.

<img width="1919" height="1080" alt="微信图片_20260512155027_686_380" src="https://github.com/user-attachments/assets/bc5379de-f0d3-4125-a142-ac8d7f23d8b8" />
<img width="1919" height="1080" alt="微信图片_20260512155506_689_380" src="https://github.com/user-attachments/assets/e603b29f-4d08-492e-a38c-4dd3f763395e" />

Fix:

Changed OnStartedLeading to use a non-blocking send (the same select/default pattern already used by doNodeNotify). If the channel already holds a pending notification — meaning register() is about to run anyway — the new notification is safely dropped without blocking the informer goroutine.

