### PR TITLE
refactor(scheduler): replace goto in Bind with fail closure

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -830,7 +830,11 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		klog.InfoS("Release node locks", "node", args.Node)
 		s.releaseAllDevices(node, current)
 		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, e)
-		return &extenderv1.ExtenderBindingResult{Error: e.Error()}, nil
+		errStr := ""
+		if e != nil {
+			errStr = e.Error()
+		}
+		return &extenderv1.ExtenderBindingResult{Error: errStr}, nil
 	}
 
 	if err = s.acquireNodeLocks(node, current); err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -826,32 +826,31 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		util.BindTimeAnnotations: strconv.FormatInt(time.Now().Unix(), 10),
 	}
 
+	fail := func(e error) (*extenderv1.ExtenderBindingResult, error) {
+		klog.InfoS("Release node locks", "node", args.Node)
+		s.releaseAllDevices(node, current)
+		s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, e)
+		return &extenderv1.ExtenderBindingResult{Error: e.Error()}, nil
+	}
+
 	if err = s.acquireNodeLocks(node, current); err != nil {
 		klog.ErrorS(err, "Failed to lock node", "node", args.Node, "pod", klog.KObj(current))
-		goto ReleaseNodeLocks
+		return fail(err)
 	}
 
-	err = util.PatchPodAnnotations(current, tmppatch)
-	if err != nil {
+	if err = util.PatchPodAnnotations(current, tmppatch); err != nil {
 		klog.ErrorS(err, "Failed to patch pod annotations", "pod", klog.KObj(current))
-		goto ReleaseNodeLocks
+		return fail(err)
 	}
 
-	err = s.kubeClient.CoreV1().Pods(args.PodNamespace).Bind(context.Background(), binding, metav1.CreateOptions{})
-	if err != nil {
+	if err = s.kubeClient.CoreV1().Pods(args.PodNamespace).Bind(context.Background(), binding, metav1.CreateOptions{}); err != nil {
 		klog.ErrorS(err, "Failed to bind pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
-		goto ReleaseNodeLocks
+		return fail(err)
 	}
 
 	s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
 	klog.InfoS("Successfully bound pod to node", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 	return &extenderv1.ExtenderBindingResult{Error: ""}, nil
-
-ReleaseNodeLocks:
-	klog.InfoS("Release node locks", "node", args.Node)
-	s.releaseAllDevices(node, current)
-	s.recordScheduleBindingResultEvent(current, EventReasonBindingFailed, []string{}, err)
-	return &extenderv1.ExtenderBindingResult{Error: err.Error()}, nil
 }
 
 func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFilterResult, error) {


### PR DESCRIPTION
## Summary

Replace 3 `goto ReleaseNodeLocks` jumps and the trailing labeled cleanup block in `Scheduler.Bind()` with an inline `fail` closure. The closure preserves the exact cleanup sequence and return contract.

## Motivation

`goto` across nested select/switch is flagged as a Go code-review anti-pattern. A named closure:

- Makes the failure path an explicit, reusable concept (`return fail(err)`)
- Keeps the early-exit branches (pod/node lookup) untouched — they must not invoke `releaseAllDevices` (no lock acquired yet)
- Future error branches can reuse the same pattern

## Changes

`pkg/scheduler/scheduler.go` — `Bind()`:
- Extract the labeled cleanup block into a `fail func(e error) (*extenderv1.ExtenderBindingResult, error)` closure
- Replace 3 `goto ReleaseNodeLocks` with `return fail(err)`
- Inline `err = ...` + `if err != nil` into `if err = ...; err != nil` (idiomatic Go)

## Behavioral equivalence

| Path | Before | After |
|---|---|---|
| acquireNodeLocks fail | goto → release + record + return (res, nil) | `return fail(err)` → same |
| PatchPodAnnotations fail | same goto path | same closure |
| kubeClient.Bind fail | same goto path | same closure |
| Success path | untouched | untouched |
| Early lookup errors | untouched (no lock yet) | untouched |

The extender contract (`return (res, nil)` for bind failures vs. scheduler-level errors) is preserved — `fail` always returns `nil` as the second value.

## AI Assistance Disclosure

This PR was authored with AI assistance (Claude Code) and is disclosed per CONTRIBUTING.md.

## Test Plan

- [x] `go build ./pkg/scheduler/...`
- [x] `go vet ./pkg/scheduler/...`
- [x] `go test -run Bind -short --race -count=1 ./pkg/scheduler/...` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pod binding failures to ensure consistent cleanup when binding cannot be completed.
  * Binding failures now return clearer failure details alongside corresponding failure events.
  * Successful pod bindings continue to behave the same, including success event reporting.
  * Eliminated inconsistent control flow that could leave locks unreleased after failed binding attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->