### PR TITLE
fix(webhook): count the resource to fit quota in webhook when reqnum > 1

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -135,12 +135,12 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 		}
 		for _, ctr := range pod.Spec.Containers {
 			req, ok := getRequest(&ctr, resourceName)
-			if ok && req == 1 {
+			if ok {
 				if memReq, ok := getRequest(&ctr, memResourceName); ok {
-					memoryReq += memReq
+					memoryReq += memReq * req
 				}
 				if coreReq, ok := getRequest(&ctr, coreResourceName); ok {
-					coresReq += coreReq
+					coresReq += coreReq * req
 				}
 			}
 		}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -356,6 +356,33 @@ func TestFitResourceQuota(t *testing.T) {
 					},
 				},
 			},
+			fit: false,
+		},
+		{
+			name: "request multiple gpus within quota",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: "hami-scheduler",
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: nil,
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":    resource.MustParse("2"),
+									"nvidia.com/gpumem": resource.MustParse("400"),
+								},
+							},
+						},
+					},
+				},
+			},
 			fit: true,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

count the resource to fit quota in webhook if reqnum > 1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU quota checks so memory and CPU requests are correctly counted when a workload requests multiple GPUs.
  * Multi-GPU jobs with matching memory requests are now more likely to pass resource fit validation as expected.
  * Added coverage for a multi-GPU scheduling scenario to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->