### PR TITLE
docs: update supported versions to v2.9.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ The following table outlines which versions of HAMi receive security updates:
 
 | Version | Supported          |
 |---------|--------------------|
-| 2.5.x   | ✅ Security fixes |
-| 2.4.x   | ✅ Security fixes |
-| before 2.4.0   | ❌ No longer supported |
+| 2.9.x   | ✅ Security fixes |
+| 2.8.x   | ✅ Security fixes |
+| before 2.8.0   | ❌ No longer supported |
 
 ## Reporting a Vulnerability
 

--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -8,7 +8,7 @@ This document provides detailed descriptions of all configurable values paramete
 |-----------|-------------|---------------|
 | `global.imageRegistry` | Global Docker image registry | `""` |
 | `global.imagePullSecrets` | Global Docker image pull secrets | `[]` |
-| `global.imageTag` | Image tag | `"v2.8.0"` |
+| `global.imageTag` | Image tag | `"v2.9.0"` |
 | `global.gpuHookPath` | GPU Hook path | `/usr/local` |
 | `global.labels` | Global labels | `{}` |
 | `global.annotations` | Global annotations | `{}` |


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

- SECURITY.md: update supported versions from 2.4.x/2.5.x to 2.8.x/2.9.x (latest release is v2.9.0)
- charts/hami/README.md: update `global.imageTag` default from v2.8.0 to v2.9.0

**Does this PR introduce a user-facing change?**:

NONE