### PR TITLE
fix(scheduler): treat an empty use/nouse gpuuuid annotation as no constraint

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -679,13 +679,14 @@ func CheckUUID(annos map[string]string, id, useKey, noUseKey, deviceType string)
 			return strings.TrimSpace(u) == id
 		})
 	}
-	if userUUID, ok := annos[useKey]; ok {
+	// An empty value means "no constraint" rather than "match nothing".
+	if userUUID, ok := annos[useKey]; ok && strings.TrimSpace(userUUID) != "" {
 		klog.V(5).Infof("check uuid for %s user uuid [%s], device id is %s", deviceType, userUUID, id)
 		if !match(userUUID) {
 			return false
 		}
 	}
-	if noUserUUID, ok := annos[noUseKey]; ok {
+	if noUserUUID, ok := annos[noUseKey]; ok && strings.TrimSpace(noUserUUID) != "" {
 		klog.V(5).Infof("check uuid for %s not user uuid [%s], device id is %s", deviceType, noUserUUID, id)
 		if match(noUserUUID) {
 			return false

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -694,3 +694,27 @@ func CheckUUID(annos map[string]string, id, useKey, noUseKey, deviceType string)
 	}
 	return true
 }
+
+// CheckType reports whether a device model is allowed by the use/noUse type
+// constraints in annos. It mirrors CheckUUID but matches the card model as a
+// case-insensitive substring instead of an exact device id. An empty value
+// means "no constraint" rather than "match nothing".
+func CheckType(annos map[string]string, cardType, useKey, noUseKey string) bool {
+	cardType = strings.ToUpper(cardType)
+	match := func(list string) bool {
+		return slices.ContainsFunc(strings.Split(list, ","), func(t string) bool {
+			return strings.Contains(cardType, strings.ToUpper(t))
+		})
+	}
+	if inuse, ok := annos[useKey]; ok && strings.TrimSpace(inuse) != "" {
+		if !match(inuse) {
+			return false
+		}
+	}
+	if noUse, ok := annos[noUseKey]; ok && strings.TrimSpace(noUse) != "" {
+		if match(noUse) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1454,6 +1454,30 @@ func TestCheckUUID(t *testing.T) {
 			id:   "abc",
 			want: true,
 		},
+		{
+			name: "empty GPUUseUUID annotation should not filter out any device",
+			annos: map[string]string{
+				GPUUseUUID: "",
+			},
+			id:   "abc",
+			want: true,
+		},
+		{
+			name: "whitespace-only GPUUseUUID annotation should not filter out any device",
+			annos: map[string]string{
+				GPUUseUUID: "   ",
+			},
+			id:   "abc",
+			want: true,
+		},
+		{
+			name: "empty GPUNoUseUUID annotation should not exclude any device",
+			annos: map[string]string{
+				GPUNoUseUUID: "",
+			},
+			id:   "abc",
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1488,6 +1488,71 @@ func TestCheckUUID(t *testing.T) {
 	}
 }
 
+func TestCheckType(t *testing.T) {
+	useKey := "example.com/use-gputype"
+	noUseKey := "example.com/nouse-gputype"
+	tests := []struct {
+		name     string
+		annos    map[string]string
+		cardType string
+		want     bool
+	}{
+		{
+			name:     "no annotation is no constraint",
+			annos:    map[string]string{},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "use list matches by substring",
+			annos:    map[string]string{useKey: "A100,V100"},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "use list does not match",
+			annos:    map[string]string{useKey: "V100"},
+			cardType: "NVIDIA-A100",
+			want:     false,
+		},
+		{
+			name:     "nouse list matches excludes the device",
+			annos:    map[string]string{noUseKey: "A100"},
+			cardType: "NVIDIA-A100",
+			want:     false,
+		},
+		{
+			name:     "nouse list does not match keeps the device",
+			annos:    map[string]string{noUseKey: "V100"},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "empty use value is no constraint",
+			annos:    map[string]string{useKey: ""},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "whitespace-only nouse value excludes nothing",
+			annos:    map[string]string{noUseKey: "   "},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "use satisfied and nouse matches still excludes",
+			annos:    map[string]string{useKey: "A100", noUseKey: "A100"},
+			cardType: "NVIDIA-A100",
+			want:     false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, CheckType(test.annos, test.cardType, useKey, noUseKey))
+		})
+	}
+}
+
 func TestDeviceUsageDeepCopy(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -96,7 +96,8 @@ func (dev *DCUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bo
 }
 
 func checkDCUtype(annos map[string]string, cardtype string) bool {
-	if inuse, ok := annos[DCUInUse]; ok {
+	// Empty value means "no constraint"; otherwise strings.Contains("") matches every type.
+	if inuse, ok := annos[DCUInUse]; ok && strings.TrimSpace(inuse) != "" {
 		if !strings.Contains(inuse, ",") {
 			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(inuse)) {
 				return true
@@ -110,7 +111,7 @@ func checkDCUtype(annos map[string]string, cardtype string) bool {
 		}
 		return false
 	}
-	if nouse, ok := annos[DCUNoUse]; ok {
+	if nouse, ok := annos[DCUNoUse]; ok && strings.TrimSpace(nouse) != "" {
 		if !strings.Contains(nouse, ",") {
 			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(nouse)) {
 				return false

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -96,36 +96,7 @@ func (dev *DCUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bo
 }
 
 func checkDCUtype(annos map[string]string, cardtype string) bool {
-	// Empty value means "no constraint"; otherwise strings.Contains("") matches every type.
-	if inuse, ok := annos[DCUInUse]; ok && strings.TrimSpace(inuse) != "" {
-		if !strings.Contains(inuse, ",") {
-			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(inuse)) {
-				return true
-			}
-		} else {
-			for val := range strings.SplitSeq(inuse, ",") {
-				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	if nouse, ok := annos[DCUNoUse]; ok && strings.TrimSpace(nouse) != "" {
-		if !strings.Contains(nouse, ",") {
-			if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(nouse)) {
-				return false
-			}
-		} else {
-			for val := range strings.SplitSeq(nouse, ",") {
-				if strings.Contains(strings.ToUpper(cardtype), strings.ToUpper(val)) {
-					return false
-				}
-			}
-		}
-		return true
-	}
-	return true
+	return device.CheckType(annos, cardtype, DCUInUse, DCUNoUse)
 }
 
 func (dev *DCUDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -191,6 +191,45 @@ func Test_checkDCUtype(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "empty use type annotation is no constraint",
+			args: struct {
+				annos    map[string]string
+				cardtype string
+			}{
+				annos: map[string]string{
+					"hygon.com/use-dcutype": "",
+				},
+				cardtype: "dcu",
+			},
+			want: true,
+		},
+		{
+			name: "empty nouse type annotation excludes nothing",
+			args: struct {
+				annos    map[string]string
+				cardtype string
+			}{
+				annos: map[string]string{
+					"hygon.com/nouse-dcutype": "",
+				},
+				cardtype: "dcu",
+			},
+			want: true,
+		},
+		{
+			name: "whitespace-only nouse type annotation excludes nothing",
+			args: struct {
+				annos    map[string]string
+				cardtype string
+			}{
+				annos: map[string]string{
+					"hygon.com/nouse-dcutype": "   ",
+				},
+				cardtype: "dcu",
+			},
+			want: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -485,25 +484,7 @@ func resourcePresent(ctr *corev1.Container, name corev1.ResourceName) bool {
 }
 
 func checkGPUtype(annos map[string]string, cardtype string) bool {
-	cardtype = strings.ToUpper(cardtype)
-	// Empty value means "no constraint"; otherwise strings.Contains("") matches every type.
-	if inuse, ok := annos[GPUInUse]; ok && strings.TrimSpace(inuse) != "" {
-		useTypes := strings.Split(inuse, ",")
-		if !slices.ContainsFunc(useTypes, func(useType string) bool {
-			return strings.Contains(cardtype, strings.ToUpper(useType))
-		}) {
-			return false
-		}
-	}
-	if unuse, ok := annos[GPUNoUse]; ok && strings.TrimSpace(unuse) != "" {
-		unuseTypes := strings.Split(unuse, ",")
-		if slices.ContainsFunc(unuseTypes, func(unuseType string) bool {
-			return strings.Contains(cardtype, strings.ToUpper(unuseType))
-		}) {
-			return false
-		}
-	}
-	return true
+	return device.CheckType(annos, cardtype, GPUInUse, GPUNoUse)
 }
 
 func assertNuma(annos map[string]string) bool {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -486,7 +486,8 @@ func resourcePresent(ctr *corev1.Container, name corev1.ResourceName) bool {
 
 func checkGPUtype(annos map[string]string, cardtype string) bool {
 	cardtype = strings.ToUpper(cardtype)
-	if inuse, ok := annos[GPUInUse]; ok {
+	// Empty value means "no constraint"; otherwise strings.Contains("") matches every type.
+	if inuse, ok := annos[GPUInUse]; ok && strings.TrimSpace(inuse) != "" {
 		useTypes := strings.Split(inuse, ",")
 		if !slices.ContainsFunc(useTypes, func(useType string) bool {
 			return strings.Contains(cardtype, strings.ToUpper(useType))
@@ -494,7 +495,7 @@ func checkGPUtype(annos map[string]string, cardtype string) bool {
 			return false
 		}
 	}
-	if unuse, ok := annos[GPUNoUse]; ok {
+	if unuse, ok := annos[GPUNoUse]; ok && strings.TrimSpace(unuse) != "" {
 		unuseTypes := strings.Split(unuse, ",")
 		if slices.ContainsFunc(unuseTypes, func(unuseType string) bool {
 			return strings.Contains(cardtype, strings.ToUpper(unuseType))

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2420,6 +2420,16 @@ func TestCheckGPUtype_NoUse(t *testing.T) {
 	assert.Equal(t, checkGPUtype(annos, "NVIDIA-V100"), true)
 }
 
+func TestCheckGPUtype_EmptyAnnotation(t *testing.T) {
+	// An empty use/nouse type annotation means "no constraint": strings.Contains
+	// treats "" as a substring of every card type, so without a guard an empty
+	// nouse-gputype would wrongly exclude every device.
+	assert.Equal(t, checkGPUtype(map[string]string{GPUInUse: ""}, "NVIDIA-A100"), true)
+	assert.Equal(t, checkGPUtype(map[string]string{GPUInUse: "   "}, "NVIDIA-A100"), true)
+	assert.Equal(t, checkGPUtype(map[string]string{GPUNoUse: ""}, "NVIDIA-A100"), true)
+	assert.Equal(t, checkGPUtype(map[string]string{GPUNoUse: "   "}, "NVIDIA-A100"), true)
+}
+
 func TestCheckType_AllocateMode(t *testing.T) {
 	dev := &NvidiaGPUDevices{}
 	req := device.ContainerDeviceRequest{Type: NvidiaGPUDevice}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`CheckUUID` splits the `use-gpuuuid` / `nouse-gpuuuid` annotation on `,` and keeps a device only if its id equals one of the parts. When the annotation is present but its value is empty, `strings.Split("", ",")` returns `[""]` and no real device id equals `""`, so an empty `nvidia.com/use-gpuuuid` (or the per-vendor equivalent, since all vendors share `CheckUUID`) makes every device fail the check and the node becomes unschedulable with `CardUuidMismatch`. This is easy to hit when the annotation value is templated and renders empty; an empty allow-list should mean "no constraint", not "match nothing".

This PR skips the check when the value is empty or whitespace. The `use` branch is the actual bug; the `nouse` branch gets the same guard only for symmetry (an empty exclude-list already excludes nothing, so its behaviour is unchanged).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Extended the existing `TestCheckUUID` with empty / whitespace-only `use-gpuuuid` and empty `nouse-gpuuuid` cases; the `use` cases fail on master (device filtered out) and pass with the fix.

Also verified end to end on real hardware — NVIDIA GeForce GTX 1080 Ti, driver 550.144.03, Kubernetes v1.29 — running the scheduler (master before / fixed after) as a separate scheduler with its own `schedulerName` in an isolated namespace:
- `nvidia.com/use-gpuuuid: ""`: before -> Pod stays Pending with `CardUuidMismatch`; after -> Pod is scheduled.
- No annotation (control): scheduled in both, confirming the empty annotation is the only difference.
- Regression check on the fixed build: a non-matching UUID still yields `CardUuidMismatch`, a matching UUID schedules — real UUID filtering is preserved.

This PR was written with AI assistance (analysis and drafting); the diagnosis, the fix, and the on-hardware testing were done and reviewed by me.

**Does this PR introduce a user-facing change?**:

Yes — a pod with an empty `use-gpuuuid`/`nouse-gpuuuid` annotation is no longer wrongly rejected with `CardUuidMismatch`; an empty value is now treated as no constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only annotation values no longer unintentionally filter out devices.
  * UUID and device-type include/exclude logic now treats blank constraints as “no restriction” rather than enforcing or excluding based on empty strings.
* **Tests**
  * Expanded unit tests for UUID and device-type filtering edge cases, including new cases for empty and whitespace-only annotation values across supported device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->