### PR TITLE
fix(scheduler): accept a vastai-only or biren-only device configuration

### DIFF
--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -266,6 +266,8 @@ func validateConfig(config *Config) error {
 		!reflect.DeepEqual(config.AWSNeuronConfig, awsneuron.AWSNeuronConfig{}) ||
 		!reflect.DeepEqual(config.EnflameConfig, enflame.EnflameConfig{}) ||
 		!reflect.DeepEqual(config.AMDGPUConfig, amd.AMDConfig{}) ||
+		!reflect.DeepEqual(config.VastaiConfig, vastai.VastaiConfig{}) ||
+		!reflect.DeepEqual(config.BirenConfig, biren.BirenConfig{}) ||
 		len(config.VNPUs.Configs) > 0 {
 		return nil
 	}

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -515,6 +515,12 @@ func Test_validateConfig(t *testing.T) {
 	emptyConfig := &Config{
 		IluvatarConfig: []iluvatar.IluvatarConfig{},
 	}
+	vastaiOnly := &Config{
+		VastaiConfig: vastai.VastaiConfig{ResourceCountName: "vastaitech.com/vgpu"},
+	}
+	birenOnly := &Config{
+		BirenConfig: biren.BirenConfig{ResourceCountName: "birentech.com/gpu"},
+	}
 
 	tests := []struct {
 		name        string
@@ -523,6 +529,8 @@ func Test_validateConfig(t *testing.T) {
 	}{
 		{"Valid config", validConfig, false},
 		{"Empty config", emptyConfig, true},
+		{"Vastai only", vastaiOnly, false},
+		{"Biren only", birenOnly, false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`validateConfig` rejects a device configuration that only enables the Vastai or Biren device. Its "at least one vendor is configured" check enumerates Nvidia, Cambricon, Hygon, Iluvatar, Mthreads, Metax, Kunlun, AWSNeuron, Enflame, AMD and VNPUs, but omits `VastaiConfig` and `BirenConfig` — even though both vendors are wired into `deviceInitializers`. As a result, a Vastai-only or Biren-only cluster fails to start the scheduler: `validateConfig` returns `all configurations are empty`, and `InitDevices` turns that into a `klog.Fatalf`, so the scheduler process exits on startup.

This PR adds Vastai and Biren to the check.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Extended the existing `Test_validateConfig` with a Vastai-only and a Biren-only case; both fail on master (`all configurations are empty`) and pass with the fix.

Also verified on real hardware — Kubernetes v1.29 — by running the scheduler built from master (before) and with the fix (after) in an isolated namespace with a single-vendor device config (the check runs at startup in `InitDevices`, before any scheduling, so no GPU is involved):
- device config with only `biren:` — before -> CrashLoopBackOff with `Failed to initialize devices: all configurations are empty`; after -> the scheduler starts and serves normally.
- device config with only `vastai:` — same result (before crash, after runs).

This PR was written with AI assistance (analysis and drafting); the diagnosis, the fix, and the on-cluster testing were done and reviewed by me.

**Does this PR introduce a user-facing change?**:

Yes — a cluster that configures only the Vastai or only the Biren device no longer fails to start the scheduler with "all configurations are empty".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration validation for Vastai and Biren device settings.
  * Configurations containing only Vastai or Biren settings are now accepted correctly instead of being reported as empty.
* **Tests**
  * Added coverage for valid Vastai-only and Biren-only configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->