### PR TITLE
feat(helm): add switch for admission webhook namespaceSelector

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -111,6 +111,7 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.admissionWebhook.customURL.host` | Custom URL host | `127.0.0.1` |
 | `scheduler.admissionWebhook.customURL.port` | Custom URL port | `31998` |
 | `scheduler.admissionWebhook.customURL.path` | Custom URL path | `/webhook` |
+| `scheduler.admissionWebhook.manageNamespaceSelector` | Whether the chart renders and manages the webhook namespaceSelector field | `true` |
 | `scheduler.admissionWebhook.reinvocationPolicy` | Reinvocation policy | `Never` |
 | `scheduler.admissionWebhook.failurePolicy` | Failure policy | `Ignore` |
 

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -23,6 +23,7 @@ webhooks:
     failurePolicy: {{ .Values.scheduler.admissionWebhook.failurePolicy }}
     matchPolicy: Equivalent
     name: vgpu.hami.io
+    {{- if .Values.scheduler.admissionWebhook.manageNamespaceSelector }}
     namespaceSelector:
       {{- if .Values.scheduler.admissionWebhook.namespaceSelector.matchLabels }}
       matchLabels:
@@ -42,6 +43,7 @@ webhooks:
       {{- if .Values.scheduler.admissionWebhook.namespaceSelector.matchExpressions }}
       {{- toYaml .Values.scheduler.admissionWebhook.namespaceSelector.matchExpressions | nindent 6 }}
       {{- end }}
+    {{- end }}
     objectSelector:
       {{- if .Values.scheduler.admissionWebhook.objectSelector.matchLabels }}
       matchLabels:

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
     failurePolicy: {{ .Values.scheduler.admissionWebhook.failurePolicy }}
     matchPolicy: Equivalent
     name: vgpu.hami.io
-    {{- if .Values.scheduler.admissionWebhook.manageNamespaceSelector }}
+    {{- if or (not (hasKey .Values.scheduler.admissionWebhook "manageNamespaceSelector")) .Values.scheduler.admissionWebhook.manageNamespaceSelector }}
     namespaceSelector:
       {{- if .Values.scheduler.admissionWebhook.namespaceSelector.matchLabels }}
       matchLabels:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -176,6 +176,11 @@ scheduler:
       # - default
       # - kube-system
       # - istio-system
+    # manageNamespaceSelector controls whether the chart renders and manages the webhook's
+    # namespaceSelector field. Keep it true on standard Kubernetes clusters.
+    # Set it to false on managed platforms (e.g. AKS) where the platform mutates and owns
+    # the namespaceSelector field, to avoid server-side apply ownership conflicts.
+    manageNamespaceSelector: true
     # namespaceSelector controls which namespaces the webhook will be applied to.
     # The default matchExpressions exclude namespaces with label "hami.io/webhook: ignore".
     # You can add additional matchLabels or matchExpressions to further filter namespaces.


### PR DESCRIPTION
**Most of this Pull Request was generated or revised with the assistance of AI tools(kimi cli with K3 max). I have reviewed the resulting content and take full responsibility for its accuracy, security, licensing compliance, and inclusion in this project.**

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an explicit chart option `scheduler.admissionWebhook.manageNamespaceSelector` (default `true`) to control whether the chart renders and manages the webhook `namespaceSelector` field:

- `true` (default): keep current behavior and render `namespaceSelector` exactly as today
- `false`: do not render `namespaceSelector`, so the field can be fully managed by the platform / external controller

On managed platforms such as AKS, the control plane mutates `MutatingWebhookConfiguration` and takes ownership of `namespaceSelector` via `admissionsenforcer` (Azure/AKS#4002). Since the chart currently always renders that field, Helm fights the platform for field ownership and subsequent `helm upgrade` / `helmfile sync` may fail with a server-side apply conflict. Setting this option to `false` lets those environments opt out.

**Which issue(s) this PR fixes**:
Fixes #2039

**Special notes for your reviewer**:

This change is about field ownership compatibility only; it does not change HAMi webhook semantics by default.

- Default rendering verified byte-identical to master (`helm template` diff against master is empty).
- With `scheduler.admissionWebhook.manageNamespaceSelector=false`, the entire `namespaceSelector:` block is omitted while `objectSelector` and all other webhook fields render unchanged.
- `helm lint` and the `trivy config` chart check (CI `lint_chart` equivalent) both pass.

**Does this PR introduce a user-facing change?**:

Yes. It introduces an optional chart value for managed Kubernetes environments where the webhook `namespaceSelector` is mutated / owned externally. Default behavior remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Helm configuration option to control whether the scheduler admission webhook manages its namespace selector.
  - The option defaults to enabled; setting it to disabled will omit the namespace selector from the webhook configuration.

- **Documentation**
  - Updated the chart values documentation to describe the new `scheduler.admissionWebhook.manageNamespaceSelector` setting and its default value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->