### PR TITLE
fix(CI): invalid generated chart SemVer

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -22,7 +22,7 @@ update-versions:
 	@# 2.9.0-0749842 (git short SHA) are rejected by helm. Prefix a purely numeric
 	@# suffix with 'g' (git-describe style) to keep the identifier alphanumeric.
 	hami_version="$(VERSION)";		\
-	chart_version=`echo $(VERSION) | sed 's/^v//' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$$/\1-g\2/'`; \
+	chart_version=`echo $(VERSION) | sed 's/^[vV]//' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$$/\1-g\2/'`; \
 	CHART_VERSION="$$chart_version" perl -i -pe 'BEGIN { $$skip = 0; } if (/^dependencies:/) { $$skip = 1; } if (!$$skip && /^version: /) { s/"*$(VERSION_REGEX)"*/$$ENV{CHART_VERSION}/; }' $(CHART_FILE);		\
 	CHART_VERSION="$$chart_version" perl -i -pe 'BEGIN { $$skip = 0; } if (/^dependencies:/) { $$skip = 1; } if (!$$skip && /^appVersion: /) { s/"*$(VERSION_REGEX)"*/"$$ENV{CHART_VERSION}"/; }' $(CHART_FILE);	\
 	HAMI_VERSION="$$hami_version" perl -i -pe 's/imageTag: "*$(VERSION_REGEX)"*/imageTag: "$$ENV{HAMI_VERSION}"/g' $(VALUES_FILE)

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -18,8 +18,11 @@ update-versions:
 	echo "FULL_BUILD_VERSION=$(FULL_BUILD_VERSION)"
 	@# Update chart versions to point to the current version.
 	@# Note: Only update the main chart version and appVersion (before dependencies section), not dependencies
+	@# SemVer forbids leading zeros in numeric pre-release IDs, so CI tags like
+	@# 2.9.0-0749842 (git short SHA) are rejected by helm. Prefix a purely numeric
+	@# suffix with 'g' (git-describe style) to keep the identifier alphanumeric.
 	hami_version="$(VERSION)";		\
-	chart_version=`echo $(VERSION) | tr -d 'v'`; \
+	chart_version=`echo $(VERSION) | sed 's/^v//' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$$/\1-g\2/'`; \
 	CHART_VERSION="$$chart_version" perl -i -pe 'BEGIN { $$skip = 0; } if (/^dependencies:/) { $$skip = 1; } if (!$$skip && /^version: /) { s/"*$(VERSION_REGEX)"*/$$ENV{CHART_VERSION}/; }' $(CHART_FILE);		\
 	CHART_VERSION="$$chart_version" perl -i -pe 'BEGIN { $$skip = 0; } if (/^dependencies:/) { $$skip = 1; } if (!$$skip && /^appVersion: /) { s/"*$(VERSION_REGEX)"*/"$$ENV{CHART_VERSION}"/; }' $(CHART_FILE);	\
 	HAMI_VERSION="$$hami_version" perl -i -pe 's/imageTag: "*$(VERSION_REGEX)"*/imageTag: "$$ENV{HAMI_VERSION}"/g' $(VALUES_FILE)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Described in comment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart version handling by deriving chart versions from the release version more accurately.
  * Prevented Helm from rejecting SemVer pre-release identifiers that are numeric and include leading zeros.
  * Continued support for version strings prefixed with `v` or `V`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->