### PR TITLE
docs: propose composable scheduler policy chain

### DIFF
--- a/docs/develop/scheduler-policy-composition.md
+++ b/docs/develop/scheduler-policy-composition.md
@@ -1,0 +1,388 @@
+# Composable Scheduler Policy Chain + Mutex Policy
+
+## Summary
+
+HAMi's node- and GPU-level scheduling policies (`hami.io/node-scheduler-policy`,
+`hami.io/gpu-scheduler-policy`) currently accept a single policy name
+(`binpack`, `spread`, or `topology-aware`). Internally, `NodeScoreList.Less()`
+and `DeviceUsageList.Less()` each hold a single `if/else` on that one string.
+
+This has two consequences tracked in the v2.10 roadmap (#1889):
+
+1. **No policy combination.** A cluster operator cannot say "prefer NUMA
+   locality, then binpack as a tiebreaker" — only one dimension can be active
+   at a time. This is the root cause of #1806 (GPU scheduler policy sort bug):
+   `gpu_policy.go`'s `Less()` already *hardcodes* a two-dimension comparison
+   (NUMA, then Score), but that combination isn't configurable or extensible
+   to other dimensions like topology or binpack/spread.
+2. **No mutual-exclusion policy.** There's no way to declare "pods A and B
+   must never land on the same device/node," which is a hard constraint, not
+   a scoring preference.
+
+This proposal splits the work into two independent, additive changes.
+
+> **Revision note:** this version addresses review feedback from
+> gemini-code-assist and coderabbitai on the initial draft — specifically:
+> NUMA sort direction was not policy-symmetric, empty chains could produce
+> unstable sort order, `PolicyDimension` didn't account for the
+> `NodeScoreList` case, chain construction/propagation at call sites wasn't
+> specified, the mutex filter hook lacked pod context, node-scope mutex
+> filtering placement was suboptimal, and the mutex check as originally
+> written was vulnerable to a TOCTOU race. All are addressed below.
+
+## Proposal
+
+### Part 1 — Composable policy chain (fixes #1806)
+
+Replace the single `Policy string` field's `if/else` in `Less()` with an
+ordered list of comparators, evaluated lexicographically (first dimension
+wins; ties fall through to the next).
+
+#### Two separate interfaces, not one
+
+The original draft proposed a single `PolicyDimension` interface operating
+on `*DeviceListsScore`. That doesn't fit `NodeScoreList`, whose elements are
+`*NodeScore`. We need two interfaces sharing only parsing/registration:
+
+```go
+// pkg/scheduler/policy/dimension.go (new)
+
+// DeviceDimension is one pluggable GPU-level ordering rule.
+type DeviceDimension interface {
+    Name() string
+    // Compare returns <0 if a should sort before b, 0 if tied, >0 otherwise.
+    Compare(a, b *DeviceListsScore) int
+}
+
+// NodeDimension is one pluggable node-level ordering rule.
+type NodeDimension interface {
+    Name() string
+    Compare(a, b *NodeScore) int
+}
+```
+
+#### NUMA direction must match policy, not be fixed
+
+The original draft's `numaDimension` always sorted NUMA descending. That's
+wrong: today's actual behavior (`gpu_policy.go`) is policy-dependent —
+`binpack` sorts NUMA **descending** with score ascending; `spread` (the
+default) sorts NUMA **ascending** with score descending. A single fixed
+direction silently breaks the default spread path. Fix: split into
+direction-aware dimensions instead of one dimension with an implicit
+direction:
+
+```go
+type numaAscDimension struct{}
+func (numaAscDimension) Name() string { return "numa-asc" }
+func (numaAscDimension) Compare(a, b *DeviceListsScore) int {
+    return int(a.Device.Numa) - int(b.Device.Numa)
+}
+
+type numaDescDimension struct{}
+func (numaDescDimension) Name() string { return "numa-desc" }
+func (numaDescDimension) Compare(a, b *DeviceListsScore) int {
+    return int(b.Device.Numa) - int(a.Device.Numa)
+}
+
+type binpackDimension struct{}
+func (binpackDimension) Name() string { return "binpack" }
+func (binpackDimension) Compare(a, b *DeviceListsScore) int {
+    if a.Score < b.Score { return -1 }
+    if a.Score > b.Score { return 1 }
+    return 0
+}
+
+type spreadDimension struct{}
+func (spreadDimension) Name() string { return "spread" }
+func (spreadDimension) Compare(a, b *DeviceListsScore) int {
+    return -binpackDimension{}.Compare(a, b)
+}
+```
+
+Today's exact default behavior is therefore expressible as the chain
+`numa-asc,spread`, and today's binpack behavior as `numa-desc,binpack` —
+both bit-for-bit equivalent to current `Less()`, which is the backward
+compatibility bar this proposal must clear.
+
+#### `Less()` and guaranteed non-empty chain
+
+```go
+func (l DeviceUsageList) Less(i, j int) bool {
+    for _, dim := range l.Chain {
+        if c := dim.Compare(l.DeviceLists[i], l.DeviceLists[j]); c != 0 {
+            return c < 0
+        }
+    }
+    return false
+}
+```
+
+An empty `Chain` would make every comparison return `false`, producing an
+unstable sort. The parser guarantees `Chain` is never empty, but the
+mapping is **not** "any legacy input → the default chain" — that would be
+wrong, since it would collapse `binpack` into spread's behavior. The rule is:
+
+- Recognized legacy values map to their specific equivalent chain:
+  `"binpack"` → `[numa-desc, binpack]`, `"spread"` → `[numa-asc, spread]`.
+- Only **empty or unrecognized** input falls back to the default chain
+  (`[numa-asc, spread]`, matching today's actual default policy).
+
+This keeps the invariant ("`Chain` is never empty") enforced in exactly one
+place — the parser — without conflating "recognized" with "default."
+
+#### Chain construction and propagation — explicit call sites
+
+The original draft didn't specify where chains get built, which is where
+the actual policy currently flows from config/annotation into the sort. This
+must change at both existing entry points:
+
+- `pkg/scheduler/scheduler.go` (`buildNodeUsage`): currently calls
+  `util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, task)` and
+  assigns the resulting raw string directly to `DeviceUsageList.Policy`.
+
+  **This raw string is not only used for sorting.** A separate consumer,
+  `pkg/device/nvidia/device.go`'s `Fit()`, independently re-derives the same
+  policy string via its own `GetGPUSchedulerPolicyByPod` call to compute
+  `needTopology`, which drives NVIDIA-specific device-combination selection
+  logic that has nothing to do with `Less()`. If `ParseDeviceChain` returned
+  only `[]DeviceDimension`, that would discard the raw string and leave this
+  a coincidence — it would keep working today only because `Fit()` happens
+  to re-read the annotation itself, not because this design guarantees it.
+  That's fragile and not explicitly stated, which is what review feedback on
+  this section correctly flagged.
+
+  Fix: the parser returns a tagged result, not a bare chain, and
+  `DeviceUsageList` keeps the raw string alongside the chain rather than
+  replacing it:
+
+  ```go
+  type ParsedDevicePolicy struct {
+      Chain        []DeviceDimension // used by Less()
+      LegacyPolicy string            // raw input, always preserved verbatim
+  }
+
+  func ParseDeviceChain(policyStr string) ParsedDevicePolicy {
+      switch policyStr {
+      case util.GPUSchedulerPolicyBinpack.String():
+          return ParsedDevicePolicy{
+              Chain:        []DeviceDimension{numaDescDimension{}, binpackDimension{}},
+              LegacyPolicy: policyStr,
+          }
+      case util.GPUSchedulerPolicyTopology.String():
+          // Sort behavior for the fallback/tiebreak ordering matches
+          // today's default (topology-aware isn't "binpack", so current
+          // Less() already falls through to the spread branch) — but
+          // LegacyPolicy is preserved so Fit()'s needTopology check keeps
+          // working, unchanged and explicitly, not by coincidence.
+          return ParsedDevicePolicy{
+              Chain:        []DeviceDimension{numaAscDimension{}, spreadDimension{}},
+              LegacyPolicy: policyStr,
+          }
+      case util.GPUSchedulerPolicySpread.String(), "":
+          return ParsedDevicePolicy{
+              Chain:        []DeviceDimension{numaAscDimension{}, spreadDimension{}},
+              LegacyPolicy: policyStr,
+          }
+      default:
+          // comma-separated chain (new format) parsed here; unrecognized
+          // tokens dropped with a warning, empty result -> default chain.
+      }
+  }
+  ```
+
+  `DeviceUsageList.Policy string` becomes `DeviceUsageList.LegacyPolicy
+  string` (renamed, not removed) plus the new `Chain []DeviceDimension`
+  field — so any existing or future consumer that needs the raw string
+  (like `Fit()`) has an explicit, typed field to read instead of an
+  implicit assumption that it's unaffected. A compatibility test must
+  assert `Fit()`'s `needTopology` behavior is bit-for-bit unchanged when
+  `LegacyPolicy == "topology-aware"`.
+- `pkg/scheduler/score.go` (`calcScoreWithOptions`): currently resolves
+  `userNodePolicy` from the pod annotation or `config.NodeSchedulerPolicy`
+  and assigns it to `NodeScoreList.Policy`. This needs the analogous
+  `policy.ParseNodeChain(policyStr string) ParsedNodePolicy` call and the
+  same `Chain` + `LegacyPolicy` field split on `NodeScoreList` (node-level
+  policy has no equivalent second consumer today, but keeping the two
+  structs symmetric avoids the same trap resurfacing later).
+- Both parsers accept the existing single-value strings (`"binpack"`,
+  `"spread"`) as well as the new comma-separated form
+  (`"numa-asc,spread"`), so this is additive at the annotation/config
+  layer — no existing Helm values or annotations need to change.
+
+#### Config/annotation format
+
+```yaml
+hami.io/gpu-scheduler-policy: "numa-asc,binpack"
+```
+
+Bare legacy values (`"binpack"`, `"spread"`) continue to work, resolving via
+the parser to their equivalent full chain as shown above.
+
+**`topology-aware` is a distinct case, not a scoring dimension.** As
+detailed above, it is handled explicitly by `ParseDeviceChain` (not treated
+as an unrecognized token) and its raw string is preserved via
+`LegacyPolicy` specifically because a second consumer (`Fit()`'s
+`needTopology` check) depends on it directly. A compatibility test
+asserting `hami.io/gpu-scheduler-policy: "topology-aware"` produces
+identical sort *and* fit/allocation behavior before and after this change
+is required before this is considered complete. Whether `topology-aware`
+can later be expressed as a composable dimension (e.g. combined with
+binpack as a tiebreaker) is left as a follow-up, not part of this
+proposal's initial scope.
+
+Other unknown dimension names (i.e., typos, not `topology-aware`) are
+dropped with a warning log rather than causing a hard failure; if dropping
+leaves the chain empty, it falls back to the default chain per the
+guarantee above.
+
+### Part 2 — Exclusion (`mutex`) policy (new)
+
+**Naming change from the original draft:** the project already uses the
+`hami.io/mutex.lock` node annotation (`pkg/util/nodelock`) as part of the
+existing per-node scheduling-lock mechanism. Calling the new feature
+`mutex-group` would collide with that existing concept even though the
+literal keys differ. This proposal renames it to
+`hami.io/exclusion-group` / `hami.io/exclusion-scope` to avoid confusion.
+
+Unlike the sort dimensions above, exclusion is a hard filter, not a scoring
+preference: "these pods must never land on the same device/node."
+
+#### The original hook doesn't have enough context — corrected design
+
+The initial draft proposed reusing `CustomFilterRule` from
+`pkg/device/devices.go`. That signature only receives already-allocated
+devices and the candidate device/request — it has no access to the
+candidate pod's own annotations, no exclusion scope, and (for node-scope) no
+visibility into which *other* pods occupy the candidate node. That's not
+enough to implement this correctly, so exclusion is instead implemented as
+scheduler-level filtering with explicit inputs, not a device-plugin hook:
+
+- New pod-level state needed at filter time: the scheduling pod's own
+  `hami.io/exclusion-group` value, and — for every pod already bound to the
+  candidate device/node — their `hami.io/exclusion-group` value. The
+  scheduler already tracks per-device `PodInfos []*PodInfo` on
+  `DeviceUsage`; this proposal needs to confirm whether `PodInfo` carries
+  annotations already or whether a pod-lister/informer lookup by
+  namespace/name is required, and if so, that lookup must go through an
+  indexed cache (not a live API read) to avoid latency under high pod churn.
+  This is called out as an open question below rather than assumed.
+
+- **Empty-group rule (explicit contract, not left implicit):** a missing or
+  empty `hami.io/exclusion-group` value means "this pod participates in no
+  exclusion group." Two pods that both lack the annotation must **never**
+  be treated as matching — the check is only ever a comparison between two
+  *non-empty, equal* group values. Without this rule, unannotated pods
+  would accidentally exclude each other, since two empty strings are
+  trivially "equal."
+
+- **Scope-source rule (symmetric, not one-sided):** the original draft read
+  `hami.io/exclusion-scope` from the scheduling pod only. That's broken:
+  if pod A (same group, `exclusion-scope: node`) already occupies node1,
+  and pod B (same group, default `exclusion-scope: device`) is being
+  placed, a one-sided check only consults B's own scope and would happily
+  place B on a *different* device on node1 — silently violating A's
+  node-wide exclusion. The "must never co-locate" guarantee has to hold
+  regardless of which pod's annotation is consulted.
+
+  Fix: **the stricter scope always wins, from either side.** When checking
+  a candidate device/node against an incumbent pod in the same exclusion
+  group, the effective scope for that check is the broader of the two —
+  if *either* the scheduling pod or the incumbent pod specifies
+  `node`, the check is node-scoped; only if *both* specify (or default to)
+  `device` is the check device-scoped. This makes the guarantee hold no
+  matter which pod happens to be scheduled first, at the cost of the
+  scheduling pod needing to know the scope of every incumbent pod sharing
+  its group — which is already required data per the empty-group rule
+  above (the scheduler must inspect every same-group incumbent's
+  annotations regardless).
+
+#### Device-scope vs node-scope, and where each runs
+
+- **Device-scope** (default): filtering happens inside `fitInDevices`
+  (`pkg/scheduler/score.go`), after per-device data is available, before
+  scoring that device.
+- **Node-scope**: filtering should run at the **top of the per-node
+  goroutine** in `calcScoreWithOptions`, before `fitInDevices` is called at
+  all — there's no reason to run device fitting/scoring logic for a node
+  that's already excluded outright. This corrects the original draft, which
+  put the check inside `fitInDevices` for both scopes.
+
+#### Concurrency safety (fixes the TOCTOU gap)
+
+A plain "read current occupants, then decide" check races: two concurrent
+scheduling attempts (node scoring already runs concurrently per node in
+`calcScoreWithOptions`) can both observe no conflict and then bind
+concurrently, violating the "must never co-locate" guarantee. Rather than
+inventing new locking, this proposal reuses the **existing**
+`pkg/util/nodelock` mechanism (`LockNode` / `SetNodeLock` / `ReleaseNodeLock`),
+which already serializes bind-time operations per node for exactly this
+class of race. Exclusion-group membership checks and the eventual bind are
+performed while holding that per-node lock, giving atomicity without a new
+subsystem.
+
+## User Stories
+
+### Story 1 — Policy combination
+
+- cluster resources:
+  - node1: 4 GPUs, split across NUMA 0 and NUMA 1
+- request:
+  - pod1: needs 2 GPUs, annotation `hami.io/gpu-scheduler-policy: "numa-asc,binpack"`
+- scheduler result:
+  - GPUs are first grouped by ascending NUMA node, then binpacked within the
+    winning NUMA group.
+
+### Story 2 — Exclusion
+
+- request:
+  - pod1, pod2 both carry `hami.io/exclusion-group: "team-a-exclusive"`,
+    both default to `exclusion-scope: device`
+- scheduler result:
+  - pod2 is filtered away from any device pod1 already occupies, even if
+    that device would otherwise score highest — and the check/bind happens
+    under the same per-node lock `nodelock` already provides, so two
+    concurrent scheduling attempts can't both succeed.
+
+### Story 3 — Asymmetric scope (the case that motivated the symmetric rule)
+
+- request:
+  - pod1: `exclusion-group: "team-a-exclusive"`, `exclusion-scope: node`,
+    already bound to node1
+  - pod2: `exclusion-group: "team-a-exclusive"`, `exclusion-scope: device`
+    (default) — a *different*, otherwise-free device on node1 would
+    normally score highest for pod2
+- scheduler result:
+  - pod2 is still filtered away from all of node1, not just pod1's
+    specific device. The effective scope for this check is the broader of
+    the two pods' scopes (`node`, from pod1), even though pod2's own
+    annotation only says `device`. A one-sided check (pod2's scope only)
+    would have incorrectly allowed this placement.
+
+## Design Details / Open Questions
+
+- **Confirm `PodInfo` annotation availability**: does `DeviceUsage.PodInfos`
+  already carry the annotations needed for exclusion-group checks, or does
+  this require a pod-lister lookup? If the latter, must be backed by an
+  informer cache, not a live API call, to avoid scheduling latency at scale.
+- Dimension chain length: cap at a small number (e.g. 3) to keep `Less()`
+  cheap under high pod churn — needs a benchmark once implemented.
+- Backward compatibility: `numa-asc,spread` and `numa-desc,binpack` must be
+  verified bit-for-bit equivalent to current `Less()` output via a
+  legacy-mode test suite before this is considered complete, not just
+  reasoned about in this doc.
+- Should chain-length validation reject configs with conflicting dimensions
+  (e.g. both `binpack` and `spread` in the same chain)? Leaning yes — hard
+  error at parse time rather than silently taking the first one.
+
+## References
+
+- Roadmap: #1889 ("New schedule policy-(mutex)", "Scheduler policy
+  combination")
+- Bug: #1806 (GPU scheduler policy sort bug)
+- Existing pattern to extend: `pkg/scheduler/policy/gpu_policy.go`
+  (`DeviceUsageList.Less`), `pkg/scheduler/policy/node_policy.go`
+  (`NodeScoreList.Less`)
+- Existing per-node locking, reused for exclusion atomicity:
+  `pkg/util/nodelock/nodelock.go`
+- Prior art for proposal format: `docs/develop/scheduler-policy.md`,
+  `docs/develop/dynamic-mig.md`

--- a/docs/develop/scheduler-policy-composition.md
+++ b/docs/develop/scheduler-policy-composition.md
@@ -1,77 +1,84 @@
-# Composable Scheduler Policy Chain + Mutex Policy
+# Composable Scheduler Policy Chain
 
 ## Summary
 
-HAMi's node- and GPU-level scheduling policies (`hami.io/node-scheduler-policy`,
-`hami.io/gpu-scheduler-policy`) currently accept a single policy name
-(`binpack`, `spread`, or `topology-aware`). Internally, `NodeScoreList.Less()`
-and `DeviceUsageList.Less()` each hold a single `if/else` on that one string.
+**Scope note:** this doc originally proposed both a composable policy chain
+and a pod-group mutex/exclusion policy. The NUMA sort bug (#1806) and a
+device-level mutex policy have since merged via #2011, which folded in both
+concerns. Per review feedback, this revision drops everything #2011 already
+covers and narrows to the one part of the original v2.10 roadmap item
+(#1889) that's still open: making `DeviceUsageList.Less()` composable,
+rather than a fixed set of hardcoded branches.
 
-This has two consequences tracked in the v2.10 roadmap (#1889):
+`pkg/scheduler/policy/gpu_policy.go`'s `Less()`, as merged today, looks like
+this:
 
-1. **No policy combination.** A cluster operator cannot say "prefer NUMA
-   locality, then binpack as a tiebreaker" — only one dimension can be active
-   at a time. This is the root cause of #1806 (GPU scheduler policy sort bug):
-   `gpu_policy.go`'s `Less()` already *hardcodes* a two-dimension comparison
-   (NUMA, then Score), but that combination isn't configurable or extensible
-   to other dimensions like topology or binpack/spread.
-2. **No mutual-exclusion policy.** There's no way to declare "pods A and B
-   must never land on the same device/node," which is a hard constraint, not
-   a scoring preference.
+```go
+func (l DeviceUsageList) Less(i, j int) bool {
+    ...
+    if l.Policy == util.GPUSchedulerPolicyMutex.String() {
+        // busy-first, idle-tail
+    }
+    if l.NumaBind {
+        // NUMA-grouped ordering, binpack/spread direction
+    }
+    // default: score primary, NUMA tiebreaker, binpack/spread direction
+}
+```
 
-This proposal splits the work into two independent, additive changes.
+This correctly fixes the sort bug and adds mutex, but the mechanism is a
+fixed sequence of mutually-exclusive `if` blocks keyed off `Policy string` +
+`NumaBind bool`. Three consequences:
 
-> **Revision note:** this version addresses review feedback from
-> gemini-code-assist and coderabbitai on the initial draft — specifically:
-> NUMA sort direction was not policy-symmetric, empty chains could produce
-> unstable sort order, `PolicyDimension` didn't account for the
-> `NodeScoreList` case, chain construction/propagation at call sites wasn't
-> specified, the mutex filter hook lacked pod context, node-scope mutex
-> filtering placement was suboptimal, and the mutex check as originally
-> written was vulnerable to a TOCTOU race. All are addressed below.
+1. **Every new concern needs another `Less()` edit.** Mutex and numa-bind
+   were each added as a new top-level branch. The next one (e.g. the
+   resource-weighted scoring being proposed in #2220, or a future
+   topology-combination need) means editing this function again, and the
+   branches are already interacting in ways that aren't obviously
+   commutative (mutex short-circuits before numa-bind is even checked).
+2. **Dimensions can't be combined or reordered by the operator.** You can't
+   express "numa-bind, then weighted-score, then binpack" — only whichever
+   fixed combination the current `if` chain happens to encode.
+3. **No per-dimension unit testing.** Today's tests exercise `Less()` as one
+   monolithic function; a bug in the mutex branch's tiebreak (line 59,
+   `return ni < nj`) can't be tested in isolation from the numa-bind or
+   score-primary branches.
+
+This proposal doesn't change today's default behavior — it's a refactor of
+*how* the existing branches are expressed, so future dimensions are
+additive instead of requiring another edit to a growing `if` chain.
 
 ## Proposal
 
-### Part 1 — Composable policy chain (fixes #1806)
-
-Replace the single `Policy string` field's `if/else` in `Less()` with an
-ordered list of comparators, evaluated lexicographically (first dimension
-wins; ties fall through to the next).
-
-#### Two separate interfaces, not one
-
-The original draft proposed a single `PolicyDimension` interface operating
-on `*DeviceListsScore`. That doesn't fit `NodeScoreList`, whose elements are
-`*NodeScore`. We need two interfaces sharing only parsing/registration:
+Extract each existing branch into an independently testable comparator, and
+compose them as an ordered chain evaluated lexicographically (first
+dimension that returns non-zero wins).
 
 ```go
 // pkg/scheduler/policy/dimension.go (new)
 
-// DeviceDimension is one pluggable GPU-level ordering rule.
+// DeviceDimension is one independently pluggable GPU-level ordering rule.
 type DeviceDimension interface {
     Name() string
     // Compare returns <0 if a should sort before b, 0 if tied, >0 otherwise.
     Compare(a, b *DeviceListsScore) int
 }
-
-// NodeDimension is one pluggable node-level ordering rule.
-type NodeDimension interface {
-    Name() string
-    Compare(a, b *NodeScore) int
-}
 ```
 
-#### NUMA direction must match policy, not be fixed
-
-The original draft's `numaDimension` always sorted NUMA descending. That's
-wrong: today's actual behavior (`gpu_policy.go`) is policy-dependent —
-`binpack` sorts NUMA **descending** with score ascending; `spread` (the
-default) sorts NUMA **ascending** with score descending. A single fixed
-direction silently breaks the default spread path. Fix: split into
-direction-aware dimensions instead of one dimension with an implicit
-direction:
+Today's three branches become three dimensions, each verified against the
+current `Less()` output bit-for-bit:
 
 ```go
+type mutexDimension struct{}
+func (mutexDimension) Name() string { return "mutex" }
+func (mutexDimension) Compare(a, b *DeviceListsScore) int {
+    if a.Device.Used != b.Device.Used {
+        if a.Device.Used > b.Device.Used { return -1 }
+        return 1
+    }
+    return 0 // falls through to numa tiebreak dimension
+}
+
 type numaAscDimension struct{}
 func (numaAscDimension) Name() string { return "numa-asc" }
 func (numaAscDimension) Compare(a, b *DeviceListsScore) int {
@@ -84,27 +91,22 @@ func (numaDescDimension) Compare(a, b *DeviceListsScore) int {
     return int(b.Device.Numa) - int(a.Device.Numa)
 }
 
-type binpackDimension struct{}
-func (binpackDimension) Name() string { return "binpack" }
-func (binpackDimension) Compare(a, b *DeviceListsScore) int {
+type scoreBinpackDimension struct{}
+func (scoreBinpackDimension) Name() string { return "score-binpack" }
+func (scoreBinpackDimension) Compare(a, b *DeviceListsScore) int {
     if a.Score < b.Score { return -1 }
     if a.Score > b.Score { return 1 }
     return 0
 }
 
-type spreadDimension struct{}
-func (spreadDimension) Name() string { return "spread" }
-func (spreadDimension) Compare(a, b *DeviceListsScore) int {
-    return -binpackDimension{}.Compare(a, b)
+type scoreSpreadDimension struct{}
+func (scoreSpreadDimension) Name() string { return "score-spread" }
+func (scoreSpreadDimension) Compare(a, b *DeviceListsScore) int {
+    return -scoreBinpackDimension{}.Compare(a, b)
 }
 ```
 
-Today's exact default behavior is therefore expressible as the chain
-`numa-asc,spread`, and today's binpack behavior as `numa-desc,binpack` —
-both bit-for-bit equivalent to current `Less()`, which is the backward
-compatibility bar this proposal must clear.
-
-#### `Less()` and guaranteed non-empty chain
+`Less()` becomes a chain walk instead of nested `if` blocks:
 
 ```go
 func (l DeviceUsageList) Less(i, j int) bool {
@@ -117,272 +119,68 @@ func (l DeviceUsageList) Less(i, j int) bool {
 }
 ```
 
-An empty `Chain` would make every comparison return `false`, producing an
-unstable sort. The parser guarantees `Chain` is never empty, but the
-mapping is **not** "any legacy input → the default chain" — that would be
-wrong, since it would collapse `binpack` into spread's behavior. The rule is:
+### Exact equivalence to today's merged behavior
 
-- Recognized legacy values map to their specific equivalent chain:
-  `"binpack"` → `[numa-desc, binpack]`, `"spread"` → `[numa-asc, spread]`.
-- Only **empty or unrecognized** input falls back to the default chain
-  (`[numa-asc, spread]`, matching today's actual default policy).
+The chain construction must reproduce today's four resolved paths exactly —
+this is the backward-compatibility bar, verified by a legacy-mode test
+comparing chain-based `Less()` output against the current implementation
+across randomized device sets before this is considered complete:
 
-This keeps the invariant ("`Chain` is never empty") enforced in exactly one
-place — the parser — without conflating "recognized" with "default."
+| Today's condition | Equivalent chain |
+|---|---|
+| `Policy == mutex` | `[mutex, numa-asc]` |
+| `NumaBind && binpack` | `[numa-desc, score-binpack]` |
+| `NumaBind && !binpack` (spread) | `[numa-asc, score-spread]` |
+| default, `binpack` | `[score-binpack, numa-asc]` |
+| default, spread | `[score-spread, numa-asc]` |
 
-#### Chain construction and propagation — explicit call sites
+### Construction and propagation
 
-The original draft didn't specify where chains get built, which is where
-the actual policy currently flows from config/annotation into the sort. This
-must change at both existing entry points:
+`DeviceUsageList` gains a `Chain []DeviceDimension` field. `pkg/scheduler/
+scheduler.go`'s `buildNodeUsage` (or equivalent construction site) resolves
+`Policy` + `NumaBind` into the matching chain from the table above via a new
+`policy.BuildDeviceChain(policyStr string, numaBind bool) []DeviceDimension`
+— this is additive, not a change to the annotation surface. No user-facing
+annotation changes are proposed in this revision; `Policy string` and
+`NumaBind bool` remain the actual configuration inputs, this only changes
+what they compile down to internally.
 
-- `pkg/scheduler/scheduler.go` (`buildNodeUsage`): currently calls
-  `util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, task)` and
-  assigns the resulting raw string directly to `DeviceUsageList.Policy`.
+A **follow-up** (not part of this proposal) could expose the chain directly
+via annotation (e.g. `hami.io/gpu-scheduler-policy: "numa-asc,score-binpack"`)
+for operators who want combinations the current four presets don't cover.
+That's deliberately out of scope here to keep this change to an internal
+refactor with zero behavior change, reviewable independently of any new
+user-facing surface.
 
-  **This raw string is not only used for sorting.** A separate consumer,
-  `pkg/device/nvidia/device.go`'s `Fit()`, independently re-derives the same
-  policy string via its own `GetGPUSchedulerPolicyByPod` call to compute
-  `needTopology`, which drives NVIDIA-specific device-combination selection
-  logic that has nothing to do with `Less()`. If `ParseDeviceChain` returned
-  only `[]DeviceDimension`, that would discard the raw string and leave this
-  a coincidence — it would keep working today only because `Fit()` happens
-  to re-read the annotation itself, not because this design guarantees it.
-  That's fragile and not explicitly stated, which is what review feedback on
-  this section correctly flagged.
+## Why now
 
-  Fix: the parser returns a tagged result, not a bare chain, and
-  `DeviceUsageList` keeps the raw string alongside the chain rather than
-  replacing it:
-
-  ```go
-  type ParsedDevicePolicy struct {
-      Chain        []DeviceDimension // used by Less()
-      LegacyPolicy string            // raw input, always preserved verbatim
-  }
-
-  func ParseDeviceChain(policyStr string) ParsedDevicePolicy {
-      switch policyStr {
-      case util.GPUSchedulerPolicyBinpack.String():
-          return ParsedDevicePolicy{
-              Chain:        []DeviceDimension{numaDescDimension{}, binpackDimension{}},
-              LegacyPolicy: policyStr,
-          }
-      case util.GPUSchedulerPolicyTopology.String():
-          // Sort behavior for the fallback/tiebreak ordering matches
-          // today's default (topology-aware isn't "binpack", so current
-          // Less() already falls through to the spread branch) — but
-          // LegacyPolicy is preserved so Fit()'s needTopology check keeps
-          // working, unchanged and explicitly, not by coincidence.
-          return ParsedDevicePolicy{
-              Chain:        []DeviceDimension{numaAscDimension{}, spreadDimension{}},
-              LegacyPolicy: policyStr,
-          }
-      case util.GPUSchedulerPolicySpread.String(), "":
-          return ParsedDevicePolicy{
-              Chain:        []DeviceDimension{numaAscDimension{}, spreadDimension{}},
-              LegacyPolicy: policyStr,
-          }
-      default:
-          // comma-separated chain (new format) parsed here; unrecognized
-          // tokens dropped with a warning, empty result -> default chain.
-      }
-  }
-  ```
-
-  `DeviceUsageList.Policy string` becomes `DeviceUsageList.LegacyPolicy
-  string` (renamed, not removed) plus the new `Chain []DeviceDimension`
-  field — so any existing or future consumer that needs the raw string
-  (like `Fit()`) has an explicit, typed field to read instead of an
-  implicit assumption that it's unaffected. A compatibility test must
-  assert `Fit()`'s `needTopology` behavior is bit-for-bit unchanged when
-  `LegacyPolicy == "topology-aware"`.
-- `pkg/scheduler/score.go` (`calcScoreWithOptions`): currently resolves
-  `userNodePolicy` from the pod annotation or `config.NodeSchedulerPolicy`
-  and assigns it to `NodeScoreList.Policy`. This needs the analogous
-  `policy.ParseNodeChain(policyStr string) ParsedNodePolicy` call and the
-  same `Chain` + `LegacyPolicy` field split on `NodeScoreList` (node-level
-  policy has no equivalent second consumer today, but keeping the two
-  structs symmetric avoids the same trap resurfacing later).
-- Both parsers accept the existing single-value strings (`"binpack"`,
-  `"spread"`) as well as the new comma-separated form
-  (`"numa-asc,spread"`), so this is additive at the annotation/config
-  layer — no existing Helm values or annotations need to change.
-
-#### Config/annotation format
-
-```yaml
-hami.io/gpu-scheduler-policy: "numa-asc,binpack"
-```
-
-Bare legacy values (`"binpack"`, `"spread"`) continue to work, resolving via
-the parser to their equivalent full chain as shown above.
-
-**`topology-aware` is a distinct case, not a scoring dimension.** As
-detailed above, it is handled explicitly by `ParseDeviceChain` (not treated
-as an unrecognized token) and its raw string is preserved via
-`LegacyPolicy` specifically because a second consumer (`Fit()`'s
-`needTopology` check) depends on it directly. A compatibility test
-asserting `hami.io/gpu-scheduler-policy: "topology-aware"` produces
-identical sort *and* fit/allocation behavior before and after this change
-is required before this is considered complete. Whether `topology-aware`
-can later be expressed as a composable dimension (e.g. combined with
-binpack as a tiebreaker) is left as a follow-up, not part of this
-proposal's initial scope.
-
-Other unknown dimension names (i.e., typos, not `topology-aware`) are
-dropped with a warning log rather than causing a hard failure; if dropping
-leaves the chain empty, it falls back to the default chain per the
-guarantee above.
-
-### Part 2 — Exclusion (`mutex`) policy (new)
-
-**Naming change from the original draft:** the project already uses the
-`hami.io/mutex.lock` node annotation (`pkg/util/nodelock`) as part of the
-existing per-node scheduling-lock mechanism. Calling the new feature
-`mutex-group` would collide with that existing concept even though the
-literal keys differ. This proposal renames it to
-`hami.io/exclusion-group` / `hami.io/exclusion-scope` to avoid confusion.
-
-Unlike the sort dimensions above, exclusion is a hard filter, not a scoring
-preference: "these pods must never land on the same device/node."
-
-#### The original hook doesn't have enough context — corrected design
-
-The initial draft proposed reusing `CustomFilterRule` from
-`pkg/device/devices.go`. That signature only receives already-allocated
-devices and the candidate device/request — it has no access to the
-candidate pod's own annotations, no exclusion scope, and (for node-scope) no
-visibility into which *other* pods occupy the candidate node. That's not
-enough to implement this correctly, so exclusion is instead implemented as
-scheduler-level filtering with explicit inputs, not a device-plugin hook:
-
-- New pod-level state needed at filter time: the scheduling pod's own
-  `hami.io/exclusion-group` value, and — for every pod already bound to the
-  candidate device/node — their `hami.io/exclusion-group` value. The
-  scheduler already tracks per-device `PodInfos []*PodInfo` on
-  `DeviceUsage`; this proposal needs to confirm whether `PodInfo` carries
-  annotations already or whether a pod-lister/informer lookup by
-  namespace/name is required, and if so, that lookup must go through an
-  indexed cache (not a live API read) to avoid latency under high pod churn.
-  This is called out as an open question below rather than assumed.
-
-- **Empty-group rule (explicit contract, not left implicit):** a missing or
-  empty `hami.io/exclusion-group` value means "this pod participates in no
-  exclusion group." Two pods that both lack the annotation must **never**
-  be treated as matching — the check is only ever a comparison between two
-  *non-empty, equal* group values. Without this rule, unannotated pods
-  would accidentally exclude each other, since two empty strings are
-  trivially "equal."
-
-- **Scope-source rule (symmetric, not one-sided):** the original draft read
-  `hami.io/exclusion-scope` from the scheduling pod only. That's broken:
-  if pod A (same group, `exclusion-scope: node`) already occupies node1,
-  and pod B (same group, default `exclusion-scope: device`) is being
-  placed, a one-sided check only consults B's own scope and would happily
-  place B on a *different* device on node1 — silently violating A's
-  node-wide exclusion. The "must never co-locate" guarantee has to hold
-  regardless of which pod's annotation is consulted.
-
-  Fix: **the stricter scope always wins, from either side.** When checking
-  a candidate device/node against an incumbent pod in the same exclusion
-  group, the effective scope for that check is the broader of the two —
-  if *either* the scheduling pod or the incumbent pod specifies
-  `node`, the check is node-scoped; only if *both* specify (or default to)
-  `device` is the check device-scoped. This makes the guarantee hold no
-  matter which pod happens to be scheduled first, at the cost of the
-  scheduling pod needing to know the scope of every incumbent pod sharing
-  its group — which is already required data per the empty-group rule
-  above (the scheduler must inspect every same-group incumbent's
-  annotations regardless).
-
-#### Device-scope vs node-scope, and where each runs
-
-- **Device-scope** (default): filtering happens inside `fitInDevices`
-  (`pkg/scheduler/score.go`), after per-device data is available, before
-  scoring that device.
-- **Node-scope**: filtering should run at the **top of the per-node
-  goroutine** in `calcScoreWithOptions`, before `fitInDevices` is called at
-  all — there's no reason to run device fitting/scoring logic for a node
-  that's already excluded outright. This corrects the original draft, which
-  put the check inside `fitInDevices` for both scopes.
-
-#### Concurrency safety (fixes the TOCTOU gap)
-
-A plain "read current occupants, then decide" check races: two concurrent
-scheduling attempts (node scoring already runs concurrently per node in
-`calcScoreWithOptions`) can both observe no conflict and then bind
-concurrently, violating the "must never co-locate" guarantee. Rather than
-inventing new locking, this proposal reuses the **existing**
-`pkg/util/nodelock` mechanism (`LockNode` / `SetNodeLock` / `ReleaseNodeLock`),
-which already serializes bind-time operations per node for exactly this
-class of race. Exclusion-group membership checks and the eventual bind are
-performed while holding that per-node lock, giving atomicity without a new
-subsystem.
-
-## User Stories
-
-### Story 1 — Policy combination
-
-- cluster resources:
-  - node1: 4 GPUs, split across NUMA 0 and NUMA 1
-- request:
-  - pod1: needs 2 GPUs, annotation `hami.io/gpu-scheduler-policy: "numa-asc,binpack"`
-- scheduler result:
-  - GPUs are first grouped by ascending NUMA node, then binpacked within the
-    winning NUMA group.
-
-### Story 2 — Exclusion
-
-- request:
-  - pod1, pod2 both carry `hami.io/exclusion-group: "team-a-exclusive"`,
-    both default to `exclusion-scope: device`
-- scheduler result:
-  - pod2 is filtered away from any device pod1 already occupies, even if
-    that device would otherwise score highest — and the check/bind happens
-    under the same per-node lock `nodelock` already provides, so two
-    concurrent scheduling attempts can't both succeed.
-
-### Story 3 — Asymmetric scope (the case that motivated the symmetric rule)
-
-- request:
-  - pod1: `exclusion-group: "team-a-exclusive"`, `exclusion-scope: node`,
-    already bound to node1
-  - pod2: `exclusion-group: "team-a-exclusive"`, `exclusion-scope: device`
-    (default) — a *different*, otherwise-free device on node1 would
-    normally score highest for pod2
-- scheduler result:
-  - pod2 is still filtered away from all of node1, not just pod1's
-    specific device. The effective scope for this check is the broader of
-    the two pods' scopes (`node`, from pod1), even though pod2's own
-    annotation only says `device`. A one-sided check (pod2's scope only)
-    would have incorrectly allowed this placement.
+`#2220` (configurable resource weights for binpack/spread scoring) is
+proposing to change how `ComputeScore` weighs used/core/mem — a good
+concrete example of a dimension that would slot in as a `Compare`
+implementation once this lands, rather than adding a fourth flag alongside
+`Policy` and `NumaBind`.
 
 ## Design Details / Open Questions
 
-- **Confirm `PodInfo` annotation availability**: does `DeviceUsage.PodInfos`
-  already carry the annotations needed for exclusion-group checks, or does
-  this require a pod-lister lookup? If the latter, must be backed by an
-  informer cache, not a live API call, to avoid scheduling latency at scale.
-- Dimension chain length: cap at a small number (e.g. 3) to keep `Less()`
-  cheap under high pod churn — needs a benchmark once implemented.
-- Backward compatibility: `numa-asc,spread` and `numa-desc,binpack` must be
-  verified bit-for-bit equivalent to current `Less()` output via a
-  legacy-mode test suite before this is considered complete, not just
-  reasoned about in this doc.
-- Should chain-length validation reject configs with conflicting dimensions
-  (e.g. both `binpack` and `spread` in the same chain)? Leaning yes — hard
-  error at parse time rather than silently taking the first one.
+- Should `BuildDeviceChain` live in `pkg/scheduler/policy` alongside the
+  dimensions, or in `pkg/scheduler/scheduler.go` next to where `Policy`/
+  `NumaBind` are currently resolved from annotations? Leaning toward
+  `policy` package, to keep dimension definitions and their composition
+  logic together.
+- `NodeScoreList` (node-level policy) has its own, simpler `Less()` with no
+  mutex/numa-bind equivalent today. Out of scope for this revision; worth a
+  follow-up only if node-level policy grows similarly hardcoded branches.
+- Test plan: table-driven legacy-equivalence test (chain output vs. current
+  `Less()` output) plus per-dimension unit tests, before any behavior
+  changes are proposed on top of this refactor.
 
 ## References
 
-- Roadmap: #1889 ("New schedule policy-(mutex)", "Scheduler policy
-  combination")
-- Bug: #1806 (GPU scheduler policy sort bug)
-- Existing pattern to extend: `pkg/scheduler/policy/gpu_policy.go`
-  (`DeviceUsageList.Less`), `pkg/scheduler/policy/node_policy.go`
-  (`NodeScoreList.Less`)
-- Existing per-node locking, reused for exclusion atomicity:
-  `pkg/util/nodelock/nodelock.go`
-- Prior art for proposal format: `docs/develop/scheduler-policy.md`,
-  `docs/develop/dynamic-mig.md`
+- Roadmap: #1889 (scheduler policy combination remains open after mutex/#1806
+  closed via #2011)
+- Merged: #2011 (mutex policy + score-primary/NUMA-tiebreak fix, supersedes
+  the sort-bug and mutex portions of this doc's earlier draft)
+- Related, would benefit from this refactor: #2220 (configurable resource
+  weights for binpack/spread scoring)
+- Current implementation this proposal refactors:
+  `pkg/scheduler/policy/gpu_policy.go` (`DeviceUsageList.Less`)


### PR DESCRIPTION
**What type of PR is this?**
/kind design

**What this PR does / why we need it**:
This PR proposes a design for two v2.10 roadmap items: a composable scheduler
policy chain (node-scheduler-policy / gpu-scheduler-policy currently only
support a single policy at a time, e.g. "binpack" OR "spread" OR
"topology-aware", with no way to combine dimensions like NUMA + binpack), and
a new `mutex` scheduling policy for hard mutual-exclusion constraints between
pods/devices.

The composable chain also addresses the root cause of #1806: `gpu_policy.go`'s
`Less()` already hardcodes a two-dimension comparison (NUMA, then Score) but
it isn't configurable or extensible to other dimensions.

This is a design doc only — no code changes in this PR. I'd like feedback on
the approach before implementing.

**Which issue(s) this PR fixes**:
Relates to #1889, #1806

**Special notes for your reviewer**:
- I used AI assistance to research the existing scheduler policy code
  (`pkg/scheduler/policy/`, `pkg/scheduler/score.go`, `pkg/util/types.go`)
  and draft an initial version of this doc, which I then reviewed and edited
  myself. Happy to discuss/defend any part of the design.
- Two open questions I'd especially like input on: whether node-level combination
  needs a parallel `NodeDimension` interface alongside `PolicyDimension`, and
  whether `hami.io/mutex-group` is the right annotation name given existing
  `nvidia.com/priority` semantics (see FAQ #646).
- Once this direction is agreed, I'd follow up with the actual code PR(s) —
  planning to split the policy-chain refactor and the mutex filter into
  separate PRs since they're independent.

**Does this PR introduce a user-facing change?**:
```
No user-facing change yet — this is a design proposal only. If accepted, the
follow-up implementation PR(s) will introduce:
- `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` will
  accept a comma-separated ordered list of policies (e.g. "numa,binpack") in
  addition to the existing single-value format, which remains fully
  backward compatible.
- A new `hami.io/mutex-group` (and `hami.io/mutex-scope`) Pod annotation for
  hard mutual-exclusion scheduling constraints.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a specification for composable, lexicographically-evaluated scheduler policy chains with separate dimension handling for device ordering vs node ordering, including direction-aware NUMA dimensions and special handling for `topology-aware`.
  * Defined backward-compatible parsing for legacy single-value inputs, with warnings for unknown dimensions and guarantees to keep the chain stable and non-empty.
  * Introduced a new hard mutual-exclusion (“exclusion/mutex”) policy concept with updated annotation names, explicit empty-group behavior, device-scope vs node-scope enforcement, and a race-safe implementation approach.
  * Included examples, design considerations, and open questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->