### PR TITLE
docs(MAINTAINERS): add community managers to offload administrative tasks

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,3 +12,12 @@
 | [Wang Leibo](https://github.com/william-wang)       | wang.platform@gmail.com | [Nvidia](https://www.nvidia.com/) |
 | [Yin Yu](https://github.com/Nimbus318)     | nimbus-nimo@proton.me | Independent Developer |
 | [Shouren Yang](https://github.com/Shouren)         | yangshouren@gmail.com | [4Paradigm](https://www.4paradigm.com/) |
+
+## Community Managers
+
+This group represents the project for administrative and program manager duties. Examples: CNCF Service Desk tickets, coordinating with CNCF Project and Events teams, and LFX Administration. No approval rights.
+
+| Name              | GitHub ID                                                    | Responsibilities |
+| ----              | ----                                                         | ----             |
+| Reza Jelveh       | [fishman](https://github.com/fishman)                        | Representative   |
+| Jimmy Song        | [rootsongjc](https://github.com/rootsongjc)                  | Representative   |


### PR DESCRIPTION
Add Community Managers Reza Jelveh and Jimmy Song to handle CNCF
Service Desk tickets, event coordination, and LFX administration,
freeing main maintainers from administrative overhead.

Signed-off-by: Reza Jelveh <fishmangit@dynamia.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Community Managers” section outlining administrative and program management responsibilities.
  * Listed designated representatives and their areas of responsibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->