### PR TITLE
docs: add SGLang GPU-sharing example for NVIDIA

### DIFF
--- a/examples/nvidia/sglang_gpu_sharing.yaml
+++ b/examples/nvidia/sglang_gpu_sharing.yaml
@@ -1,0 +1,83 @@
+# Serve an LLM with SGLang on a HAMi-virtualized (shared) NVIDIA GPU.
+#
+# This mirrors the spirit of vllm_cross_vgpu.yaml but for the SGLang engine,
+# and focuses on GPU *sharing*: the pod is fenced to a fraction of one physical
+# GPU via HAMi's device memory (`nvidia.com/gpumem`) and compute-core
+# (`nvidia.com/gpucores`) limits. Because it only asks for a slice, other
+# workloads (another SGLang/vLLM server, batch jobs, etc.) can be scheduled
+# onto the SAME physical card at the same time.
+#
+# Inside the pod, `nvidia-smi` will report the *capped* memory total (here
+# 12000 MiB), not the full card — that is HAMi software vGPU sharing in action
+# (no hardware MIG required, so it works on any NVIDIA GPU, e.g. A10/A100/H100).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-qwen
+  labels:
+    app: sglang-qwen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sglang-qwen
+  template:
+    metadata:
+      labels:
+        app: sglang-qwen
+    spec:
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:latest
+          command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path=Qwen/Qwen3-1.7B   # pulled from Hugging Face by default
+            - --host=0.0.0.0
+            - --port=30000
+            - --mem-fraction-static=0.7       # fraction of the HAMi-granted slice
+            - --context-length=8192
+            - --attention-backend=triton
+          # To load the model from ModelScope instead of Hugging Face, set:
+          #   env:
+          #     - name: SGLANG_USE_MODELSCOPE
+          #       value: "true"
+          ports:
+            - containerPort: 30000
+          resources:
+            limits:
+              nvidia.com/gpu: 1            # request 1 (virtual) GPU
+              nvidia.com/gpumem: 12000     # hard cap: 12000 MiB of GPU memory in the pod
+              nvidia.com/gpucores: 30      # cap: 30% of the GPU's compute cores
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60            # model load + CUDA graph capture can take minutes
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        # SGLang needs a larger /dev/shm than the container default.
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-qwen
+spec:
+  selector:
+    app: sglang-qwen
+  ports:
+    - protocol: TCP
+      port: 8000          # OpenAI-compatible API: POST /v1/chat/completions
+      targetPort: 30000
+      name: sglang
+  type: ClusterIP


### PR DESCRIPTION

 Adds examples/nvidia/sglang_gpu_sharing.yaml, demonstrating how to serve an LLM with the SGLang engine
  on a HAMi-virtualized NVIDIA GPU. The pod is fenced to a fraction of one physical card via
  nvidia.com/gpumem and nvidia.com/gpucores, so other workloads can share the same GPU.

 This complements the existing vllm_cross_vgpu.yaml (vLLM) example — there was no SGLang example
  previously. The manifest is generic (upstream lmsysorg/sglang:latest, a Hugging Face model, with a
  commented ModelScope alternative) and is heavily commented to explain the HAMi sharing fields and that
  this is software vGPU sharing (no MIG required, works on any NVIDIA GPU).

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

  Adds examples/nvidia/sglang_gpu_sharing.yaml, demonstrating how to serve an LLM with the SGLang engine
  on a HAMi-virtualized NVIDIA GPU. The pod is fenced to a fraction of one physical card via
  nvidia.com/gpumem and nvidia.com/gpucores, so other workloads can share the same GPU.

  This complements the existing vllm_cross_vgpu.yaml (vLLM) example — there was no SGLang example
  previously. The manifest is generic (upstream lmsysorg/sglang:latest, a Hugging Face model, with a
  commented ModelScope alternative) and is heavily commented to explain the HAMi sharing fields and that
  this is software vGPU sharing (no MIG required, works on any NVIDIA GPU).

**Which issue(s) this PR fixes**:
  N/A — small docs/example addition (no tracking issue).

**Special notes for your reviewer**:

  - Mirrors the structure/style of examples/nvidia/vllm_cross_vgpu.yaml.
  - Verified on a HAMi cluster (NVIDIA A10, 23 GB): inside the pod nvidia-smi reports the capped memory
  total (12000 MiB), and the SGLang OpenAI-compatible API served live inference while co-scheduled with
  other GPU workloads on the same card.
  - AI assistance disclosure (per CONTRIBUTING): this example manifest and the PR text were drafted with
  the help of Claude Code (Anthropic), then reviewed and tested by me.

  ---
  Notes on a couple of fields:
  - Fixes # — delete that line (or leave the "N/A" I put), since there's no issue. A docs/example PR
  doesn't need one.
  - release-note — examples/docs don't ship a user-facing change, so NONE in the block is correct.
  - The AI disclosure is required by HAMi's CONTRIBUTING ("any AI assistance must be disclosed") — keep
  that line in.


**Does this PR introduce a user-facing change?**:_

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Kubernetes example for running SGLang with shared GPU resources.
  * Includes a ready-to-use deployment and service configuration for exposing an OpenAI-compatible API.
  * Sets up health checks and shared memory settings for improved startup and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->