### PR TITLE
docs: add vulnerability scope note to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,13 @@ When reporting a security issue, please include:
 - Any potential attack scenarios or security impact.
 - Suggested mitigations or fixes, if available.
 
+## Is It In Scope?
+
+HAMi's in-container enforcement (HAMi-core/libvgpu and vendor libraries) limits GPU memory and compute for cooperative multi-tenant sharing on a trusted cluster. It is not a hard security boundary against a workload with enough privilege to bypass its own hook, for example by unsetting `LD_PRELOAD`, using a static binary, or `ptrace`.
+
+- A report that a workload can exceed its own quota, without affecting another tenant, is not a new vulnerability by itself.
+- A report that lets a workload reach another tenant's data, device, or namespace it was not granted is in scope, please report it through the process above.
+
 ## Response Process
 
 We follow a structured process to handle security reports:


### PR DESCRIPTION
Add a short scope note to SECURITY.md.

HAMi-core/libvgpu enforcement is a resource-sharing mechanism for cooperative multi-tenant use, not a hard boundary against a workload with enough privilege to bypass its own hook. A report that a workload can exceed its own quota is not a new vulnerability by itself. Cross-tenant impact stays in scope.

This helps triage inbound reports without expanding the existing CNCF security self-assessment doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying the scope and limitations of in-container enforcement.
  * Provided examples of out-of-scope and in-scope security reports.
  * Clarified how to report eligible cross-tenant access issues through the existing disclosure process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->