### PR TITLE
fix: require Ascend core resource for soft slicing

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -153,6 +153,10 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	isHAMiCore := (vnpuMode == VNPUModeHamiCore)
 
 	if isHAMiCore {
+		if dev.config.ResourceCoreName != "" && !dev.hasPositiveCoreResourceRequest(ctr) {
+			return false, fmt.Errorf("ascend soft slicing requires positive core resource %s to be requested together with %s", dev.config.ResourceCoreName, dev.config.ResourceMemoryName)
+		}
+
 		klog.V(3).Infof("Ascend core resource detected, injecting postStart lifecycle for container %s", ctr.Name)
 
 		if ctr.Lifecycle == nil {
@@ -198,6 +202,15 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		p.Spec.RuntimeClassName = &dev.config.RuntimeClassName
 	}
 	return true, nil
+}
+
+func (dev *Devices) hasPositiveCoreResourceRequest(ctr *corev1.Container) bool {
+	coreName := corev1.ResourceName(dev.config.ResourceCoreName)
+	if core, ok := ctr.Resources.Limits[coreName]; ok {
+		return core.Value() > 0
+	}
+	core, ok := ctr.Resources.Requests[coreName]
+	return ok && core.Value() > 0
 }
 
 func (dev *Devices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -805,9 +805,10 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 			ctr corev1.Container
 			pod corev1.Pod
 		}
-		wantPostStart bool
-		wantMem       int64
-		wantCore      int64
+		wantPostStart   bool
+		wantMem         int64
+		wantCore        int64
+		wantErrContains string
 	}{
 		{
 			name: "vNPU-mode hami-core: inject postStart and keep raw memory",
@@ -842,6 +843,66 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 			wantMem:       15360,
 			wantCore:      20,
 		},
+		{
+			name: "vNPU-mode hami-core: reject memory-only request",
+			args: struct {
+				ctr corev1.Container
+				pod corev1.Pod
+			}{
+				ctr: corev1.Container{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"huawei.com/Ascend910B3":        resource.MustParse("1"),
+							"huawei.com/Ascend910B3-memory": resource.MustParse("15360"),
+						},
+						Requests: corev1.ResourceList{
+							"huawei.com/Ascend910B3":        resource.MustParse("1"),
+							"huawei.com/Ascend910B3-memory": resource.MustParse("15360"),
+						},
+					},
+				},
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							VNPUModeAnnotation: VNPUModeHamiCore,
+						},
+					},
+				},
+			},
+			wantErrContains: "positive core resource huawei.com/Ascend910B3-core",
+		},
+		{
+			name: "vNPU-mode hami-core: reject zero core request",
+			args: struct {
+				ctr corev1.Container
+				pod corev1.Pod
+			}{
+				ctr: corev1.Container{
+					Name: "test-container",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"huawei.com/Ascend910B3":        resource.MustParse("1"),
+							"huawei.com/Ascend910B3-memory": resource.MustParse("15360"),
+							"huawei.com/Ascend910B3-core":   resource.MustParse("0"),
+						},
+						Requests: corev1.ResourceList{
+							"huawei.com/Ascend910B3":        resource.MustParse("1"),
+							"huawei.com/Ascend910B3-memory": resource.MustParse("15360"),
+							"huawei.com/Ascend910B3-core":   resource.MustParse("0"),
+						},
+					},
+				},
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							VNPUModeAnnotation: VNPUModeHamiCore,
+						},
+					},
+				},
+			},
+			wantErrContains: "positive core resource huawei.com/Ascend910B3-core",
+		},
 	}
 
 	for _, test := range tests {
@@ -857,6 +918,11 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 			}
 
 			ok, err := dev.MutateAdmission(&test.args.ctr, &test.args.pod)
+			if test.wantErrContains != "" {
+				assert.ErrorContains(t, err, test.wantErrContains)
+				assert.Equal(t, ok, false)
+				return
+			}
 			assert.NilError(t, err)
 			assert.Equal(t, ok, true)
 


### PR DESCRIPTION
## Summary

This PR adds an admission-time validation for Ascend soft slicing.

When a pod explicitly selects HAMi soft slicing with:

```yaml
metadata:
  annotations:
    huawei.com/vnpu-mode: hami-core
```

and the Ascend device config defines a `resourceCoreName`, the workload must request the corresponding core resource together with the memory resource. Otherwise the admission webhook now rejects the pod with a clear error.

This prevents memory-only soft-slicing requests from silently entering the template-matching path where the actual allocated memory can be greater than the requested value.

## Changes

- Validate `hami-core` Ascend workloads in `MutateAdmission`.
- Require the configured `resourceCoreName` when soft slicing is requested.
- Keep the validation scoped to configs that define a core resource, so legacy configs without `resourceCoreName` are not affected.
- Add a unit test for the memory-only rejection case.

## Related

- Related issue: Project-HAMi/ascend-device-plugin#101
- Related docs PR: Project-HAMi/ascend-device-plugin#102
- Discussion issue: #2027
## Test

- `go test ./pkg/device/ascend`
- `go test ./pkg/device`
- `go test ./pkg/scheduler`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened admission checks for vNPU core mode: containers are now rejected unless they specify a **positive** quantity for the configured core resource in either resource **limits** or **requests** (not just memory).
  * Updated the rejection message to require requesting the configured core resource together with the corresponding memory resource.
* **Tests**
  * Expanded vNPU core mode tests with new failure cases for missing core requests and core requests set to zero, including assertions on the expected error content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->