### PR TITLE
fix: resolve libvgpu git metadata path for linked worktree Docker builds

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -46,14 +46,12 @@ function docker_build() {
       if [ -n "$_git_common" ] && [ -d "$_git_common/modules/libvgpu" ]; then
         _restore_git=$(mktemp)
         cp .git "$_restore_git"
+        # shellcheck disable=SC2064
+        trap "rm -rf .git && cp '$_restore_git' .git && rm -f '$_restore_git'" EXIT
         rm -f .git
         mkdir -p .git/modules
         cp -r "$_git_common/modules/libvgpu" .git/modules/
       fi
-    fi
-    if [ -n "$_restore_git" ]; then
-      # shellcheck disable=SC2064
-      trap "rm -rf .git && cp '$_restore_git' .git && rm -f '$_restore_git'" EXIT
     fi
 
     docker build --build-arg VERSION="${VERSION}" --build-arg GOLANG_IMAGE=${GOLANG_IMAGE} --build-arg NVIDIA_IMAGE=${NVIDIA_IMAGE} --build-arg DEST_DIR=${DEST_DIR} -t "${IMAGE}:${VERSION}" -f docker/Dockerfile .

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -34,6 +34,28 @@ function go_build() {
 }
 
 function docker_build() {
+    # Linked git worktrees have .git as a file, not a directory.
+    # Docker build context then lacks .git/modules/libvgvu, which
+    # the Dockerfile COPYs to preserve libvgpu git metadata for
+    # 'git describe' inside the container build.
+    # Temporarily create it; restore on exit.
+    local _restore_git=""
+    if [ -f .git ]; then
+      local _git_common
+      _git_common=$(git rev-parse --git-common-dir 2>/dev/null)
+      if [ -n "$_git_common" ] && [ -d "$_git_common/modules/libvgpu" ]; then
+        _restore_git=$(mktemp)
+        cp .git "$_restore_git"
+        rm -f .git
+        mkdir -p .git/modules
+        cp -r "$_git_common/modules/libvgpu" .git/modules/
+      fi
+    fi
+    if [ -n "$_restore_git" ]; then
+      # shellcheck disable=SC2064
+      trap "rm -rf .git && cp '$_restore_git' .git && rm -f '$_restore_git'" EXIT
+    fi
+
     docker build --build-arg VERSION="${VERSION}" --build-arg GOLANG_IMAGE=${GOLANG_IMAGE} --build-arg NVIDIA_IMAGE=${NVIDIA_IMAGE} --build-arg DEST_DIR=${DEST_DIR} -t "${IMAGE}:${VERSION}" -f docker/Dockerfile .
     docker tag "${IMAGE}:${VERSION}" "${IMAGE}:${SHORT_VERSION}"
     docker tag "${IMAGE}:${VERSION}" "${IMAGE}:${LATEST_VERSION}"


### PR DESCRIPTION
### What does this PR do?

Fixes #2041 — Docker build fails when the repository is a linked git worktree because `.git/modules/libvgpu` does not exist (in worktrees, `.git` is a file, not a directory).

### Root Cause

The Dockerfile uses `COPY .git/modules/libvgpu /libvgpu-git` to preserve libvgpu's git metadata for version detection inside the container. In a linked worktree, the repository root `.git` is a text file pointing to the real gitdir, so `.git/modules/libvgpu` is not a valid path.

### Fix

In `hack/build.sh`'s `docker_build()` function: detect worktrees via `[ -f .git ]`, use `git rev-parse --git-common-dir` to find the real modules path, and temporarily create `.git/modules/libvgpu` for the Docker build context. The `.git` file is restored on exit via a trap.

### Testing

- ✅ Normal checkout: `[ -f .git ]` is false, code path skipped — no change in behavior
- ✅ Linked worktree: verified path resolution logic with `git rev-parse --git-common-dir`
- ✅ Cleanup: trap restores `.git` file on both success and failure

### AI Assistance Disclosure

This PR was developed with the assistance of Claude Code (Anthropic) for code generation and debugging. The author reviewed, tested, and takes full responsibility for all changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability when the project is checked out using linked Git worktrees, preventing Docker builds from failing due to missing or unexpected repository metadata.
  * Ensures required Git module metadata is correctly available during the Docker build, while keeping the existing build and image-tagging flow unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->