### PR TITLE
docs: clarify claiming roadmap items before starting work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Please see [Contributing](#contributing) below for the workflow.
 
 When you are willing to take on an issue, simply reply to the issue and a maintainer will assign it to you.
 
-Roadmap issues (e.g. the yearly roadmap tracking issue) list many items in one checklist instead of one task per issue, so an item may already be claimed by a comment even if the issue itself has no assignee. Before starting design or implementation work on a roadmap item, comment on the tracking issue to claim it and wait for maintainer confirmation.
+Roadmap issues (e.g., the yearly roadmap tracking issue) list many items in one checklist instead of one task per issue, so an item may already be claimed by a comment even if the issue itself has no assignee. Before starting design or implementation work on a roadmap item, comment on the tracking issue to claim it and wait for maintainer confirmation.
 
 ### File an Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ Please see [Contributing](#contributing) below for the workflow.
 
 When you are willing to take on an issue, simply reply to the issue and a maintainer will assign it to you.
 
+Roadmap issues (e.g. the yearly roadmap tracking issue) list many items in one checklist instead of one task per issue, so an item may already be claimed by a comment even if the issue itself has no assignee. Before starting design or implementation work on a roadmap item, comment on the tracking issue to claim it and wait for maintainer confirmation.
+
 ### File an Issue
 
 While we encourage everyone to contribute code, we also appreciate when someone reports an issue.


### PR DESCRIPTION
Roadmap tracking issues (like the yearly roadmap) list many items in one checklist, so an item can already be claimed by a comment even with no formal GitHub assignee. This adds one short paragraph to CONTRIBUTING.md making the expected process explicit: comment on the tracking issue and wait for maintainer (@archlitchi) confirmation before starting design or implementation work on a roadmap item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for claiming roadmap checklist items.
  * Clarified that contributors should comment on tracking issues and wait for maintainer confirmation before beginning work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->