### PR TITLE
fix(cambricon): avoid scheduler panic when a leading container requests no MLU

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -286,9 +286,16 @@ func (dev *CambriconDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 
 func (dev *CambriconDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]string, pd device.PodDevices) map[string]string {
 	devlist, ok := pd[CambriconMLUDevice]
-	if ok {
+	if ok && len(devlist) > 0 {
 		(*annoinput)[DsmluResourceAssigned] = "false"
-		(*annoinput)[DsmluProfile] = fmt.Sprintf("%d_%d_%d", devlist[0][0].Idx, devlist[0][0].Usedcores, devlist[0][0].Usedmem/256)
+		for _, ctrdevs := range devlist {
+			// Leading containers that request no MLU are padded with empty entries; use the first one that holds a device.
+			if len(ctrdevs) > 0 {
+				d := ctrdevs[0]
+				(*annoinput)[DsmluProfile] = fmt.Sprintf("%d_%d_%d", d.Idx, d.Usedcores, d.Usedmem/256)
+				break
+			}
+		}
 		deviceStr := device.EncodePodSingleDevice(devlist)
 		(*annoinput)[device.InRequestDevices[CambriconMLUDevice]] = deviceStr
 		(*annoinput)[device.SupportDevices[CambriconMLUDevice]] = deviceStr

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -351,6 +351,36 @@ func Test_PatchAnnotations(t *testing.T) {
 			},
 			want: map[string]string{},
 		},
+		{
+			// First container has no MLU (padded empty), real device in the second; used to panic on devlist[0][0].
+			name: "leading container without device",
+			args: struct {
+				annoinput map[string]string
+				pd        device.PodDevices
+			}{
+				annoinput: map[string]string{},
+				pd: device.PodDevices{
+					CambriconMLUDevice: device.PodSingleDevice{
+						[]device.ContainerDevice{},
+						[]device.ContainerDevice{
+							{
+								Idx:       0,
+								UUID:      "device-0",
+								Type:      "MLU",
+								Usedcores: 1,
+								Usedmem:   256000,
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"CAMBRICON_DSMLU_ASSIGNED":                  "false",
+				"CAMBRICON_DSMLU_PROFILE":                   "0_1_1000",
+				"hami.io/cambricon-mlu-devices-to-allocate": ";device-0,MLU,256000,1:;",
+				"hami.io/cambricon-mlu-devices-allocated":   ";device-0,MLU,256000,1:;",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`CambriconDevices.PatchAnnotations` reads `devlist[0][0]` unconditionally. When a pod's first container requests no MLU but a later container does, the scheduler pads the leading container with an empty `ContainerDevices{}` entry (see `score.go`, added to keep container indices aligned for pods that contain containers with no device request). `pd["MLU"]` then looks like `[ {}, {realDevice} ]`, so `devlist[0]` is empty and `devlist[0][0]` panics with `index out of range [0] with length 0`.

The panic happens inside the extender's `/filter` handler, which `net/http` recovers per connection, so the scheduler process keeps running — but the affected pod fails scheduling on every retry (the `/filter` call returns an INTERNAL_ERROR stream error) and stays `Pending` forever, while the scheduler log fills with panics. Any pod whose first container has no MLU but a later one does (a sidecar/logging container first, the workload second) hits this.

This PR picks the first container that actually holds a device instead of hard-coding `devlist[0][0]`. Other vendors already handle the padded empty entries — e.g. enflame skips them with `if len(ctrDevices) == 0 { continue }` before indexing, and most others only iterate with `range` or call `EncodePodSingleDevice`. Cambricon is the only vendor that indexes a per-container slice (`devlist[0][0]`) without first checking it is non-empty.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Extended the existing `Test_PatchAnnotations` with a case where the first container is empty and the real device sits in the second container; it panics on master and passes with the fix.

Also reproduced on real hardware — Cambricon MLU370-X4 (driver v5.10.34), Kubernetes v1.29. I ran the scheduler built from master (before) and with the fix (after) in an isolated namespace with its own scheduler name, pointed only at that node, so production pods keep using the production scheduler. This is a scheduler-side panic in the annotation-patching path, so the trigger is the pod's container layout rather than the device itself; the only variable between the two runs is the scheduler binary.
- before: a two-container pod (container 0 requests no MLU, container 1 requests a Cambricon MLU) stays `Pending`; on every scheduling retry the extender logs `panic: index out of range [0] with length 0` at `pkg/device/cambricon/device.go:291` (`/filter` returns an INTERNAL_ERROR stream error), while the process itself survives.
- after: the same pod is scheduled with no panic; `CAMBRICON_DSMLU_PROFILE` is derived from the first non-empty container.

This PR was written with AI assistance (analysis and drafting); the diagnosis, the fix, and the on-cluster testing were done and reviewed by me.

**Does this PR introduce a user-facing change?**:

Yes — a pod whose first container requests no MLU while a later container does is now scheduled instead of getting stuck `Pending` behind a scheduler panic.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device annotation handling when containers have empty device entries.
  * Prevented failures during resource assignment when the first available device appears in a later container.
  * Ensured device allocation annotations are correctly generated for padded or partially empty device lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->