### PR TITLE
fix(device): CheckUUID ignores noUseKey when useKey is also set

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -667,20 +667,22 @@ func Resourcereqs(pod *corev1.Pod) (counts PodDeviceRequests) {
 }
 
 func CheckUUID(annos map[string]string, id, useKey, noUseKey, deviceType string) bool {
-	userUUID, ok := annos[useKey]
-	if ok {
-		klog.V(5).Infof("check uuid for %s user uuid [%s], device id is %s", deviceType, userUUID, id)
-		// use , symbol to connect multiple uuid
-		userUUIDs := strings.Split(userUUID, ",")
-		return slices.Contains(userUUIDs, id)
+	match := func(list string) bool {
+		return slices.ContainsFunc(strings.Split(list, ","), func(u string) bool {
+			return strings.TrimSpace(u) == id
+		})
 	}
-
-	noUserUUID, ok := annos[noUseKey]
-	if ok {
+	if userUUID, ok := annos[useKey]; ok {
+		klog.V(5).Infof("check uuid for %s user uuid [%s], device id is %s", deviceType, userUUID, id)
+		if !match(userUUID) {
+			return false
+		}
+	}
+	if noUserUUID, ok := annos[noUseKey]; ok {
 		klog.V(5).Infof("check uuid for %s not user uuid [%s], device id is %s", deviceType, noUserUUID, id)
-		// use , symbol to connect multiple uuid
-		noUserUUIDs := strings.Split(noUserUUID, ",")
-		return !slices.Contains(noUserUUIDs, id)
+		if match(noUserUUID) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1390,6 +1390,32 @@ func TestCheckUUID(t *testing.T) {
 			id:   "1abc",
 			want: true,
 		},
+		{
+			name: "both GPUUseUUID and GPUNoUseUUID set, device in use list but also in nouse list",
+			annos: map[string]string{
+				GPUUseUUID:   "abc,123",
+				GPUNoUseUUID: "abc",
+			},
+			id:   "abc",
+			want: false,
+		},
+		{
+			name: "both GPUUseUUID and GPUNoUseUUID set, device in use list and not in nouse list",
+			annos: map[string]string{
+				GPUUseUUID:   "abc,123",
+				GPUNoUseUUID: "456",
+			},
+			id:   "abc",
+			want: true,
+		},
+		{
+			name: "use list with spaces around uuids, device matches after trim",
+			annos: map[string]string{
+				GPUUseUUID: " abc , 123 ",
+			},
+			id:   "abc",
+			want: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
when a pod sets both `use-uuid` and `nouse-uuid`, the `nouse-uuid` list is never checked.

the old code returns as soon as `use-uuid` matches, so `nouse-uuid` has no effect. a user who sets `use-uuid=A,B` and `nouse-uuid=B` still gets device B.

fix: check both annotations without early return. if the device is in the use list, continue and check the nouse list too.

two test cases added: device in both lists (should be rejected), device only in use list (should be allowed).