### PR TITLE
docs: add SECURITY-INSIGHTS.yml security metadata file

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,131 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2026-07-20'
+  last-reviewed: '2026-07-20'
+  url: https://github.com/Project-HAMi/HAMi/blob/master/SECURITY-INSIGHTS.yml
+  comment: |
+    Security metadata for the HAMi project, following the OpenSSF
+    Security Insights specification.
+
+project:
+  name: HAMi
+  homepage: https://project-hami.io
+  documentation:
+    code-of-conduct: https://github.com/Project-HAMi/HAMi/blob/master/CODE_OF_CONDUCT.md
+  administrators:
+    - name: Li Mengxuan
+      affiliation: dynamia.ai
+      email: archlitchi@gmail.com
+      primary: true
+    - name: Xiao Zhang
+      affiliation: dynamia.ai
+      email: xiaozhang0210@hotmail.com
+      primary: false
+  repositories:
+    - name: HAMi
+      url: https://github.com/Project-HAMi/HAMi
+      comment: |
+        Main repository, heterogeneous AI computing virtualization
+        middleware for Kubernetes.
+    - name: HAMi-core
+      url: https://github.com/Project-HAMi/HAMi-core
+      comment: |
+        In-container GPU resource controller (libvgpu), compiled into
+        HAMi release images via a git submodule.
+    - name: HAMi-WebUI
+      url: https://github.com/Project-HAMi/HAMi-WebUI
+      comment: |
+        Web dashboard for HAMi resource monitoring.
+    - name: ascend-device-plugin
+      url: https://github.com/Project-HAMi/ascend-device-plugin
+      comment: |
+        Device plugin for Huawei Ascend NPUs, deployed with HAMi.
+    - name: volcano-vgpu-device-plugin
+      url: https://github.com/Project-HAMi/volcano-vgpu-device-plugin
+      comment: |
+        vGPU device plugin variant for the Volcano scheduler.
+    - name: website
+      url: https://github.com/Project-HAMi/website
+      comment: |
+        Source for the project documentation site at project-hami.io.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: HAMi maintainers
+      primary: true
+    security-policy: https://github.com/Project-HAMi/HAMi/blob/master/SECURITY.md
+    comment: |
+      Report vulnerabilities privately via GitHub Security Advisories:
+      https://github.com/Project-HAMi/HAMi/security/advisories/new
+      See SECURITY.md for the full policy, scope, and response process.
+
+repository:
+  url: https://github.com/Project-HAMi/HAMi
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  bug-fixes-only: false
+  no-third-party-packages: false
+  core-team:
+    - name: Li Mengxuan
+      affiliation: dynamia.ai
+      email: archlitchi@gmail.com
+      primary: true
+    - name: Xiao Zhang
+      affiliation: dynamia.ai
+      email: xiaozhang0210@hotmail.com
+      primary: false
+    - name: Wang Leibo
+      affiliation: Nvidia
+      email: wang.platform@gmail.com
+      primary: false
+    - name: Yin Yu
+      affiliation: Independent Developer
+      email: nimbus-nimo@proton.me
+      primary: false
+    - name: Shouren Yang
+      affiliation: 4Paradigm
+      email: yangshouren@gmail.com
+      primary: false
+  documentation:
+    contributing-guide: https://github.com/Project-HAMi/HAMi/blob/master/CONTRIBUTING.md
+    dependency-management-policy: https://github.com/Project-HAMi/HAMi/blob/master/DEPENDENCY.md
+    security-policy: https://github.com/Project-HAMi/HAMi/blob/master/SECURITY.md
+    governance: https://github.com/Project-HAMi/community/blob/main/community-membership.md
+  license:
+    url: https://github.com/Project-HAMi/HAMi/blob/master/LICENSE
+    expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        comment: |
+          Dependencies are monitored with Dependabot and scanned in CI
+          (CodeQL, image scanning, FOSSA license and dependency checks).
+          Go toolchain and module updates are applied promptly when
+          vulnerabilities are published.
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          Automated dependency update PRs for Go modules and GitHub Actions.
+      - name: CodeQL
+        type: SAST
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          Static analysis on pull requests via GitHub Actions.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds an [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec) v2.0.0 metadata file at the repository root. This lets automated security assessments, such as the [LFX Insights security dashboard](https://insights.linuxfoundation.org/project/hami/repository/project-hami_hami/security?timeRange=alltime&auth=success), discover the project's security policy, vulnerability reporting channel, maintainer contacts, license, and security tooling (Dependabot, CodeQL).

Content is sourced from SECURITY.md, MAINTAINERS.md, and the existing CI configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Maintainer names and emails are taken verbatim from MAINTAINERS.md. Happy to adjust the administrators list if a different set of contacts should be published here.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenSSF Security Insights metadata for the project, including schema, timestamps, and project identity.
  * Documented vulnerability reporting and intake preferences, plus repository-level status and change/request acceptance settings.
  * Included security self-assessment and the security tooling used for dependency scanning and code analysis (e.g., Dependabot and CodeQL with CI integration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
