### PR TITLE
ci: sign release images and publish provenance

### DIFF
--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -121,4 +121,6 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign hami-core image
-        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_REPO_HAMICORE }}@${{ steps.build.outputs.digest }}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${REGISTRY}/${IMAGE_REPO_HAMICORE}@${DIGEST}"

--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -99,6 +99,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO_HAMICORE }}
 
       - name: Build & Pushing hami-core image
+        id: build
         uses: docker/build-push-action@v7.3.0
         with:
             context: .
@@ -112,4 +113,12 @@ jobs:
               DEST_DIR=/usr/local
             tags: ${{ steps.meta.outputs.tags }}
             push: true
+            provenance: mode=max
+            sbom: true
             github-token: ${{ env.REGISTER_PASSWORD }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign hami-core image
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_REPO_HAMICORE }}@${{ steps.build.outputs.digest }}"

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -105,6 +105,7 @@ jobs:
             images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
 
       - name: Build & Pushing hami image
+        id: build
         uses: docker/build-push-action@v7.3.0
         with:
             context: .
@@ -118,5 +119,13 @@ jobs:
               DEST_DIR=/usr/local
             tags: ${{ steps.meta1.outputs.tags }}
             push: true
+            provenance: mode=max
+            sbom: true
             github-token: ${{ env.REGISTER_PASSWORD }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign hami image
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}@${{ steps.build.outputs.digest }}"
 

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -127,5 +127,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign hami image
-        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}@${{ steps.build.outputs.digest }}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${REGISTRY}/${IMAGE_REPO}@${DIGEST}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Release images are pushed unsigned today: a user pulling `projecthami/hami` has no way to verify the image actually came from this repo's CI rather than a tampered registry or mirror. For a scheduler that runs with cluster-wide privileges, unverifiable artifacts are a real supply chain exposure.

This adds to both image release workflows:

- Keyless `cosign sign` (GitHub OIDC, no keys or secrets to manage) on the pushed digest for the `hami` and `hami-core` images.
- BuildKit SLSA provenance (`mode=max`) and SBOM attestations, so every artifact carries a verifiable statement of which commit and workflow built it.

Users can then verify with:

```
cosign verify docker.io/projecthami/hami@<digest> \
  --certificate-identity-regexp 'github.com/Project-HAMi/HAMi' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

**Which issue(s) this PR fixes**:
Fixes #2107

**Special notes for your reviewer**:

The workflows already run with `permissions: write-all`, which includes the `id-token: write` needed for keyless signing, so no permission change is required. Signing only takes effect on the next release run; it cannot be exercised by PR CI.

**Does this PR introduce a user-facing change?**:

```release-note
Release images (hami, hami-core) are now cosign-signed and ship SLSA provenance and SBOM attestations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Compliance**
  * Container image publishing now generates software bills of materials (SBOMs) and provenance attestations.
  * Published images are now digitally signed using the build’s resulting image digest to strengthen authenticity and integrity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->