### PR TITLE
docs: fix typo and wrong repo URL in release-process.md

### DIFF
--- a/.github/release-process.md
+++ b/.github/release-process.md
@@ -67,7 +67,7 @@ Update version information through PR and create a new tag
 
 ## [automatic] push a version tag
 
-> planing indicates that the plan is in progress and has not yet started.
+> planning indicates that the step is planned for automation but not yet implemented.
 
 If a tag vx.x.x is pushed , the following steps will automatically run:
 
@@ -86,14 +86,14 @@ If a tag vx.x.x is pushed , the following steps will automatically run:
     you cloud get the chart with command `helm repo add hami https://Project-HAMi.github.io/HAMi`
 
 6. generate release-notes and upload helm charts to github release
-   1. upload HAMi chart tgz to release <https://github.com/wawa0210/HAMi/releases>
-   2. **[planing]** save changelogs to <https://github.com/Project-HAMi/HAMi/blob/master/docs/CHANGELOG/${latest_tag}.md>
+   1. upload HAMi chart tgz to release <https://github.com/Project-HAMi/HAMi/releases>
+   2. **[planning]** save changelogs to <https://github.com/Project-HAMi/HAMi/blob/master/docs/CHANGELOG/${latest_tag}.md>
 
-7. **[planing]** build HAMi website
+7. **[planning]** build HAMi website
 
-8. **[planing]** Running e2e tests
+8. **[planning]** Run e2e tests
 
-9. **[planing]** Run version compatibility e2e test
+9. **[planning]** Run version compatibility e2e test
 
 For the detail, refer to <https://github.com/Project-HAMi/HAMi/blob/master/.github/workflows/auto-release.yaml>
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Two fixes in `.github/release-process.md`:
- "planing" typo corrected to "planning" (4 occurrences)
- Wrong URL `github.com/wawa0210/HAMi/releases` corrected to `github.com/Project-HAMi/HAMi/releases`

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

No logic changes, only text corrections.

**Does this PR introduce a user-facing change?**:

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the release process instructions.
  * Clarified the meaning of the “planning” status for upcoming automation steps.
  * Updated the GitHub Releases link to point to the current project location.
  * Standardized status labels across the release planning workflow (e.g., consistently using “planning” for related tasks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->