### PR TITLE
build(docker): fix stale cuda 13 runtime references

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN bash ./build.sh
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \
-    apt-mark hold cuda-toolkit-config-common cuda-toolkit-12-config-common && \
+    apt-mark hold cuda-toolkit-config-common cuda-toolkit-13-config-common && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.hamicore
+++ b/docker/Dockerfile.hamicore
@@ -11,7 +11,7 @@ RUN bash ./build.sh
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \
-    apt-mark hold cuda-toolkit-config-common cuda-toolkit-12-config-common && \
+    apt-mark hold cuda-toolkit-config-common cuda-toolkit-13-config-common && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.hamimaster
+++ b/docker/Dockerfile.hamimaster
@@ -12,11 +12,11 @@ RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \
-    apt-mark hold cuda-toolkit-config-common cuda-toolkit-12-config-common && \
+    apt-mark hold cuda-toolkit-config-common cuda-toolkit-13-config-common && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*
+RUN rm -rf /usr/local/cuda-13.3/compat/libcuda.so*
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/docker/Dockerfile.withlib
+++ b/docker/Dockerfile.withlib
@@ -12,11 +12,11 @@ RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \
-    apt-mark hold cuda-toolkit-config-common cuda-toolkit-12-config-common && \
+    apt-mark hold cuda-toolkit-config-common cuda-toolkit-13-config-common && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN rm -rf /usr/local/cuda-12.6/compat/libcuda.so*
+RUN rm -rf /usr/local/cuda-13.3/compat/libcuda.so*
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility


### PR DESCRIPTION
## Summary

Follow-up cleanup after #1958 to align the CUDA 13 runtime Dockerfiles with the actual 13.3 runtime image contents.

## Changes

- replace `cuda-toolkit-12-config-common` with `cuda-toolkit-13-config-common`
- replace `cuda-12.6/compat` cleanup path with `cuda-13.3/compat`
- apply the same fix consistently across:
  - `docker/Dockerfile`
  - `docker/Dockerfile.hamicore`
  - `docker/Dockerfile.hamimaster`
  - `docker/Dockerfile.withlib`

## Validation

- `git diff --check`
- `PATH=/usr/local/go/bin:$PATH go test ./...`
  - existing env-dependent failures remain in `pkg/util/client`, `test/e2e`, and `test/e2e/node|pod` because this machine has no kubeconfig / cluster
- verified the branch diff is limited to the four runtime Dockerfiles
- verified the resulting strings now consistently reference:
  - `cuda-toolkit-13-config-common`
  - `/usr/local/cuda-13.3/compat/libcuda.so*`
