### PR TITLE
fix(vgpu-init): correct source and destination path handling

### DIFF
--- a/charts/hami/templates/device-plugin/configmap.yaml
+++ b/charts/hami/templates/device-plugin/configmap.yaml
@@ -10,6 +10,4 @@ metadata:
 data:
   config.json: |
 {{- .Values.devicePlugin.nodeConfiguration.config | nindent 4 }}
-  ld.so.preload: |
-    {{ .Values.devicePlugin.libPath }}/libvgpu.so
 {{- end }}

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -147,10 +147,6 @@ spec:
               subPath: device-config.yaml
             - name: cdi-root
               mountPath: /var/run/cdi
-            - name: deviceconfig
-              mountPath: /k8s-vgpu/lib/nvidia/ld.so.preload
-              subPath: ld.so.preload
-              readOnly: true
             {{- if typeIs "string" .Values.devicePlugin.nvidiaDriverRoot }}
             # We always mount the driver root at /driver-root in the container.
             # This is required for CDI detection to work correctly.

--- a/docker/vgpu-init.sh
+++ b/docker/vgpu-init.sh
@@ -7,10 +7,17 @@ if [ -z "$1" ]; then
 fi
 
 # Source directory
-SOURCE_DIR="/k8s-vgpu/lib/nvidia/"
+SOURCE_DIR="/k8s-vgpu/lib/nvidia"
 
-# Destination directory from the argument
-DEST_DIR="$1"
+# Destination directory from the argument. Strip trailing slash so we can
+# safely compose paths as "$DEST_DIR/$relative_path" below without producing
+# double slashes, and so that the preload content we generate at the end
+# matches the actual runtime layout exactly.
+DEST_DIR="${1%/}"
+
+if [ -z "$DEST_DIR" ]; then
+    DEST_DIR="/"
+fi
 
 
 # Check if the destination directory exists, create it if it doesn't
@@ -21,16 +28,26 @@ fi
 # Traverse all files in the source directory
 find "$SOURCE_DIR" -type f | while read -r source_file; do
     # Get the relative path of the source file
-    relative_path="${source_file#$SOURCE_DIR}"
+    relative_path="${source_file#$SOURCE_DIR/}"
+
+    # ld.so.preload is intentionally NOT copied from the image source tree.
+    # Its content is a runtime pointer to libvgpu.so and MUST match DEST_DIR,
+    # otherwise vGPU isolation silently fails when the runtime dir is
+    # customized away from the historical /usr/local/vgpu (e.g. via Helm).
+    # We regenerate it from DEST_DIR at the end of this script.
+    if [ "$relative_path" = "ld.so.preload" ]; then
+        echo "Skipped managed file: $source_file"
+        continue
+    fi
 
     # Construct the destination file path
-    dest_file="$DEST_DIR$relative_path"
+    dest_file="$DEST_DIR/$relative_path"
 
     # If the destination file doesn't exist, copy the source file
     if [ ! -f "$dest_file" ]; then
         # Create the parent directory of the destination file if it doesn't exist
         mkdir -p "$(dirname "$dest_file")"
-        
+
         # Copy the file from source to destination
         cp "$source_file" "$dest_file"
         echo "Copied: $source_file -> $dest_file"
@@ -48,3 +65,10 @@ find "$SOURCE_DIR" -type f | while read -r source_file; do
         fi
     fi
 done
+
+# Regenerate ld.so.preload so it always points at the actual mounted
+# libvgpu.so under DEST_DIR. Treating this file as runtime-generated (rather
+# than a static packaged asset) is what keeps the preload path aligned with
+# whatever runtime directory the chart passes in.
+printf '%s/libvgpu.so\n' "$DEST_DIR" > "$DEST_DIR/ld.so.preload"
+echo "Updated: $DEST_DIR/ld.so.preload -> $DEST_DIR/libvgpu.so"


### PR DESCRIPTION


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug
**What this PR does / why we need it**:

When the HAMi vGPU runtime directory is customized away from the default `/usr/local/vgpu` (for example, changed to `/var/lib/hami/vgpu` via Helm values), `docker/vgpu-init.sh` still writes an `ld.so.preload` whose content points to the old hardcoded path `/usr/local/vgpu/libvgpu.so`. The dynamic linker fails to preload `libvgpu.so` at the actual mounted location, and vGPU memory/core isolation is silently not enforced.

Root cause: `docker/vgpu-init.sh` treats `ld.so.preload` as a static packaged file and copies it verbatim from `/k8s-vgpu/lib/nvidia/ld.so.preload`, whose content is hardcoded to `/usr/local/vgpu/libvgpu.so`. No matter what `$DEST_DIR` is passed to the script, the resulting preload content never changes.
**Which issue(s) this PR fixes**:
Fixes # https://github.com/Project-HAMi/HAMi/issues/2017

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vGPU image setup to normalize destination paths (including trailing slashes/empty values) and ensure consistent file relative-path handling.
  * Regenerate the `ld.so.preload` target at install time to point to the correct runtime library location.
  * Prevent packaging of the generated preload pointer file to avoid stale or incorrect startup behavior.
* **Helm Chart Updates**
  * Removed `ld.so.preload` from the device-plugin ConfigMap output.
  * Updated the NVIDIA device-plugin DaemonSet mounts by dropping the `deviceconfig` `ld.so.preload` subPath and conditionally mounting the host driver root to `/driver-root` (read-only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->