### PR TITLE
docs: fix typo and annotation keys in protocol.md

### DIFF
--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -24,7 +24,7 @@ hami.io/node-mlu-register: MLU-45013011-2257-0000-0000-000000000000,10,23308,0,M
 hami.io/node-nvidia-register: GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true:GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true:
 
 ```
-In this example, this node has two different AI devices, 2 Nvidia-V100 GPUs, and 2 Cambircon 370-X4 MLUs
+In this example, this node has two different AI devices, 2 Nvidia-V100 GPUs, and 2 Cambricon 370-X4 MLUs
 
 Note that a device node may become unavailable due to hardware or network failure, if a node hasn't registered in last 5 minutes, scheduler will mark that node as 'unavailable'.
 
@@ -44,9 +44,9 @@ If hami.io/node-handshake annotations remains in "Requesting_xxxx" and {schedule
 HAMi scheduler needs to patch schedule decisions into pod annotations, in the format of the following:
 
 ```
-hami.io/devices-to-allocate:{ctr1 request}:{ctr2 request}:...{Last ctr request}:
-hami.io/device-node: {schedule decision node}
-hami.io/device-schedule-time: {timestamp}
+hami.io/{device-type}-devices-to-allocate:{ctr1 request}:{ctr2 request}:...{Last ctr request}:
+hami.io/vgpu-node: {schedule decision node}
+hami.io/vgpu-time: {timestamp}
 ```
 
 each container request is in the following format:

--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -60,7 +60,7 @@ for example:
 A pod with 2 containers, first container requests 1 GPU with 3G device Memory, second container requests 1 GPU with 5G device Memory, then the patched annotations will be like the
 
 ```
-hami.io/devices-to-allocate: GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,3000,0:GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,5000,0: 
+hami.io/nvidia-devices-to-allocate: GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,3000,0:GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,5000,0: 
 hami.io/vgpu-node: node67-4v100
 hami.io/vgpu-time: 1705054796
 ```


### PR DESCRIPTION
- Fix typo: `Cambircon` -> `Cambricon` in device example description
- Correct annotation keys to match actual implementation:
  - `hami.io/devices-to-allocate` -> `hami.io/{device-type}-devices-to-allocate`
  - `hami.io/device-node` -> `hami.io/vgpu-node`
  - `hami.io/device-schedule-time` -> `hami.io/vgpu-time`