### PR TITLE
device-plugin: opt-in NUMA topology for vGPU replicas

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -27,6 +27,7 @@ data:
       deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
       deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
       deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
+      enableNumaTopology: {{ .Values.devicePlugin.enableNumaTopology | default false }}
       gpuCorePolicy: {{ .Values.devices.nvidia.gpuCorePolicy }}
       libCudaLogLevel: {{ .Values.devices.nvidia.libCudaLogLevel }}
       runtimeClassName: "{{ .Values.devicePlugin.runtimeClassName }}"

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -342,6 +342,10 @@ devicePlugin:
   deviceSplitCount: 10
   deviceMemoryScaling: 1
   deviceCoreScaling: 1
+  # Advertise the physical GPU's NUMA node on each vGPU replica so kubelet's
+  # TopologyManager can align CPU and GPU NUMA nodes. Opt-in because it changes
+  # admission behavior when topologyManagerPolicy is single-numa-node.
+  enableNumaTopology: false
   # Pre-configured device memory in MB for GPUs that don't support memory query (e.g., unified memory architecture GPUs like NVIDIA GB10/DGX Spark).
   # Set to 0 to use auto-detection (default). For unified memory GPUs, set to the total GPU memory (e.g., 131072 for 128GB).
   # Can be overridden per-node via nodeConfiguration.config.
@@ -359,6 +363,7 @@ devicePlugin:
             "devicememoryscaling": 1,
             "devicesplitcount": 10,
             "preconfigureddevicememory": 0,
+            "enablenumatopology": false,
             "migstrategy": "none",
             "filterdevices": {
               "uuid": [],

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -953,7 +953,8 @@ func (plugin *NvidiaDevicePlugin) apiDeviceSpecs(devRoot string, ids []string) [
 }
 
 func (plugin *NvidiaDevicePlugin) apiDevices() []*kubeletdevicepluginv1beta1.Device {
-	return plugin.Devices().GetPluginDevices(*plugin.schedulerConfig.DeviceSplitCount)
+	numaTopology := plugin.schedulerConfig.EnableNUMATopology != nil && *plugin.schedulerConfig.EnableNUMATopology
+	return plugin.Devices().GetPluginDevices(*plugin.schedulerConfig.DeviceSplitCount, numaTopology)
 }
 
 func (plugin *NvidiaDevicePlugin) processMigConfigs(migConfigs map[string]nvidia.MigConfigSpecSlice, deviceCount int) (nvidia.MigConfigSpecSlice, error) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
@@ -192,17 +192,25 @@ func (ds Devices) GetUUIDs() []string {
 }
 
 // GetPluginDevices returns the plugin Devices from all devices in the Devices
-func (ds Devices) GetPluginDevices(count uint) []*kubeletdevicepluginv1beta1.Device {
+func (ds Devices) GetPluginDevices(count uint, numaTopology bool) []*kubeletdevicepluginv1beta1.Device {
 	var res []*kubeletdevicepluginv1beta1.Device
+
+	if len(ds) == 0 {
+		return res
+	}
 
 	if !strings.Contains(ds.GetIDs()[0], "MIG") {
 		for _, dev := range ds {
+			topology := dev.Topology
+			if !numaTopology {
+				topology = nil
+			}
 			for i := uint(0); i < count; i++ {
 				id := fmt.Sprintf("%v-%v", dev.ID, i)
 				res = append(res, &kubeletdevicepluginv1beta1.Device{
 					ID:       id,
 					Health:   dev.Health,
-					Topology: nil,
+					Topology: topology,
 				})
 			}
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func TestGetPluginDevicesTopology(t *testing.T) {
+	numaTopology := &kubeletdevicepluginv1beta1.TopologyInfo{
+		Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 3}},
+	}
+
+	testCases := []struct {
+		description          string
+		devices              Devices
+		count                uint
+		numaTopology         bool
+		expectedIDs          []string
+		expectedTopologyNil  bool
+		expectedTopologyNode int64
+	}{
+		{
+			description:  "empty device list returns empty result",
+			devices:      Devices{},
+			count:        2,
+			numaTopology: true,
+			expectedIDs:  nil,
+		},
+		{
+			description: "non-MIG replicas do not get topology when disabled",
+			devices: Devices{
+				"GPU-uuid-1": &Device{
+					Device: kubeletdevicepluginv1beta1.Device{
+						ID:       "GPU-uuid-1",
+						Health:   kubeletdevicepluginv1beta1.Healthy,
+						Topology: numaTopology,
+					},
+				},
+			},
+			count:               2,
+			numaTopology:        false,
+			expectedIDs:         []string{"GPU-uuid-1-0", "GPU-uuid-1-1"},
+			expectedTopologyNil: true,
+		},
+		{
+			description: "non-MIG replicas inherit topology when enabled",
+			devices: Devices{
+				"GPU-uuid-1": &Device{
+					Device: kubeletdevicepluginv1beta1.Device{
+						ID:       "GPU-uuid-1",
+						Health:   kubeletdevicepluginv1beta1.Healthy,
+						Topology: numaTopology,
+					},
+				},
+			},
+			count:                2,
+			numaTopology:         true,
+			expectedIDs:          []string{"GPU-uuid-1-0", "GPU-uuid-1-1"},
+			expectedTopologyNil:  false,
+			expectedTopologyNode: 3,
+		},
+		{
+			description: "MIG devices always keep their topology",
+			devices: Devices{
+				"MIG-GPU-uuid-1[0]": &Device{
+					Device: kubeletdevicepluginv1beta1.Device{
+						ID:       "MIG-GPU-uuid-1[0]",
+						Health:   kubeletdevicepluginv1beta1.Healthy,
+						Topology: numaTopology,
+					},
+				},
+			},
+			count:                1,
+			numaTopology:         false,
+			expectedIDs:          []string{"MIG-GPU-uuid-1[0]"},
+			expectedTopologyNil:  false,
+			expectedTopologyNode: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := tc.devices.GetPluginDevices(tc.count, tc.numaTopology)
+			require.Len(t, result, len(tc.expectedIDs))
+
+			var ids []string
+			for _, d := range result {
+				ids = append(ids, d.ID)
+				if tc.expectedTopologyNil {
+					require.Nil(t, d.Topology)
+				} else {
+					require.NotNil(t, d.Topology)
+					require.Len(t, d.Topology.Nodes, 1)
+					require.Equal(t, tc.expectedTopologyNode, d.Topology.Nodes[0].ID)
+				}
+			}
+			require.Equal(t, tc.expectedIDs, ids)
+		})
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -338,7 +338,15 @@ func (r *nvmlResourceManager) getMigDeviceParts(d *Device) (string, uint32, uint
 		//nolint:gosec  // We know that the values returned from Get*InstanceId are within the valid uint32 range.
 		return parentUUID, uint32(gi), uint32(ci), nil
 	}
-	return parseMigDeviceUUID(uuid)
+	// Fall back to parsing the legacy MIG UUID format (MIG-GPU-<parent-uuid>/<gi>/<ci>).
+	// Modern drivers assign opaque MIG UUIDs that carry no placement information,
+	// so if parsing fails the NVML error above must not be masked: it is the
+	// actual reason the device placement could not be determined.
+	parentUUID, gi, ci, err := parseMigDeviceUUID(uuid)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("failed to get MIG device handle for %s: %s; %v", uuid, nvml.ErrorString(ret), err)
+	}
+	return parentUUID, gi, ci, nil
 }
 
 // parseMigDeviceUUID splits the MIG device UUID into the parent device UUID and ci and gi

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_test.go
@@ -37,7 +37,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	mock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/require"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 func TestNewHealthCheckXIDs(t *testing.T) {
@@ -234,6 +237,167 @@ func TestGetHealthCheckXids(t *testing.T) {
 				disabled[xid] = xids.IsDisabled(xid)
 			}
 			require.Equal(t, tc.expectedDisabled, disabled)
+		})
+	}
+}
+
+func TestParseMigDeviceUUID(t *testing.T) {
+	testCases := []struct {
+		description    string
+		uuid           string
+		expectedParent string
+		expectedGi     uint32
+		expectedCi     uint32
+		expectError    bool
+	}{
+		{
+			description:    "legacy MIG UUID format",
+			uuid:           "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3/0",
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description: "opaque MIG UUID format carries no placement information",
+			uuid:        "MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2",
+			expectError: true,
+		},
+		{
+			description: "full device UUID",
+			uuid:        "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectError: true,
+		},
+		{
+			description: "legacy format with missing compute instance",
+			uuid:        "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3",
+			expectError: true,
+		},
+		{
+			description: "legacy format with non-numeric instance ids",
+			uuid:        "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/a/b",
+			expectError: true,
+		},
+		{
+			description: "empty string",
+			uuid:        "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			parent, gi, ci, err := parseMigDeviceUUID(tc.uuid)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedParent, parent)
+			require.Equal(t, tc.expectedGi, gi)
+			require.Equal(t, tc.expectedCi, ci)
+		})
+	}
+}
+
+func TestGetMigDeviceParts(t *testing.T) {
+	newMigDevice := func(uuid string) *Device {
+		return &Device{
+			Device: kubeletdevicepluginv1beta1.Device{ID: uuid},
+			Index:  "0:0",
+		}
+	}
+
+	migHandle := &mock.Device{
+		GetDeviceHandleFromMigDeviceHandleFunc: func() (nvml.Device, nvml.Return) {
+			return &mock.Device{
+				GetUUIDFunc: func() (string, nvml.Return) {
+					return "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f", nvml.SUCCESS
+				},
+			}, nvml.SUCCESS
+		},
+		GetGpuInstanceIdFunc: func() (int, nvml.Return) {
+			return 3, nvml.SUCCESS
+		},
+		GetComputeInstanceIdFunc: func() (int, nvml.Return) {
+			return 0, nvml.SUCCESS
+		},
+	}
+
+	testCases := []struct {
+		description      string
+		device           *Device
+		nvmlRet          nvml.Return
+		expectedParent   string
+		expectedGi       uint32
+		expectedCi       uint32
+		expectError      bool
+		expectedInErrMsg []string
+	}{
+		{
+			description:    "placement resolved via NVML handle",
+			device:         newMigDevice("MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2"),
+			nvmlRet:        nvml.SUCCESS,
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description:    "NVML lookup fails but legacy UUID format is parseable",
+			device:         newMigDevice("MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3/0"),
+			nvmlRet:        nvml.ERROR_NOT_SUPPORTED,
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description: "NVML lookup fails for opaque UUID: the NVML error is surfaced",
+			device:      newMigDevice("MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2"),
+			nvmlRet:     nvml.ERROR_NO_PERMISSION,
+			expectError: true,
+			expectedInErrMsg: []string{
+				"MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2",
+				nvml.ErrorString(nvml.ERROR_NO_PERMISSION),
+			},
+		},
+		{
+			description: "full device is rejected",
+			device: &Device{
+				Device: kubeletdevicepluginv1beta1.Device{ID: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f"},
+				Index:  "0",
+			},
+			nvmlRet:     nvml.SUCCESS,
+			expectError: true,
+			expectedInErrMsg: []string{
+				"cannot get GI and CI of full device",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			r := &nvmlResourceManager{
+				nvml: &mock.Interface{
+					DeviceGetHandleByUUIDFunc: func(string) (nvml.Device, nvml.Return) {
+						if tc.nvmlRet != nvml.SUCCESS {
+							return nil, tc.nvmlRet
+						}
+						return migHandle, nvml.SUCCESS
+					},
+				},
+			}
+
+			parent, gi, ci, err := r.getMigDeviceParts(tc.device)
+			if tc.expectError {
+				require.Error(t, err)
+				for _, msg := range tc.expectedInErrMsg {
+					require.Contains(t, err.Error(), msg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedParent, parent)
+			require.Equal(t, tc.expectedGi, gi)
+			require.Equal(t, tc.expectedCi, ci)
 		})
 	}
 }

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -130,6 +130,10 @@ type NodeDefaultConfig struct {
 	PreConfiguredDeviceMemory *int64   `yaml:"preConfiguredDeviceMemory" json:"preconfigureddevicememory"`
 	// LogLevel is LIBCUDA_LOG_LEVEL value
 	LogLevel *LibCudaLogLevel `yaml:"libCudaLogLevel" json:"libcudaloglevel"`
+	// EnableNUMATopology advertises the physical GPU's NUMA node on each vGPU
+	// replica so kubelet's TopologyManager can align CPU and GPU NUMA nodes.
+	// Defaults to false to preserve existing admission behavior.
+	EnableNUMATopology *bool `yaml:"enableNumaTopology" json:"enablenumatopology"`
 }
 
 type FilterDevice struct {


### PR DESCRIPTION
Populates pluginapi.Device.TopologyInfo on vGPU replicas with the physical GPU's NUMA node when devicePlugin.enableNumaTopology is true. Closes #1889 (Phase 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `enableNumaTopology` setting to enable NUMA-aware device splitting and advertise NUMA placement for Kubernetes Topology Manager alignment.
  * Updated Helm configuration so generated scheduler/node settings include `enablenumatopology` (defaulting to `false`).
* **Bug Fixes**
  * Improved MIG UUID/placement error handling by preserving NVML failure details and falling back to legacy UUID parsing when applicable.
* **Tests**
  * Added unit tests for NUMA topology propagation behavior and for MIG UUID parsing/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->