### PR TITLE
fix(nvidia): validate gpumem-percentage range to prevent silent unschedulability

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -571,11 +571,11 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 			if ok {
 				mempnums, ok := mem.AsInt64()
 				if ok {
-					mempnum = int32(mempnums)
-					if mempnum < 0 || mempnum > 100 {
-						klog.ErrorS(nil, "memory percentage request out of range, clamping to 100", "container", ctr.Name, "requested", mempnum)
-						mempnum = 100
+					if mempnums < 0 || mempnums > 100 {
+						klog.ErrorS(nil, "memory percentage request out of range, clamping to 100", "container", ctr.Name, "requested", mempnums)
+						mempnums = 100
 					}
+					mempnum = int32(mempnums)
 				}
 			}
 			if mempnum == 101 && memnum == 0 {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -344,6 +344,16 @@ func (dev *NvidiaGPUDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo
 
 func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	/*gpu related */
+	if err := dev.validateMemoryPercentage(ctr); err != nil {
+		return false, err
+	}
+	// Init containers are scheduled by Resourcereqs but are not passed to
+	// MutateAdmission by the webhook, so validate them here as well.
+	for idx := range p.Spec.InitContainers {
+		if err := dev.validateMemoryPercentage(&p.Spec.InitContainers[idx]); err != nil {
+			return false, err
+		}
+	}
 	priority, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourcePriority)]
 	if ok {
 		ctr.Env = append(ctr.Env, corev1.EnvVar{
@@ -379,6 +389,15 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 		})
 	}
 	return hasResource, nil
+}
+
+func (dev *NvidiaGPUDevices) validateMemoryPercentage(ctr *corev1.Container) error {
+	if pct, ok := resourceValue(ctr, corev1.ResourceName(dev.config.ResourceMemoryPercentageName)); ok {
+		if pct < 0 || pct > 100 {
+			return fmt.Errorf("invalid %s value %d in container %s: must be an integer between 0 and 100", dev.config.ResourceMemoryPercentageName, pct, ctr.Name)
+		}
+	}
+	return nil
 }
 
 func (dev *NvidiaGPUDevices) mutateContainerResource(ctr *corev1.Container) bool {
@@ -553,6 +572,10 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 				mempnums, ok := mem.AsInt64()
 				if ok {
 					mempnum = int32(mempnums)
+					if mempnum < 0 || mempnum > 100 {
+						klog.ErrorS(nil, "memory percentage request out of range, clamping to 100", "container", ctr.Name, "requested", mempnum)
+						mempnum = 100
+					}
 				}
 			}
 			if mempnum == 101 && memnum == 0 {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -347,13 +347,6 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 	if err := dev.validateMemoryPercentage(ctr); err != nil {
 		return false, err
 	}
-	// Init containers are scheduled by Resourcereqs but are not passed to
-	// MutateAdmission by the webhook, so validate them here as well.
-	for idx := range p.Spec.InitContainers {
-		if err := dev.validateMemoryPercentage(&p.Spec.InitContainers[idx]); err != nil {
-			return false, err
-		}
-	}
 	priority, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourcePriority)]
 	if ok {
 		ctr.Env = append(ctr.Env, corev1.EnvVar{

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1834,6 +1834,24 @@ func TestGenerateResourceRequests(t *testing.T) {
 			},
 		},
 		{
+			name: "gpu count + memory percentage beyond int32 range — clamped to 100 without wrapping",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(int64(1)<<32+50, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
+				Coresreq:         0,
+			},
+		},
+		{
 			name: "gpu count + memory percentage equal to sentinel 101 — clamped to 100",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -183,38 +183,6 @@ func Test_MutateAdmission_MemoryPercentageValidation(t *testing.T) {
 				t.Fatalf("expected MutateAdmission to accept percentage %d, but got error: %v", test.pct, err)
 			}
 		})
-		t.Run(test.name+" (init container)", func(t *testing.T) {
-			ctr := &corev1.Container{
-				Name: "test",
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
-					},
-				},
-			}
-			pod := &corev1.Pod{
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name: "init",
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
-									"nvidia.com/gpumem-percentage": *resource.NewQuantity(test.pct, resource.DecimalSI),
-								},
-							},
-						},
-					},
-				},
-			}
-			_, err := gpuDevices.MutateAdmission(ctr, pod)
-			if test.wantErr && err == nil {
-				t.Fatalf("expected MutateAdmission to reject init container percentage %d, but got no error", test.pct)
-			}
-			if !test.wantErr && err != nil {
-				t.Fatalf("expected MutateAdmission to accept init container percentage %d, but got error: %v", test.pct, err)
-			}
-		})
 	}
 }
 

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -128,6 +128,96 @@ func Test_MutateAdmission(t *testing.T) {
 	}
 }
 
+func Test_MutateAdmission_MemoryPercentageValidation(t *testing.T) {
+	gpuDevices := &NvidiaGPUDevices{
+		config: NvidiaConfig{
+			ResourceCountName:            "nvidia.com/gpu",
+			ResourceMemoryName:           "nvidia.com/gpumem",
+			ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+			ResourceCoreName:             "nvidia.com/gpucores",
+			DefaultGPUNum:                int32(1),
+		},
+	}
+	tests := []struct {
+		name    string
+		pct     int64
+		wantErr bool
+	}{
+		{
+			name:    "percentage of 0 is accepted",
+			pct:     0,
+			wantErr: false,
+		},
+		{
+			name:    "percentage of 100 is accepted",
+			pct:     100,
+			wantErr: false,
+		},
+		{
+			name:    "percentage of 101 is rejected",
+			pct:     101,
+			wantErr: true,
+		},
+		{
+			name:    "percentage above 100 is rejected",
+			pct:     150,
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctr := &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(test.pct, resource.DecimalSI),
+					},
+				},
+			}
+			_, err := gpuDevices.MutateAdmission(ctr, &corev1.Pod{})
+			if test.wantErr && err == nil {
+				t.Fatalf("expected MutateAdmission to reject percentage %d, but got no error", test.pct)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("expected MutateAdmission to accept percentage %d, but got error: %v", test.pct, err)
+			}
+		})
+		t.Run(test.name+" (init container)", func(t *testing.T) {
+			ctr := &corev1.Container{
+				Name: "test",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+					},
+				},
+			}
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+									"nvidia.com/gpumem-percentage": *resource.NewQuantity(test.pct, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err := gpuDevices.MutateAdmission(ctr, pod)
+			if test.wantErr && err == nil {
+				t.Fatalf("expected MutateAdmission to reject init container percentage %d, but got no error", test.pct)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("expected MutateAdmission to accept init container percentage %d, but got error: %v", test.pct, err)
+			}
+		})
+	}
+}
+
 func TestMutateAdmissionDefaultsExclusiveCore(t *testing.T) {
 	ptr := func(v int64) *int64 { return &v }
 	clone := func(in corev1.ResourceList) corev1.ResourceList {
@@ -1722,6 +1812,42 @@ func TestGenerateResourceRequests(t *testing.T) {
 				Type:             NvidiaGPUDevice,
 				Memreq:           0,
 				MemPercentagereq: 50,
+				Coresreq:         0,
+			},
+		},
+		{
+			name: "gpu count + memory percentage above 100 — clamped to 100",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(150, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
+				Coresreq:         0,
+			},
+		},
+		{
+			name: "gpu count + memory percentage equal to sentinel 101 — clamped to 100",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(101, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
 				Coresreq:         0,
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`nvidia.com/gpumem-percentage` is never range-validated. A pod requesting a value > 100 passes admission, but the scheduler then computes `memreq = Totalmem * pct / 100` — larger than any card — so the pod stays **Pending forever** with a misleading `CardInsufficientMemory` reason. A value of exactly `101` silently collides with the internal "percentage not set" sentinel in `GenerateResourceRequests`.

This PR:
- Rejects percentages outside `[0, 100]` at admission time in `MutateAdmission` with a clear error message (same pattern as Ascend's validation).
- Clamps out-of-range percentages to `100` in `GenerateResourceRequests` (validated on the raw int64 before the int32 cast to avoid wraparound), mirroring the existing `Coresreq > 100` clamp in `Fit`. This also covers init containers and pods that bypass the webhook — admission-time validation for init containers was dropped per review, as it needs more careful design.
- Adds regression tests for both paths, including an int32-overflow case.

Valid `0–100` requests are unchanged; only invalid specs (negative, 101, >100) change behavior — from silent forever-Pending to an immediate, actionable rejection.

**Which issue(s) this PR fixes**:
Fixes #1781

**Special notes for your reviewer**:

The scenario as originally reported (missing `gpumem` on v2.6.14) is largely resolved on current releases: whole-card default exists since v2.3.2 and human-readable filter reasons landed in v2.7.0 (#1097). This PR closes the remaining gap that still reproduces the silent-unschedulability on master: out-of-range percentage values.

Known pre-existing limitation (not introduced here): pods bypassing the webhook don't get the admission-time exclusive-core mutation from `defaultExclusiveCoreIfNeeded`; the clamp keeps scheduling sane for them regardless.

**Does this PR introduce a user-facing change?**:

```release-note
Pods requesting an out-of-range nvidia.com/gpumem-percentage (outside 0-100) are now rejected at admission with a clear error message instead of remaining permanently unschedulable.
```
