### PR TITLE
build: bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -107,7 +107,7 @@ jobs:
             platforms: ${{ env.BUILD_PLATFORM }}
             build-args: |
               VERSION=${{ env.ref }}
-              GOLANG_IMAGE=golang:1.26.2-bookworm
+              GOLANG_IMAGE=golang:1.26.5-bookworm
               NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
               DEST_DIR=/usr/local
             tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -113,7 +113,7 @@ jobs:
             platforms: ${{ env.BUILD_PLATFORM }}
             build-args: |
               VERSION=${{ env.ref }}
-              GOLANG_IMAGE=golang:1.26.2-bookworm
+              GOLANG_IMAGE=golang:1.26.5-bookworm
               HAMICORE_IMAGE=${{ steps.meta.outputs.tags }}
               DEST_DIR=/usr/local
             tags: ${{ steps.meta1.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           labels: ${{ needs.get_info.outputs.version }}
           build-args: |
             VERSION=${{ needs.get_info.outputs.version }}
-            GOLANG_IMAGE=golang:1.26.2-bookworm
+            GOLANG_IMAGE=golang:1.26.5-bookworm
             NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
             DEST_DIR=/usr/local
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:${{ needs.get_info.outputs.version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_IMAGE=golang:1.26.2-bookworm
+ARG GOLANG_IMAGE=golang:1.26.5-bookworm
 ARG NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 
 FROM $GOLANG_IMAGE AS gobuild

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Project-HAMi/HAMi
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/NVIDIA/go-gpuallocator v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NVIDIA/go-gpuallocator v0.6.0 h1:2PA2swx59gJYREPkZNTGtyCP6Pnz3WEgnYsXlRkyvkk=
 github.com/NVIDIA/go-gpuallocator v0.6.0/go.mod h1:c+Yspg+/QxWOmoSQeuI48Z/7nS+mMPtxyj1NYUTwewY=
-github.com/NVIDIA/go-nvlib v0.11.0 h1:J6c9deWGJ1x4yY7fKg+aOdm2v5+WmCIeCLsuaO3tRtA=
-github.com/NVIDIA/go-nvlib v0.11.0/go.mod h1:uQNH63NoDuSfn/1lixD1D1Hvhko/xdnBHmc4H1mFUlY=
 github.com/NVIDIA/go-nvlib v0.12.0 h1:LICVlUGlDnpbwQv64rOZQn11xQae1J+c+dvH9CCi7jc=
 github.com/NVIDIA/go-nvlib v0.12.0/go.mod h1:J5M/QPIJJtaipjdONqevSnfgBlkW49uVWX5cFOoQpoA=
 github.com/NVIDIA/go-nvml v0.13.3-1 h1:P76U2h88OZSiMtdhRsJjSF5DXyXUqHIXKeDicVAaae0=
@@ -226,8 +224,6 @@ gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -22,7 +22,7 @@ export SHORT_VERSION
 export COMMIT_CODE
 export VERSION="${SHORT_VERSION}-${COMMIT_CODE}"
 export LATEST_VERSION="latest"
-export GOLANG_IMAGE="golang:1.26.2-bookworm"
+export GOLANG_IMAGE="golang:1.26.5-bookworm"
 export NVIDIA_IMAGE="nvidia/cuda:13.3.0-cudnn-devel-ubi8"
 export DEST_DIR="/usr/local"
 

--- a/version.mk
+++ b/version.mk
@@ -4,7 +4,7 @@ CMDS=scheduler vGPUmonitor
 DEVICES=nvidia
 OUTPUT_DIR=bin
 TARGET_PLATFORMS=linux/amd64
-GOLANG_IMAGE=golang:1.26.2-bookworm
+GOLANG_IMAGE=golang:1.26.5-bookworm
 NVIDIA_IMAGE=nvidia/cuda:13.3.0-cudnn-devel-ubi8
 DEST_DIR=/usr/local/vgpu/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps the Go toolchain from 1.26.2 to 1.26.5 everywhere it is pinned: go.mod, version.mk, docker/Dockerfile, hack/build.sh, and the GOLANG_IMAGE overrides in ci.yaml, call-release-image.yaml and call-release-image-hamicore.yaml.

This resolves the 13 open Go stdlib vulnerabilities reported on the [LFX Insights security dashboard](https://insights.linuxfoundation.org/project/hami/repository/project-hami_hami/security?timeRange=alltime&auth=success): CVE-2026-39822, CVE-2026-42505, CVE-2026-27145, CVE-2026-42504, CVE-2026-42507, CVE-2026-33814, CVE-2026-39836, CVE-2026-39825, CVE-2026-42499, CVE-2026-39826, CVE-2026-33811, CVE-2026-39823 and CVE-2026-39820.

`govulncheck ./...` reports no vulnerabilities after the bump.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Test jobs read the Go version from go.mod (`go-version-file`); the workflow changes only touch the hardcoded GOLANG_IMAGE build args used for image builds. `go mod tidy` also dropped two stale go.sum entries.
