### PR TITLE
build(docker): align HAMi with HAMi-core compile image

### DIFF
--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -108,7 +108,7 @@ jobs:
             build-args: |
               VERSION=${{ env.ref }}
               GOLANG_IMAGE=golang:1.26.2-bookworm
-              NVIDIA_IMAGE=nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04
+              NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
               DEST_DIR=/usr/local
             tags: ${{ steps.meta.outputs.tags }}
             push: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
           build-args: |
             VERSION=${{ needs.get_info.outputs.version }}
             GOLANG_IMAGE=golang:1.26.2-bookworm
-            NVIDIA_IMAGE=nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04
+            NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
             DEST_DIR=/usr/local
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:${{ needs.get_info.outputs.version }}
           push: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*
+RUN rm -rf /usr/local/cuda-13.3/compat/libcuda.so*
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_IMAGE=golang:1.26.2-bookworm
-ARG NVIDIA_IMAGE=nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04
+ARG NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 
 FROM $GOLANG_IMAGE AS build
 FROM $GOLANG_IMAGE AS gobuild
@@ -16,8 +16,8 @@ COPY ./libvgpu /libvgpu
 COPY .git/modules/libvgpu /libvgpu-git
 RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y --no-install-recommends install cmake git && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y cmake git && dnf clean all
+RUN rm -rf /libvgpu/build
 RUN bash ./build.sh
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,11 @@ RUN cd /k8s-vgpu && make all VERSION=$VERSION
 RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM $NVIDIA_IMAGE AS nvbuild
+RUN dnf install -y cmake git && dnf clean all
 COPY ./libvgpu /libvgpu
 COPY .git/modules/libvgpu /libvgpu-git
 RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
-RUN dnf install -y cmake git && dnf clean all
 RUN rm -rf /libvgpu/build
 RUN bash ./build.sh
 

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -1,12 +1,12 @@
-ARG NVIDIA_IMAGE=nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04
+ARG NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 
 FROM $NVIDIA_IMAGE AS nvbuild
 COPY ./libvgpu /libvgpu
 COPY .git/modules/libvgpu /libvgpu-git
 RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update; apt-get -y --no-install-recommends install cmake git && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y cmake git && dnf clean all
+RUN rm -rf /libvgpu/build
 RUN bash ./build.sh
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -1,11 +1,11 @@
 ARG NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 
 FROM $NVIDIA_IMAGE AS nvbuild
+RUN dnf install -y cmake git && dnf clean all
 COPY ./libvgpu /libvgpu
 COPY .git/modules/libvgpu /libvgpu-git
 RUN rm -rf /libvgpu/.git && echo "gitdir: /libvgpu-git" > /libvgpu/.git
 WORKDIR /libvgpu
-RUN dnf install -y cmake git && dnf clean all
 RUN rm -rf /libvgpu/build
 RUN bash ./build.sh
 

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -15,7 +15,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*
+RUN rm -rf /usr/local/cuda-13.3/compat/libcuda.so*
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -23,7 +23,7 @@ export COMMIT_CODE
 export VERSION="${SHORT_VERSION}-${COMMIT_CODE}"
 export LATEST_VERSION="latest"
 export GOLANG_IMAGE="golang:1.26.2-bookworm"
-export NVIDIA_IMAGE="nvidia/cuda:12.2.0-devel-ubuntu20.04"
+export NVIDIA_IMAGE="nvidia/cuda:13.3.0-cudnn-devel-ubi8"
 export DEST_DIR="/usr/local"
 
 IMAGE=${IMAGE-"projecthami/hami"}

--- a/version.mk
+++ b/version.mk
@@ -5,7 +5,7 @@ DEVICES=nvidia
 OUTPUT_DIR=bin
 TARGET_PLATFORMS=linux/amd64
 GOLANG_IMAGE=golang:1.26.2-bookworm
-NVIDIA_IMAGE=nvidia/cuda:12.3.2-devel-ubuntu20.04
+NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 DEST_DIR=/usr/local/vgpu/
 
 VERSION = v0.0.1


### PR DESCRIPTION
## Summary
- align HAMi compile-image references with the HAMi-core base image upgrade
- bump the `libvgpu` submodule to the HAMi-core commit that switched the compile image to CUDA 13.3 UBI8
- update HAMi Docker build stages to use `dnf` and clear stale `libvgpu/build` state for the new UBI8 compile image

## Details
- update `docker/Dockerfile` and `docker/Dockerfile.hamicore` compile stages from `nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04` to `nvidia/cuda:13.3.0-cudnn-devel-ubi8`
- replace `apt-get` install steps in those compile stages with `dnf install -y cmake git && dnf clean all`
- add `rm -rf /libvgpu/build` before rebuilding `libvgpu` to match HAMi-core#204 behavior
- align the repo-level build-image constants in `version.mk` and `hack/build.sh` to the same `13.3.0-cudnn-devel-ubi8` image
- move `libvgpu` from `8c32de6` to `a26e57e`

## Validation
- `git diff --check`
- audited the remaining compile-image references to ensure HAMi no longer carries the old `12.9.1` / `12.3.2` / `12.2.0` devel image strings
