### PR TITLE
fix: harden HTTP servers and migconfig file permissions

### DIFF
--- a/.github/workflows/call-release-website.yaml
+++ b/.github/workflows/call-release-website.yaml
@@ -1,4 +1,4 @@
-name: Call Release webiste
+name: Call Release website
 
 on:
   workflow_call:

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -160,6 +160,7 @@ func start() error {
 			Addr:              config.HTTPBind,
 			Handler:           router,
 			ReadHeaderTimeout: 15 * time.Second,
+			ReadTimeout:       60 * time.Second,
 		}
 		if err := server.ListenAndServe(); err != nil {
 			return fmt.Errorf("listen and Serve error, %v", err)
@@ -188,6 +189,7 @@ func start() error {
 			Handler:           handler,
 			TLSConfig:         tlsCfg,
 			ReadHeaderTimeout: 15 * time.Second,
+			ReadTimeout:       60 * time.Second,
 		}
 		klog.InfoS("Starting HTTPS server", "address", addr)
 		if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -156,7 +156,12 @@ func start() error {
 	}
 
 	if len(tlsCertFile) == 0 || len(tlsKeyFile) == 0 {
-		if err := http.ListenAndServe(config.HTTPBind, router); err != nil {
+		server := &http.Server{
+			Addr:              config.HTTPBind,
+			Handler:           router,
+			ReadHeaderTimeout: 15 * time.Second,
+		}
+		if err := server.ListenAndServe(); err != nil {
 			return fmt.Errorf("listen and Serve error, %v", err)
 		}
 	} else {
@@ -179,9 +184,10 @@ func start() error {
 		addr := config.HTTPBind
 		handler := router
 		server := &http.Server{
-			Addr:      addr,
-			Handler:   handler,
-			TLSConfig: tlsCfg,
+			Addr:              addr,
+			Handler:           handler,
+			TLSConfig:         tlsCfg,
+			ReadHeaderTimeout: 15 * time.Second,
 		}
 		klog.InfoS("Starting HTTPS server", "address", addr)
 		if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -397,6 +398,12 @@ func initMetrics(bindAddress string, legacyMetrics bool) {
 
 	NewClusterManager("vGPU", reg, legacyMetrics)
 
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(bindAddress, nil))
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	server := &http.Server{
+		Addr:              bindAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -404,6 +404,7 @@ func initMetrics(bindAddress string, legacyMetrics bool) {
 		Addr:              bindAddress,
 		Handler:           mux,
 		ReadHeaderTimeout: 15 * time.Second,
+		ReadTimeout:       60 * time.Second,
 	}
 	log.Fatal(server.ListenAndServe())
 }

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -25,6 +25,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin"
 	versionmetrics "github.com/Project-HAMi/HAMi/pkg/metrics"
@@ -152,8 +153,9 @@ func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) e
 	//	prometheus.NewGoCollector(),
 	//)
 
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	server := &http.Server{Addr: metricsBindAddress, Handler: nil}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	server := &http.Server{Addr: metricsBindAddress, Handler: mux, ReadHeaderTimeout: 15 * time.Second}
 
 	// Starting the HTTP server in a goroutine
 	go func() {

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -155,7 +155,7 @@ func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) e
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	server := &http.Server{Addr: metricsBindAddress, Handler: mux, ReadHeaderTimeout: 15 * time.Second}
+	server := &http.Server{Addr: metricsBindAddress, Handler: mux, ReadHeaderTimeout: 15 * time.Second, ReadTimeout: 60 * time.Second}
 
 	// Starting the HTTP server in a goroutine
 	go func() {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -313,7 +313,9 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 			} else {
 				outStr := stdout.Bytes()
 				yaml.Unmarshal(outStr, &plugin.migCurrent)
-				os.WriteFile("/tmp/migconfig.yaml", outStr, os.ModePerm)
+				if err := os.WriteFile("/tmp/migconfig.yaml", outStr, 0o600); err != nil {
+					klog.Errorf("failed to write /tmp/migconfig.yaml: %v", err)
+				}
 
 				HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
 				if err != nil {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -313,9 +313,7 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 			} else {
 				outStr := stdout.Bytes()
 				yaml.Unmarshal(outStr, &plugin.migCurrent)
-				if err := os.WriteFile("/tmp/migconfig.yaml", outStr, 0o600); err != nil {
-					klog.Errorf("failed to write /tmp/migconfig.yaml: %v", err)
-				}
+				writeMigConfig(outStr)
 
 				HamiInitMigConfig, err := plugin.processMigConfigs(plugin.migCurrent.MigConfigs, deviceNumbers)
 				if err != nil {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -335,7 +335,9 @@ func (nv *NvidiaDevicePlugin) ApplyMigTemplate() {
 		klog.Error("marshal failed", err.Error())
 	}
 	klog.Infoln("Applying data=", string(data))
-	os.WriteFile("/tmp/migconfig.yaml", data, os.ModePerm)
+	if err := os.WriteFile("/tmp/migconfig.yaml", data, 0o600); err != nil {
+		klog.Errorf("failed to write /tmp/migconfig.yaml: %v", err)
+	}
 	cmd := exec.Command("nvidia-mig-parted", "apply", "-f", "/tmp/migconfig.yaml")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -328,10 +328,16 @@ func (nv *NvidiaDevicePlugin) EnableOtherNVMLOperation() {
 var migConfigPath = "/tmp/migconfig.yaml"
 
 // writeMigConfig persists the rendered MIG config with owner-only permissions.
+// On write failure any previous file is removed, so a later
+// nvidia-mig-parted apply fails on a missing file instead of silently
+// applying a stale config.
 func writeMigConfig(data []byte) {
 	if err := os.WriteFile(migConfigPath, data, 0o600); err != nil {
 		klog.Errorf("failed to write %s: %v", migConfigPath, err)
+		_ = os.Remove(migConfigPath)
+		return
 	}
+	klog.V(4).InfoS("wrote MIG config", "path", migConfigPath, "bytes", len(data))
 }
 
 func (nv *NvidiaDevicePlugin) ApplyMigTemplate() {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -323,6 +323,17 @@ func (nv *NvidiaDevicePlugin) EnableOtherNVMLOperation() {
 	nv.disableWatchAndRegister <- false
 }
 
+// migConfigPath is where nvidia-mig-parted reads the rendered MIG config.
+// Variable rather than const so tests can redirect the write.
+var migConfigPath = "/tmp/migconfig.yaml"
+
+// writeMigConfig persists the rendered MIG config with owner-only permissions.
+func writeMigConfig(data []byte) {
+	if err := os.WriteFile(migConfigPath, data, 0o600); err != nil {
+		klog.Errorf("failed to write %s: %v", migConfigPath, err)
+	}
+}
+
 func (nv *NvidiaDevicePlugin) ApplyMigTemplate() {
 	nv.applyMutex.Lock()
 	nv.DisableOtherNVMLOperation()
@@ -335,10 +346,8 @@ func (nv *NvidiaDevicePlugin) ApplyMigTemplate() {
 		klog.Error("marshal failed", err.Error())
 	}
 	klog.Infoln("Applying data=", string(data))
-	if err := os.WriteFile("/tmp/migconfig.yaml", data, 0o600); err != nil {
-		klog.Errorf("failed to write /tmp/migconfig.yaml: %v", err)
-	}
-	cmd := exec.Command("nvidia-mig-parted", "apply", "-f", "/tmp/migconfig.yaml")
+	writeMigConfig(data)
+	cmd := exec.Command("nvidia-mig-parted", "apply", "-f", migConfigPath)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -801,3 +801,23 @@ func TestWriteMigConfig(t *testing.T) {
 		t.Errorf("expected write to fail for missing directory")
 	}
 }
+
+func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("file permissions do not block root")
+	}
+	orig := migConfigPath
+	defer func() { migConfigPath = orig }()
+
+	migConfigPath = filepath.Join(t.TempDir(), "migconfig.yaml")
+	if err := os.WriteFile(migConfigPath, []byte("stale"), 0o400); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	// Read-only file makes the write fail; the stale file must be removed so
+	// nvidia-mig-parted cannot pick it up afterwards.
+	writeMigConfig([]byte("fresh"))
+	if _, err := os.Stat(migConfigPath); !os.IsNotExist(err) {
+		t.Errorf("expected stale config to be removed, stat err: %v", err)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -17,6 +17,8 @@
 package plugin
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -767,5 +769,35 @@ func TestCheckCDISpec(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWriteMigConfig(t *testing.T) {
+	orig := migConfigPath
+	defer func() { migConfigPath = orig }()
+
+	migConfigPath = filepath.Join(t.TempDir(), "migconfig.yaml")
+	writeMigConfig([]byte("version: v1"))
+
+	info, err := os.Stat(migConfigPath)
+	if err != nil {
+		t.Fatalf("expected config file to exist: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected permissions 0600, got %o", perm)
+	}
+	data, err := os.ReadFile(migConfigPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != "version: v1" {
+		t.Errorf("unexpected content: %q", string(data))
+	}
+
+	// Write into a missing directory must not panic; the error is only logged.
+	migConfigPath = filepath.Join(t.TempDir(), "missing", "migconfig.yaml")
+	writeMigConfig([]byte("x"))
+	if _, err := os.Stat(migConfigPath); err == nil {
+		t.Errorf("expected write to fail for missing directory")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes gosec findings: sets `ReadHeaderTimeout` (15s) on the scheduler HTTP/HTTPS servers, the scheduler metrics server, and the vGPUmonitor metrics server (G112/G114, Slowloris); writes `/tmp/migconfig.yaml` with `0600` instead of `os.ModePerm` (G306). Also fixes a "webiste" typo in a workflow name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The fixed `/tmp/migconfig.yaml` path itself is unchanged; nvidia-mig-parted reads the same path and it lives inside the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened permissions on the generated MIG configuration file so only the owning process can read it.
  * Improved logging when saving the generated MIG configuration fails.
* **Reliability**
  * Increased scheduler and GPU monitoring HTTP resilience by adding request header and read timeouts.
  * Updated metrics endpoints to run on dedicated routing instead of the default HTTP mux.
* **Tests**
  * Added unit coverage for MIG configuration file writing (content, permissions, and failure behavior).
* **Chores**
  * Corrected the release workflow display name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->