### PR TITLE
fix(device-plugin): avoid nil pointer panic in CheckHealth when checkHealth returns nil

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_checkhealth_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_checkhealth_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rm
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// checkHealth returns a nil error whenever health checks are disabled (for
+// example DP_DISABLE_HEALTHCHECKS=all). CheckHealth must not dereference that
+// nil error.
+func TestCheckHealthNilErrorDoesNotPanic(t *testing.T) {
+	t.Setenv(envDisableHealthChecks, "all")
+
+	r := &nvmlResourceManager{}
+	stop := make(chan interface{})
+	unhealthy := make(chan *Device, 1)
+	disableNVML := make(chan bool, 1)
+	ack := make(chan bool, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				done <- fmt.Errorf("CheckHealth panicked: %v", p)
+			}
+		}()
+		done <- r.CheckHealth(stop, unhealthy, disableNVML, ack)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("CheckHealth returned an error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("CheckHealth did not return")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -119,7 +119,8 @@ func (r *nvmlResourceManager) CheckHealth(stop <-chan interface{}, unhealthy cha
 		// first check if disableNVML channel signal is pass close into checkHealth function
 		// if signal is pass close, return error "close signal received"
 		err := r.checkHealth(stop, r.devices, unhealthy, disableNVML)
-		if err.Error() == "close signal received" {
+		// checkHealth returns nil when health checks are disabled or on shutdown.
+		if err != nil && err.Error() == "close signal received" {
 			ackDisableHealthChecks <- true
 			klog.Info("Check Health has been closed")
 			// when disableNVML channel signal is pass restart, continue to restart checkHealth function


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The NVIDIA device plugin crashes with a nil pointer panic in the health-check goroutine. `nvmlResourceManager.CheckHealth` calls `err.Error()` on the error returned by `checkHealth`, but `checkHealth` legitimately returns a nil error in several cases: health checks disabled via `DP_DISABLE_HEALTHCHECKS=all`, NVML init fails while `fail-on-init-error` is off, and the stop channel is closed on plugin shutdown/restart. In all three, `CheckHealth` does `nil.Error()` and panics. The goroutine is started from `Start()` with no recover, so the panic kills the whole device-plugin process.

Symptoms: setting `DP_DISABLE_HEALTHCHECKS=all` puts the plugin into CrashLoopBackOff; on SIGHUP / kubelet-socket recreation / the 30s restart, the intended in-process restart panics and the container restarts instead. This PR guards the nil error before dereferencing it.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Tested with a regression unit test that sets `DP_DISABLE_HEALTHCHECKS=all` and asserts `CheckHealth` returns without panicking — it fails on master with a nil pointer dereference and passes with the fix.

Also verified end to end on real hardware — a node with 2x NVIDIA GeForce GTX 1080 Ti, driver 550.144.03, Kubernetes v1.29. I built the plugin from master (before) and with the fix (after) and ran each in an isolated namespace under a separate resource name so it wouldn't disturb the production plugin:
- `DP_DISABLE_HEALTHCHECKS=all`: before -> CrashLoopBackOff, panic at `nvml_manager.go` in `CheckHealth`; after -> Running.
- SIGHUP to the running plugin: before -> `Received SIGHUP, restarting.` immediately followed by the panic and a container restart; after -> re-registers with kubelet, no panic, no restart.

This PR was written with AI assistance (analysis and drafting); the diagnosis, the fix, and the on-hardware testing were done and reviewed by me.

**Does this PR introduce a user-facing change?**:

Yes — the NVIDIA device plugin no longer crashes with a nil pointer panic when health checks are disabled (`DP_DISABLE_HEALTHCHECKS`) or when the plugin restarts.