### PR TITLE
docs: add contribution gates to AI assistance policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Welcome to HAMi!
   - [Code of Conduct](#code-of-conduct)
   - [Community Expectations](#community-expectations)
   - [AI Assistance Notice](#ai-assistance-notice)
+  - [Contribution Gates](#contribution-gates)
 - [Getting started](#getting-started)
 - [Your First Contribution](#your-first-contribution)
   - [Find something to work on](#find-something-to-work-on)
@@ -70,6 +71,22 @@ isn't a maintainer's job to review a PR so broken that it requires
 significant rework to be acceptable.
 
 Please be respectful to maintainers and disclose AI assistance.
+
+## Contribution Gates
+
+The following rules are enforced on all contributions.
+
+**1. Author-understanding gate.** If a maintainer asks how a change works and the author cannot explain it, the PR is closed. Repeated cases may result in interaction limits.
+
+**2. Hardware validation.** Changes affecting device allocation or in-container isolation must be validated on real GPU hardware before submitting. Record in the PR what was tested, the device type, and the driver version. Changes scoped to the scheduler extender may use mock or unit testing instead.
+
+**3. Scope and commit messages.** Large AI-generated PRs are not accepted. For AI-assisted contributions, anything beyond a small fix must start as an issue and be split into reviewable commits. Write your own commit messages; AI-generated commit messages are not accepted.
+
+**4. Review replies.** The reply you post must be written by you and must address the specific point raised. Verbatim or canned AI replies, or replies that do not engage the comment, lead to the PR being closed.
+
+**5. Commit trailer hygiene.** Do not list AI as a co-author. No `assisted-by`, `co-developed-by`, or similar trailers. Disclosure belongs in the PR description only.
+
+**6. AI-generated comments.** Do not post AI-generated comments in review threads. Remove any filler or redundant AI-generated text before posting. Exceptions apply only when the underlying technical assessment is entirely your own and AI is used solely to assist with language translation or formatting, provided you have fully verified and edited the output.
 
 # Getting started
 


### PR DESCRIPTION
Adds six enforceable contribution gates to the AI Assistance section of `CONTRIBUTING.md`, based on maintainer discussion in #1998.

The existing notice is kept unchanged. The new gates cover:

1. Author-understanding gate: PR closed if author cannot explain their change when asked
2. Hardware validation: required for device allocation and in-container isolation changes; scheduler extender changes may use mock testing
3. Scope and commit messages: no large AI-generated PRs; write your own commit messages
4. Review replies: must be written by the author and address the specific point
5. Commit trailer hygiene: no AI co-author trailers; disclosure in PR description only
6. AI-generated comments: do not post filler or redundant AI-generated review comments

Rule 2 is scoped per @Shouren's feedback (#1998 (comment)): scheduler extender changes do not require real GPU hardware.
Rule 6 is added per @archlitchi's feedback (#1998 (comment)).
Rules 6-8 from the original proposal are deferred pending further discussion.

## Does this PR introduce a user-facing change?

No.

Closes #1998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Contribution Gates” section to the contributor guide.
  * Updated the table of contents to include the new guidance.
  * Clarified contributor requirements, including validation expectations, scope/commit-message rules, review reply etiquette, and restrictions on review-thread comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->