### PR TITLE
docs: fix typo and mark AMD and MIG as supported in roadmap

### DIFF
--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -1,5 +1,5 @@
 # roadmap
-| Production | Manufactor    | Type             | MemoryIsolation | CoreIsolation | MultiCard support |
+| Production | Manufacturer  | Type             | MemoryIsolation | CoreIsolation | MultiCard support |
 |------------|---------------|------------------|-----------------|---------------|-------------------|
 | GPU        | NVIDIA        | All              | ✅              | ✅            | ✅                |
 | MLU        | Cambricon     | 370, 590         | ✅              | ✅            | ❌                |
@@ -16,7 +16,7 @@
 
 
 - [ ] Support video codec processing
-- [ ] Support Multi-Instance GPUs (MIG)
+- [x] Support Multi-Instance GPUs (MIG)
 - [ ] Support Flexible scheduling policies
   - [x] binpack
   - [x] spread
@@ -25,5 +25,5 @@
 - [ ] Rich observability support
 - [ ] DRA Support
 - [ ] Support Intel GPU device
-- [ ] Support AMD GPU device
+- [x] Support AMD GPU device
 - [x] Support Enflame GCU device


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

- "Manufactor" -> "Manufacturer" in table header
- AMD GPU: `[ ]` -> `[x]`, `pkg/device/amd/` exists and is registered
- MIG: `[ ]` -> `[x]`, dynamic MIG is implemented and documented in `docs/develop/dynamic-mig.md`

**Does this PR introduce a user-facing change?**:

NONE