### PR TITLE
fix(nvidia): detect NVLink through NVSwitch for topology scoring

### DIFF
--- a/pkg/device/nvidia/links.go
+++ b/pkg/device/nvidia/links.go
@@ -169,6 +169,13 @@ func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 		return direct, nil
 	}
 
+	// No enabled NVLinks on dev1 — skip NVSwitch detection.
+	// Remove if GetNvLinkRemotePciInfo and GetNvLinkRemoteDeviceType
+	// ever diverge in NOT_SUPPORTED behavior.
+	if len(pciInfos) == 0 {
+		return P2PLinkUnknown, nil
+	}
+
 	// NVSwitch: remote PCI is the switch, not the peer GPU.
 	// Both GPUs must connect through NVSwitch; the link count is the
 	// minimum active count across the pair.

--- a/pkg/device/nvidia/links.go
+++ b/pkg/device/nvidia/links.go
@@ -161,6 +161,9 @@ func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 	}
 	dev2BusID := PciInfo(dev2PciInfo).BusID()
 
+	// A GPU with both direct and NVSwitch links is not expected on current
+	// NVIDIA hardware; if it ever occurs, the NVSwitch links would be
+	// silently ignored here.
 	direct := nvlinkCountToType(countMatchingLinks(pciInfos, dev2BusID))
 	if direct != P2PLinkUnknown {
 		return direct, nil
@@ -237,7 +240,13 @@ func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool, err error
 			continue
 		}
 		deviceType, ret := dev.GetNvLinkRemoteDeviceType(i)
-		if errors.Is(ret, nvml.SUCCESS) && deviceType == nvml.NVLINK_DEVICE_TYPE_SWITCH {
+		if errors.Is(ret, nvml.ERROR_NOT_SUPPORTED) || errors.Is(ret, nvml.ERROR_INVALID_ARGUMENT) {
+			continue
+		}
+		if !errors.Is(ret, nvml.SUCCESS) {
+			return 0, false, fmt.Errorf("failed to get nvlink remote device type: %v", ret)
+		}
+		if deviceType == nvml.NVLINK_DEVICE_TYPE_SWITCH {
 			count++
 		}
 	}
@@ -246,8 +255,8 @@ func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool, err error
 
 // nvlinkCountToType converts a count to the corresponding P2PLinkType.
 func nvlinkCountToType(n int) P2PLinkType {
-	// ponytail: linear scan, array would be cleaner but it's 18 items.
-	types := []P2PLinkType{
+	// Covers up to 18 NVLinks per GPU (current max: H100/B200).
+	types := [...]P2PLinkType{
 		P2PLinkUnknown,
 		SingleNVLINKLink, TwoNVLINKLinks, ThreeNVLINKLinks,
 		FourNVLINKLinks, FiveNVLINKLinks, SixNVLINKLinks,

--- a/pkg/device/nvidia/links.go
+++ b/pkg/device/nvidia/links.go
@@ -169,11 +169,16 @@ func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 	// NVSwitch: remote PCI is the switch, not the peer GPU.
 	// Both GPUs must connect through NVSwitch; the link count is the
 	// minimum active count across the pair.
-	links1, viaSwitch1 := countNvSwitchLinks(dev1)
-	links2, viaSwitch2 := countNvSwitchLinks(dev2)
+	links1, viaSwitch1, err := countNvSwitchLinks(dev1)
+	if err != nil {
+		return P2PLinkUnknown, fmt.Errorf("failed to check nvswitch links for dev1: %v", err)
+	}
+	links2, viaSwitch2, err := countNvSwitchLinks(dev2)
+	if err != nil {
+		return P2PLinkUnknown, fmt.Errorf("failed to check nvswitch links for dev2: %v", err)
+	}
 	if viaSwitch1 && viaSwitch2 {
-		n := min(links1, links2)
-		return nvlinkCountToType(n), nil
+		return nvlinkCountToType(min(links1, links2)), nil
 	}
 
 	return P2PLinkUnknown, nil
@@ -219,10 +224,16 @@ func countMatchingLinks(pciInfos []PciInfo, busID string) int {
 
 // countNvSwitchLinks returns the count of enabled NVLinks whose remote is
 // an NVSwitch, and whether the device has any such links at all.
-func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool) {
+func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool, err error) {
 	for i := range nvml.NVLINK_MAX_LINKS {
 		state, ret := dev.GetNvLinkState(i)
-		if !errors.Is(ret, nvml.SUCCESS) || state != nvml.FEATURE_ENABLED {
+		if errors.Is(ret, nvml.ERROR_NOT_SUPPORTED) || errors.Is(ret, nvml.ERROR_INVALID_ARGUMENT) {
+			continue
+		}
+		if !errors.Is(ret, nvml.SUCCESS) {
+			return 0, false, fmt.Errorf("failed to get nvlink state: %v", ret)
+		}
+		if state != nvml.FEATURE_ENABLED {
 			continue
 		}
 		deviceType, ret := dev.GetNvLinkRemoteDeviceType(i)
@@ -230,7 +241,7 @@ func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool) {
 			count++
 		}
 	}
-	return count, count > 0
+	return count, count > 0, nil
 }
 
 // nvlinkCountToType converts a count to the corresponding P2PLinkType.

--- a/pkg/device/nvidia/links.go
+++ b/pkg/device/nvidia/links.go
@@ -149,6 +149,7 @@ func GetP2PLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 
 // GetNVLink gets the number of NVLinks between the specified devices.
 func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
+	// Direct GPU <-> GPU: match remote PCI bus IDs.
 	pciInfos, err := getAllNvLinkRemotePciInfo(dev1)
 	if err != nil {
 		return P2PLinkUnknown, fmt.Errorf("failed to get nvlink remote pci info: %v", err)
@@ -160,53 +161,22 @@ func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 	}
 	dev2BusID := PciInfo(dev2PciInfo).BusID()
 
-	nvlink := P2PLinkUnknown
-	for _, pciInfo := range pciInfos {
-		if pciInfo.BusID() != dev2BusID {
-			continue
-		}
-		switch nvlink {
-		case P2PLinkUnknown:
-			nvlink = SingleNVLINKLink
-		case SingleNVLINKLink:
-			nvlink = TwoNVLINKLinks
-		case TwoNVLINKLinks:
-			nvlink = ThreeNVLINKLinks
-		case ThreeNVLINKLinks:
-			nvlink = FourNVLINKLinks
-		case FourNVLINKLinks:
-			nvlink = FiveNVLINKLinks
-		case FiveNVLINKLinks:
-			nvlink = SixNVLINKLinks
-		case SixNVLINKLinks:
-			nvlink = SevenNVLINKLinks
-		case SevenNVLINKLinks:
-			nvlink = EightNVLINKLinks
-		case EightNVLINKLinks:
-			nvlink = NineNVLINKLinks
-		case NineNVLINKLinks:
-			nvlink = TenNVLINKLinks
-		case TenNVLINKLinks:
-			nvlink = ElevenNVLINKLinks
-		case ElevenNVLINKLinks:
-			nvlink = TwelveNVLINKLinks
-		case TwelveNVLINKLinks:
-			nvlink = ThirteenNVLINKLinks
-		case ThirteenNVLINKLinks:
-			nvlink = FourteenNVLINKLinks
-		case FourteenNVLINKLinks:
-			nvlink = FifteenNVLINKLinks
-		case FifteenNVLINKLinks:
-			nvlink = SixteenNVLINKLinks
-		case SixteenNVLINKLinks:
-			nvlink = SeventeenNVLINKLinks
-		case SeventeenNVLINKLinks:
-			nvlink = EighteenNVLINKLinks
-		}
+	direct := nvlinkCountToType(countMatchingLinks(pciInfos, dev2BusID))
+	if direct != P2PLinkUnknown {
+		return direct, nil
 	}
-	// TODO(klueska): Handle NVSwitch semantics
 
-	return nvlink, nil
+	// NVSwitch: remote PCI is the switch, not the peer GPU.
+	// Both GPUs must connect through NVSwitch; the link count is the
+	// minimum active count across the pair.
+	links1, viaSwitch1 := countNvSwitchLinks(dev1)
+	links2, viaSwitch2 := countNvSwitchLinks(dev2)
+	if viaSwitch1 && viaSwitch2 {
+		n := min(links1, links2)
+		return nvlinkCountToType(n), nil
+	}
+
+	return P2PLinkUnknown, nil
 }
 
 // getAllNvLinkRemotePciInfo returns the PCI info for all devices attached to the specified device by an NVLink.
@@ -234,6 +204,51 @@ func getAllNvLinkRemotePciInfo(dev device.Device) ([]PciInfo, error) {
 	}
 
 	return pciInfos, nil
+}
+
+// countMatchingLinks counts how many remote PCI entries match busID.
+func countMatchingLinks(pciInfos []PciInfo, busID string) int {
+	n := 0
+	for _, pci := range pciInfos {
+		if pci.BusID() == busID {
+			n++
+		}
+	}
+	return n
+}
+
+// countNvSwitchLinks returns the count of enabled NVLinks whose remote is
+// an NVSwitch, and whether the device has any such links at all.
+func countNvSwitchLinks(dev device.Device) (count int, viaSwitch bool) {
+	for i := range nvml.NVLINK_MAX_LINKS {
+		state, ret := dev.GetNvLinkState(i)
+		if !errors.Is(ret, nvml.SUCCESS) || state != nvml.FEATURE_ENABLED {
+			continue
+		}
+		deviceType, ret := dev.GetNvLinkRemoteDeviceType(i)
+		if errors.Is(ret, nvml.SUCCESS) && deviceType == nvml.NVLINK_DEVICE_TYPE_SWITCH {
+			count++
+		}
+	}
+	return count, count > 0
+}
+
+// nvlinkCountToType converts a count to the corresponding P2PLinkType.
+func nvlinkCountToType(n int) P2PLinkType {
+	// ponytail: linear scan, array would be cleaner but it's 18 items.
+	types := []P2PLinkType{
+		P2PLinkUnknown,
+		SingleNVLINKLink, TwoNVLINKLinks, ThreeNVLINKLinks,
+		FourNVLINKLinks, FiveNVLINKLinks, SixNVLINKLinks,
+		SevenNVLINKLinks, EightNVLINKLinks, NineNVLINKLinks,
+		TenNVLINKLinks, ElevenNVLINKLinks, TwelveNVLINKLinks,
+		ThirteenNVLINKLinks, FourteenNVLINKLinks, FifteenNVLINKLinks,
+		SixteenNVLINKLinks, SeventeenNVLINKLinks, EighteenNVLINKLinks,
+	}
+	if n < 1 || n >= len(types) {
+		return P2PLinkUnknown
+	}
+	return types[n]
 }
 
 // PciInfo is a type alias to nvml.PciInfo to allow for functions to be defined on the type.

--- a/pkg/device/nvidia/links_test.go
+++ b/pkg/device/nvidia/links_test.go
@@ -131,7 +131,9 @@ func Test_nvlinkCountToType(t *testing.T) {
 
 // mockPciInfo creates a PciInfo whose BusID() method returns busID.
 func mockPciInfo(busIDStr string) PciInfo {
-	var raw [32]uint8
-	copy(raw[:], busIDStr)
+	var raw [32]int8
+	for i, c := range busIDStr {
+		raw[i] = int8(c)
+	}
 	return PciInfo{BusId: raw}
 }

--- a/pkg/device/nvidia/links_test.go
+++ b/pkg/device/nvidia/links_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"testing"
+)
+
+func Test_countMatchingLinks(t *testing.T) {
+	tests := []struct {
+		name    string
+		pciList []PciInfo
+		busID   string
+		want    int
+	}{
+		{
+			name:    "empty",
+			pciList: nil,
+			busID:   "01:00.0",
+			want:    0,
+		},
+		{
+			name: "single match",
+			pciList: []PciInfo{
+				mockPciInfo("00000000:01:00.0"),
+			},
+			busID: "0000:01:00.0",
+			want:  1,
+		},
+		{
+			name: "no match",
+			pciList: []PciInfo{
+				mockPciInfo("00000000:01:00.0"),
+			},
+			busID: "0000:02:00.0",
+			want:  0,
+		},
+		{
+			name: "multiple matches",
+			pciList: []PciInfo{
+				mockPciInfo("00000000:01:00.0"),
+				mockPciInfo("00000000:02:00.0"),
+				mockPciInfo("00000000:01:00.0"),
+			},
+			busID: "0000:01:00.0",
+			want:  2,
+		},
+		{
+			name: "all match",
+			pciList: []PciInfo{
+				mockPciInfo("00000000:0a:00.0"),
+				mockPciInfo("00000000:0a:00.0"),
+				mockPciInfo("00000000:0a:00.0"),
+			},
+			busID: "0000:0a:00.0",
+			want:  3,
+		},
+		{
+			name: "NVSwitch remote PCI vs GPU PCI — no match",
+			pciList: []PciInfo{
+				mockPciInfo("00000000:05:00.0"),
+				mockPciInfo("00000000:06:00.0"),
+				mockPciInfo("00000000:07:00.0"),
+				mockPciInfo("00000000:08:00.0"),
+			},
+			busID: "0000:18:00.0",
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countMatchingLinks(tt.pciList, tt.busID)
+			if got != tt.want {
+				t.Errorf("countMatchingLinks() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nvlinkCountToType(t *testing.T) {
+	tests := []struct {
+		n    int
+		want P2PLinkType
+	}{
+		{-1, P2PLinkUnknown},
+		{0, P2PLinkUnknown},
+		{1, SingleNVLINKLink},
+		{2, TwoNVLINKLinks},
+		{3, ThreeNVLINKLinks},
+		{4, FourNVLINKLinks},
+		{5, FiveNVLINKLinks},
+		{6, SixNVLINKLinks},
+		{7, SevenNVLINKLinks},
+		{8, EightNVLINKLinks},
+		{9, NineNVLINKLinks},
+		{10, TenNVLINKLinks},
+		{11, ElevenNVLINKLinks},
+		{12, TwelveNVLINKLinks},
+		{13, ThirteenNVLINKLinks},
+		{14, FourteenNVLINKLinks},
+		{15, FifteenNVLINKLinks},
+		{16, SixteenNVLINKLinks},
+		{17, SeventeenNVLINKLinks},
+		{18, EighteenNVLINKLinks},
+		{19, P2PLinkUnknown}, // beyond max
+		{100, P2PLinkUnknown},
+	}
+
+	for _, tt := range tests {
+		got := nvlinkCountToType(tt.n)
+		if got != tt.want {
+			t.Errorf("nvlinkCountToType(%d) = %v, want %v", tt.n, got, tt.want)
+		}
+	}
+}
+
+// mockPciInfo creates a PciInfo whose BusID() method returns busID.
+func mockPciInfo(busIDStr string) PciInfo {
+	var raw [32]uint8
+	copy(raw[:], busIDStr)
+	return PciInfo{BusId: raw}
+}

--- a/pkg/device/nvidia/links_test.go
+++ b/pkg/device/nvidia/links_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package nvidia
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
 
 func Test_countMatchingLinks(t *testing.T) {
@@ -122,18 +127,364 @@ func Test_nvlinkCountToType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := nvlinkCountToType(tt.n)
-		if got != tt.want {
-			t.Errorf("nvlinkCountToType(%d) = %v, want %v", tt.n, got, tt.want)
-		}
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			got := nvlinkCountToType(tt.n)
+			if got != tt.want {
+				t.Errorf("nvlinkCountToType(%d) = %v, want %v", tt.n, got, tt.want)
+			}
+		})
 	}
 }
 
 // mockPciInfo creates a PciInfo whose BusID() method returns busID.
 func mockPciInfo(busIDStr string) PciInfo {
 	var raw [32]int8
-	for i, c := range busIDStr {
-		raw[i] = int8(c)
+	for i := 0; i < len(busIDStr) && i < len(raw); i++ {
+		raw[i] = int8(busIDStr[i])
 	}
 	return PciInfo{BusId: raw}
+}
+
+// newMockDevice wraps a go-nvml mock.Device into a go-nvlib device.Device,
+// following the same pattern used by go-nvlib's own internal tests.
+func newMockDevice(mockDev *nvmlmock.Device) device.Device {
+	lib := device.New(nil, device.WithVerifySymbols(false))
+	dev, _ := lib.NewDevice(mockDev)
+	return dev
+}
+
+// makeNvLinkStateFunc returns a GetNvLinkStateFunc that reports `enabledCount`
+// links as FEATURE_ENABLED and the rest as FEATURE_DISABLED.
+func makeNvLinkStateFunc(enabledCount int) func(int) (nvml.EnableState, nvml.Return) {
+	return func(i int) (nvml.EnableState, nvml.Return) {
+		if i < enabledCount {
+			return nvml.FEATURE_ENABLED, nvml.SUCCESS
+		}
+		return nvml.FEATURE_DISABLED, nvml.SUCCESS
+	}
+}
+
+// makeNvLinkStateErrorFunc returns a GetNvLinkStateFunc where link `errLink`
+// returns `errRet` and all other links return SUCCESS+ENABLED.
+func makeNvLinkStateErrorFunc(errLink int, errRet nvml.Return) func(int) (nvml.EnableState, nvml.Return) {
+	return func(i int) (nvml.EnableState, nvml.Return) {
+		if i == errLink {
+			return nvml.FEATURE_DISABLED, errRet
+		}
+		return nvml.FEATURE_ENABLED, nvml.SUCCESS
+	}
+}
+
+// makeRemoteDeviceTypeFunc returns a GetNvLinkRemoteDeviceTypeFunc where the
+// first `switchCount` enabled links report NVLINK_DEVICE_TYPE_SWITCH and the
+// rest report NVLINK_DEVICE_TYPE_GPU.
+func makeRemoteDeviceTypeFunc(switchCount int) func(int) (nvml.IntNvLinkDeviceType, nvml.Return) {
+	return func(i int) (nvml.IntNvLinkDeviceType, nvml.Return) {
+		if i < switchCount {
+			return nvml.NVLINK_DEVICE_TYPE_SWITCH, nvml.SUCCESS
+		}
+		return nvml.NVLINK_DEVICE_TYPE_GPU, nvml.SUCCESS
+	}
+}
+
+// makeRemoteDeviceTypeErrorFunc returns a GetNvLinkRemoteDeviceTypeFunc where
+// link `errLink` returns `errRet` and all other links return SUCCESS+SWITCH.
+func makeRemoteDeviceTypeErrorFunc(errLink int, errRet nvml.Return) func(int) (nvml.IntNvLinkDeviceType, nvml.Return) {
+	return func(i int) (nvml.IntNvLinkDeviceType, nvml.Return) {
+		if i == errLink {
+			return nvml.NVLINK_DEVICE_TYPE_UNKNOWN, errRet
+		}
+		return nvml.NVLINK_DEVICE_TYPE_SWITCH, nvml.SUCCESS
+	}
+}
+
+// makeRemotePciInfoFunc returns a GetNvLinkRemotePciInfoFunc where all enabled
+// links report the given busID as the remote PCI address.
+func makeRemotePciInfoFunc(busID string) func(int) (nvml.PciInfo, nvml.Return) {
+	return func(int) (nvml.PciInfo, nvml.Return) {
+		return nvml.PciInfo(mockPciInfo(busID)), nvml.SUCCESS
+	}
+}
+
+func Test_countNvSwitchLinks(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateFunc func(int) (nvml.EnableState, nvml.Return)
+		typeFunc  func(int) (nvml.IntNvLinkDeviceType, nvml.Return)
+		wantCount int
+		wantVia   bool
+		wantErr   bool
+	}{
+		{
+			name:      "all_links_via_nvswitch",
+			stateFunc: makeNvLinkStateFunc(int(nvml.NVLINK_MAX_LINKS)),
+			typeFunc:  makeRemoteDeviceTypeFunc(int(nvml.NVLINK_MAX_LINKS)),
+			wantCount: int(nvml.NVLINK_MAX_LINKS),
+			wantVia:   true,
+		},
+		{
+			name:      "no_links_enabled",
+			stateFunc: makeNvLinkStateFunc(0),
+			typeFunc:  makeRemoteDeviceTypeFunc(0),
+			wantCount: 0,
+			wantVia:   false,
+		},
+		{
+			name:      "links_enabled_but_not_switch",
+			stateFunc: makeNvLinkStateFunc(int(nvml.NVLINK_MAX_LINKS)),
+			typeFunc:  makeRemoteDeviceTypeFunc(0), // all GPU
+			wantCount: 0,
+			wantVia:   false,
+		},
+		{
+			name: "mixed_switch_and_gpu",
+			// Tests counting accuracy when link types are mixed, not a real
+			// topology. countNvSwitchLinks should only count SWITCH links.
+			stateFunc: makeNvLinkStateFunc(int(nvml.NVLINK_MAX_LINKS)),
+			typeFunc:  makeRemoteDeviceTypeFunc(10), // 10 SWITCH, rest GPU
+			wantCount: 10,
+			wantVia:   true,
+		},
+		{
+			name:      "nvlink_state_not_supported_skipped",
+			stateFunc: makeNvLinkStateErrorFunc(0, nvml.ERROR_NOT_SUPPORTED),
+			typeFunc:  makeRemoteDeviceTypeFunc(int(nvml.NVLINK_MAX_LINKS)),
+			wantCount: int(nvml.NVLINK_MAX_LINKS) - 1, // 1 skipped
+			wantVia:   true,
+		},
+		{
+			name:      "nvlink_state_unexpected_error",
+			stateFunc: makeNvLinkStateErrorFunc(0, nvml.ERROR_UNKNOWN),
+			typeFunc:  makeRemoteDeviceTypeFunc(int(nvml.NVLINK_MAX_LINKS)),
+			wantErr:   true,
+		},
+		{
+			name:      "remote_type_not_supported_skipped",
+			stateFunc: makeNvLinkStateFunc(int(nvml.NVLINK_MAX_LINKS)),
+			typeFunc:  makeRemoteDeviceTypeErrorFunc(0, nvml.ERROR_NOT_SUPPORTED),
+			wantCount: int(nvml.NVLINK_MAX_LINKS) - 1, // 1 skipped
+			wantVia:   true,
+		},
+		{
+			name:      "remote_type_unexpected_error",
+			stateFunc: makeNvLinkStateFunc(int(nvml.NVLINK_MAX_LINKS)),
+			typeFunc:  makeRemoteDeviceTypeErrorFunc(0, nvml.ERROR_UNKNOWN),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := newMockDevice(&nvmlmock.Device{
+				GetNvLinkStateFunc:            tt.stateFunc,
+				GetNvLinkRemoteDeviceTypeFunc: tt.typeFunc,
+			})
+			gotCount, gotVia, err := countNvSwitchLinks(dev)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("countNvSwitchLinks() err = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if gotCount != tt.wantCount {
+				t.Errorf("countNvSwitchLinks() count = %d, want %d", gotCount, tt.wantCount)
+			}
+			if gotVia != tt.wantVia {
+				t.Errorf("countNvSwitchLinks() viaSwitch = %v, want %v", gotVia, tt.wantVia)
+			}
+		})
+	}
+}
+
+func Test_GetNVLink(t *testing.T) {
+	const dev2BusID = "00000000:2a:00.0"
+	const switchBusID = "00000000:07:00.0"
+
+	dev2PciFunc := func() (nvml.PciInfo, nvml.Return) {
+		return nvml.PciInfo(mockPciInfo(dev2BusID)), nvml.SUCCESS
+	}
+
+	tests := []struct {
+		name     string
+		dev1Mock *nvmlmock.Device
+		dev2Mock *nvmlmock.Device
+		want     P2PLinkType
+		wantErr  bool
+	}{
+		{
+			name: "direct_connect_18_links",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:         makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc: makeRemotePciInfoFunc(dev2BusID),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc: dev2PciFunc,
+			},
+			want: EighteenNVLINKLinks,
+		},
+		{
+			name: "direct_connect_partial",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:         makeNvLinkStateFunc(4),
+				GetNvLinkRemotePciInfoFunc: makeRemotePciInfoFunc(dev2BusID),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc: dev2PciFunc,
+			},
+			want: FourNVLINKLinks,
+		},
+		{
+			name: "nvswitch_full_mesh_18",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID), // remote is NVSwitch, not dev2
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc, // does not match switchBusID
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			want: EighteenNVLINKLinks,
+		},
+		{
+			name: "nvswitch_asymmetric",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc,
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(4),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(4),
+			},
+			want: FourNVLINKLinks, // min(18, 4)
+		},
+		{
+			name: "one_side_no_nvswitch",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc,
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(0), // no links
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(0),
+			},
+			want: P2PLinkUnknown,
+		},
+		{
+			name: "no_nvlink_anywhere",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:         makeNvLinkStateFunc(0),
+				GetNvLinkRemotePciInfoFunc: makeRemotePciInfoFunc(switchBusID),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:     dev2PciFunc,
+				GetNvLinkStateFunc: makeNvLinkStateFunc(0),
+			},
+			want: P2PLinkUnknown,
+		},
+		{
+			name: "dev1_nvlink_state_error",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:         makeNvLinkStateErrorFunc(0, nvml.ERROR_UNKNOWN),
+				GetNvLinkRemotePciInfoFunc: makeRemotePciInfoFunc(switchBusID),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc: dev2PciFunc,
+			},
+			wantErr: true,
+		},
+		{
+			name: "dev1_nvswitch_count_error",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID), // won't match dev2
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeErrorFunc(0, nvml.ERROR_UNKNOWN),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc: dev2PciFunc,
+			},
+			wantErr: true,
+		},
+		// Swapped dev1/dev2 variants — GetNVLink is asymmetric:
+		// getAllNvLinkRemotePciInfo(dev1) then countNvSwitchLinks(dev1) then (dev2).
+		{
+			name: "nvswitch_asymmetric_swapped",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(4),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(4),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc,
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			want: FourNVLINKLinks, // min(4, 18)
+		},
+		{
+			name: "one_side_no_nvswitch_swapped",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(0), // no NVSwitch links
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(0),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc,
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			want: P2PLinkUnknown, // viaSwitch1=false
+		},
+		{
+			name: "dev2_nvswitch_state_error",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:     dev2PciFunc,
+				GetNvLinkStateFunc: makeNvLinkStateErrorFunc(0, nvml.ERROR_UNKNOWN),
+			},
+			wantErr: true,
+		},
+		{
+			name: "dev2_nvswitch_count_error",
+			dev1Mock: &nvmlmock.Device{
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemotePciInfoFunc:    makeRemotePciInfoFunc(switchBusID),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeFunc(18),
+			},
+			dev2Mock: &nvmlmock.Device{
+				GetPciInfoFunc:                dev2PciFunc,
+				GetNvLinkStateFunc:            makeNvLinkStateFunc(18),
+				GetNvLinkRemoteDeviceTypeFunc: makeRemoteDeviceTypeErrorFunc(0, nvml.ERROR_UNKNOWN),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev1 := newMockDevice(tt.dev1Mock)
+			dev2 := newMockDevice(tt.dev2Mock)
+			got, err := GetNVLink(dev1, dev2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetNVLink() err = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetNVLink() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`GetNVLink()` currently detects NVLink by matching remote PCI bus IDs — it expects each NVLink's remote endpoint PCI to equal the peer GPU's PCI. This works for direct-connect topologies (V100, A100 pre-NVSwitch), but fails on NVSwitch architectures (H100, B200, etc.).

On NVSwitch systems, `GetNvLinkRemotePciInfo` returns the NVSwitch chip's PCI address (e.g. `0000:07:00.0`), which never matches any GPU's BusID (e.g. `0000:2a:00.0`). All pairs return `P2PLinkUnknown` (0 NVLink score), and topology-aware scheduling degrades to NUMA-only.

This PR adds an NVSwitch fallback:

1. Direct PCI matching is attempted first (existing path)
2. If no match, `countNvSwitchLinks()` uses `GetNvLinkRemoteDeviceType()` to  check whether both GPUs connect through NVSwitch
3. If both do, effective NVLink count = `min(links₁, links₂)` — matching `nvidia-smi topo -m`

Also refactors `GetNVLink`:
- Replaces the 30-line `switch` cascade with `nvlinkCountToType` array-lookup
- Aligns `countNvSwitchLinks` error handling with `getAllNvLinkRemotePciInfo`
- Removes `TODO(klueska): Handle NVSwitch semantics`

**Verification** — tested on 8×H100 NV18 node:

```
Summary: OLD detected NVLink in 0 pairs, missed 28 pairs.
```

OLD `GetNVLink` returned `P2PLinkUnknown` for all GPU pairs (scores 10–20, NUMA-only). NEW correctly returns `EighteenNVLINKLinks` (scores 1810–1820, matching `nvidia-smi topo -m` NV18).

**Which issue(s) this PR fixes**:
None filed. The `TODO(klueska): Handle NVSwitch semantics` comment has been
present since the NVIDIA code was imported.

**Special notes for your reviewer**:

- `getAllNvLinkRemotePciInfo` and `countNvSwitchLinks` are intentionally kept
  separate — they call different NVML APIs, have different error semantics,
  and are called at different control-flow points.
- `countMatchingLinks` and `nvlinkCountToType` have unit tests; NVML-dependent
  functions verified via the prototype below.

**Does this PR introduce a user-facing change?**:
No breaking changes. NVSwitch nodes now report correct topology scores.

---

> **AI Assistance Disclosure**: This PR was written with the assistance of
> Claude Code (pi coding agent). All code was reviewed by the author.

---

<details>
<summary>Prototype: side-by-side OLD vs NEW verification on 8×H100</summary>

Build: `go build -o nvlink-diag ./cmd/nvlink-diag/` then run on an H100 node.

```go
// cmd/nvlink-diag/main.go
// Prototype: verify NVSwitch NVLink detection on the current node.
// Compares original HAMi implementation (PCI matching only) against
// the fixed version (PCI matching + NVSwitch fallback).
package main

import (
	"errors"
	"fmt"
	"os"
	"strings"

	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
	"github.com/NVIDIA/go-nvml/pkg/nvml"

	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
)

// ---- Original HAMi GetNVLink (PCI-matching only, pre-NVSwitch fix) ----

func getNVLinkOld(dev1, dev2 device.Device) (nvidia.P2PLinkType, error) {
	pciInfos, err := getAllNvLinkRemotePciInfoOld(dev1)
	if err != nil {
		return nvidia.P2PLinkUnknown, fmt.Errorf("failed to get nvlink remote pci info: %v", err)
	}
	dev2PciInfo, ret := dev2.GetPciInfo()
	if !errors.Is(ret, nvml.SUCCESS) {
		return nvidia.P2PLinkUnknown, fmt.Errorf("failed to get pci info: %v", ret)
	}
	dev2BusID := nvidia.PciInfo(dev2PciInfo).BusID()

	nvlink := nvidia.P2PLinkUnknown
	for _, pciInfo := range pciInfos {
		if pciInfo.BusID() != dev2BusID {
			continue
		}
		switch nvlink {
		case nvidia.P2PLinkUnknown:
			nvlink = nvidia.SingleNVLINKLink
		case nvidia.SingleNVLINKLink:
			nvlink = nvidia.TwoNVLINKLinks
		case nvidia.TwoNVLINKLinks:
			nvlink = nvidia.ThreeNVLINKLinks
		case nvidia.ThreeNVLINKLinks:
			nvlink = nvidia.FourNVLINKLinks
		case nvidia.FourNVLINKLinks:
			nvlink = nvidia.FiveNVLINKLinks
		case nvidia.FiveNVLINKLinks:
			nvlink = nvidia.SixNVLINKLinks
		case nvidia.SixNVLINKLinks:
			nvlink = nvidia.SevenNVLINKLinks
		case nvidia.SevenNVLINKLinks:
			nvlink = nvidia.EightNVLINKLinks
		case nvidia.EightNVLINKLinks:
			nvlink = nvidia.NineNVLINKLinks
		case nvidia.NineNVLINKLinks:
			nvlink = nvidia.TenNVLINKLinks
		case nvidia.TenNVLINKLinks:
			nvlink = nvidia.ElevenNVLINKLinks
		case nvidia.ElevenNVLINKLinks:
			nvlink = nvidia.TwelveNVLINKLinks
		case nvidia.TwelveNVLINKLinks:
			nvlink = nvidia.ThirteenNVLINKLinks
		case nvidia.ThirteenNVLINKLinks:
			nvlink = nvidia.FourteenNVLINKLinks
		case nvidia.FourteenNVLINKLinks:
			nvlink = nvidia.FifteenNVLINKLinks
		case nvidia.FifteenNVLINKLinks:
			nvlink = nvidia.SixteenNVLINKLinks
		case nvidia.SixteenNVLINKLinks:
			nvlink = nvidia.SeventeenNVLINKLinks
		case nvidia.SeventeenNVLINKLinks:
			nvlink = nvidia.EighteenNVLINKLinks
		}
	}
	return nvlink, nil
}

func getAllNvLinkRemotePciInfoOld(dev device.Device) ([]nvidia.PciInfo, error) {
	var pciInfos []nvidia.PciInfo
	for i := range nvml.NVLINK_MAX_LINKS {
		state, ret := dev.GetNvLinkState(i)
		if errors.Is(ret, nvml.ERROR_NOT_SUPPORTED) || errors.Is(ret, nvml.ERROR_INVALID_ARGUMENT) {
			continue
		}
		if !errors.Is(ret, nvml.SUCCESS) {
			return nil, fmt.Errorf("failed to get nvlink state: %v", ret)
		}
		if state != nvml.FEATURE_ENABLED {
			continue
		}
		pciInfo, ret := dev.GetNvLinkRemotePciInfo(i)
		if errors.Is(ret, nvml.ERROR_NOT_SUPPORTED) || errors.Is(ret, nvml.ERROR_INVALID_ARGUMENT) {
			continue
		}
		if !errors.Is(ret, nvml.SUCCESS) {
			return nil, fmt.Errorf("failed to get remote pci info: %v", ret)
		}
		pciInfos = append(pciInfos, nvidia.PciInfo(pciInfo))
	}
	return pciInfos, nil
}

func main() {
	nvmllib := nvml.New()
	if ret := nvmllib.Init(); !errors.Is(ret, nvml.SUCCESS) {
		fmt.Fprintf(os.Stderr, "nvml.Init failed: %v\n", ret)
		os.Exit(1)
	}
	defer nvmllib.Shutdown()

	devicelib := device.New(nvmllib)
	nvmlDevices, err := devicelib.GetDevices()
	if err != nil {
		fmt.Fprintf(os.Stderr, "GetDevices failed: %v\n", err)
		os.Exit(1)
	}

	n := len(nvmlDevices)
	fmt.Printf("Found %d GPU(s)\n\n", n)

	// --- Raw diagnostic: per-link details ---
	fmt.Println("=== Per-GPU NVLink Diagnostics ===")
	for i, d := range nvmlDevices {
		uuid, _ := d.GetUUID()
		fmt.Printf("GPU %d [%s]:\n", i, uuid)

		switchCount := 0
		gpuCount := 0
		for link := 0; link < nvml.NVLINK_MAX_LINKS; link++ {
			state, ret := d.GetNvLinkState(link)
			if errors.Is(ret, nvml.ERROR_NOT_SUPPORTED) {
				break
			}
			if !errors.Is(ret, nvml.SUCCESS) || state != nvml.FEATURE_ENABLED {
				continue
			}

			remoteType, _ := d.GetNvLinkRemoteDeviceType(link)
			pciInfo, ret2 := d.GetNvLinkRemotePciInfo(link)
			busID := "?"
			if errors.Is(ret2, nvml.SUCCESS) {
				busID = nvidia.PciInfo(pciInfo).BusID()
			}

			typeLabel := "?"
			switch remoteType {
			case nvml.NVLINK_DEVICE_TYPE_GPU:
				typeLabel = "GPU"
				gpuCount++
			case nvml.NVLINK_DEVICE_TYPE_SWITCH:
				typeLabel = "NVSwitch"
				switchCount++
			default:
				typeLabel = fmt.Sprintf("other(%d)", remoteType)
			}

			fmt.Printf("  Link %2d: state=ENABLED  remote=%s  type=%s\n", link, busID, typeLabel)
		}
		fmt.Printf("  → direct-GPU links: %d, NVSwitch links: %d\n\n", gpuCount, switchCount)
	}

	// --- Side-by-side comparison: OLD vs NEW ---
	fmt.Println("=== NVLink Detection Comparison: OLD (PCI-match) vs NEW (+NVSwitch) ===")
	fmt.Println("                                          OLD               NEW")
	fmt.Println("       GPU pair         P2P       NVLink   Score    NVLink   Score")
	fmt.Println(strings.Repeat("-", 85))

	nvMissedOld := 0
	for i := 0; i < n; i++ {
		for j := i + 1; j < n; j++ {
			p2p, _ := nvidia.GetP2PLink(nvmlDevices[i], nvmlDevices[j])
			nvOld, _ := getNVLinkOld(nvmlDevices[i], nvmlDevices[j])
			nvNew, _ := nvidia.GetNVLink(nvmlDevices[i], nvmlDevices[j])

			oldScore := p2pScoreOf(p2p) + nvlinkScoreOf(nvOld)
			newScore := p2pScoreOf(p2p) + nvlinkScoreOf(nvNew)

			oldAbbrev := abbrev(nvOld)
			newAbbrev := abbrev(nvNew)
			if oldAbbrev == "" || oldAbbrev == "Unknown" {
				oldAbbrev = "---"
			}

			marker := ""
			if newScore > oldScore {
				marker = " ← FIXED"
				nvMissedOld++
			}

			fmt.Printf("GPU%d↔GPU%d  %-12s  %-8s  %-7d  %-8s  %-7d%s\n",
				i, j, p2p, oldAbbrev, oldScore, newAbbrev, newScore, marker)
		}
		fmt.Println()
	}

	fmt.Printf("\nSummary: OLD missed NVLink in %d/%d pairs.\n", nvMissedOld, n*(n-1)/2)

	// --- Pairwise matrix: NEW only ---
	fmt.Println("\n=== NVLink Pairwise Matrix (NEW: fixed) ===")
	fmt.Print("       ")
	for j := 0; j < n; j++ {
		fmt.Printf(" GPU%-2d", j)
	}
	fmt.Println()

	for i := 0; i < n; i++ {
		fmt.Printf("GPU %-2d ", i)
		for j := 0; j < n; j++ {
			if i == j {
				fmt.Printf("   X  ")
				continue
			}
			linkType, err := nvidia.GetNVLink(nvmlDevices[i], nvmlDevices[j])
			if err != nil {
				fmt.Printf(" ERR  ")
				continue
			}
			fmt.Printf(" %-4s", abbrev(linkType))
		}
		fmt.Println()
	}
}

func abbrev(lt nvidia.P2PLinkType) string {
	s := lt.String()
	s = strings.TrimPrefix(s, "P2PLink")
	switch s {
	case "EighteenNVLINKLinks":
		return "NV18"
	case "SingleNVLINKLink":
		return "NV1"
	case "TwoNVLINKLinks":
		return "NV2"
	case "ThreeNVLINKLinks":
		return "NV3"
	case "FourNVLINKLinks":
		return "NV4"
	case "FiveNVLINKLinks":
		return "NV5"
	case "SixNVLINKLinks":
		return "NV6"
	case "SevenNVLINKLinks":
		return "NV7"
	case "EightNVLINKLinks":
		return "NV8"
	case "NineNVLINKLinks":
		return "NV9"
	case "TenNVLINKLinks":
		return "NV10"
	case "ElevenNVLINKLinks":
		return "NV11"
	case "TwelveNVLINKLinks":
		return "NV12"
	case "ThirteenNVLINKLinks":
		return "NV13"
	case "FourteenNVLINKLinks":
		return "NV14"
	case "FifteenNVLINKLinks":
		return "NV15"
	case "SixteenNVLINKLinks":
		return "NV16"
	case "SeventeenNVLINKLinks":
		return "NV17"
	default:
		return s
	}
}

func p2pScoreOf(lt nvidia.P2PLinkType) int {
	switch lt {
	case nvidia.P2PLinkCrossCPU:
		return 10
	case nvidia.P2PLinkSameCPU:
		return 20
	case nvidia.P2PLinkHostBridge:
		return 30
	case nvidia.P2PLinkMultiSwitch:
		return 40
	case nvidia.P2PLinkSingleSwitch:
		return 50
	case nvidia.P2PLinkSameBoard:
		return 60
	}
	return 0
}

func nvlinkScoreOf(lt nvidia.P2PLinkType) int {
	switch lt {
	case nvidia.SingleNVLINKLink:
		return 100
	case nvidia.TwoNVLINKLinks:
		return 200
	case nvidia.ThreeNVLINKLinks:
		return 300
	case nvidia.FourNVLINKLinks:
		return 400
	case nvidia.FiveNVLINKLinks:
		return 500
	case nvidia.SixNVLINKLinks:
		return 600
	case nvidia.SevenNVLINKLinks:
		return 700
	case nvidia.EightNVLINKLinks:
		return 800
	case nvidia.NineNVLINKLinks:
		return 900
	case nvidia.TenNVLINKLinks:
		return 1000
	case nvidia.ElevenNVLINKLinks:
		return 1100
	case nvidia.TwelveNVLINKLinks:
		return 1200
	case nvidia.ThirteenNVLINKLinks:
		return 1300
	case nvidia.FourteenNVLINKLinks:
		return 1400
	case nvidia.FifteenNVLINKLinks:
		return 1500
	case nvidia.SixteenNVLINKLinks:
		return 1600
	case nvidia.SeventeenNVLINKLinks:
		return 1700
	case nvidia.EighteenNVLINKLinks:
		return 1800
	}
	return 0
}
```

**Output on 8×H100 NV18 all-to-all:**

```
GPU0↔GPU1  P2PLinkSameCPU  ---        20      NV18      1820    ← FIXED
GPU0↔GPU2  P2PLinkSameCPU  ---        20      NV18      1820    ← FIXED
GPU0↔GPU3  P2PLinkSameCPU  ---        20      NV18      1820    ← FIXED
GPU0↔GPU4  P2PLinkCrossCPU ---        10      NV18      1810    ← FIXED
...
Summary: OLD missed NVLink in 28/28 pairs.

=== NVLink Pairwise Matrix (NEW: fixed) ===
        GPU0  GPU1  GPU2  GPU3  GPU4  GPU5  GPU6  GPU7 
GPU 0     X   NV18 NV18 NV18 NV18 NV18 NV18 NV18
GPU 1   NV18   X   NV18 NV18 NV18 NV18 NV18 NV18
GPU 2   NV18 NV18   X   NV18 NV18 NV18 NV18 NV18
GPU 3   NV18 NV18 NV18   X   NV18 NV18 NV18 NV18
GPU 4   NV18 NV18 NV18 NV18   X   NV18 NV18 NV18
GPU 5   NV18 NV18 NV18 NV18 NV18   X   NV18 NV18
GPU 6   NV18 NV18 NV18 NV18 NV18 NV18   X   NV18
GPU 7   NV18 NV18 NV18 NV18 NV18 NV18 NV18   X  
```

Each GPU has 18 active NVLinks, all remote-type `NVSwitch`. The new matrix
matches `nvidia-smi topo -m` exactly.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA NVLink/P2P link type detection by accurately deriving link type from enabled NVLink relationships that match peer PCI bus IDs.
  * Enhanced NVSwitch-aware classification when direct NVLink matching is inconclusive, with safer handling when required link details are missing.

* **Tests**
  * Added unit tests to validate NVLink matching behavior and the mapping from NVLink counts to link types, including unknown and out-of-range scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->