### PR TITLE
fix(scheduler): scope per-type device list in fitInDevices

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -51,7 +51,6 @@ func getNodeResources(list NodeUsage, t string) []*device.DeviceUsage {
 
 func fitInDevices(node *NodeUsage, requests device.ContainerDeviceRequests, pod *corev1.Pod, nodeInfo *device.NodeInfo, devinput *device.PodDevices) (bool, string) {
 	//devmap := make(map[string]device.ContainerDevices)
-	devs := device.ContainerDevices{}
 	total, totalCore, totalMem := int32(0), int32(0), int32(0)
 	free, freeCore, freeMem := int32(0), int32(0), int32(0)
 	sums := 0
@@ -93,11 +92,10 @@ func fitInDevices(node *NodeUsage, requests device.ContainerDeviceRequests, pod 
 					klog.V(5).Infoln("After AddResourceUsage:", node.Devices.DeviceLists[nidx].Device)
 				}
 			}
-			devs = append(devs, tmpDevs[k.Type]...)
 		} else {
 			return false, reason
 		}
-		(*devinput)[k.Type] = append((*devinput)[k.Type], devs)
+		(*devinput)[k.Type] = append((*devinput)[k.Type], tmpDevs[k.Type])
 	}
 	return true, ""
 }

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3571,3 +3571,91 @@ func Test_Nvidia_GPU_Topology(t *testing.T) {
 		})
 	}
 }
+
+// fitMockDevice is a minimal device.Devices implementation whose Fit always
+// succeeds and returns a single device of its own type. Used to exercise
+// fitInDevices with more than one device type in a single container.
+type fitMockDevice struct {
+	typeName string
+	uuid     string
+}
+
+func (m *fitMockDevice) CommonWord() string { return m.typeName }
+func (m *fitMockDevice) MutateAdmission(_ *corev1.Container, _ *corev1.Pod) (bool, error) {
+	return false, nil
+}
+func (m *fitMockDevice) CheckHealth(_ string, _ *corev1.Node) (bool, bool) { return true, true }
+func (m *fitMockDevice) NodeCleanUp(_ string) error                        { return nil }
+func (m *fitMockDevice) GetResourceNames() device.ResourceNames            { return device.ResourceNames{} }
+func (m *fitMockDevice) GetNodeDevices(_ corev1.Node) ([]*device.DeviceInfo, error) {
+	return nil, nil
+}
+func (m *fitMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error        { return nil }
+func (m *fitMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error { return nil }
+func (m *fitMockDevice) GenerateResourceRequests(_ *corev1.Container) device.ContainerDeviceRequest {
+	return device.ContainerDeviceRequest{}
+}
+func (m *fitMockDevice) PatchAnnotations(_ *corev1.Pod, _ *map[string]string, _ device.PodDevices) map[string]string {
+	return nil
+}
+func (m *fitMockDevice) ScoreNode(_ *corev1.Node, _ device.PodSingleDevice, _ []*device.DeviceUsage, _ string) float32 {
+	return 0
+}
+func (m *fitMockDevice) AddResourceUsage(_ *corev1.Pod, _ *device.DeviceUsage, _ *device.ContainerDevice) error {
+	return nil
+}
+func (m *fitMockDevice) Fit(_ []*device.DeviceUsage, _ device.ContainerDeviceRequest, _ *corev1.Pod, _ *device.NodeInfo, _ *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
+	return true, map[string]device.ContainerDevices{
+		m.typeName: {{UUID: m.uuid, Type: m.typeName}},
+	}, ""
+}
+
+// Test_fitInDevices_MultiTypePartition guards against cross-device-type
+// pollution: when one container requests two device types, each type's entry
+// in the output PodDevices must contain only its own device.
+func Test_fitInDevices_MultiTypePartition(t *testing.T) {
+	oldDevicesMap := device.DevicesMap
+	defer func() { device.DevicesMap = oldDevicesMap }()
+	device.DevicesMap = map[string]device.Devices{
+		"mockA": &fitMockDevice{typeName: "mockA", uuid: "uuid-a"},
+		"mockB": &fitMockDevice{typeName: "mockB", uuid: "uuid-b"},
+	}
+
+	node := NodeUsage{
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		Devices: policy.DeviceUsageList{
+			DeviceLists: []*policy.DeviceListsScore{
+				{Device: &device.DeviceUsage{
+					ID: "uuid-a", Type: "mockA",
+					Count: 4, Used: 0, Totalcore: 100, Usedcores: 0, Totalmem: 8192, Usedmem: 0, Health: true,
+				}},
+				{Device: &device.DeviceUsage{
+					ID: "uuid-b", Type: "mockB",
+					Count: 4, Used: 0, Totalcore: 100, Usedcores: 0, Totalmem: 8192, Usedmem: 0, Health: true,
+				}},
+			},
+		},
+	}
+	requests := device.ContainerDeviceRequests{
+		"mockA": {Nums: 1, Type: "mockA", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1},
+		"mockB": {Nums: 1, Type: "mockB", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1},
+	}
+	devinput := &device.PodDevices{}
+
+	viewStatus(node)
+	fit, reason := fitInDevices(&node, requests, &corev1.Pod{}, nil, devinput)
+
+	assert.Equal(t, fit, true)
+	assert.Equal(t, reason, "")
+
+	// One container was processed, so each type has exactly one container entry.
+	assert.Equal(t, len((*devinput)["mockA"]), 1)
+	assert.Equal(t, len((*devinput)["mockB"]), 1)
+
+	// Each type's entry must contain ONLY its own device (the bug leaks the
+	// first-processed type's device into the second-processed type's entry).
+	assert.Equal(t, len((*devinput)["mockA"][0]), 1)
+	assert.Equal(t, (*devinput)["mockA"][0][0].UUID, "uuid-a")
+	assert.Equal(t, len((*devinput)["mockB"][0]), 1)
+	assert.Equal(t, (*devinput)["mockB"][0][0].UUID, "uuid-b")
+}


### PR DESCRIPTION
## What this fixes

Fixes #2104.

`fitInDevices` in `pkg/scheduler/score.go` declared its `devs` accumulator once, above the `for _, k := range requests` loop, and never reset it between device types. When a single container requests two device types, the second-processed type's entry in the returned `PodDevices` accumulated the first type's devices as well. That list is later serialized verbatim by `PatchAnnotations` → `EncodePodSingleDevice` into the pod's per-type allocation annotation (which does not filter by type), so a wrong-type device UUID is written into a type's annotation and read back by the device plugin during `Allocate`.

## The change

Declare `devs := device.ContainerDevices{}` as the first statement inside the per-type loop so each device type records only its own devices.

- Behavior-preserving for single-device-type requests (the common case): the loop runs once and `devs` starts empty either way.
- Correct for multi-type requests: each type's entry contains only its own devices.
- `devs` is not referenced anywhere after the loop, so narrowing its scope is safe.

## Testing

Added `Test_fitInDevices_MultiTypePartition`, which drives `fitInDevices` with two device types in one container and asserts each type's entry in the output `PodDevices` contains only its own device. The assertions check both type entries, so the test fails on the previous code regardless of Go's random map iteration order and passes after the fix.

- `go test ./pkg/scheduler/... -race -count=1` — pass
- `make verify` — pass (license headers, import aliases, golangci-lint, goimports)

This change is scoped to the scheduler extender and is validated by unit tests; no GPU hardware is required.

---

## AI assistance disclosure

This contribution used AI assistance (Claude Code): the bug was surfaced during an AI-assisted code review, and the one-line fix plus the regression test were drafted with Claude Code under my review. I have read and verified the change, understand the root cause and the fix, and take full responsibility for its correctness and for responding to review feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device allocation handling for requests that require multiple device types, ensuring results are correctly partitioned per type.
  * Prevented cross-type allocation leakage between device types within a single scheduling decision.
* **Tests**
  * Added a unit test covering multi-type device requests to verify per-type isolation of allocated device UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->