### PR TITLE
docs: drop stale glibc upper bound from prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For the NVIDIA device plugin path, prepare:
 - `nvidia-docker` version > 2.0
 - NVIDIA configured as the default runtime for containerd, Docker, or CRI-O
 - Kubernetes >= 1.23
-- glibc >= 2.17 and < 2.30
+- glibc >= 2.17
 - Linux kernel >= 3.10
 - Helm > 3.0
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -97,7 +97,7 @@ HAMi 支持多种异构加速器后端，包括 GPU、NPU、DCU、MLU、GCU、XP
 - `nvidia-docker` 版本 > 2.0
 - NVIDIA 配置为 containerd、Docker 或 CRI-O 的默认运行时
 - Kubernetes >= 1.23
-- glibc >= 2.17 且 < 2.30
+- glibc >= 2.17
 - Linux 内核 >= 3.10
 - Helm > 3.0
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -97,7 +97,7 @@ NVIDIA デバイスプラグインを使用する場合：
 - `nvidia-docker` バージョン > 2.0
 - NVIDIA が containerd、Docker、または CRI-O のデフォルトランタイムとして設定されていること
 - Kubernetes >= 1.23
-- glibc >= 2.17 および < 2.30
+- glibc >= 2.17
 - Linux カーネル >= 3.10
 - Helm > 3.0
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Drops the stale `glibc < 2.30` upper bound from the prerequisites in both READMEs. The limit came from HAMi-core's use of the private `_dl_sym` glibc symbol, which was removed in glibc 2.34. HAMi-core no longer uses it (Project-HAMi/HAMi-core#175) and that fix is included in the libvgpu commit pinned by v2.9.0, so newer glibc (e.g. AL2023 with glibc 2.34) works.

**Which issue(s) this PR fixes**:
Fixes #2101

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA prerequisite guidance in the English README to require glibc 2.17 or newer (removed the prior upper-bound constraint).
  * Updated the Chinese README “前置条件” to match the revised glibc requirement (glibc ≥ 2.17).
  * Updated the Japanese README “前提条件” to align with glibc ≥ 2.17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->