### PR TITLE
docs: add AMD Instinct vGPU design draft (#1707)

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -60,18 +60,29 @@ The allocation result is written under the **AMD-specific** key (each vendor has
 hami.io/amd-devices-allocated: <UUID>,AMDGPU,<memMB>,<cuCount>:;
 ```
 
-Plus, an AMD-specific annotation carrying the CU bitmap:
+Plus, a dedicated AMD annotation carrying the per-device CU bitmap. Following the
+convention other vendors use for allocation data that does not fit the standard
+`UUID,Type,mem,cores` encoding (e.g. Ascend's `huawei.com/<model>`), 
+this is a separate annotation under the **`amd.com/`** namespace with a JSON value, for example:
 
-```text
-hami.io/amd-cu-mask: <UUID>=<cu_mask_hex>:;
+```json
+amd.com/cu-mask: [{"uuid":"<UUID1>","cu_mask":"0x337f"},{"uuid":"<UUID2>","cu_mask":"0x00ff"}]
 ```
+
+`cu_mask` uses ROCm's hex-bitmask form of `CU_list` (`0x[0-F]*`, e.g. `0x337f`; see
+<https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html>). 
+A JSON value avoids inventing a delimiter scheme (and the :/; collision with 
+`ROC_GLOBAL_CU_MASK`'s own grammar).
+
+The device-plugin translates each entry into the per-GPU `ROC_GLOBAL_CU_MASK` 
+at container start.
 
 Exclusivity of CU bitmaps across pods on a device must be enforced 
 under a node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`) so multiple pods never receive overlapping masks.
 
 Optional handshake:
 ```text
-hami.io/amd-cu-mask-assigned: "false" -> "true"  (set by device-plugin)
+amd.com/cu-mask-assigned: "false" -> "true"  (set by device-plugin)
 ```
 
 ## 5. Resource model and core_limit -> CU mask

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -13,10 +13,11 @@ AMD ROCm GPUs, so multiple pods can share one Instinct GPU.
 
 ## 3. Approach
 
-**Why LD_AUDIT instead of LD_PRELOAD?** ROCm 7.x HIP's internal symbol
-resolution breaks under LD_PRELOAD due to recursive interception of HIP-internal
-calls. LD_AUDIT's `la_symbind64` intercepts only cross-library bindings, avoiding
-this. The existing NVIDIA LD_PRELOAD path is unchanged. 
+**Why LD_AUDIT instead of LD_PRELOAD?**
+In our prototype on ROCm 7.x, LD_PRELOAD broke HIP — interposing HIP symbols leads 
+to recursive re-entry through HIP-internal calls. 
+Switching to LD_AUDIT (`la_symbind64`), which intercepts only cross-library bindings, 
+resolved it. The existing NVIDIA LD_PRELOAD path is unchanged.
 
 **Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
 Masking (`ROC_GLOBAL_CU_MASK`) assigns an arbitrary and fine-grained per-pod CU partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)). 
@@ -55,13 +56,13 @@ Registered under `hami.io/node-amd-register`, in JSON format — an array of `De
 
 The allocation result is written under the **AMD-specific** key (each vendor has its own):
 
-```
+```text
 hami.io/amd-devices-allocated: <UUID>,AMDGPU,<memMB>,<cuCount>:;
 ```
 
 Plus, an AMD-specific annotation carrying the CU bitmap:
 
-```
+```text
 hami.io/amd-cu-mask: <UUID>=<cu_mask_hex>:;
 ```
 
@@ -69,7 +70,7 @@ Exclusivity of CU bitmaps across pods on a device must be enforced
 under a node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`) so multiple pods never receive overlapping masks.
 
 Optional handshake:
-```
+```text
 hami.io/amd-cu-mask-assigned: "false" -> "true"  (set by device-plugin)
 ```
 

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -1,0 +1,119 @@
+# AMD Instinct vGPU Support (issue:#1707)
+
+## 1. Motivation
+
+This proposal adds per-pod **memory limiting** and **compute-unit (CU) partitioning** for 
+AMD ROCm GPUs, so multiple pods can share one Instinct GPU.
+
+## 2. Goals
+
+- Fractional allocation by memory (`amd.com/gpumem`, MB) and compute (`amd.com/gpucores`, CU count).
+- Exclusive, non-overlapping CU partitioning across pods.
+- Following HAMi's existing architecture design to achieve the functionality.
+
+## 3. Approach
+
+**Why LD_AUDIT instead of LD_PRELOAD?** ROCm 7.x HIP's internal symbol
+resolution breaks under LD_PRELOAD due to recursive interception of HIP-internal
+calls. LD_AUDIT's `la_symbind64` intercepts only cross-library bindings, avoiding
+this. The existing NVIDIA LD_PRELOAD path is unchanged. 
+
+**Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
+Masking (`ROC_GLOBAL_CU_MASK`) assigns an arbitrary and fine-grained per-pod CU partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)). 
+On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD granularity and is set per physical GPU.
+
+## 4. Protocol (scheduler <-> device-plugin)
+
+For AMD, it adds one AMD-specific annotation for the CU bitmap.
+
+### 4.1 Node registration (device-plugin -> node annotations)
+
+Registered under `hami.io/node-amd-register`, in JSON format — an array of `DeviceInfo` as follows for example:
+
+```json
+[
+  {
+    "id": "<device-id>",
+    "index": 0,
+    "count": 1,
+    "devmem": 196608,
+    "devcore": 304,
+    "type": "AMDGPU",
+    "numa": 0,
+    "mode": "hami-core",
+    "health": true
+  }
+]
+```
+
+- `devmem`  = total device memory in MB (e.g. 196608 for MI300X).
+- `devcore` = total CU count (e.g. 304 for MI300X). 
+- `id`      = device identifier.
+
+
+### 4.2 Pod allocation (scheduler -> pod annotations -> Allocate)
+
+The allocation result is written under the **AMD-specific** key (each vendor has its own):
+
+```
+hami.io/amd-devices-allocated: <UUID>,AMDGPU,<memMB>,<cuCount>:;
+```
+
+Plus, an AMD-specific annotation carrying the CU bitmap:
+
+```
+hami.io/amd-cu-mask: <UUID>=<cu_mask_hex>:;
+```
+
+Exclusivity of CU bitmaps across pods on a device must be enforced 
+under a node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`) so multiple pods never receive overlapping masks.
+
+Optional handshake:
+```
+hami.io/amd-cu-mask-assigned: "false" -> "true"  (set by device-plugin)
+```
+
+## 5. Resource model and core_limit -> CU mask
+
+Example Pod request:
+
+```yaml
+resources:
+  limits:
+    amd.com/gpu: 1          # number of physical AMD GPUs
+    amd.com/gpumem: 16384   # MB
+    amd.com/gpucores: 152   # CU count
+```
+
+### 5.1 Memory limit
+`amd.com/gpumem` (MB) flows through the shared annotation, is 
+injected by the device plugin as `HIP_DEVICE_MEMORY_LIMIT_<i>` (value `<MB>m`).
+
+### 5.2 Core limit -> CU mask (Discussion needed)
+
+`amd.com/gpucores` is a **CU count**, not a percentage (contrast NVIDIA's
+SM-utilization %). 
+And converting a count into a usable `ROC_GLOBAL_CU_MASK` is not a
+simple "set N bits" operation:
+
+1. **The hard guarantee is non-overlap.** The scheduler
+   assigns each pod a CU bitmap that does **not overlap** any other pod's bitmap on the same device. 
+   We enforce it via the bitmap allocator under a node lock.
+
+2. **Zero-interference is not guaranteed.** Even with non-overlapping 
+   masks, residual interference remains (as reported in #1707).
+
+The count -> bitmap conversion is a **scheduler's** responsibility, because non-overlap requires knowledge of the device's current
+allocation state. 
+
+The device-plugin simply passes the scheduler-decided mask through verbatim as `ROC_GLOBAL_CU_MASK`.
+
+## 6. Known limitations
+
+- **No `amd-smi` / `rocm-smi` virtualization.** 
+  These read sysfs/drm, not HIP, so
+  LD_AUDIT cannot intercept them; in-container tools may report physical resources.
+
+## 7. Discussion points
+
+- **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (to be confirmed).

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -77,8 +77,9 @@ A JSON value avoids inventing a delimiter scheme (and the :/; collision with
 The device-plugin translates each entry into the per-GPU `ROC_GLOBAL_CU_MASK` 
 at container start.
 
-Exclusivity of CU bitmaps across pods on a device must be enforced 
+Exclusivity of CU bitmaps across pods on a device will be enforced 
 under a node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`) so multiple pods never receive overlapping masks.
+(These are currently stubs; the node-lock enforcement is not yet implemented — TODO.)
 
 Optional handshake:
 ```text
@@ -110,7 +111,7 @@ simple "set N bits" operation:
 
 1. **The hard guarantee is non-overlap.** The scheduler
    assigns each pod a CU bitmap that does **not overlap** any other pod's bitmap on the same device. 
-   We enforce it via the bitmap allocator under a node lock.
+   This will be enforced via the bitmap allocator under a node lock (`LockNode` / `ReleaseNodeLock`), which currently return `nil` (TODO: implement).
 
 2. **Zero-interference is not guaranteed.** Even with non-overlapping 
    masks, residual interference remains (as reported in #1707).


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a design document (`docs/develop/amd-vgpu.md`) for AMD Instinct GPU isolation
(per-pod memory limiting + CU partitioning) on ROCm. It covers the scheduler<->device-plugin protocol
(node/pod annotations), the CU-count -> ROC_GLOBAL_CU_MASK model, and open discussion points.

Submitted as a design draft per the discussion in #1707
(https://github.com/Project-HAMi/HAMi/issues/1707#issuecomment-4160136477).

**Which issue(s) this PR fixes**:

Relates to #1707

**Special notes for your reviewer**:

AI assistance disclosure: I used Claude Code to (double) fact-check claims against the HAMi source
(annotation keys, DeviceInfo fields, per-vendor conventions) and to draft wording.
The final text was authored, edited, and reviewed by me, and all technical claims were verified against the codebase.

**Does this PR introduce a user-facing change?**:

NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new design document for AMD Instinct vGPU support on Kubernetes pods.
  * Documented fractional GPU sharing via per-pod GPU memory and compute-unit (CU) limits.
  * Explained how allocation details are conveyed between scheduling components and containers.
  * Included current limitations and guidance for required CU mask handling and enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->