### PR TITLE
fix(ascend): stop whole-card/memory-less hami-core requests from bypassing the node mode gate

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -460,21 +460,12 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		totalMemPerCard = devices[0].Totalmem
 	}
 
-	// A hami-core (soft-split) pod must land on a hami-core node regardless of
-	// how much memory it requests. Whole-card (Memreq == card capacity) and
-	// memory-less (Memreq == 0) requests skip the memory-range check below, so
-	// keeping this arm outside that condition closes the bypass of the node
-	// soft/hard exclusivity introduced in #1812.
 	if isHAMiCore && !nodeSupportHamiCore {
 		reason[common.ModeNotFit]++
 		klog.V(4).InfoS("Node filtered: pod requests hami-core but node does not support it", "pod", klog.KObj(pod))
 		return false, nil, common.GenReason(reason, len(devices))
 	}
 
-	// A node reserved for hami-core rejects legacy vNPU (template-based) pods
-	// that carve out part of a card. Whole-card legacy requests are intentionally
-	// left untouched so plain jobs are not stranded when a node, or the global
-	// hamiVnpuCore default, marks the node as hami-core.
 	if request.Memreq > 0 && request.Memreq < totalMemPerCard && request.Nums > 0 {
 		if nodeSupportHamiCore && !isHAMiCore {
 			reason[common.ModeNotFit]++

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -460,12 +460,23 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		totalMemPerCard = devices[0].Totalmem
 	}
 
+	// A hami-core (soft-split) pod must land on a hami-core node regardless of
+	// how much memory it requests. Whole-card (Memreq == card capacity) and
+	// memory-less (Memreq == 0) requests skip the memory-range check below, so
+	// keeping this arm outside that condition closes the bypass of the node
+	// soft/hard exclusivity introduced in #1812.
+	if isHAMiCore && !nodeSupportHamiCore {
+		reason[common.ModeNotFit]++
+		klog.V(4).InfoS("Node filtered: pod requests hami-core but node does not support it", "pod", klog.KObj(pod))
+		return false, nil, common.GenReason(reason, len(devices))
+	}
+
+	// A node reserved for hami-core rejects legacy vNPU (template-based) pods
+	// that carve out part of a card. Whole-card legacy requests are intentionally
+	// left untouched so plain jobs are not stranded when a node, or the global
+	// hamiVnpuCore default, marks the node as hami-core.
 	if request.Memreq > 0 && request.Memreq < totalMemPerCard && request.Nums > 0 {
-		if !nodeSupportHamiCore && isHAMiCore {
-			reason[common.ModeNotFit]++
-			klog.V(4).InfoS("Node filtered: Node does not support hami-core mode", "node", nodeInfo.Node.Name, "pod", pod.Name)
-			return false, nil, common.GenReason(reason, len(devices))
-		} else if nodeSupportHamiCore && !isHAMiCore {
+		if nodeSupportHamiCore && !isHAMiCore {
 			reason[common.ModeNotFit]++
 			klog.V(4).InfoS("Node filtered: Reserved for hami-core but pod is legacy vNPU", "node", nodeInfo.Node.Name, "pod", pod.Name)
 			return false, nil, common.GenReason(reason, len(devices))

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -478,7 +478,7 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 	if request.Memreq > 0 && request.Memreq < totalMemPerCard && request.Nums > 0 {
 		if nodeSupportHamiCore && !isHAMiCore {
 			reason[common.ModeNotFit]++
-			klog.V(4).InfoS("Node filtered: Reserved for hami-core but pod is legacy vNPU", "node", nodeInfo.Node.Name, "pod", pod.Name)
+			klog.V(4).InfoS("Node filtered: node reserved for hami-core but pod is legacy vNPU", "pod", klog.KObj(pod))
 			return false, nil, common.GenReason(reason, len(devices))
 		}
 	}

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1814,9 +1814,6 @@ func TestDevices_Fit(t *testing.T) {
 			nodeAnnotation: map[string]string{VNPUNodeSelectorAnnotation: "true"},
 		},
 		{
-			// F5: whole-card memory request (Memreq == card capacity) must not
-			// bypass the node mode gate; a hami-core pod still requires a
-			// hami-core node.
 			name: "fit fail: whole-card hami-core pod on legacy node (ModeNotFit)",
 			devices: []*device.DeviceUsage{{
 				ID: "dev-0", Index: 0, Used: 0, Count: 100,
@@ -1836,8 +1833,6 @@ func TestDevices_Fit(t *testing.T) {
 			nodeAnnotation: map[string]string{},
 		},
 		{
-			// F5: memory-less request (Memreq == 0) must not bypass the node
-			// mode gate either.
 			name: "fit fail: memory-less hami-core pod on legacy node (ModeNotFit)",
 			devices: []*device.DeviceUsage{{
 				ID: "dev-0", Index: 0, Used: 0, Count: 100,
@@ -1857,8 +1852,6 @@ func TestDevices_Fit(t *testing.T) {
 			nodeAnnotation: map[string]string{},
 		},
 		{
-			// F5 guard: a whole-card hami-core pod on a hami-core node must
-			// still fit (the gate must not over-block matching modes).
 			name: "fit success: whole-card hami-core pod on hami-core node",
 			devices: []*device.DeviceUsage{{
 				ID: "dev-0", Index: 0, Used: 0, Count: 100,
@@ -1878,11 +1871,6 @@ func TestDevices_Fit(t *testing.T) {
 			nodeAnnotation: map[string]string{VNPUNodeSelectorAnnotation: "true"},
 		},
 		{
-			// F5 regression guard: a whole-card legacy (non hami-core) pod on a
-			// hami-core reserved node must still fit. Only the soft-pod arm is
-			// lifted out of the memory-range condition; a symmetric change would
-			// wrongly reject plain whole-card jobs (and break the global
-			// hamiVnpuCore=true default).
 			name: "fit success: whole-card legacy pod on hami-core node",
 			devices: []*device.DeviceUsage{{
 				ID: "dev-0", Index: 0, Used: 0, Count: 100,

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1813,6 +1813,92 @@ func TestDevices_Fit(t *testing.T) {
 			wantReason:     "1/1 ModeNotFit",
 			nodeAnnotation: map[string]string{VNPUNodeSelectorAnnotation: "true"},
 		},
+		{
+			// F5: whole-card memory request (Memreq == card capacity) must not
+			// bypass the node mode gate; a hami-core pod still requires a
+			// hami-core node.
+			name: "fit fail: whole-card hami-core pod on legacy node (ModeNotFit)",
+			devices: []*device.DeviceUsage{{
+				ID: "dev-0", Index: 0, Used: 0, Count: 100,
+				Usedmem: 0, Totalmem: 32768, Totalcore: 100, Usedcores: 0,
+				Numa: 0, Health: true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums: 1, Memreq: 32768, MemPercentagereq: 0, Coresreq: 0,
+			},
+			annos: map[string]string{
+				VNPUModeAnnotation: VNPUModeHamiCore,
+			},
+			wantFit:        false,
+			wantLen:        0,
+			wantDevIDs:     []string{},
+			wantReason:     "1/1 ModeNotFit",
+			nodeAnnotation: map[string]string{},
+		},
+		{
+			// F5: memory-less request (Memreq == 0) must not bypass the node
+			// mode gate either.
+			name: "fit fail: memory-less hami-core pod on legacy node (ModeNotFit)",
+			devices: []*device.DeviceUsage{{
+				ID: "dev-0", Index: 0, Used: 0, Count: 100,
+				Usedmem: 0, Totalmem: 32768, Totalcore: 100, Usedcores: 0,
+				Numa: 0, Health: true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums: 1, Memreq: 0, MemPercentagereq: 101, Coresreq: 0,
+			},
+			annos: map[string]string{
+				VNPUModeAnnotation: VNPUModeHamiCore,
+			},
+			wantFit:        false,
+			wantLen:        0,
+			wantDevIDs:     []string{},
+			wantReason:     "1/1 ModeNotFit",
+			nodeAnnotation: map[string]string{},
+		},
+		{
+			// F5 guard: a whole-card hami-core pod on a hami-core node must
+			// still fit (the gate must not over-block matching modes).
+			name: "fit success: whole-card hami-core pod on hami-core node",
+			devices: []*device.DeviceUsage{{
+				ID: "dev-0", Index: 0, Used: 0, Count: 100,
+				Usedmem: 0, Totalmem: 32768, Totalcore: 100, Usedcores: 0,
+				Numa: 0, Health: true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums: 1, Memreq: 32768, MemPercentagereq: 0, Coresreq: 0,
+			},
+			annos: map[string]string{
+				VNPUModeAnnotation: VNPUModeHamiCore,
+			},
+			wantFit:        true,
+			wantLen:        1,
+			wantDevIDs:     []string{"dev-0"},
+			wantReason:     "",
+			nodeAnnotation: map[string]string{VNPUNodeSelectorAnnotation: "true"},
+		},
+		{
+			// F5 regression guard: a whole-card legacy (non hami-core) pod on a
+			// hami-core reserved node must still fit. Only the soft-pod arm is
+			// lifted out of the memory-range condition; a symmetric change would
+			// wrongly reject plain whole-card jobs (and break the global
+			// hamiVnpuCore=true default).
+			name: "fit success: whole-card legacy pod on hami-core node",
+			devices: []*device.DeviceUsage{{
+				ID: "dev-0", Index: 0, Used: 0, Count: 100,
+				Usedmem: 0, Totalmem: 32768, Totalcore: 100, Usedcores: 0,
+				Numa: 0, Health: true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums: 1, Memreq: 32768, MemPercentagereq: 0, Coresreq: 0,
+			},
+			annos:          map[string]string{},
+			wantFit:        true,
+			wantLen:        1,
+			wantDevIDs:     []string{"dev-0"},
+			wantReason:     "",
+			nodeAnnotation: map[string]string{VNPUNodeSelectorAnnotation: "true"},
+		},
 	}
 
 	for _, dev := range devs {


### PR DESCRIPTION
## What this PR does

Fixes #2028.

The node soft/hard-split exclusivity added in #1812 rejects a mismatched pod with `ModeNotFit`, but the check sits inside `request.Memreq > 0 && request.Memreq < totalMemPerCard && request.Nums > 0`. A whole-card memory request (`Memreq == card capacity`) or a memory-less request (`Memreq == 0`) skips the block, so a hami-core (soft-split) pod can be scheduled onto a hard-split node.

This PR lifts the **soft-pod arm** out of the memory-range condition: a pod that declares `vnpu-mode: hami-core` must land on a hami-core node regardless of how much memory it requests.

```go
// applies to whole-card and memory-less requests too
if isHAMiCore && !nodeSupportHamiCore {
    reason[common.ModeNotFit]++
    return false, nil, common.GenReason(reason, len(devices))
}

// reverse arm kept inside the memory-range condition on purpose
if request.Memreq > 0 && request.Memreq < totalMemPerCard && request.Nums > 0 {
    if nodeSupportHamiCore && !isHAMiCore {
        reason[common.ModeNotFit]++
        return false, nil, common.GenReason(reason, len(devices))
    }
}
```

### Why only the soft-pod arm (not a symmetric change)

The reverse arm (a legacy/whole-card pod on a hami-core node) is deliberately left inside the memory-range condition. Making it symmetric would newly reject **plain whole-card jobs** on any hami-core node, and because `nodeSupportHamiCore` defaults to the global `hamiVnpuCore` value, a cluster with `hamiVnpuCore: true` would then reject every whole-card legacy request. A hami-core pod on a hard node is a correctness problem (no soft-split limiter to enforce its limits); a legacy whole-card pod on a hami-core node is not — so only the soft-pod direction is unconditional.

## Testing

### Unit tests
`pkg/device/ascend` `TestDevices_Fit`: **115/115 pass**, `go build/vet/gofmt` clean. Added 4 cases:
- whole-card (`Memreq == capacity`) hami-core on hard node → `ModeNotFit`
- memory-less (`Memreq == 0`) hami-core on hard node → `ModeNotFit`
- whole-card hami-core on hami-core node → fits (not over-blocked)
- whole-card **legacy** on hami-core node → fits (regression guard for the asymmetry above)

### Real hardware (8× Ascend 910B4, hard node) — before/after A/B
Same scheduler build, toggling only this change (`v2.9.0` and `master` have this gate byte-identical):

| case (all `vnpu-mode: hami-core`) | before | after |
|---|---|---|
| partial mem 16384 | Pending `ModeNotFit` | Pending `ModeNotFit` |
| partial mem 32767 | Pending `ModeNotFit` | Pending `ModeNotFit` |
| **whole-card mem 32768** | **bound to hard node (bypass)** | **Pending `ModeNotFit`** |
| **memory-less** | **bound to hard node (bypass)** | **Pending `ModeNotFit`** |
| legacy whole-card (no vnpu-mode) | Running | Running (not over-blocked) |

Before: `FilteringSucceed: 1 nodes fit(node-001)` + `BindingSucceed` for the whole-card hami-core pod.
After: `NodeUnfitPod ... reason="1/8 ModeNotFit"` for the same pod; the legacy whole-card pod still schedules.

## Scope note
The bypass is confirmed on real hardware. Demonstrating the *runtime* failure of a whole-card soft pod on a hard-only node needs a second node without soft-split assets, which I can't construct on a single node (the device-plugin always ships soft-split assets). See the linked issue.

---

*This PR was written with AI assistance (Claude Code): the analysis is from my own testing on real Ascend 910B4 hardware, and the code and tests were drafted with AI and reviewed/validated by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved core-mode (hami-core) scheduling by rejecting incompatible nodes earlier when the pod requests core-mode but the node doesn’t support it.
  * Tightened compatibility behavior for whole-card and memory-less requests to prevent incorrect placement decisions.
  * Preserved existing legacy workload behavior on nodes reserved for hami-core.
* **Tests**
  * Expanded core-mode gating tests with additional whole-card and memory-less scenarios, including negative cases and regression/positive coverage for reserved-node compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->