### PR TITLE
docs: add ecosystem integrations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ HAMi also provides:
 
 ![HAMi WebUI](imgs/hami-webui-overview.png)
 
+## Ecosystem Integrations
+
+| Project | What the integration enables |
+| --- | --- |
+| [vLLM](https://github.com/vllm-project/vllm) | Run inference servers with GPU memory caps, enabling multiple models to share one GPU |
+| [Volcano](https://volcano.sh/) | Gang scheduling and queue-based batch scheduling for GPU workloads |
+| [Kueue](https://kueue.sigs.k8s.io/) | HAMi resources exposed to Kueue via ResourceTransformation for batch job queueing |
+| [Prometheus](https://prometheus.io/) | HAMi exposes per-container GPU metrics including memory usage and utilization |
+| [Grafana](https://grafana.com/) | Pre-built dashboard available for visualizing HAMi GPU metrics |
+| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | Can coexist with GPU Operator when HAMi manages scheduling and the Operator manages drivers |
+
 ## Roadmap, Governance, And Contributing
 
 HAMi is governed by [maintainers](./MAINTAINERS.md) and [contributors](./AUTHORS.md). Governance is described in the [HAMi community repository](https://github.com/Project-HAMi/community/blob/main/governance.md).

--- a/README_cn.md
+++ b/README_cn.md
@@ -165,6 +165,17 @@ HAMi 还提供：
 
 ![HAMi WebUI](imgs/hami-webui-overview.png)
 
+## 生态系统集成
+
+| 项目 | 集成说明 |
+| --- | --- |
+| [vLLM](https://github.com/vllm-project/vllm) | 以 GPU 显存上限运行推理服务器，让多个模型共享同一 GPU |
+| [Volcano](https://volcano.sh/) | 为 GPU 工作负载提供 Gang 调度和基于队列的批量调度 |
+| [Kueue](https://kueue.sigs.k8s.io/) | 通过 ResourceTransformation 将 HAMi 资源暴露给 Kueue，实现批量作业排队 |
+| [Prometheus](https://prometheus.io/) | HAMi 上报每个容器的 GPU 指标，包括显存用量和利用率 |
+| [Grafana](https://grafana.com/) | 提供预构建仪表盘，用于可视化 HAMi GPU 指标 |
+| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | 当 HAMi 负责调度、GPU Operator 负责驱动管理时，两者可共存 |
+
 ## 路线图、治理与贡献
 
 HAMi 由[维护者](./MAINTAINERS.md)和[贡献者](./AUTHORS.md)共同治理。治理规则详见 [HAMi 社区仓库](https://github.com/Project-HAMi/community/blob/main/governance.md)。

--- a/README_ja.md
+++ b/README_ja.md
@@ -165,6 +165,17 @@ HAMi は他にも以下を提供します：
 
 ![HAMi WebUI](imgs/hami-webui-overview.png)
 
+## エコシステム連携
+
+| プロジェクト | 連携内容 |
+| --- | --- |
+| [vLLM](https://github.com/vllm-project/vllm) | GPU メモリ上限付きで推論サーバーを実行し、複数モデルで 1 枚の GPU を共有 |
+| [Volcano](https://volcano.sh/) | GPU ワークロード向けのギャングスケジューリングおよびキューベースのバッチスケジューリング |
+| [Kueue](https://kueue.sigs.k8s.io/) | ResourceTransformation を通じて HAMi リソースを Kueue に公開し、バッチジョブのキューイングを実現 |
+| [Prometheus](https://prometheus.io/) | HAMi はコンテナごとの GPU メトリクス（メモリ使用量・利用率）を公開 |
+| [Grafana](https://grafana.com/) | HAMi GPU メトリクスを可視化するための事前構築済みダッシュボードを提供 |
+| [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) | HAMi がスケジューリング、GPU Operator がドライバー管理を担う構成で共存可能 |
+
 ## ロードマップ、ガバナンス、コントリビューション
 
 HAMi は[メンテナー](./MAINTAINERS.md)と[コントリビューター](./AUTHORS.md)によって管理されています。ガバナンスについては、[HAMi コミュニティリポジトリ](https://github.com/Project-HAMi/community/blob/main/governance.md)を参照してください。


### PR DESCRIPTION
Adds an Ecosystem Integrations section to README.md listing the projects and tools that integrate with HAMi.

The main README already covers Why HAMi, architecture, and supported devices well. This fills the one remaining gap from issue Project-HAMi/website#418: a table of ecosystem integrations with a one-line description per entry.

Integrations covered:
- vLLM
- Volcano
- Kueue
- Prometheus
- Grafana
- NVIDIA GPU Operator

Closes Project-HAMi/website#418