### PR TITLE
fix(quota): clamp Used to zero in RmUsage to prevent negative tracking

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -157,6 +157,10 @@ func (q *QuotaManager) RmUsage(pod *corev1.Pod, podDev PodDevices) {
 	for idx, val := range usage {
 		if qInfo, ok := (*dp)[idx]; ok && qInfo != nil {
 			qInfo.Used -= val
+			if qInfo.Used < 0 {
+				klog.V(4).InfoS("RmUsage: clamping negative Used to zero", "quota", idx, "val", val)
+				qInfo.Used = 0
+			}
 		}
 	}
 	if klog.V(4).Enabled() {

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -198,6 +198,15 @@ func TestAddUsageAndRmUsage(t *testing.T) {
 	if (*qm.Quotas[ns])[coreName].Used != 0 {
 		t.Errorf("RmUsage: expected Used core 0, got %d", (*qm.Quotas[ns])[coreName].Used)
 	}
+
+	// remove more than tracked: Used must not go below zero
+	qm.RmUsage(pod, podDev)
+	if (*qm.Quotas[ns])[memName].Used < 0 {
+		t.Errorf("RmUsage: Used memory went negative: %d", (*qm.Quotas[ns])[memName].Used)
+	}
+	if (*qm.Quotas[ns])[coreName].Used < 0 {
+		t.Errorf("RmUsage: Used core went negative: %d", (*qm.Quotas[ns])[coreName].Used)
+	}
 }
 
 func TestIsManagedQuota(t *testing.T) {


### PR DESCRIPTION
`RmUsage` subtracts without clamping, so `Used` can go below zero.

`Used < 0` is invariably wrong: a negative counter makes `FitQuota` see more capacity than actually exists, allowing pods to be scheduled past the namespace quota limit.

all current `RmUsage` call sites are gated by `TakeAndDeletePod` or the `added` flag, so this cannot be triggered today. the clamp is a defensive invariant that prevents future regressions if an ungated call site is introduced later.

fix: clamp `Used` to zero after each subtraction.

test: call `RmUsage` twice on counters already at zero, verify `Used` stays at 0.