### PR TITLE
fix(chart): declare metrics port on vGPU monitor container

### DIFF
--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -191,6 +191,10 @@ spec:
             {{- with .Values.devicePlugin.monitor.extraEnvs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9394
+              protocol: TCP
           resources:
           {{- toYaml .Values.devicePlugin.monitor.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `vgpu-monitor` container in the device-plugin DaemonSet serves Prometheus
metrics on `:9394` (the `--metrics-bind-address` default in `cmd/vGPUmonitor/main.go`),
and the `hami-device-plugin-monitor` Service forwards to that port. However, the
port was never declared in the container's `ports:` spec.

This means the metrics endpoint is not discoverable from the Pod spec (e.g. for
`PodMonitor`/`ServiceMonitor` selectors that reference a named port).

This PR declares the named `metrics` containerPort (9394) on the `vgpu-monitor`
container, matching the convention already used by the scheduler Deployment.

The monitor Service is intentionally left unchanged: it keeps a **numeric**
`targetPort: 9394`. A numeric targetPort routes to any selected pod serving on
that port, whereas a named targetPort would require every pod the Service
selects to declare a container port of that name. Keeping it numeric makes this
change fully non-breaking.

This replaces #1085, whose branch had drifted too far from `master` to rebase.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Verified with `helm template`; the container now renders a `metrics` port and the
Service `targetPort` remains the numeric `9394` (unchanged from `master`).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

---

AI assistance disclosure: this change was prepared with the help of Claude Code (per CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed a metrics port for the vGPU monitor container, making its metrics endpoint explicitly available on TCP port 9394.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->