### PR TITLE
design(amd): update amd design docs

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -106,7 +106,7 @@ HSA_CU_MASK=0:0-75;1:0-75
 Each `CU_list` uses HSA's CU ID-list grammar, for example `0-3,8,10-12`.
 
 Exclusivity of CU ranges across pods on a device is enforced under the AMD
-node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`).
+node lock (`AMDDevices.LockNode` and `ReleaseNodeLock` which are unimplemented now).
 
 ## 5. Resource model and core_limit -> CU mask
 

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -7,7 +7,7 @@ AMD ROCm GPUs, so multiple pods can share one Instinct GPU.
 
 ## 2. Goals
 
-- Fractional allocation by memory (`amd.com/gpumem`, MB) and compute (`amd.com/gpucores`, CU count).
+- Fractional allocation by memory (`amd.com/gpumem`, MiB) and compute (`amd.com/gpucores`, percentage).
 - Exclusive, non-overlapping CU partitioning across pods.
 - Following HAMi's existing architecture design to achieve the functionality.
 
@@ -20,7 +20,7 @@ Switching to LD_AUDIT (`la_symbind64`), which intercepts only cross-library bind
 resolved it. The existing NVIDIA LD_PRELOAD path is unchanged.
 
 **Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
-Masking (`ROC_GLOBAL_CU_MASK`) assigns an arbitrary and fine-grained per-pod CU partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)). 
+Masking (`HSA_CU_MASK`) assigns an arbitrary and fine-grained per-pod CU partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
 On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD granularity and is set per physical GPU.
 
 ## 4. Protocol (scheduler <-> device-plugin)
@@ -47,44 +47,33 @@ Registered under `hami.io/node-amd-register`, in JSON format — an array of `De
 ]
 ```
 
-- `devmem`  = total device memory in MB (e.g. 196608 for MI300X).
+- `devmem`  = total device memory in MiB (e.g. 196608 for MI300X).
 - `devcore` = total CU count (e.g. 304 for MI300X). 
 - `id`      = device identifier.
 
 
 ### 4.2 Pod allocation (scheduler -> pod annotations -> Allocate)
 
-The allocation result is written under the **AMD-specific** key (each vendor has its own):
+The scheduler allocation result is written under the **AMD-specific** keys:
 
 ```text
-hami.io/amd-devices-allocated: <UUID>,AMDGPU,<memMB>,<cuCount>:;
+hami.io/amd-devices-to-allocate: <UUID>,amd,<memMiB>,<cuCount>:;
+hami.io/amd-devices-allocated:   <UUID>,amd,<memMiB>,<cuCount>:;
 ```
 
-Plus, a dedicated AMD annotation carrying the per-device CU bitmap. Following the
-convention other vendors use for allocation data that does not fit the standard
-`UUID,Type,mem,cores` encoding (e.g. Ascend's `huawei.com/<model>`), 
-this is a separate annotation under the **`amd.com/`** namespace with a JSON value, for example:
+The device-plugin converts `cuCount` into a non-overlapping CU range during
+`Allocate`, and stores the per-device result in a separate annotation:
 
 ```json
-amd.com/cu-mask: [{"uuid":"<UUID1>","cu_mask":"0x337f"},{"uuid":"<UUID2>","cu_mask":"0x00ff"}]
+hami.io/amd-cu-allocated: {"<UUID1>":"0-75","<UUID2>":"0-75"}
 ```
 
-`cu_mask` uses ROCm's hex-bitmask form of `CU_list` (`0x[0-F]*`, e.g. `0x337f`; see
-<https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html>). 
-A JSON value avoids inventing a delimiter scheme (and the :/; collision with 
-`ROC_GLOBAL_CU_MASK`'s own grammar).
+Each value uses HSA's CU ID-list grammar, for example `0-3,8,10-12`. The
+device-plugin translates each entry into the container-local `HSA_CU_MASK` at
+container start.
 
-The device-plugin translates each entry into the per-GPU `ROC_GLOBAL_CU_MASK` 
-at container start.
-
-Exclusivity of CU bitmaps across pods on a device will be enforced 
-under a node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`) so multiple pods never receive overlapping masks.
-(These are currently stubs; the node-lock enforcement is not yet implemented — TODO.)
-
-Optional handshake:
-```text
-amd.com/cu-mask-assigned: "false" -> "true"  (set by device-plugin)
-```
+Exclusivity of CU ranges across pods on a device is enforced under the AMD
+node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`).
 
 ## 5. Resource model and core_limit -> CU mask
 
@@ -94,39 +83,37 @@ Example Pod request:
 resources:
   limits:
     amd.com/gpu: 1          # number of physical AMD GPUs
-    amd.com/gpumem: 16384   # MB
-    amd.com/gpucores: 152   # CU count
+    amd.com/gpumem: 16384   # MiB
+    amd.com/gpucores: 25    # percentage of physical CUs
 ```
 
 ### 5.1 Memory limit
-`amd.com/gpumem` (MB) flows through the shared annotation, is 
-injected by the device plugin as `HIP_DEVICE_MEMORY_LIMIT_<i>` (value `<MB>m`).
+`amd.com/gpumem` (MiB) flows through the shared annotation and is injected by
+the device plugin as `HIP_DEVICE_MEMORY_LIMIT=<MiB>m`. The limit is scoped to
+the container and applies to all GPUs mounted in that container. Each
+container receives an independent allocation response and environment.
 
-### 5.2 Core limit -> CU mask (Discussion needed)
+### 5.2 Core limit -> CU mask
 
-`amd.com/gpucores` is a **CU count**, not a percentage (contrast NVIDIA's
-SM-utilization %). 
-And converting a count into a usable `ROC_GLOBAL_CU_MASK` is not a
-simple "set N bits" operation:
+`amd.com/gpucores` is a **percentage**, not a CU count. The scheduler converts
+the requested percentage into the physical CU count for the selected device.
+For example, `25` on a 304-CU MI300X allocates 76 CUs.
 
-1. **The hard guarantee is non-overlap.** The scheduler
-   assigns each pod a CU bitmap that does **not overlap** any other pod's bitmap on the same device. 
-   This will be enforced via the bitmap allocator under a node lock (`LockNode` / `ReleaseNodeLock`), which currently return `nil` (TODO: implement).
+The scheduler records the computed CU count in the standard AMD allocation
+annotation. The device-plugin selects a non-overlapping CU range and injects
+it as `HSA_CU_MASK`.
 
-2. **Zero-interference is not guaranteed.** Even with non-overlapping 
-   masks, residual interference remains (as reported in #1707).
-
-The count -> bitmap conversion is a **scheduler's** responsibility, because non-overlap requires knowledge of the device's current
-allocation state. 
-
-The device-plugin simply passes the scheduler-decided mask through verbatim as `ROC_GLOBAL_CU_MASK`.
+**Zero-interference is not guaranteed.** Even with non-overlapping masks,
+residual interference remains (as reported in #1707).
 
 ## 6. Known limitations
 
 - **No `amd-smi` / `rocm-smi` virtualization.** 
   These read sysfs/drm, not HIP, so
   LD_AUDIT cannot intercept them; in-container tools may report physical resources.
+- **Not support mixed type in one node.**
+  Currently, device plugin get gpu type form the label `amd.com/gpu.product-name`, This label can not describe more than one gpu types.
 
 ## 7. Discussion points
 
-- **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (to be confirmed).
+- **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (optional, is not must have for hami while can be useful for other schedulers).

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -9,6 +9,8 @@ AMD ROCm GPUs, so multiple pods can share one Instinct GPU.
 
 - Fractional allocation by memory (`amd.com/gpumem`, MiB) and compute (`amd.com/gpucores`, percentage).
 - Exclusive, non-overlapping CU partitioning across pods.
+- Support all AMD ROCm GPU types; initial CU masking starts on non-WGP
+  (CDNA) devices, then extends to WGP-capable (RDNA) with pair-aligned masks.
 - Following HAMi's existing architecture design to achieve the functionality.
 
 ## 3. Approach
@@ -20,12 +22,31 @@ Switching to LD_AUDIT (`la_symbind64`), which intercepts only cross-library bind
 resolved it. The existing NVIDIA LD_PRELOAD path is unchanged.
 
 **Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
-Masking (`HSA_CU_MASK`) assigns an arbitrary and fine-grained per-pod CU partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
-On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD granularity and is set per physical GPU.
+Masking (`HSA_CU_MASK`) assigns fine-grained, hardware-valid per-pod CU
+partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD
+granularity and is set per physical GPU.
+
+**WGP pairing and rollout scope.** ROCm documents that not every CU mask is
+valid on every device: on GPUs where two CUs form a Work Group Processor
+(WGP) and kernels run in WGP mode, disabling only one CU of a pair is
+invalid ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+WGP is an **RDNA** construct (GFX10+); HIP describes it under the RDNA hardware
+model ([HIP hardware implementation](https://rocm.docs.amd.com/projects/HIP/en/latest/understand/hardware_implementation.html)).
+**CDNA** devices (e.g. Instinct MI300X, `gfx942`) keep independent CUs and are
+not subject to that pairing rule.
+
+The design aims to support **all AMD ROCm GPU types**. Initial implementation
+starts on **non-WGP** devices (CDNA / Instinct), where CU ranges can be chosen
+without pair alignment. Support for WGP-capable (RDNA) devices follows later
+and must select CU masks in adjacent pairs so `HSA_CU_MASK` remains
+hardware-valid.
 
 ## 4. Protocol (scheduler <-> device-plugin)
 
-For AMD, it adds one AMD-specific annotation for the CU bitmap.
+For AMD, the scheduler writes AMD-specific pod annotations; the device-plugin
+injects `ROCR_VISIBLE_DEVICES`, `HSA_CU_MASK`, and `HIP_DEVICE_MEMORY_LIMIT`
+into each container's allocation response.
 
 ### 4.1 Node registration (device-plugin -> node annotations)
 
@@ -57,20 +78,32 @@ Registered under `hami.io/node-amd-register`, in JSON format — an array of `De
 The scheduler allocation result is written under the **AMD-specific** keys:
 
 ```text
-hami.io/amd-devices-to-allocate: <UUID>,amd,<memMiB>,<cuCount>:;
-hami.io/amd-devices-allocated:   <UUID>,amd,<memMiB>,<cuCount>:;
+hami.io/amd-devices-to-allocate: <UUID>,AMDGPU,<memMiB>,<cuCount>:;
+hami.io/amd-devices-allocated:   <UUID>,AMDGPU,<memMiB>,<cuCount>:;
 ```
 
-The device-plugin converts `cuCount` into a non-overlapping CU range during
-`Allocate`, and stores the per-device result in a separate annotation:
+The type field uses the existing `AMDGPU` constant (see `pkg/device/amd/device.go`).
 
-```json
-hami.io/amd-cu-allocated: {"<UUID1>":"0-75","<UUID2>":"0-75"}
+During `Allocate`, the device-plugin reads `hami.io/amd-devices-allocated`
+from the pod annotations, converts each device's `cuCount` into a
+non-overlapping CU range, and returns the result in the container's
+`ContainerAllocateResponse.Envs` (not as a pod annotation):
+
+- `ROCR_VISIBLE_DEVICES` — limits which GPUs the container sees; UUID order
+  defines the container-local GPU index.
+- `HSA_CU_MASK` — restricts CUs per visible GPU, using `GPU_list:CU_list`
+  where the GPU index is resolved **after** `ROCR_VISIBLE_DEVICES` reordering
+  (index `0` = first visible GPU, `1` = second, …).
+
+For a multi-GPU pod, the device-plugin pairs each allocated UUID with its
+container-local index when building `HSA_CU_MASK`, for example:
+
+```text
+# two GPUs: UUID-A (index 0) gets CUs 0-75, UUID-B (index 1) gets CUs 0-75
+HSA_CU_MASK=0:0-75;1:0-75
 ```
 
-Each value uses HSA's CU ID-list grammar, for example `0-3,8,10-12`. The
-device-plugin translates each entry into the container-local `HSA_CU_MASK` at
-container start.
+Each `CU_list` uses HSA's CU ID-list grammar, for example `0-3,8,10-12`.
 
 Exclusivity of CU ranges across pods on a device is enforced under the AMD
 node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`).
@@ -89,19 +122,30 @@ resources:
 
 ### 5.1 Memory limit
 `amd.com/gpumem` (MiB) flows through the shared annotation and is injected by
-the device plugin as `HIP_DEVICE_MEMORY_LIMIT=<MiB>m`. The limit is scoped to
-the container and applies to all GPUs mounted in that container. Each
-container receives an independent allocation response and environment.
+the device plugin as `HIP_DEVICE_MEMORY_LIMIT=<MiB>m`. HAMi's AMD LD_AUDIT
+layer enforces this limit at the HIP API boundary; the value must use the
+`<MiB>m` format. The limit is scoped to the container and applies to all GPUs
+mounted in that container. Each container receives an independent allocation
+response and environment.
 
 ### 5.2 Core limit -> CU mask
 
-`amd.com/gpucores` is a **percentage**, not a CU count. The scheduler converts
-the requested percentage into the physical CU count for the selected device.
-For example, `25` on a 304-CU MI300X allocates 76 CUs.
+`amd.com/gpucores` is a **percentage** in the inclusive range `1`–`100` (values
+outside this range are rejected at admission), not a CU count. The scheduler
+converts the requested percentage into a physical CU count with:
 
-The scheduler records the computed CU count in the standard AMD allocation
-annotation. The device-plugin selects a non-overlapping CU range and injects
-it as `HSA_CU_MASK`.
+```text
+cuCount = round(percentage × devcore / 100)
+```
+
+where `devcore` is the device's total CU count from node registration. The
+result is clamped to `[1, devcore]`. For example, `25` on a 304-CU MI300X
+yields `76` CUs; `33` yields `100` CUs.
+
+The scheduler records this `cuCount` in `hami.io/amd-devices-allocated`. The
+device-plugin selects a non-overlapping CU range of that size and injects it
+as `HSA_CU_MASK`. On WGP-capable devices, the chosen range must additionally
+align to adjacent CU pairs within each WGP.
 
 **Zero-interference is not guaranteed.** Even with non-overlapping masks,
 residual interference remains (as reported in #1707).
@@ -111,9 +155,15 @@ residual interference remains (as reported in #1707).
 - **No `amd-smi` / `rocm-smi` virtualization.** 
   These read sysfs/drm, not HIP, so
   LD_AUDIT cannot intercept them; in-container tools may report physical resources.
-- **Not support mixed type in one node.**
-  Currently, device plugin get gpu type form the label `amd.com/gpu.product-name`, This label can not describe more than one gpu types.
+- **Mixed GPU types are not supported on one node.**
+  The device plugin derives the GPU type from `amd.com/gpu.product-name`, but
+  this label cannot describe multiple GPU types.
+- **WGP-aware CU allocation is phased.** First ship CU partitioning on
+  non-WGP devices (CDNA / Instinct). RDNA (GFX10+) devices need WGP pair
+  alignment when building `HSA_CU_MASK`
+  ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html))
+  and land in a follow-up.
 
 ## 7. Discussion points
 
-- **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (optional, is not must have for hami while can be useful for other schedulers).
+- **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (optional, which is not a must-have for HAMi but can be useful for other schedulers).

--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -135,12 +135,13 @@ outside this range are rejected at admission), not a CU count. The scheduler
 converts the requested percentage into a physical CU count with:
 
 ```text
-cuCount = round(percentage × devcore / 100)
+cuCount = floor(percentage × devcore / 100)
 ```
 
 where `devcore` is the device's total CU count from node registration. The
 result is clamped to `[1, devcore]`. For example, `25` on a 304-CU MI300X
-yields `76` CUs; `33` yields `100` CUs.
+yields `76` CUs; `33` yields `100` CUs (`floor(100.32)`); `67` yields
+`203` CUs (`floor(203.68)`).
 
 The scheduler records this `cuCount` in `hami.io/amd-devices-allocated`. The
 device-plugin selects a non-overlapping CU range of that size and injects it


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**What this PR does / why we need it**:

This pr update the design docs in following points:
major changes:
1. using HSA_CU_MASK instead of ROC_GLOBAL_CU_MASK
HSA_CU_MASK supports per GPU CU mask which is essential for multi-gpu tasks. As tasks request different num of vGPU will create a cross using for GPUs. For example, task1 request 25% one gpu, it get gpu 0 CU 0-76. Then task2 requests 25% 
 but 2 GPUs, it can not use gpu 1 CU 0-76 though they are ideal for gpu 0 is allocated.
2. gpucore represents CU percentage instead of CU count
This design is intended to align with other device apis and it also guarantee the consistency in metrics. Besides, CU total count may not exposed to the user.
3. using HIP_DEVICE_MEMORY_LIMIT for all device HBM limit
HAMi api only allow same gpumem allocation for all request devices. So one env for all devices can satisfy it.
4. device plugin calculates concrete CUs instead of scheduler
Device related logic better place in device plugin.

minor changes:
1. using cu range instead of cu mask to describe allocation for better human readable
2. add hami.io/amd-devices-to-allocate for better compatibility of exists progress 
3. add know limit Not support mixed type in one node

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AMD Instinct vGPU guidance to use fractional GPU memory in MiB (`amd.com/gpumem`, reflected as `HIP_DEVICE_MEMORY_LIMIT=<MiB>m`) and compute-unit partitioning as an inclusive 1–100% (`amd.com/gpucores`).
  * Reworked CU selection to replace the prior CU-mask hex-bitmask flow with container startup using `ROCR_VISIBLE_DEVICES` ordering and `HSA_CU_MASK` expressed as `GPU_list:CU_list` for non-overlapping CU ranges.
  * Refreshed WGP behavior/limitations, including adjacent CU-pair alignment for WGP-capable devices and that zero-interference isn’t guaranteed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->