### PR TITLE
docs: declare secret scanning tooling in SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,7 +1,7 @@
 header:
   schema-version: 2.0.0
-  last-updated: '2026-07-20'
-  last-reviewed: '2026-07-20'
+  last-updated: '2026-07-22'
+  last-reviewed: '2026-07-22'
   url: https://github.com/Project-HAMi/HAMi/blob/master/SECURITY-INSIGHTS.yml
   comment: |
     Security metadata for the HAMi project, following the OpenSSF
@@ -129,3 +129,17 @@ repository:
         results: {}
         comment: |
           Static analysis on pull requests via GitHub Actions.
+      - name: GitHub secret scanning
+        type: secret-scanning
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          GitHub native secret scanning with push protection, enabled
+          on the repository to detect supported secret patterns and
+          block them from being pushed.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a `type: secret-scanning` tool entry to the security tooling list in SECURITY-INSIGHTS.yml. GitHub secret scanning and push protection are already enabled on this repository, but the corresponding API field is only visible to admin tokens, so automated assessments such as the LFX Insights OSPS baseline check BR-07.01 cannot observe it and report "secret scanning is not enabled". Declaring the tool here makes the enabled tooling publicly verifiable.

Also bumps the header timestamps.

**Which issue(s) this PR fixes**:
Fixes #2111

**Special notes for your reviewer**:

No configuration change, the file now documents what is already enabled in the repository settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Updated security metadata review dates to July 22, 2026.
  - Added GitHub secret scanning to vulnerability reporting using built-in rulesets.
  - Enabled CI-only integration and configured push protection guidance to help block supported secret patterns from being pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->