### PR TITLE
fix: correct typos in comments and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ add metrics bind address flag for scheduler
 
 Improved log messages
 
-fix: loss of metrics after vdeivce restart
+fix: loss of metrics after device restart
 
 bugfix: device-plugin monitor serves too slowly in big cluster
 

--- a/docs/develop/dynamic-mig.md
+++ b/docs/develop/dynamic-mig.md
@@ -6,7 +6,7 @@ This feature will not be implemented without the help of @sailorvii.
 
 ## Introduction
 
-The NVIDIA GPU build-in sharing method includes: time-slice, MPS and MIG. The context switch for time slice sharing would waste some time, so we chose the MPS and MIG. The GPU MIG profile is variable, the user could acquire the MIG device in the profile definition, but current implementation only defines the dedicated profile before the user requirement. That limits the usage of MIG. We want to develop an automatic slice plugin and create the slice when the user require it.
+The NVIDIA GPU built-in sharing methods include: time-slicing, MPS, and MIG. The context switch for time-slice sharing wastes time, so we chose MPS and MIG. The GPU MIG profile is variable; users can acquire the MIG device in the profile definition, but the current implementation only defines a dedicated profile before the user requires it. This limits the usage of MIG. We want to develop an automatic slice plugin to create the slice when the user requires it.
 For the scheduling method, node-level binpack and spread will be supported. Referring to the binpack plugin, we consider the CPU, Mem, GPU memory and other user-defined resource.
 HAMi is done by using [hami-core](https://github.com/Project-HAMi/HAMi-core), which is a cuda-hacking library. But mig is also widely used across the world. A unified API for dynamic-mig and hami-core is needed.
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mps.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mps.go
@@ -64,6 +64,6 @@ func (m *mpsOptions) waitForDaemon() error {
 	return nil
 }
 
-func (m *mpsOptions) updateReponse(response *kubeletdevicepluginv1beta1.ContainerAllocateResponse) {
+func (m *mpsOptions) updateResponse(response *kubeletdevicepluginv1beta1.ContainerAllocateResponse) {
 	return
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -404,7 +404,7 @@ func (plugin *NvidiaDevicePlugin) Serve() error {
 		}
 	}()
 
-	// Wait for server to start by launching a blocking connexion
+	// Wait for server to start by launching a blocking connection
 	conn, err := plugin.dial(plugin.socket, 5*time.Second)
 	if err != nil {
 		return err

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -250,7 +250,7 @@ func (d DeviceMap) isEmpty() bool {
 	return true
 }
 
-// getIDsOfDevicesToReplicate returns a list of dervice IDs that we want to replicate.
+// getIDsOfDevicesToReplicate returns a list of device IDs that we want to replicate.
 func (d DeviceMap) getIDsOfDevicesToReplicate(r *spec.ReplicatedResource) ([]string, error) {
 	devices, exists := d[r.Name]
 	if !exists {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -206,13 +206,13 @@ func (h disabledXIDs) IsAllDisabled() bool {
 	if allDisabled, ok := h[allXIDs]; ok {
 		return allDisabled
 	}
-	// At this point we wither have explicitly disabled XIDs or explicitly
+	// At this point we either have explicitly disabled XIDs or explicitly
 	// enabled XIDs. Since ANY XID that's not specified is assumed enabled, we
 	// return here.
 	return false
 }
 
-// IsDisabled checks whether the specified XID has been explicitly disalbled.
+// IsDisabled checks whether the specified XID has been explicitly disabled.
 // An XID is considered disabled if it has been explicitly disabled, or all XIDs
 // have been disabled.
 func (h disabledXIDs) IsDisabled(xid uint64) bool {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fixes 7 spelling errors found across comments, doc strings, and documentation files.

| File | Wrong | Correct |
|------|-------|---------|
| `pkg/device-plugin/.../rm/health.go:209` | `wither` | `either` |
| `pkg/device-plugin/.../rm/health.go:215` | `disalbled` | `disabled` |
| `pkg/device-plugin/.../rm/device_map.go:253` | `dervice` | `device` |
| `pkg/device-plugin/.../plugin/server.go:407` | `connexion` | `connection` |
| `pkg/device-plugin/.../plugin/mps.go:67` | `updateReponse` | `updateResponse` |
| `docs/develop/dynamic-mig.md:9` | `build-in` | `built-in` |
| `CHANGELOG.md:214` | `vdeivce` | `device` |

No logic changes. Comments and doc text only (except `mps.go` which is an unexported dead-code function name).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The first four files are under `pkg/device-plugin/nvidiadevice/` which is synced from NVIDIA upstream. These are comment-only fixes.

This PR was written with AI assistance (scanning); the review and fixes were done by me.

**Does this PR introduce a user-facing change?**:

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an internal response handler name to ensure allocation responses are updated correctly.
  * Fixed a changelog typo describing metrics loss after device restart.

* **Documentation**
  * Corrected wording in developer documentation for dynamic MIG guidance.
  * Improved typos/spelling in code comments related to server startup and device ID replication/health handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->