### PR TITLE
docs: design for init-container GPU resource accounting

### DIFF
--- a/docs/develop/imgs/before-after-math.svg
+++ b/docs/develop/imgs/before-after-math.svg
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 900 440" xmlns="http://www.w3.org/2000/svg">
+  <rect width="900" height="440" fill="#DFF3FE" rx="16"/>
+  <text x="450" y="40" font-family="Verdana, Arial, sans-serif" font-size="21" font-weight="bold" fill="#0B4F6C" text-anchor="middle">Two Ways To Add Up a Pod's GPU Need</text>
+
+  <line x1="40" y1="178" x2="860" y2="178" stroke="#DC2626" stroke-width="2" stroke-dasharray="8,6"/>
+  <text x="860" y="173" font-family="Verdana, Arial, sans-serif" font-size="13" fill="#DC2626" text-anchor="end">24Gi limit</text>
+
+  <text x="220" y="90" font-family="Verdana, Arial, sans-serif" font-size="17" font-weight="bold" fill="#B91C1C" text-anchor="middle">Today: Add Them Up</text>
+  <rect x="140" y="290" width="160" height="80" fill="#34D399" stroke="#047857" stroke-width="2"/>
+  <text x="220" y="335" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#013D2C" text-anchor="middle">app: 10Gi</text>
+  <rect x="140" y="130" width="160" height="160" fill="#FBBF24" stroke="#B45309" stroke-width="2"/>
+  <text x="220" y="215" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#5A3800" text-anchor="middle">init: 20Gi</text>
+  <text x="220" y="110" font-family="Verdana, Arial, sans-serif" font-size="15" font-weight="bold" fill="#B91C1C" text-anchor="middle">= 30Gi — over the limit!</text>
+
+  <text x="680" y="90" font-family="Verdana, Arial, sans-serif" font-size="17" font-weight="bold" fill="#047857" text-anchor="middle">After the Fix: Take the Bigger One</text>
+  <rect x="600" y="210" width="160" height="160" fill="#FBBF24" stroke="#B45309" stroke-width="2"/>
+  <text x="680" y="295" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#5A3800" text-anchor="middle">bigger one: 20Gi</text>
+  <text x="680" y="190" font-family="Verdana, Arial, sans-serif" font-size="15" font-weight="bold" fill="#047857" text-anchor="middle">= 20Gi — fits, 4Gi to spare</text>
+
+  <text x="450" y="410" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#0B4F6C" text-anchor="middle">Since init and app never run together, we should never add their numbers — just take whichever is bigger.</text>
+</svg>

--- a/docs/develop/imgs/pod-lifecycle-journey.svg
+++ b/docs/develop/imgs/pod-lifecycle-journey.svg
@@ -1,0 +1,48 @@
+<svg viewBox="0 0 1100 300" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1100" height="300" fill="#DFF3FE" rx="16"/>
+  <text x="550" y="35" font-family="Verdana, Arial, sans-serif" font-size="20" font-weight="bold" fill="#0B4F6C" text-anchor="middle">The Journey of One Pod</text>
+
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#0B4F6C"/>
+    </marker>
+  </defs>
+  <g stroke="#0B4F6C" stroke-width="3" fill="none" marker-end="url(#arrow2)">
+    <line x1="180" y1="170" x2="200" y2="170"/>
+    <line x1="360" y1="170" x2="380" y2="170"/>
+    <line x1="540" y1="170" x2="560" y2="170"/>
+    <line x1="720" y1="170" x2="740" y2="170"/>
+    <line x1="900" y1="170" x2="920" y2="170"/>
+  </g>
+
+  <rect x="20" y="110" width="160" height="120" rx="12" fill="#E5E7EB" stroke="#6B7280" stroke-width="2"/>
+  <text x="100" y="150" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#374151" text-anchor="middle">1. Pod</text>
+  <text x="100" y="168" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#374151" text-anchor="middle">Created</text>
+
+  <rect x="200" y="110" width="160" height="120" rx="12" fill="#93C5FD" stroke="#1D4ED8" stroke-width="2"/>
+  <text x="280" y="145" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#1E3A8A" text-anchor="middle">2. Scheduled</text>
+  <text x="280" y="165" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#1E3A8A" text-anchor="middle">Reserves 20Gi</text>
+  <text x="280" y="182" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#1E3A8A" text-anchor="middle">(the bigger one)</text>
+
+  <rect x="380" y="110" width="160" height="120" rx="12" fill="#FBBF24" stroke="#B45309" stroke-width="2"/>
+  <text x="460" y="145" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#5A3800" text-anchor="middle">3. Init Running</text>
+  <text x="460" y="165" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#5A3800" text-anchor="middle">Really using</text>
+  <text x="460" y="182" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#5A3800" text-anchor="middle">20Gi</text>
+
+  <rect x="560" y="110" width="160" height="120" rx="12" fill="#C4B5FD" stroke="#6D28D9" stroke-width="2"/>
+  <text x="640" y="140" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#4C1D95" text-anchor="middle">4. Init Finishes</text>
+  <text x="640" y="160" font-family="Verdana, Arial, sans-serif" font-size="18" fill="#4C1D95" text-anchor="middle">✓</text>
+  <text x="640" y="182" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#4C1D95" text-anchor="middle">Reservation shrinks</text>
+
+  <rect x="740" y="110" width="160" height="120" rx="12" fill="#34D399" stroke="#047857" stroke-width="2"/>
+  <text x="820" y="140" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#013D2C" text-anchor="middle">5. App Running</text>
+  <text x="820" y="158" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#013D2C" text-anchor="middle">Alone</text>
+  <text x="820" y="178" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#013D2C" text-anchor="middle">Really using 10Gi</text>
+
+  <rect x="920" y="110" width="160" height="120" rx="12" fill="#E5E7EB" stroke="#6B7280" stroke-width="2"/>
+  <text x="1000" y="145" font-family="Verdana, Arial, sans-serif" font-size="13" font-weight="bold" fill="#374151" text-anchor="middle">6. Pod Deleted</text>
+  <text x="1000" y="165" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#374151" text-anchor="middle">Reservation</text>
+  <text x="1000" y="182" font-family="Verdana, Arial, sans-serif" font-size="12" fill="#374151" text-anchor="middle">back to 0Gi</text>
+
+  <text x="550" y="270" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#0B4F6C" text-anchor="middle">The reservation always matches what's really happening — never more, never less than what's safe.</text>
+</svg>

--- a/docs/develop/imgs/timeline-init-vs-app.svg
+++ b/docs/develop/imgs/timeline-init-vs-app.svg
@@ -1,0 +1,28 @@
+<svg viewBox="0 0 900 320" xmlns="http://www.w3.org/2000/svg">
+  <rect width="900" height="320" fill="#DFF3FE" rx="16"/>
+  <text x="450" y="42" font-family="Verdana, Arial, sans-serif" font-size="21" font-weight="bold" fill="#0B4F6C" text-anchor="middle">Init and App Containers Never Run at the Same Time</text>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#0B4F6C"/>
+    </marker>
+  </defs>
+
+  <line x1="60" y1="230" x2="840" y2="230" stroke="#0B4F6C" stroke-width="3" marker-end="url(#arrow)"/>
+  <text x="845" y="235" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#0B4F6C">Time</text>
+
+  <rect x="80" y="100" width="330" height="100" rx="14" fill="#FBBF24" stroke="#B45309" stroke-width="2"/>
+  <text x="245" y="135" font-family="Verdana, Arial, sans-serif" font-size="16" font-weight="bold" fill="#5A3800" text-anchor="middle">Init Container</text>
+  <text x="245" y="158" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#5A3800" text-anchor="middle">convert-weights</text>
+  <text x="245" y="180" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#5A3800" text-anchor="middle">using 20Gi</text>
+
+  <rect x="450" y="100" width="330" height="100" rx="14" fill="#34D399" stroke="#047857" stroke-width="2"/>
+  <text x="615" y="135" font-family="Verdana, Arial, sans-serif" font-size="16" font-weight="bold" fill="#013D2C" text-anchor="middle">App Container</text>
+  <text x="615" y="158" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#013D2C" text-anchor="middle">server</text>
+  <text x="615" y="180" font-family="Verdana, Arial, sans-serif" font-size="14" fill="#013D2C" text-anchor="middle">using 10Gi</text>
+
+  <text x="430" y="158" font-family="Verdana, Arial, sans-serif" font-size="22" fill="#0B4F6C" text-anchor="middle">→</text>
+
+  <text x="450" y="270" font-family="Verdana, Arial, sans-serif" font-size="15" fill="#0B4F6C" text-anchor="middle">Only one box is ever running. They never overlap.</text>
+  <text x="450" y="295" font-family="Verdana, Arial, sans-serif" font-size="15" font-weight="bold" fill="#0B4F6C" text-anchor="middle">So the pod never really needs more than 20Gi at once.</text>
+</svg>

--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -2,12 +2,12 @@
 
 ## Problem Summary
 
-When a pod has both init containers and app containers requesting gpu resources , HAMi allocate the resources simultaneously/parallelly. But kubernetes runs the init container sequentially to completion before any app container starts,so init and app containers never execute at the same time.
+When a pod has both init containers and app containers requesting GPU resources, HAMi allocates the resources simultaneously/parallelly. But Kubernetes runs the init container sequentially to completion before any app container starts, so init and app containers never execute at the same time.
   
 
 ## The Problem in HAMi Today
 
-`device.Resourcereqs()` this is build for one request entry per container, **init
+`device.Resourcereqs()` this is built for one request entry per container, **init
 containers first, then app containers**, in this order.
 
 **1. Admission — `fitResourceQuota` (`webhook.go`)**
@@ -73,10 +73,10 @@ effective = max( sum(app container requests), max(single init container request)
 
 ## Proposal
 
-Applying this formula consistently, for all the resource dimension GPU count,
-memory, cores and per device UUID(a multi-GPU pod where init and app
-containers land on different physical devices must not have those
-devices usage merged together):
+Applying this formula consistently for all resource dimensions (GPU count,
+memory, cores, and per-device UUID; a multi-GPU pod where init and app
+containers land on different physical devices must not have usage on
+those devices merged):
 
 - **Admission quota check** computes this effective value and checks it
   against namespace quota.
@@ -146,6 +146,13 @@ different physical devices: each device gets its own effective value.
 2. `appReq` per resource = **sum** across app containers.
 3. `effectiveReq = max(appReq, initReq)`; deny if it exceeds quota.
 
+**GPU count:** today's quota check enforces **memory and cores only** —
+GPU count is not an independent quota dimension. `effectiveReq` is still
+computed for count (steps 1–2) so the scheduler and usage recorder have a
+consistent value to work with, but `FitQuota` does not compare it against
+a namespace quota. Threading count through `FitQuota` the same way memory
+and cores are is a possible future extension, not part of this change.
+
 **Memory factor:** applied **once**, to the already-computed effective
 value — not per container.
 
@@ -198,13 +205,23 @@ itself derived from container statuses by kubelet, so relying on only one
 risks acting on a momentarily stale read of the other.
 
 ```
-new_usage[uuid] = sum of app-container requests on uuid only
-delta[uuid]     = new_usage[uuid] - old_usage[uuid]  
+new_usage[uuid] = sum of app-container usage values on uuid only
+                  (the same per-container fields — e.g. Usedmem — that
+                  AddUsage/getNodesUsage already collapse; not raw
+                  requests)
+delta[uuid]     = new_usage[uuid] - old_usage[uuid]
 apply delta[uuid] to QuotaManager and PodManager
 ```
+
+Requests stay the basis for admission and scheduling decisions above;
+once a pod is running, the recorded/shrunk value — the number quota and
+node-capacity accounting compare against — is always derived from the
+same usage fields `AddUsage`/`getNodesUsage` already track, so it can
+never drift from what `CollapseInitContainerUsage` produced when the pod
+started.
 
 Only ever runs **after** `pod.Status` confirms completion.
 
 **Idempotency:** `PodManager` stores a boolean `initContainersShrunk` flag
 per pod. The shrink applies only while `false`; once applied it flips to
-`true` and is never re-applie.
+`true` and is never re-applied.

--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -199,17 +199,39 @@ add and remove always operate on the same number, so there's no drift.
 
 ![The journey of one pod](./imgs/pod-lifecycle-journey.svg)
 
-**Condition:** `pod.Status.Phase == Running` **and** every init container
-has `Status.Terminated{ExitCode: 0}`. Checked together — `Phase` is
-itself derived from container statuses by kubelet, so relying on only one
-risks acting on a momentarily stale read of the other.
+**Condition:** every init container has `Status.Terminated` set (finished,
+regardless of exit code), checked on every reconcile against current
+object state — not gated on observing any particular `Phase` value.
+`Phase == Running` is not required, since it was found to be unreliable
+(does not consistently appear before `Succeeded`).
+
+Two actions (shrink) and one no‑op (hold) once every init container has terminated:
+
+- **Pod reaches a terminal phase (`Succeeded` or `Failed`):** every
+  container in the pod — init and app — has finished. Usage shrinks to
+  zero regardless of exit codes, since nothing in the pod is using GPU
+  anymore. Unlike `Running`, `Succeeded`/`Failed` are true terminal
+  states with no further transitions, so `Phase` is safe to use here.
+- **All init containers exited `ExitCode: 0`, pod not yet terminal:**
+  app containers have started or are starting → shrink to
+  app-containers-only usage.
+- **Any init container exited non-zero, pod not yet terminal:** pod may still restart (depending on restartPolicy). It still holds its allocated GPU devices, so usage is not shrunk at this point. The pod will either restart and eventually succeed, or be terminated permanently (phase → Failed), which will then trigger a shrink.
 
 ```
-new_usage[uuid] = sum of app-container usage values on uuid only
-                  (the same per-container fields — e.g. Usedmem — that
-                  AddUsage/getNodesUsage already collapse; not raw
-                  requests)
-delta[uuid]     = new_usage[uuid] - old_usage[uuid]
+for each uuid:
+if pod.Status.Phase in (Succeeded, Failed):
+    new_usage[uuid] = 0   
+else if all init containers terminated with ExitCode == 0:
+    new_usage[uuid] = sum of app-container usage values on uuid only
+                      (the same per-container fields — e.g. Usedmem —
+                      that AddUsage/getNodesUsage already collapse;
+                      not raw requests)
+else :
+   // init containers still running, or some exited non-zero, pod not terminal.
+  // No shrink: keep current effective usage unchanged.
+        continue   
+
+delta[uuid] = new_usage[uuid] - old_usage[uuid]
 apply delta[uuid] to QuotaManager and PodManager
 ```
 
@@ -222,6 +244,15 @@ started.
 
 Only ever runs **after** `pod.Status` confirms completion.
 
-**Idempotency:** `PodManager` stores a boolean `initContainersShrunk` flag
-per pod. The shrink applies only while `false`; once applied it flips to
-`true` and is never re-applied.
+**Idempotency:** `PodManager` stores a `PodShrinkState` per pod —
+`NotShrunk`, `AppOnly`, or `Zero` — replacing a single boolean, since the
+three outcomes above mean a pod can legitimately shrink twice (once to
+`AppOnly`, later to `Zero`), not just once.
+
+Allowed transitions:
+- `NotShrunk → AppOnly`: when all init containers exit `0` and the pod is
+  not yet terminal.
+- `NotShrunk → Zero` or `AppOnly → Zero`: when the pod reaches a terminal
+  phase(Succeeded or Failed).
+
+  (Note: the case “any init container exits non‑zero” is removed; it will naturally end up in a terminal phase later if the pod does not restart, so no separate branch is needed.)

--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -3,6 +3,8 @@
 ## Problem Summary
 
 When a pod has both init containers and app containers requesting GPU resources, HAMi allocates the resources simultaneously/parallelly. But Kubernetes runs the init container sequentially to completion before any app container starts, so init and app containers never execute at the same time.
+
+Note : This design covers init and app containers only. Sidecar containers are out of scope here and will be handled in a separate PR.
   
 
 ## The Problem in HAMi Today
@@ -70,6 +72,7 @@ So the correct formula for a pod's GPU footprint at any instant is:
 ```
 effective = max( sum(app container requests), max(single init container request) )
 ```
+**Assumption:**  The resources requested by the init container will always be the same as one of the app containers.
 
 ## Proposal
 
@@ -227,9 +230,13 @@ else if all init containers terminated with ExitCode == 0:
                       that AddUsage/getNodesUsage already collapse;
                       not raw requests)
 else :
-   // init containers still running, or some exited non-zero, pod not terminal.
-  // No shrink: keep current effective usage unchanged.
-        continue   
+   // No shrink. Init containers are still running, or one failed and the pod hasn't ended yet.
+   //
+   // Gap: if an earlier init container already succeeded, we still hold its memory until the whole pod ends — it's not released early.
+   //
+   // TODO(future): release memory as each init container finishes, not just at the end. Track which init container index last succeeded
+   // (they run in order), and only count what's left after that.
+        continue
 
 delta[uuid] = new_usage[uuid] - old_usage[uuid]
 apply delta[uuid] to QuotaManager and PodManager
@@ -244,15 +251,16 @@ started.
 
 Only ever runs **after** `pod.Status` confirms completion.
 
-**Idempotency:** `PodManager` stores a `PodShrinkState` per pod —
-`NotShrunk`, `AppOnly`, or `Zero` — replacing a single boolean, since the
-three outcomes above mean a pod can legitimately shrink twice (once to
-`AppOnly`, later to `Zero`), not just once.
+**Idempotency:** `PodManager` stores one boolean per pod,
+`initContainerResourceReleased` (default `false`), guarding only the
+init-container shrink step:
 
-Allowed transitions:
-- `NotShrunk → AppOnly`: when all init containers exit `0` and the pod is
-  not yet terminal.
-- `NotShrunk → Zero` or `AppOnly → Zero`: when the pod reaches a terminal
-  phase(Succeeded or Failed).
+if all initContainers terminated with ExitCode == 0 and !initContainerResourceReleased:
+    shrink usage to app-containers-only
+    initContainerResourceReleased = true
 
-  (Note: the case “any init container exits non‑zero” is removed; it will naturally end up in a terminal phase later if the pod does not restart, so no separate branch is needed.)
+The terminal-phase release is not persisted as a separate state — it's
+recomputed on every reconcile directly from `pod.Status.Phase`:
+
+    if pod.Status.Phase in (Succeeded, Failed):
+        usage = 0

--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -1,0 +1,210 @@
+# HAMi Support for Init Container GPU Resource Accounting — Design
+
+## Problem Summary
+
+When a pod has both init containers and app containers requesting gpu resources , HAMi allocate the resources simultaneously/parallelly. But kubernetes runs the init container sequentially to completion before any app container starts,so init and app containers never execute at the same time.
+  
+
+## The Problem in HAMi Today
+
+`device.Resourcereqs()` this is build for one request entry per container, **init
+containers first, then app containers**, in this order.
+
+**1. Admission — `fitResourceQuota` (`webhook.go`)**
+
+```
+for _, ctr := range pod.Spec.Containers { 
+    memoryReq += memReq * req
+}
+
+```
+
+`pod.Spec.InitContainers` is never referenced. An init container's GPU
+request is invisible to the quota check.
+
+**2. Scheduling — `calcScore` / `fitInDevices` (`score.go`)**
+
+```
+for ctrid, n := range resourceReqs {       
+    fit, reason := fitInDevices(node, n, task, nodeInfo, &score.Devices)
+}
+```
+
+`calcScore` passes the **same `node` object** into `fitInDevices` on every
+iteration, and it permanently adds each container's request
+onto that node's tracked usage. That addition carries into the *next*
+container's check, with no reset and no idea that init containers finish
+before app containers start.
+
+**Example:** A pod with an init container requesting 20Gi and an
+app container requesting 10Gi, on a node with 24Gi free. The scheduler
+checks it as if it needs `20 + 10 = 30Gi` at once, and rejects it — even
+though the pod never uses more than 20Gi at any single moment.
+
+**3. Usage recording — `AddPod`/`AddUsage`/`getNodesUsage`**
+
+```
+for _, ctrdevice := range ctrdevices {  
+    res[memName] += int64(ctrdevice.Usedmem)
+}
+```
+
+Both the namespace quota tracker and the per-node capacity aggregator sum
+every container's stored usage, with no idea some entries came from
+containers that terminated long ago.
+
+These three problems share a root cause — nothing in HAMi knows "init
+containers are sequential and finish before app containers start" — but
+they are three independent code paths that each need to know it.
+
+## The Core Idea
+
+Think of a pod like a kitchen: one chef (the **init container**) preps
+ingredients and leaves; only then does a second chef (the **app
+container**) start cooking. They are never both in the kitchen at once.
+
+![Init and app containers never overlap](./imgs/timeline-init-vs-app.svg)
+
+So the correct formula for a pod's GPU footprint at any instant is:
+
+```
+effective = max( sum(app container requests), max(single init container request) )
+```
+
+## Proposal
+
+Applying this formula consistently, for all the resource dimension GPU count,
+memory, cores and per device UUID(a multi-GPU pod where init and app
+containers land on different physical devices must not have those
+devices usage merged together):
+
+- **Admission quota check** computes this effective value and checks it
+  against namespace quota.
+- **Scheduler fit & scoring** evaluates init containers independently
+  against a fresh copy of node state, app containers cumulatively against
+  a separate copy, then merges per device UUID via the same `max()`.
+- **Usage recording** stores this effective value per device instead of
+  the raw per-container sum, and automatically shrinks it to
+  app-containers-only once a pod's init containers are confirmed finished
+  via `pod.Status` — never before.
+
+Pod annotations are untouched — the device plugin still needs the full
+per-container device list to know which physical GPU each container uses.
+Only accounting changes.
+
+### Different cases
+
+Assume a GPU cluster with one node, `node1`, with a single 24Gi GPU, and a
+namespace quota of `nvidia.com/gpumem: 24Gi`.
+
+#### Case 1 — Admission catches an init container request that could never fit
+
+- **Pod request:** init container `convert-weights` requests 30Gi, app
+  container `server` requests 4Gi.
+- **Before:** allowed — only `server`'s 4Gi is checked.
+- **After:** denied — `max(4Gi, 30Gi) = 30Gi` exceeds the 24Gi quota.
+
+#### Case 2 — A pod that fits is no longer wrongly rejected
+
+- **Node state:** empty, 24Gi available.
+- **Pod request:** init 20Gi, app 10Gi.
+- **Before:** rejected, "0 nodes fit" — scheduler required `20+10=30Gi`.
+- **After:** scheduled — effective usage `max(10,20)=20Gi`, 4Gi headroom.
+
+#### Case 3 — Recorded usage matches reality
+
+- **Node state:** pod from Story 2 bound and running.
+- **Before:** recorded `Used = 30Gi` — exceeds the node's entire capacity.
+- **After:** recorded `Used = 20Gi` — matches the real peak.
+
+#### Case 4 — Usage shrinks once the init container finishes
+
+- **New pod request:** 12Gi, submitted while `model-warmup` is running.
+- **Before:** denied forever — recorded usage never learns the init
+  container finished, stays at 30Gi.
+- **After:** once `convert-weights` is confirmed `Terminated`, recorded
+  usage drops to 10Gi; `24-10=14Gi` free → the 12Gi pod is scheduled.
+
+![Wrong math versus right math](./imgs/before-after-math.svg)
+
+## Design Details
+
+### Per-Resource, Per-Device Formulas
+
+```
+effective_gpu_count[uuid] = max( sum(app count requests on uuid),  max(init count requests on uuid) )
+effective_mem[uuid]       = max( sum(app memory requests on uuid), max(init memory requests on uuid) )
+effective_cores[uuid]     = max( sum(app core requests on uuid),   max(init core requests on uuid) )
+```
+
+Scoping per UUID also handles init and app containers landing on
+different physical devices: each device gets its own effective value.
+
+### Admission Quota Check
+
+1. `initReq` per resource = **max** across init containers.
+2. `appReq` per resource = **sum** across app containers.
+3. `effectiveReq = max(appReq, initReq)`; deny if it exceeds quota.
+
+**Memory factor:** applied **once**, to the already-computed effective
+value — not per container.
+
+```
+effective_mem = max(app_mem_sum, init_mem_peak)
+if memoryFactor > 1:
+    quota_check_mem = effective_mem * memoryFactor
+```
+
+### Scheduler Fit & Scoring
+
+1. **Init pass:** fit each init container independently against a fresh
+   deep-copy of node state; track the **max** per-device usage seen.
+2. **App pass:** fit app containers cumulatively against a separate fresh
+   copy.
+3. **Merge**, per device UUID and resource:
+   `effective_usage[uuid][resource] = max(app_cumulative, init_peak)`.
+   Reject the node if this exceeds capacity.
+
+### Usage Recording (Quota & Node Capacity)
+
+Before storing usage, collapse the raw per-container `PodDevices` into an
+accounting-only view:
+
+```
+collapsed = CollapseInitContainerUsage(pod, podDevices)
+```
+
+Passed to `PodManager.AddPod` / `QuotaManager.AddUsage` — never the raw
+structure.
+
+**On every pod update:**
+1. Decode annotations to recover each container's device UUID.
+2. Classify each container init/app using `pod.Spec`.
+3. Re-apply `CollapseInitContainerUsage` (or `AppContainersOnly` once
+   confirmed done).
+4. Apply only the **delta** between old and new stored value.
+
+**On deletion**, `TakeAndDeletePod` returns exactly the currently-stored
+(possibly already-shrunk) value, and `RmUsage` subtracts exactly that —
+add and remove always operate on the same number, so there's no drift.
+
+### Shrink on Init Container Completion
+
+![The journey of one pod](./imgs/pod-lifecycle-journey.svg)
+
+**Condition:** `pod.Status.Phase == Running` **and** every init container
+has `Status.Terminated{ExitCode: 0}`. Checked together — `Phase` is
+itself derived from container statuses by kubelet, so relying on only one
+risks acting on a momentarily stale read of the other.
+
+```
+new_usage[uuid] = sum of app-container requests on uuid only
+delta[uuid]     = new_usage[uuid] - old_usage[uuid]  
+apply delta[uuid] to QuotaManager and PodManager
+```
+
+Only ever runs **after** `pod.Status` confirms completion.
+
+**Idempotency:** `PodManager` stores a boolean `initContainersShrunk` flag
+per pod. The shrink applies only while `false`; once applied it flips to
+`true` and is never re-applie.


### PR DESCRIPTION
Currently HAMi sums init and app container requests as if they run together, causing false quota passes, scheduler rejections, and inflated usage that never shrinks. This PR corrects all three layers – admission, scheduling, and usage recording – to use the correct formula effective = max(sum(app), max(init)). Usage is stored as the peak value and automatically reduced to app‑only once init containers terminate. Pod annotations remain untouched.
Related to  #1667 
#1773 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a design document describing improved GPU resource accounting for workloads that include init containers.
  * Clarifies consistent behavior across admission checks, scheduling fit/scoring, and usage tracking throughout init and app phases.
  * Explains how resource accounting is adjusted after successful init completion and how usage is corrected on updates and deletions.
  * Includes safeguards to prevent repeated or incorrect post-init adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->