### PR TITLE
fix: skip owner check for legacy lock format

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -176,7 +176,7 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 		return nil
 	}
 	// Keep backward compatibility with the legacy format, which is simply a timestamp
-	if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, fmt.Sprintf("%s%s", NodeLockSep, GeneratePodNamespaceName(pod, NodeLockSep))) {
+	if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, NodeLockSep+GeneratePodNamespaceName(pod, NodeLockSep)) {
 		klog.InfoS("NodeLock is not set by this pod", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
 		return nil
 	}

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -175,7 +175,8 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 	if !ok {
 		return nil
 	}
-	if !skipNodeLockOwnerCheck && !strings.HasSuffix(lockStr, fmt.Sprintf("%s%s", NodeLockSep, GeneratePodNamespaceName(pod, NodeLockSep))) {
+	// Keep backward compatibility with the legacy format, which is simply a timestamp
+	if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, fmt.Sprintf("%s%s", NodeLockSep, GeneratePodNamespaceName(pod, NodeLockSep))) {
 		klog.InfoS("NodeLock is not set by this pod", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
 		return nil
 	}

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -241,9 +241,10 @@ func TestReleaseNodeLock(t *testing.T) {
 		timeout  bool
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name          string
+		args          args
+		wantErr       bool
+		checkNodeLock bool
 	}{
 		{
 			name: "node not found",
@@ -323,7 +324,8 @@ func TestReleaseNodeLock(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:       false,
+			checkNodeLock: true,
 		},
 		{
 			name: "node lock is legacy timestamp format",
@@ -344,13 +346,25 @@ func TestReleaseNodeLock(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:       false,
+			checkNodeLock: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ReleaseNodeLock(tt.args.nodeName(), tt.args.lockname, tt.args.pod, tt.args.timeout); (err != nil) != tt.wantErr {
+			nodeName := tt.args.nodeName()
+			if err := ReleaseNodeLock(nodeName, tt.args.lockname, tt.args.pod, tt.args.timeout); (err != nil) != tt.wantErr {
 				t.Errorf("ReleaseNodeLock() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.checkNodeLock {
+				node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get node %s after releasing lock: %v", nodeName, err)
+				}
+				if _, ok := node.Annotations[NodeLockKey]; ok {
+					t.Errorf("expected %s annotation to be removed from node %s", NodeLockKey, nodeName)
+				}
 			}
 		})
 	}

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -325,6 +325,27 @@ func TestReleaseNodeLock(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "node lock is legacy timestamp format",
+			args: args{
+				nodeName: func() string {
+					name := "worker-5"
+					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: map[string]string{
+							NodeLockKey: "2026-07-03T15:35:10+08:00",
+						}},
+					}, metav1.CreateOptions{})
+					return name
+				},
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hami",
+						Namespace: "hami-ns",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When using HAMi vNPU with Volcano and enabling node lock, the node lock value stored in Volcano is a timestamp. However, the `ReleaseNodeLock` function called in `ascend-device-plugin` expects the lock value to contain the pod's namespace and name. Since the timestamp format does not match the lock is never released.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed node lock release handling for legacy timestamp-only annotation values, allowing locks to be released when the stored format is older than the current one.
* **Tests**
  * Expanded node lock release test coverage with new cases for legacy-format locks and additional post-release verification that the lock annotation is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->