### PR TITLE
fix: return deep copies from ListPodsInfo to prevent data race

### DIFF
--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -543,6 +543,22 @@ func TestContainerDeviceDeepCopy(t *testing.T) {
 	assert.False(t, exists, "original CustomInfo should not have key2")
 }
 
+func TestListPodsInfoReturnsDeepCopy(t *testing.T) {
+	pm := NewPodManager()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "p", Namespace: "ns"}}
+	pm.AddPod(pod, "node-1", PodDevices{"dev": {{{UUID: "GPU-0"}}}})
+
+	listed := pm.ListPodsInfo()
+	assert.Len(t, listed, 1)
+
+	listed[0].NodeID = "mutated"
+	listed[0].Devices["dev"][0][0].UUID = "mutated"
+
+	inner := pm.pods[k8stypes.UID("uid-1")]
+	assert.Equal(t, "node-1", inner.NodeID)
+	assert.Equal(t, "GPU-0", inner.Devices["dev"][0][0].UUID)
+}
+
 func TestTakeAndDeletePodIsAtomic(t *testing.T) {
 	pm := NewPodManager()
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "p", Namespace: "ns"}}

--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -155,7 +155,7 @@ func (m *PodManager) ListPodsInfo() []*PodInfo {
 
 	pods := make([]*PodInfo, 0, len(m.pods))
 	for _, pod := range m.pods {
-		pods = append(pods, pod)
+		pods = append(pods, pod.DeepCopy())
 		klog.V(5).InfoS("Pod info",
 			"pod", klog.KRef(pod.Namespace, pod.Name),
 			"nodeID", pod.NodeID,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ListPodsInfo` returned raw `*PodInfo` pointers from the internal map. The read lock is released before callers in `getNodesUsage` read `p.NodeID`, `p.Devices`, and store the pointer in device state. A concurrent `AddPod` or `UpdatePod` can write through the same pointer at the same time, causing a data race.

`PodInfo.DeepCopy()` already existed. This PR uses it so callers get an independent snapshot. One line change.

Same class of race fixed in #1967.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

This change is scoped to the scheduler. Unit test added: `TestListPodsInfoReturnsDeepCopy` mutates the returned slice and checks the internal map is unchanged. Passes with `-race`.

**Does this PR introduce a user-facing change?**:

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod information listing so returned data is isolated from internal records.
  * Changes made to listed pod details no longer unintentionally alter cached pod information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->