### PR TITLE
ci: add OpenSSF Scorecard workflow and README badge

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,33 @@
+name: OpenSSF Scorecard
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 2 * * 1'
+  push:
+    branches: [master]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout; job-level permissions replace the workflow default
+      security-events: write # to upload SARIF results
+      id-token: write # to publish results to the OpenSSF REST API
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ English version | [中文版](README_cn.md) | [日本語版](README_ja.md)
 [![build status](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml/badge.svg)](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml)
 [![Releases](https://img.shields.io/github/v/release/Project-HAMi/HAMi)](https://github.com/Project-HAMi/HAMi/releases/latest)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9416/badge)](https://www.bestpractices.dev/en/projects/9416)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Project-HAMi/HAMi/badge)](https://scorecard.dev/viewer/?uri=github.com/Project-HAMi/HAMi)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Project-HAMi/HAMi)](https://goreportcard.com/report/github.com/Project-HAMi/HAMi)
 [![codecov](https://codecov.io/gh/Project-HAMi/HAMi/branch/master/graph/badge.svg?token=ROM8CMPXZ6)](https://codecov.io/gh/Project-HAMi/HAMi)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi?ref=badge_shield)
@@ -191,8 +192,8 @@ The HAMi community is open to users, contributors, hardware vendors, and platfor
 - Slack: [#hami-dev on CNCF Slack](https://cloud-native.slack.com/archives/C07T10BU4R2)
 - Mailing list: [hami-project](https://groups.google.com/forum/#!forum/hami-project)
 - [Meeting notes and agenda](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-- Chinese community meeting: Friday 16:00 UTC+8, weekly — [Meeting link](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- English community meeting: Wednesday 16:00 UTC+8, biweekly — [Meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
+- Chinese community meeting: Friday 16:00 UTC+8, weekly, [Meeting link](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
+- English community meeting: Wednesday 16:00 UTC+8, biweekly, [Meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
 
 ## Talks And References
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -6,6 +6,7 @@
 [![build status](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml/badge.svg)](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml)
 [![Releases](https://img.shields.io/github/v/release/Project-HAMi/HAMi)](https://github.com/Project-HAMi/HAMi/releases/latest)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9416/badge)](https://www.bestpractices.dev/en/projects/9416)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Project-HAMi/HAMi/badge)](https://scorecard.dev/viewer/?uri=github.com/Project-HAMi/HAMi)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Project-HAMi/HAMi)](https://goreportcard.com/report/github.com/Project-HAMi/HAMi)
 [![codecov](https://codecov.io/gh/Project-HAMi/HAMi/branch/master/graph/badge.svg?token=ROM8CMPXZ6)](https://codecov.io/gh/Project-HAMi/HAMi)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi?ref=badge_shield)
@@ -191,8 +192,8 @@ HAMi 社区欢迎用户、贡献者、硬件厂商和构建 Kubernetes AI 基础
 - Slack：[CNCF Slack #hami-dev](https://cloud-native.slack.com/archives/C07T10BU4R2)
 - 邮件列表：[hami-project](https://groups.google.com/forum/#!forum/hami-project)
 - [会议记录和议程](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-- 中文社区周会：每周五 16:00 UTC+8 — [会议链接](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- 英文社区双周会：隔周三 16:00 UTC+8 — [会议链接](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
+- 中文社区周会：每周五 16:00 UTC+8，[会议链接](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
+- 英文社区双周会：隔周三 16:00 UTC+8，[会议链接](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
 
 ## 演讲和参考资料
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,6 +6,7 @@
 [![build status](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml/badge.svg)](https://github.com/Project-HAMi/HAMi/actions/workflows/ci.yaml)
 [![Releases](https://img.shields.io/github/v/release/Project-HAMi/HAMi)](https://github.com/Project-HAMi/HAMi/releases/latest)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9416/badge)](https://www.bestpractices.dev/en/projects/9416)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Project-HAMi/HAMi/badge)](https://scorecard.dev/viewer/?uri=github.com/Project-HAMi/HAMi)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Project-HAMi/HAMi)](https://goreportcard.com/report/github.com/Project-HAMi/HAMi)
 [![codecov](https://codecov.io/gh/Project-HAMi/HAMi/branch/master/graph/badge.svg?token=ROM8CMPXZ6)](https://codecov.io/gh/Project-HAMi/HAMi)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2FHAMi?ref=badge_shield)
@@ -159,9 +160,9 @@ http://<scheduler-ip>:<monitor-port>/metrics
 
 HAMi は他にも以下を提供します：
 
-- [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) — ビジュアルクラスタおよびデバイス管理。
-- Grafana ダッシュボードの例 — アクセラレータモニタリング用。
-- ベンチマーク素材 — ワークロードの動作とスケジューリング効果の評価用。
+- [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI)：ビジュアルクラスタおよびデバイス管理。
+- Grafana ダッシュボードの例：アクセラレータモニタリング用。
+- ベンチマーク素材：ワークロードの動作とスケジューリング効果の評価用。
 
 ![HAMi WebUI](imgs/hami-webui-overview.png)
 
@@ -191,8 +192,8 @@ HAMi コミュニティは、ユーザー、コントリビューター、ハー
 - Slack：[CNCF Slack #hami-dev](https://cloud-native.slack.com/archives/C07T10BU4R2)
 - メーリングリスト：[hami-project](https://groups.google.com/forum/#!forum/hami-project)
 - [ミーティングノートとアジェンダ](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-- 中国語コミュニティミーティング：毎週金曜日 16:00 UTC+8 — [ミーティングリンク](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- 英語コミュニティミーティング：隔週水曜日 16:00 UTC+8 — [ミーティングリンク](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
+- 中国語コミュニティミーティング：毎週金曜日 16:00 UTC+8、[ミーティングリンク](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
+- 英語コミュニティミーティング：隔週水曜日 16:00 UTC+8、[ミーティングリンク](https://zoom-lfx.platform.linuxfoundation.org/meeting/95994137931?password=55b961b5-3e8e-4040-8657-0f2d26511f1d)
 
 ## 講演と参考資料
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds the standard [ossf/scorecard-action](https://github.com/ossf/scorecard-action) workflow: weekly schedule plus pushes to master, results published to the OpenSSF REST API and uploaded as SARIF to code scanning. Adds the Scorecard badge to the README next to the existing OpenSSF Best Practices badge.

This addresses the `openssf_scorecard_badge` check surfaced via CLOMonitor/LFX Insights and gives the project a continuously updated public Scorecard rating.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The badge will render once the first scheduled run publishes results. Also replaced two em dashes with commas in the community-meeting lines while touching the README.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated OpenSSF Scorecard assessments to monitor repository security practices.
  * Security results are published and available through the project’s status badge.

* **Documentation**
  * Added the OpenSSF Scorecard badge to the README.
  * Improved formatting for community meeting schedule information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
