### PR TITLE
fix(device): prevent panic in CheckHealth when Requesting has no timestamp

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -506,7 +506,14 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (bool, bool) {
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
-		formertime, _ := time.ParseInLocation(time.DateTime, strings.Split(handshake, "_")[1], time.Local)
+		_, timestampStr, found := strings.Cut(handshake, "_")
+		if !found {
+			return true, false
+		}
+		formertime, err := time.ParseInLocation(time.DateTime, timestampStr, time.Local)
+		if err != nil {
+			return true, false
+		}
 		if time.Now().Before(formertime.Add(time.Second * 60)) {
 			return true, false
 		}

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -712,6 +712,44 @@ func Test_CheckHealth(t *testing.T) {
 			want2: false,
 		},
 		{
+			name: "Requesting state without timestamp",
+			args: struct {
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
+			}{
+				devType: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Requesting",
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			name: "Requesting state with unparsable timestamp",
+			args: struct {
+				devType           string
+				resourceCountName string
+				n                 corev1.Node
+			}{
+				devType: "huawei.com/Ascend910",
+				n: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							util.HandshakeAnnos["huawei.com/Ascend910"]: "Requesting_not-a-timestamp",
+						},
+					},
+				},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
 			name: "Deleted state",
 			args: struct {
 				devType           string


### PR DESCRIPTION
`CheckHealth` panics on a bare `"Requesting"` annotation.

`strings.Split(handshake, "_")[1]` crashes when there is no `_` in the string. this can happen with old or hand-edited annotations.

the `Deleted` branch below already guards this with `SplitN` + a length check. the `Requesting` branch was missing the same guard.

fix: use `SplitN(handshake, "_", 2)`, return `(true, false)` if fewer than 2 parts or the timestamp does not parse.

two test cases added: bare `"Requesting"` and `"Requesting_not-a-timestamp"`.