### PR TITLE
fix(nvidia): refresh cache on register annotation changes

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -159,9 +159,10 @@ type DeviceConfig struct {
 }
 
 type NvidiaGPUDevices struct {
-	config         NvidiaConfig
-	ReportedGPUNum map[string]int64 // key: nodeName, value: reported GPU count
-	mu             sync.Mutex       // protects concurrent access to ReportedGPUNum
+	config                NvidiaConfig
+	ReportedGPUNum        map[string]int64  // key: nodeName, value: reported GPU count
+	ReportedRegisterAnnos map[string]string // key: nodeName, value: last observed register annotation
+	mu                    sync.Mutex        // protects concurrent access to reported node state
 }
 
 func InitNvidiaDevice(nvconfig NvidiaConfig) *NvidiaGPUDevices {
@@ -174,8 +175,9 @@ func InitNvidiaDevice(nvconfig NvidiaConfig) *NvidiaGPUDevices {
 	}
 	MemoryFactor = nvconfig.MemoryFactor
 	return &NvidiaGPUDevices{
-		config:         nvconfig,
-		ReportedGPUNum: make(map[string]int64),
+		config:                nvconfig,
+		ReportedGPUNum:        make(map[string]int64),
+		ReportedRegisterAnnos: make(map[string]string),
 	}
 }
 
@@ -233,18 +235,27 @@ func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, 
 	klog.V(3).InfoS("checking device health for node", "nodeName", n.Name, "deviceType", devType, "currentDevices", current, "reportedDevices", reported)
 
 	handshakeHealthy, handshakeChanged := device.CheckHealth(devType, dev.config.ResourceCountName, n)
+	registerAnno := n.Annotations[RegisterAnnos]
+	reportedRegisterAnno := dev.ReportedRegisterAnnos[n.Name]
 
 	if current == 0 {
 		if reported == 0 {
 			return handshakeHealthy, handshakeChanged
 		}
 		dev.ReportedGPUNum[n.Name] = current
+		dev.ReportedRegisterAnnos[n.Name] = registerAnno
 		return false, handshakeChanged
 	}
 
 	if reported != current {
 		dev.ReportedGPUNum[n.Name] = current
+		dev.ReportedRegisterAnnos[n.Name] = registerAnno
 		return true, true
+	}
+
+	if reportedRegisterAnno != registerAnno {
+		dev.ReportedRegisterAnnos[n.Name] = registerAnno
+		return handshakeHealthy, true
 	}
 
 	return handshakeHealthy, handshakeChanged

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1632,6 +1632,8 @@ func TestCheckHealth(t *testing.T) {
 		current             int64
 		reported            int64
 		handshakeAnnotation string
+		cachedRegisterAnno  string
+		registerAnno        string
 		wantHealthy         bool
 		wantNeedReset       bool
 	}{
@@ -1683,6 +1685,46 @@ func TestCheckHealth(t *testing.T) {
 			wantHealthy:         false,
 			wantNeedReset:       false,
 		},
+		{
+			name:                "current>0 reported same: changed register annotation requests refresh",
+			current:             4,
+			reported:            4,
+			handshakeAnnotation: "Requesting_" + pastTime,
+			cachedRegisterAnno: device.MarshalNodeDevices([]*device.DeviceInfo{
+				{ID: "GPU-0", Count: 10, Devmem: 8192, Devcore: 100, Type: "NVIDIA-A100", Health: true, Mode: "hami-core"},
+			}),
+			registerAnno: device.MarshalNodeDevices([]*device.DeviceInfo{
+				{ID: "GPU-0", Count: 10, Devmem: 8192, Devcore: 100, Type: "NVIDIA-A100", Health: false, Mode: "hami-core"},
+			}),
+			wantHealthy:   true,
+			wantNeedReset: true,
+		},
+		{
+			name:                "current>0 reported same: unchanged register annotation keeps cache",
+			current:             4,
+			reported:            4,
+			handshakeAnnotation: "Requesting_" + pastTime,
+			cachedRegisterAnno: device.MarshalNodeDevices([]*device.DeviceInfo{
+				{ID: "GPU-0", Count: 10, Devmem: 8192, Devcore: 100, Type: "NVIDIA-A100", Health: true, Mode: "hami-core"},
+			}),
+			registerAnno: device.MarshalNodeDevices([]*device.DeviceInfo{
+				{ID: "GPU-0", Count: 10, Devmem: 8192, Devcore: 100, Type: "NVIDIA-A100", Health: true, Mode: "hami-core"},
+			}),
+			wantHealthy:   true,
+			wantNeedReset: false,
+		},
+		{
+			name:                "current>0 reported same: deleted register annotation requests refresh",
+			current:             4,
+			reported:            4,
+			handshakeAnnotation: "Requesting_" + pastTime,
+			cachedRegisterAnno: device.MarshalNodeDevices([]*device.DeviceInfo{
+				{ID: "GPU-0", Count: 10, Devmem: 8192, Devcore: 100, Type: "NVIDIA-A100", Health: true, Mode: "hami-core"},
+			}),
+			registerAnno:  "",
+			wantHealthy:   true,
+			wantNeedReset: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1703,9 +1745,15 @@ func TestCheckHealth(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{Allocatable: allocatable},
 			}
+			if tt.registerAnno != "" {
+				node.Annotations[RegisterAnnos] = tt.registerAnno
+			}
 
 			if tt.reported > 0 {
 				dev.ReportedGPUNum["test-node"] = tt.reported
+			}
+			if tt.cachedRegisterAnno != "" {
+				dev.ReportedRegisterAnnos["test-node"] = tt.cachedRegisterAnno
 			}
 
 			healthy, needReset := dev.CheckHealth("NVIDIA", node)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR refreshes the NVIDIA scheduler device cache whenever hami.io/node-nvidia-register changes—even if the node's nvidia.com/gpu allocatable count remains unchanged.

**Which issue(s) this PR fixes**:
Fixes #2020

**Special notes for your reviewer**:
The fix is intentionally scoped to NVIDIA health refresh behavior. It does not change the device plugin health detection logic or the hami.io/node-nvidia-register format.

Verification run locally:
```
make verify
go test ./pkg/device/nvidia -run TestCheckHealth -count=1
go test ./pkg/device/nvidia -run TestDevices_Fit -count=1
go test ./pkg/device -run Test_CheckHealth -count=1
```

**Does this PR introduce a user-facing change?**:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU health checks to also track and respond to node-level GPU registration annotation updates, not only changes in allocatable GPU count.
  * Reduced unnecessary resets by treating unchanged GPU counts with changed registration metadata as an additional health-change signal.
  * Fixed handling of zero-GPU scenarios to keep cached health state consistent.
* **Tests**
  * Expanded health-check test coverage to verify correct reset/health outcomes when registration metadata changes, matches, or is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->