### PR TITLE
docs: fix wrong release dates in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,7 @@ Add support for Ascend910B3 device
 
 Add "NVIDIA_VISIBLE_DEVICES=none" to none-gpu tasks
 
-## v2.4.0 - 2024-09-29
+## v2.4.0 - 2024-09-28
 
 **New features**
 - Add support for Ascend 910P device
@@ -346,7 +346,7 @@ Add "NVIDIA_VISIBLE_DEVICES=none" to none-gpu tasks
 - Fix error when creating Iluvatar pod
 - Fix scheduler name overwrite option
 
-## v2.7.1 - 2026-01-23
+## v2.7.1 - 2025-11-07
 
 **Bug fixes**
 - Update HAMi-core to fix vLLM-related issues


### PR DESCRIPTION
v2.4.0 and v2.7.1 dates in CHANGELOG.md did not match their git tag dates.

- v2.4.0: 2024-09-29 -> 2024-09-28
- v2.7.1: 2026-01-23 -> 2025-11-07

Checked every dated entry in the file against its tag, no other mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the release dates listed for versions 2.4.0 and 2.7.1 in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->