### PR TITLE
docs: fix Spread score description in scheduler-policy.md

### DIFF
--- a/docs/develop/scheduler-policy.md
+++ b/docs/develop/scheduler-policy.md
@@ -106,7 +106,7 @@ So, in `Binpack` policy we can select `Node1`.
 
 #### Spread
 
-Spread mainly considers node resource usage. The less it is used, the higher the score.
+Spread mainly considers node resource usage. The less it is used, the lower the score. Spread selects the node with the lowest score.
 
 ```
 score: ((request + used) / allocatable) * 10 
@@ -149,7 +149,7 @@ So, in `Binpack` policy we can select `GPU2`.
 
 #### Spread
 
-Spread mainly focuses on the computing power and video memory usage of each card. The less it is used, the higher the score.
+Spread mainly focuses on the computing power and video memory usage of each card. The less it is used, the lower the score. Spread selects the GPU with the lowest score.
 ```
 score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Both Spread sections said "the less it is used, the higher the score" which is wrong. The score formula is identical for Binpack and Spread; what differs is selection: Spread picks the node/GPU with the **lowest** score. Verified in `pkg/scheduler/policy/gpu_policy.go` (`Less` returns `score[i] > score[j]` for Spread, so sort picks the lowest).

**Does this PR introduce a user-facing change?**:

NONE