### PR TITLE
ci: set explicit top-level token permissions on remaining workflows

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -2,6 +2,8 @@ name: Trivy Scan
 on:
   schedule:
     - cron: "0 0 * * *"
+permissions:
+  contents: read
 jobs:
   trivy-scan:
     permissions:

--- a/.github/workflows/issue-translate.yaml
+++ b/.github/workflows/issue-translate.yaml
@@ -5,6 +5,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   translate: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 0 * * 2'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Three workflows ran without an explicit top-level `permissions` block, so their GITHUB_TOKEN fell back to the repository default scope. This sets least-privilege permissions on each:

- `stale.yaml`: `issues: write`, `pull-requests: write` (what actions/stale needs to label and close)
- `issue-translate.yaml`: `issues: write` (title/comment edits; the bot token secret is used where configured)
- `ci-image-scanning.yaml`: top-level `contents: read`; the existing job-level block still grants `security-events: write` for SARIF upload

This addresses the OpenSSF Scorecard [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) check surfaced via CLOMonitor/LFX Insights.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

No behavior change expected; every permission granted is one the workflows already rely on.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows with explicit access permissions.
  * Restricted repository content access and enabled only the issue and pull request permissions required by applicable workflows.
  * Improved workflow security and predictability without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
