### PR TITLE
fix(ascend): reject -core on hard-split vNPU and fix "nor"->"not" typo

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -152,6 +152,21 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	vnpuMode := p.Annotations[VNPUModeAnnotation]
 	isHAMiCore := (vnpuMode == VNPUModeHamiCore)
 
+	// -core is only meaningful in hami-core (soft split) mode. On hard split the
+	// compute is fixed by the driver template, so a requested -core is reserved by
+	// the scheduler but dropped by PatchAnnotations and never delivered to the
+	// container (and exceeding the physical core count leaves the pod Pending with
+	// CardInsufficientCore). Reject the invalid combination at admission.
+	if !isHAMiCore && dev.config.ResourceCoreName != "" {
+		coreQ, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceCoreName)]
+		if !ok {
+			coreQ, ok = ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceCoreName)]
+		}
+		if ok && coreQ.Value() > 0 {
+			return false, fmt.Errorf("%s is only supported in hami-core (soft split) mode", dev.config.ResourceCoreName)
+		}
+	}
+
 	if isHAMiCore {
 		klog.V(3).Infof("Ascend core resource detected, injecting postStart lifecycle for container %s", ctr.Name)
 

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -152,11 +152,8 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	vnpuMode := p.Annotations[VNPUModeAnnotation]
 	isHAMiCore := (vnpuMode == VNPUModeHamiCore)
 
-	// -core is only meaningful in hami-core (soft split) mode. On hard split the
-	// compute is fixed by the driver template, so a requested -core is reserved by
-	// the scheduler but dropped by PatchAnnotations and never delivered to the
-	// container (and exceeding the physical core count leaves the pod Pending with
-	// CardInsufficientCore). Reject the invalid combination at admission.
+	// -core only applies to hami-core (soft split); on hard split the template
+	// fixes compute, so reject it here.
 	if !isHAMiCore && dev.config.ResourceCoreName != "" {
 		coreQ, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceCoreName)]
 		if !ok {

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -202,7 +202,7 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 	if count.Value() > 1 && !isHAMiCore {
 		if trimMem != dev.config.MemoryAllocatable {
-			return true, errors.New("vNPU nor supported for multiple devices")
+			return true, errors.New("vNPU not supported for multiple devices")
 		}
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -881,8 +881,7 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 // rejected on hard split (non hami-core) but accepted in hami-core soft-split
 // mode, and that a hard-split request without -core is unaffected.
 func Test_MutateAdmission_HardSplitCoreRejected(t *testing.T) {
-	const VNPUModeAnnotation = "huawei.com/vnpu-mode"
-	const VNPUModeHamiCore = "hami-core"
+	// VNPUModeAnnotation and VNPUModeHamiCore are the package-level constants from device.go.
 
 	// 8738 maps to the vir08 template so hard-split memory trimming succeeds.
 	newCtr := func(core string) corev1.Container {

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -877,6 +877,79 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 	}
 }
 
+// Test_MutateAdmission_HardSplitCoreRejected verifies that a -core request is
+// rejected on hard split (non hami-core) but accepted in hami-core soft-split
+// mode, and that a hard-split request without -core is unaffected.
+func Test_MutateAdmission_HardSplitCoreRejected(t *testing.T) {
+	const VNPUModeAnnotation = "huawei.com/vnpu-mode"
+	const VNPUModeHamiCore = "hami-core"
+
+	// 8738 maps to the vir08 template so hard-split memory trimming succeeds.
+	newCtr := func(core string) corev1.Container {
+		limits := corev1.ResourceList{
+			"huawei.com/Ascend910B3":        resource.MustParse("1"),
+			"huawei.com/Ascend910B3-memory": resource.MustParse("8738"),
+		}
+		requests := corev1.ResourceList{
+			"huawei.com/Ascend910B3":        resource.MustParse("1"),
+			"huawei.com/Ascend910B3-memory": resource.MustParse("8738"),
+		}
+		if core != "" {
+			limits["huawei.com/Ascend910B3-core"] = resource.MustParse(core)
+			requests["huawei.com/Ascend910B3-core"] = resource.MustParse(core)
+		}
+		return corev1.Container{
+			Name:      "test-container",
+			Resources: corev1.ResourceRequirements{Limits: limits, Requests: requests},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		ctr      corev1.Container
+		hamiCore bool
+		wantErr  bool
+	}{
+		{name: "hard split with core is rejected", ctr: newCtr("10"), hamiCore: false, wantErr: true},
+		{name: "hard split with core over physical is rejected", ctr: newCtr("25"), hamiCore: false, wantErr: true},
+		{name: "hard split with core=0 is allowed", ctr: newCtr("0"), hamiCore: false, wantErr: false},
+		{name: "hard split without core is allowed", ctr: newCtr(""), hamiCore: false, wantErr: false},
+		{name: "hami-core soft split with core is allowed", ctr: newCtr("10"), hamiCore: true, wantErr: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := Devices{
+				config: VNPUConfig{
+					CommonWord:         "Ascend910B3",
+					ResourceName:       "huawei.com/Ascend910B3",
+					ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+					ResourceCoreName:   "huawei.com/Ascend910B3-core",
+					MemoryAllocatable:  32768,
+					MemoryCapacity:     32768,
+					Templates: []Template{
+						{Name: "vir08", Memory: 8738, AICore: 8},
+						{Name: "vir16", Memory: 17476, AICore: 16},
+					},
+				},
+			}
+			pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{}}
+			if test.hamiCore {
+				pod.Annotations = map[string]string{VNPUModeAnnotation: VNPUModeHamiCore}
+			}
+			ctr := test.ctr
+			_, err := dev.MutateAdmission(&ctr, &pod)
+			if test.wantErr {
+				assert.Assert(t, err != nil, "expected admission to be rejected")
+				assert.Assert(t, strings.Contains(err.Error(), "hami-core"),
+					"error should mention hami-core, got %v", err)
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}
+
 func Test_GenerateResourceRequests(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -881,8 +881,6 @@ func Test_MutateAdmission_VNPUCoreMode(t *testing.T) {
 // rejected on hard split (non hami-core) but accepted in hami-core soft-split
 // mode, and that a hard-split request without -core is unaffected.
 func Test_MutateAdmission_HardSplitCoreRejected(t *testing.T) {
-	// VNPUModeAnnotation and VNPUModeHamiCore are the package-level constants from device.go.
-
 	// 8738 maps to the vir08 template so hard-split memory trimming succeeds.
 	newCtr := func(core string) corev1.Container {
 		limits := corev1.ResourceList{


### PR DESCRIPTION
Fixes #2025

## What this changes

On Ascend hard split the compute of a vNPU is fixed by the driver template, so a per-container `-core` request cannot be honored. Today it is dropped by `PatchAnnotations` but still reserved by the scheduler (`Fit`), and when it exceeds the physical core count the pod stays `Pending` with `CardInsufficientCore` for no visible reason.

This PR rejects the invalid combination at admission:

- `MutateAdmission`: when the pod is **not** in `hami-core` (soft split) mode and a `<resource>-core` limit/request > 0 is present, admission fails with `<resource>-core is only supported in hami-core (soft split) mode`.
- Soft split (`hami-core`) with `-core` is unchanged.
- Hard split without `-core` is unchanged.

Also folds in a one-word typo fix: the multi-device rejection message `"vNPU nor supported for multiple devices"` → `"not"`.

## Commits

1. `fix(ascend): reject -core request on hard-split vNPU` — fix + unit test `Test_MutateAdmission_HardSplitCoreRejected`.
2. `fix(ascend): correct typo "nor" -> "not" in multi-device rejection message`.

## Testing

**Unit** (`go test ./pkg/device/ascend/...`): all pass, incl. the new table test covering hard-split core (rejected), hard-split core=0 / no-core (allowed), and hami-core soft split with core (allowed).

**Hardware validation** (CONTRIBUTING.md gate 2):

- Device: Huawei Ascend **910B4** (32G SKU, physical AICore=20), 8 cards, single node
- Driver **25.5.1**; ascend-device-plugin **v1.3.0**; k8s v1.29.15 (arm64)
- Scheduler/webhook built from this branch (arm64) and deployed on the node; commercial device-plugin left untouched (its `hami.io/node-register-Ascend910B4` is read fine by the open-source scheduler).

| case | request | before this PR | with this PR (verified) |
|---|---|---|---|
| f6-1 | `mem 16384 + core 10` (≤20), hard split | Running, core dropped but reserved | **rejected at admission**: `huawei.com/Ascend910B4-core is only supported in hami-core (soft split) mode` |
| f6-2 | `mem 16384 + core 25` (>20), hard split | Pending `CardInsufficientCore` | **rejected at admission** (fail fast, no misleading Pending) |
| hn-quarter | `mem 8192`, hard split, no core | Running (`vir05_1c_8g`) | **Running**, `temp=vir05_1c_8g` (unchanged) |
| soft-core | `mem + core`, `hami-core` annotation | admitted (soft split) | **admitted** (unchanged; not rejected by the new check) |
| f7-multidev | 2 devices, sub-card mem, hard split | rejected: `...nor...` | rejected: `vNPU not supported for multiple devices` |

Server-side webhook log:

```
E ... webhook.go:83] validating pod failed:huawei.com/Ascend910B4-core is only supported in hami-core (soft split) mode   # f6-1
E ... webhook.go:83] validating pod failed:huawei.com/Ascend910B4-core is only supported in hami-core (soft split) mode   # f6-2
E ... webhook.go:83] validating pod failed:vNPU not supported for multiple devices                                        # f7
```

## AI assistance disclosure

Per CONTRIBUTING.md: this change was investigated and implemented with the assistance of Claude Code. The root-cause analysis is based on my own hardware testing on an 8×910B4 node (6 rounds). I understand the code and can explain and defend it. AI helped navigate the codebase, draft the fix, and write the tests; I reviewed and verified everything, including the hardware validation above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Behavior change & compatibility note
- Admission now **rejects** pods requesting a non-zero Ascend **“core”** resource on **hard-split** vNPU. Pods in **`hami-core`** mode, or pods that omit the core request or set it to **0**, are unaffected.

* **Bug Fixes**
  * Reject non-zero core requests on hard-split vNPU.
  * Refined admission error wording for multi-device requests when not using `hami-core`.

* **Tests**
  * Added coverage for hard-split vs `hami-core` core-resource admission outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->