### PR TITLE
docs(CONTRIBUTING): add guideline to separate cosmetics from function…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,3 +154,4 @@ To make it easier for your PR to receive reviews, consider that reviewers will n
 * Follow [good coding guidelines](https://github.com/golang/go/wiki/CodeReviewComments)
 * Write [good commit messages](https://chris.beams.io/posts/git-commit/)
 * Break large changes into a logical series of smaller patches which individually make easily understandable changes, and in aggregate solve a broader issue
+* Separate cosmetics from functional changes. Cosmetic changes (reindentation, whitespace, comment wording, style fixes) must not be mixed with logic changes in the same commit — split them into their own commit. If the cosmetics are unrelated to the PR's purpose, they belong in a separate PR entirely. This keeps diffs reviewable: reviewers should not have to filter out formatting noise to find what actually changed.


### PR DESCRIPTION
…al commits

Inspired by FFmpeg code-review practices, this rule keeps diffs reviewable by requiring cosmetic changes to be in their own commits.

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In general this is good practice, but beyond that it catches a lot of cases where AI generated code edits and beautifies comments.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for code reviews.
  * Added advice to keep cosmetic changes separate from functional changes, and to split mixed work into separate commits or pull requests when helpful for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->