### PR TITLE
fix(scheduler): do not exit on a transient error updating the leader label

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -448,10 +448,11 @@ func (s *Scheduler) updateSchedulerLabel() {
 	schedulerSelector := labels.Set(map[string]string{util.HAMiComponentLabel: util.HAMiComponentScheduler}).AsSelector()
 	schedulerPods, err := s.podLister.Pods(os.Getenv("POD_NAMESPACE")).List(schedulerSelector)
 	if err != nil {
-		klog.Fatalf("Failed to list hami scheduler pods from lister: namespace %s selector %s",
-			os.Getenv("POD_NAMESPACE"),
-			schedulerSelector.String(),
+		klog.ErrorS(err, "Failed to list hami scheduler pods from lister",
+			"namespace", os.Getenv("POD_NAMESPACE"),
+			"selector", schedulerSelector.String(),
 		)
+		return
 	}
 
 	for idx := range schedulerPods {
@@ -465,9 +466,9 @@ func (s *Scheduler) updateSchedulerLabel() {
 					map[string]string{util.HAMiRoleLabel: util.HAMiRoleLabelValueLeader},
 				)
 				if err != nil {
-					klog.Fatalf("Failed to patch the leader label to hami scheduler pod: namespace %s pod %s",
-						pod.Namespace,
-						pod.Name,
+					klog.ErrorS(err, "Failed to patch the leader label to hami scheduler pod",
+						"namespace", pod.Namespace,
+						"pod", pod.Name,
 					)
 				} else {
 					klog.V(4).InfoS("Successfully patched leader label to hami scheduler pod",

--- a/pkg/scheduler/scheduler_label_test.go
+++ b/pkg/scheduler/scheduler_label_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
+)
+
+// Test_updateSchedulerLabel_PatchErrorDoesNotExit verifies that a failing leader
+// label patch is logged and does not terminate the scheduler. If updateSchedulerLabel
+// still called klog.Fatalf, os.Exit would kill the test binary before the assertion,
+// failing the whole package; reaching require.Positive proves it returned instead.
+func Test_updateSchedulerLabel_PatchErrorDoesNotExit(t *testing.T) {
+	const ns, name = "kube-system", "hami-scheduler-0"
+	t.Setenv("POD_NAMESPACE", ns)
+	t.Setenv("POD_NAME", name)
+
+	// Leader pod with the component label but no role label, so the leader-patch branch runs.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: ns,
+		Labels:    map[string]string{util.HAMiComponentLabel: util.HAMiComponentScheduler},
+	}}
+
+	fakeClient := fake.NewClientset()
+	var patched atomic.Int32
+	fakeClient.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		patched.Add(1)
+		return true, nil, fmt.Errorf("the server was unable to return a response in time")
+	})
+	origKubeClient := client.KubeClient
+	client.KubeClient = fakeClient
+	t.Cleanup(func() { client.KubeClient = origKubeClient })
+
+	s := NewScheduler()
+	s.kubeClient = fakeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, 0)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	require.NoError(t, informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod))
+
+	s.updateSchedulerLabel()
+
+	require.Positive(t, patched.Load(), "the leader label patch should have been attempted")
+}
+
+// failingPodLister is a PodLister whose List always fails, used to exercise the
+// list-error branch of updateSchedulerLabel.
+type failingPodLister struct{ err error }
+
+func (l failingPodLister) List(labels.Selector) ([]*corev1.Pod, error) { return nil, l.err }
+func (l failingPodLister) Pods(string) listerscorev1.PodNamespaceLister {
+	return failingPodNamespaceLister(l)
+}
+
+type failingPodNamespaceLister struct{ err error }
+
+func (l failingPodNamespaceLister) List(labels.Selector) ([]*corev1.Pod, error) { return nil, l.err }
+func (l failingPodNamespaceLister) Get(string) (*corev1.Pod, error)             { return nil, l.err }
+
+// Test_updateSchedulerLabel_ListErrorDoesNotExit verifies that a failing pod
+// list is logged and does not terminate the scheduler. Reaching the end of the
+// test proves updateSchedulerLabel returned instead of calling os.Exit.
+func Test_updateSchedulerLabel_ListErrorDoesNotExit(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "kube-system")
+
+	s := NewScheduler()
+	s.podLister = failingPodLister{err: fmt.Errorf("the server was unable to return a response in time")}
+
+	s.updateSchedulerLabel()
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`updateSchedulerLabel` calls `klog.Fatalf` (i.e. `os.Exit`) when listing the scheduler pods or patching the leader label fails. Both hit the live API server, so a transient error (apiserver restart, throttling, a 409) kills the scheduler. The follower branch already logs the same patch error with `klog.ErrorS` and keeps going — this just makes the leader branch and the list do the same.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Tested on a kind cluster with the real scheduler image: dropping `patch pods` from RBAC makes the leader patch fail — the current code goes to CrashLoopBackOff, this change stays Running and logs the error each cycle. Unit test added; `go test ./pkg/scheduler/`, `go vet` and `gofmt` are clean.

**Does this PR introduce a user-facing change?**

The scheduler no longer exits on a transient API error while updating its role label; it logs and retries on the next cycle.

**AI Assistant disclosure**:

This PR was written with the help of Claude Code. I reviewed and understand the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of scheduler label updates: failures during pod discovery or label patching are now handled gracefully without stopping the scheduler process.
  * Error details are recorded in logs while the scheduler continues operating.

* **Tests**
  * Added unit tests to confirm the scheduler does not exit when label patching fails.
  * Added unit tests to confirm the scheduler does not exit when pod listing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->