### PR TITLE
Export nvidia device plugin methods for ascend device plugin

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -608,21 +608,21 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 		if strings.Contains(req.DevicesIds[0], "MIG") {
 			if plugin.config.Sharing.TimeSlicing.FailRequestsGreaterThanOne && rm.AnnotatedIDs(req.DevicesIds).AnyHasAnnotations() {
 				if len(req.DevicesIds) > 1 {
-					podAllocationFailed(nodename, current, NodeLockNvidia)
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
 					return nil, fmt.Errorf("request for '%v: %v' too large: maximum request size for shared resources is 1", plugin.rm.Resource(), len(req.DevicesIds))
 				}
 			}
 
 			for _, id := range req.DevicesIds {
 				if !plugin.rm.Devices().Contains(id) {
-					podAllocationFailed(nodename, current, NodeLockNvidia)
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
 					return nil, fmt.Errorf("invalid allocation request for '%s': unknown device: %s", plugin.rm.Resource(), id)
 				}
 			}
 
 			response, err := plugin.getAllocateResponse(req.DevicesIds)
 			if err != nil {
-				podAllocationFailed(nodename, current, NodeLockNvidia)
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}
 			responses.ContainerResponses = append(responses.ContainerResponses, response)
@@ -630,17 +630,17 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			currentCtr, devreq, err := GetNextDeviceRequest(nvidia.NvidiaGPUDevice, *current)
 			klog.Infoln("deviceAllocateFromAnnotation=", devreq)
 			if err != nil {
-				podAllocationFailed(nodename, current, NodeLockNvidia)
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
 			}
 			if len(devreq) != len(reqs.ContainerRequests[idx].DevicesIds) {
-				podAllocationFailed(nodename, current, NodeLockNvidia)
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return &kubeletdevicepluginv1beta1.AllocateResponse{}, errors.New("device number not matched")
 			}
 			if enableGetPreferredAllocation && plugin.operatingMode != "mig" {
 				alignedDevreq, err := plugin.alignContainerDevicesWithAllocatedIDs(devreq, reqs.ContainerRequests[idx].DevicesIds)
 				if err != nil {
-					podAllocationFailed(nodename, current, NodeLockNvidia)
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
 					return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
 				}
 				devreq = alignedDevreq
@@ -652,7 +652,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 
 			err = eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, *current)
 			if err != nil {
-				podAllocationFailed(nodename, current, NodeLockNvidia)
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
 			}
 
@@ -727,7 +727,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 		}
 	}
 	klog.Infoln("Allocate Response", responses.ContainerResponses)
-	podAllocationTrySuccess(nodename, nvidia.NvidiaGPUDevice, NodeLockNvidia, current)
+	PodAllocationTrySuccess(nodename, nvidia.NvidiaGPUDevice, NodeLockNvidia, current)
 	return &responses, nil
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -507,6 +507,10 @@ var podAllocationTrySuccess = func(nodeName string, devName string, lockName str
 	PodAllocationSuccess(nodeName, pod, lockName)
 }
 
+func PodAllocationTrySuccess(nodeName string, devName string, lockName string, pod *corev1.Pod) {
+	podAllocationTrySuccess(nodeName, devName, lockName, pod)
+}
+
 func PodAllocationSuccess(nodeName string, pod *corev1.Pod, lockName string) {
 	klog.Infof("Pod allocation successful for pod %s/%s on node %s", pod.Namespace, pod.Name, nodeName)
 	updatePodAnnotationsAndReleaseLock(nodeName, pod, lockName, util.DeviceBindSuccess)
@@ -526,6 +530,10 @@ func updatePodAnnotationsAndReleaseLock(nodeName string, pod *corev1.Pod, lockNa
 var podAllocationFailed = func(nodeName string, pod *corev1.Pod, lockName string) {
 	klog.Infof("Pod allocation failed for pod %s/%s on node %s", pod.Namespace, pod.Name, nodeName)
 	updatePodAnnotationsAndReleaseLock(nodeName, pod, lockName, util.DeviceBindFailed)
+}
+
+func PodAllocationFailed(nodeName string, pod *corev1.Pod, lockName string) {
+	podAllocationFailed(nodeName, pod, lockName)
 }
 
 func checkCDISpecFile(filePath, kind string) error {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -388,7 +388,7 @@ func Test_PodAllocationTrySuccess(t *testing.T) {
 	lockName := "test-lock"
 
 	// Call the function under test
-	podAllocationTrySuccess(nodeName, devName, lockName, pod)
+	PodAllocationTrySuccess(nodeName, devName, lockName, pod)
 
 	// Refresh the pod state from the fake clientset and check the annotations
 	refreshedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
@@ -461,8 +461,8 @@ func Test_PodAllocationFailed(t *testing.T) {
 	nodeName := "test-node"
 	lockName := "test-lock"
 
-	// simulate a failed pod allocation
-	podAllocationFailed(nodeName, pod, lockName)
+	// simulate a failed pods
+	PodAllocationFailed(nodeName, pod, lockName)
 
 	// retrieve the pod from the fake client
 	refreshedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -461,7 +461,7 @@ func Test_PodAllocationFailed(t *testing.T) {
 	nodeName := "test-node"
 	lockName := "test-lock"
 
-	// simulate a failed pods
+	// simulate a failed pod allocation
 	PodAllocationFailed(nodeName, pod, lockName)
 
 	// retrieve the pod from the fake client


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind feature

**What this PR does / why we need it**:

commit 1040c1f3da3830f150a6edbeac6e43021155e48a unexport `PodAllocationTrySuccess` and `podAllocationFailed` functions which ascend device plugin need

Re-export nvidia device plugin util methods for ascend device plugin for unify behavior

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of NVIDIA GPU device allocation status updates across additional failure paths (invalid requests, unknown device IDs, allocation response/annotation issues, and device-count mismatches).
  * Standardized completion signaling so the system consistently reports “allocation succeeded” when a device assignment is successful.
  * Updated allocation hook handling and corresponding tests to ensure consistent behavior going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->