### PR TITLE
feat(ascend): support 910C vNPU templates vir05_1c_16g and vir10_3c_32g

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -443,5 +443,14 @@ data:
         aiCPU: 7
         runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
         overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
+        templates:
+          - name: vir05_1c_16g
+            memory: 16384
+            aiCore: 5
+            aiCPU: 1
+          - name: vir10_3c_32g
+            memory: 32768
+            aiCore: 10
+            aiCPU: 3
   {{ end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -443,6 +443,7 @@ data:
         aiCPU: 7
         runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
         overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
+        superPod: true
         templates:
           - name: vir05_1c_16g
             memory: 16384

--- a/examples/ascend/job-910C.yaml
+++ b/examples/ascend/job-910C.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ascend910c-job
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ascendhub.huawei.com/public-ascendhub/ascend-mindspore:23.0.RC3-centos7
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          huawei.com/Ascend910C: 1 # requesting 1 NPU
+          # requesting device memory; the value maps to a vNPU template (Ascend HDK 26.0.RC1):
+          #   16384 -> vir05_1c_16g (16GB, 5 aiCore, 1 aiCPU)
+          #   32768 -> vir10_3c_32g (32GB, 10 aiCore, 3 aiCPU)
+          huawei.com/Ascend910C-memory: 16384

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -131,7 +131,7 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 
 	reqNum := count.Value()
-	if dev.config.CommonWord == Ascend910CType {
+	if dev.config.CommonWord == Ascend910CType && dev.config.SuperPod {
 		if reqNum == 1 {
 			// Since the minimum allocation unit is one physical module (2 NPUs), round up the limits and requests to 2.
 			klog.InfoS("Adjusted Ascend910C device request from 1 to 2 (minimum allocation unit)", "pod", klog.KObj(p))

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -688,6 +688,7 @@ func Test_MutateAdmission910C(t *testing.T) {
 				ResourceName:      "huawei.com/Ascend910C",
 				MemoryAllocatable: 65536,
 				MemoryCapacity:    65536,
+				SuperPod:          true,
 			},
 			args: struct {
 				ctr corev1.Container
@@ -715,6 +716,7 @@ func Test_MutateAdmission910C(t *testing.T) {
 				ResourceName:      "huawei.com/Ascend910C",
 				MemoryAllocatable: 65536,
 				MemoryCapacity:    65536,
+				SuperPod:          true,
 			},
 			args: struct {
 				ctr corev1.Container
@@ -742,6 +744,7 @@ func Test_MutateAdmission910C(t *testing.T) {
 				ResourceName:      "huawei.com/Ascend910C",
 				MemoryAllocatable: 65536,
 				MemoryCapacity:    65536,
+				SuperPod:          true,
 			},
 			args: struct {
 				ctr corev1.Container
@@ -793,6 +796,67 @@ func Test_MutateAdmission910C(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_MutateAdmission910C_VNPUSplit(t *testing.T) {
+	devCfg := VNPUConfig{
+		CommonWord:         "Ascend910C",
+		ResourceName:       "huawei.com/Ascend910C",
+		ResourceMemoryName: "huawei.com/Ascend910C-memory",
+		MemoryAllocatable:  65536,
+		MemoryCapacity:     65536,
+		Templates: []Template{
+			{Name: "vir05_1c_16g", Memory: 16384, AICore: 5, AICPU: 1},
+			{Name: "vir10_3c_32g", Memory: 32768, AICore: 10, AICPU: 3},
+		},
+	}
+
+	t.Run("request 1 + vNPU memory slice is not rounded up", func(t *testing.T) {
+		ctr := corev1.Container{
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910C":        resource.MustParse("1"),
+					"huawei.com/Ascend910C-memory": resource.MustParse("16384"),
+				},
+				Requests: corev1.ResourceList{
+					"huawei.com/Ascend910C": resource.MustParse("1"),
+				},
+			},
+		}
+		dev := Devices{config: devCfg}
+		result, err := dev.MutateAdmission(&ctr, &corev1.Pod{})
+		assert.NilError(t, err)
+		assert.Assert(t, result)
+
+		npuQty := ctr.Resources.Limits["huawei.com/Ascend910C"]
+		gotNPU, _ := npuQty.AsInt64()
+		assert.Equal(t, gotNPU, int64(1), "vNPU request must stay at 1, not be rounded up to 2")
+
+		memQty := ctr.Resources.Limits["huawei.com/Ascend910C-memory"]
+		gotMem, _ := memQty.AsInt64()
+		assert.Equal(t, gotMem, int64(16384), "memory should map to the vir05_1c_16g template")
+	})
+
+	t.Run("odd NPU count is allowed when the card is split", func(t *testing.T) {
+		ctr := corev1.Container{
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910C": resource.MustParse("3"),
+				},
+				Requests: corev1.ResourceList{
+					"huawei.com/Ascend910C": resource.MustParse("3"),
+				},
+			},
+		}
+		dev := Devices{config: devCfg}
+		result, err := dev.MutateAdmission(&ctr, &corev1.Pod{})
+		assert.NilError(t, err)
+		assert.Assert(t, result)
+
+		npuQty := ctr.Resources.Limits["huawei.com/Ascend910C"]
+		gotNPU, _ := npuQty.AsInt64()
+		assert.Equal(t, gotNPU, int64(3), "odd count must be preserved in split mode")
+	})
 }
 
 func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {

--- a/pkg/device/ascend/vnpu.go
+++ b/pkg/device/ascend/vnpu.go
@@ -37,6 +37,7 @@ type VNPUConfig struct {
 	RuntimeClassName   string     `yaml:"runtimeClassName"`
 	OverwriteEnv       bool       `yaml:"overwriteEnv"`
 	Templates          []Template `yaml:"templates"`
+	SuperPod           bool       `yaml:"superPod"`
 }
 
 // VNPUs holds the global Ascend VNPU configuration, including a flag to enable


### PR DESCRIPTION
Ascend HDK 26.0.RC1 enables NPU virtualization (vNPU) on the 910C. The 910C was previously registered without any vNPU templates, so it could only be allocated as a whole card and fractional (memory/core) requests could not be scheduled.

Add the vir05_1c_16g (16GB/5 aiCore/1 aiCPU) and vir10_3c_32g (32GB/10 aiCore/3 aiCPU) templates to the scheduler device config, and add examples/ascend/job-910C.yaml demonstrating a vNPU request.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2004 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new VNPU template profiles for Ascend910C/Ascend910 in scheduler configuration.
  * Introduced a new example Pod manifest demonstrating template-specific Ascend910C resource requests.
* **Behavior Changes**
  * Enhanced Ascend910C request handling: allocation rounding and related validation now apply only when “SuperPod” mode is enabled.
* **Tests**
  * Updated and expanded admission logic tests to cover SuperPod and vNPU split behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->