### PR TITLE
feat: init-container GPU resource accounting

### DIFF
--- a/pkg/device/initcontainer.go
+++ b/pkg/device/initcontainer.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Init-container GPU resource accounting.
+//
+// Kubernetes runs init containers sequentially to completion before any app
+// container starts, so an init container and an app container never use GPU at
+// the same instant. HAMi's raw per-container device list (PodDevices) records
+// one entry per container, and the accounting consumers (countPodDevices for
+// quota, getNodesUsage for node capacity) naively sum every entry. That double
+// counts init+app usage.
+//
+// The correct footprint at any instant, per device UUID and per resource
+// dimension, is:
+//
+//	effective = max( sum(app container usage), max(single init container usage) )
+//
+// CollapseInitContainerUsage rewrites a PodDevices into an accounting-only view
+// whose per-UUID sums equal that effective value, so the existing summing
+// consumers become correct without change. See docs/develop/initContainer-design.md.
+
+// effectiveUsage holds the collapsed per-UUID accounting values for a single
+// device type. Count is the number of shared instances on the UUID (each maps
+// to one Used++ in getNodesUsage); mem/cores are the peak resource footprint.
+type effectiveUsage struct {
+	uuid  string
+	typ   string
+	count int32
+	mem   int32
+	cores int32
+}
+
+// collapseSingleDevice computes the effective per-UUID usage for one device
+// type's PodSingleDevice. numInit is the number of leading entries that belong
+// to init containers (annotation index order matches pod.Spec order: init
+// containers first, then app containers). When appOnly is true the init
+// contribution is ignored entirely (used once init containers are confirmed
+// finished).
+func collapseSingleDevice(psd PodSingleDevice, numInit int, appOnly bool) []effectiveUsage {
+	// Per-UUID cumulative app usage (sum across app containers).
+	type acc struct {
+		typ         string
+		appCount    int32
+		appMem      int32
+		appCores    int32
+		initCount   int32
+		initMem     int32
+		initCores   int32
+		firstSeenIx int
+	}
+	order := make([]string, 0)
+	byUUID := make(map[string]*acc)
+
+	get := func(uuid string) *acc {
+		a, ok := byUUID[uuid]
+		if !ok {
+			a = &acc{firstSeenIx: len(order)}
+			byUUID[uuid] = a
+			order = append(order, uuid)
+		}
+		return a
+	}
+
+	for ctrIdx, ctrDevs := range psd {
+		isInit := ctrIdx < numInit
+		if isInit && appOnly {
+			continue
+		}
+		// Aggregate this single container's usage per UUID first, then fold
+		// into app-sum or init-max accordingly.
+		perCtr := make(map[string]*effectiveUsage)
+		ctrOrder := make([]string, 0)
+		for _, d := range ctrDevs {
+			e, ok := perCtr[d.UUID]
+			if !ok {
+				e = &effectiveUsage{uuid: d.UUID, typ: d.Type}
+				perCtr[d.UUID] = e
+				ctrOrder = append(ctrOrder, d.UUID)
+			}
+			e.count++
+			e.mem += d.Usedmem
+			e.cores += d.Usedcores
+		}
+		for _, uuid := range ctrOrder {
+			e := perCtr[uuid]
+			a := get(uuid)
+			if a.typ == "" {
+				a.typ = e.typ
+			}
+			if isInit {
+				// max across individual init containers
+				if e.count > a.initCount {
+					a.initCount = e.count
+				}
+				if e.mem > a.initMem {
+					a.initMem = e.mem
+				}
+				if e.cores > a.initCores {
+					a.initCores = e.cores
+				}
+			} else {
+				// sum across app containers
+				a.appCount += e.count
+				a.appMem += e.mem
+				a.appCores += e.cores
+			}
+		}
+	}
+
+	res := make([]effectiveUsage, 0, len(order))
+	for _, uuid := range order {
+		a := byUUID[uuid]
+		eff := effectiveUsage{
+			uuid:  uuid,
+			typ:   a.typ,
+			count: max(a.appCount, a.initCount),
+			mem:   max(a.appMem, a.initMem),
+			cores: max(a.appCores, a.initCores),
+		}
+		if eff.count == 0 {
+			continue
+		}
+		res = append(res, eff)
+	}
+	return res
+}
+
+// buildCollapsedSingleDevice turns effective per-UUID usage back into a valid
+// PodSingleDevice. It synthesizes a single container-devices list: for each
+// UUID it emits `count` ContainerDevice entries so that getNodesUsage records
+// the correct Used count, carrying the full effective mem/cores on the first
+// entry (the consumers sum per UUID, so the split is irrelevant to totals).
+func buildCollapsedSingleDevice(effs []effectiveUsage) PodSingleDevice {
+	if len(effs) == 0 {
+		return PodSingleDevice{}
+	}
+	cd := make(ContainerDevices, 0, len(effs))
+	for _, e := range effs {
+		for i := int32(0); i < e.count; i++ {
+			dev := ContainerDevice{
+				UUID: e.uuid,
+				Type: e.typ,
+			}
+			if i == 0 {
+				dev.Usedmem = e.mem
+				dev.Usedcores = e.cores
+			}
+			cd = append(cd, dev)
+		}
+	}
+	return PodSingleDevice{cd}
+}
+
+// collapse rewrites podDev into an accounting-only view. When appOnly is true
+// the init containers' contribution is dropped (used after they finish).
+func collapse(pod *corev1.Pod, podDev PodDevices, appOnly bool) PodDevices {
+	if podDev == nil {
+		return nil
+	}
+	numInit := len(pod.Spec.InitContainers)
+	// No init containers: only meaningful when appOnly==false, and the app-sum
+	// view is identical to the raw structure's per-UUID totals. Still collapse
+	// so behaviour is uniform, but this is a no-op for correctness.
+	out := make(PodDevices, len(podDev))
+	for devType, psd := range podDev {
+		effs := collapseSingleDevice(psd, numInit, appOnly)
+		out[devType] = buildCollapsedSingleDevice(effs)
+	}
+	return out
+}
+
+// CollapseInitContainerUsage returns an accounting view of podDev where, per
+// device UUID and per resource dimension, usage equals
+// max(sum(app entries), max(init entry)). It never merges usage across distinct
+// UUIDs, so a multi-GPU pod whose init and app containers land on different
+// physical devices keeps them separate.
+func CollapseInitContainerUsage(pod *corev1.Pod, podDev PodDevices) PodDevices {
+	return collapse(pod, podDev, false)
+}
+
+// AppContainersOnly returns an accounting view counting app containers only.
+// Used to shrink recorded usage once a pod's init containers are confirmed
+// finished.
+func AppContainersOnly(pod *corev1.Pod, podDev PodDevices) PodDevices {
+	return collapse(pod, podDev, true)
+}
+
+// InitContainersAllTerminated reports whether every init container has a
+// Terminated status set, regardless of exit code. Checked against the current
+// object state on every reconcile (Phase is unreliable here per the design).
+func InitContainersAllTerminated(pod *corev1.Pod) bool {
+	if len(pod.Spec.InitContainers) == 0 {
+		return false
+	}
+	if len(pod.Status.InitContainerStatuses) < len(pod.Spec.InitContainers) {
+		return false
+	}
+	for _, st := range pod.Status.InitContainerStatuses {
+		if st.State.Terminated == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// InitContainersAllSucceeded reports whether every init container has
+// terminated with ExitCode 0. When true (and the pod is not yet terminal) the
+// app containers have started, so recorded usage can shrink to app-only.
+func InitContainersAllSucceeded(pod *corev1.Pod) bool {
+	if !InitContainersAllTerminated(pod) {
+		return false
+	}
+	for _, st := range pod.Status.InitContainerStatuses {
+		if st.State.Terminated == nil || st.State.Terminated.ExitCode != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/device/initcontainer_test.go
+++ b/pkg/device/initcontainer_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const testDevType = "test-gpu"
+
+// sumUsage sums the collapsed per-UUID usage the accounting consumers see
+// (countPodDevices / getNodesUsage both sum every ContainerDevice entry).
+func sumUsage(pd PodDevices) map[string]struct {
+	count int
+	mem   int32
+	cores int32
+} {
+	res := make(map[string]struct {
+		count int
+		mem   int32
+		cores int32
+	})
+	for _, psd := range pd {
+		for _, ctrDevs := range psd {
+			for _, d := range ctrDevs {
+				v := res[d.UUID]
+				v.count++
+				v.mem += d.Usedmem
+				v.cores += d.Usedcores
+				res[d.UUID] = v
+			}
+		}
+	}
+	return res
+}
+
+func ctr(devs ...ContainerDevice) ContainerDevices { return ContainerDevices(devs) }
+
+func dev(uuid string, mem, cores int32) ContainerDevice {
+	return ContainerDevice{UUID: uuid, Type: testDevType, Usedmem: mem, Usedcores: cores}
+}
+
+func podWithInit(numInit, numApp int) *corev1.Pod {
+	p := &corev1.Pod{}
+	for range numInit {
+		p.Spec.InitContainers = append(p.Spec.InitContainers, corev1.Container{})
+	}
+	for range numApp {
+		p.Spec.Containers = append(p.Spec.Containers, corev1.Container{})
+	}
+	return p
+}
+
+func TestCollapseInitContainerUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		podDev  PodDevices
+		appOnly bool
+		// expected per-UUID effective usage
+		want map[string]struct {
+			count int
+			mem   int32
+			cores int32
+		}
+	}{
+		{
+			name:   "no init containers - app sum unchanged",
+			pod:    podWithInit(0, 2),
+			podDev: PodDevices{testDevType: PodSingleDevice{ctr(dev("gpu-0", 10, 30)), ctr(dev("gpu-0", 4, 20))}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 2, mem: 14, cores: 50}},
+		},
+		{
+			name: "init smaller than app - app wins",
+			pod:  podWithInit(1, 1),
+			// init 10Gi, app 20Gi on same uuid
+			podDev: PodDevices{testDevType: PodSingleDevice{ctr(dev("gpu-0", 10, 0)), ctr(dev("gpu-0", 20, 0))}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 1, mem: 20, cores: 0}},
+		},
+		{
+			name: "init larger than app - init wins (Case 2)",
+			pod:  podWithInit(1, 1),
+			// init 20Gi, app 10Gi
+			podDev: PodDevices{testDevType: PodSingleDevice{ctr(dev("gpu-0", 20, 0)), ctr(dev("gpu-0", 10, 0))}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 1, mem: 20, cores: 0}},
+		},
+		{
+			name: "multi init - max across init containers",
+			pod:  podWithInit(2, 1),
+			// init1 12Gi, init2 20Gi, app 10Gi -> max(sum(app)=10, max(init)=20)=20
+			podDev: PodDevices{testDevType: PodSingleDevice{
+				ctr(dev("gpu-0", 12, 0)),
+				ctr(dev("gpu-0", 20, 0)),
+				ctr(dev("gpu-0", 10, 0)),
+			}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 1, mem: 20, cores: 0}},
+		},
+		{
+			name: "multi app sum beats single init",
+			pod:  podWithInit(1, 2),
+			// init 15Gi, app1 10Gi, app2 10Gi -> max(sum(app)=20, init=15)=20
+			podDev: PodDevices{testDevType: PodSingleDevice{
+				ctr(dev("gpu-0", 15, 0)),
+				ctr(dev("gpu-0", 10, 0)),
+				ctr(dev("gpu-0", 10, 0)),
+			}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 2, mem: 20, cores: 0}},
+		},
+		{
+			name: "distinct UUIDs never merged",
+			pod:  podWithInit(1, 1),
+			// init on gpu-0 20Gi, app on gpu-1 10Gi
+			podDev: PodDevices{testDevType: PodSingleDevice{
+				ctr(dev("gpu-0", 20, 0)),
+				ctr(dev("gpu-1", 10, 0)),
+			}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{
+				"gpu-0": {count: 1, mem: 20, cores: 0},
+				"gpu-1": {count: 1, mem: 10, cores: 0},
+			},
+		},
+		{
+			name:    "app only view drops init",
+			pod:     podWithInit(1, 1),
+			appOnly: true,
+			// init 20Gi, app 10Gi -> app-only = 10Gi
+			podDev: PodDevices{testDevType: PodSingleDevice{ctr(dev("gpu-0", 20, 0)), ctr(dev("gpu-0", 10, 0))}},
+			want: map[string]struct {
+				count int
+				mem   int32
+				cores int32
+			}{"gpu-0": {count: 1, mem: 10, cores: 0}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got PodDevices
+			if tt.appOnly {
+				got = AppContainersOnly(tt.pod, tt.podDev)
+			} else {
+				got = CollapseInitContainerUsage(tt.pod, tt.podDev)
+			}
+			sums := sumUsage(got)
+			if len(sums) != len(tt.want) {
+				t.Fatalf("uuid count = %d, want %d (got %+v)", len(sums), len(tt.want), sums)
+			}
+			for uuid, w := range tt.want {
+				g, ok := sums[uuid]
+				if !ok {
+					t.Fatalf("missing uuid %s in %+v", uuid, sums)
+				}
+				if g.count != w.count || g.mem != w.mem || g.cores != w.cores {
+					t.Errorf("uuid %s = {count:%d mem:%d cores:%d}, want {count:%d mem:%d cores:%d}",
+						uuid, g.count, g.mem, g.cores, w.count, w.mem, w.cores)
+				}
+			}
+		})
+	}
+}
+
+func termStatus(exitCode int32) corev1.ContainerStatus {
+	return corev1.ContainerStatus{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode}}}
+}
+
+func runningStatus() corev1.ContainerStatus {
+	return corev1.ContainerStatus{State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+}
+
+func TestInitContainersAllTerminated(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		wantTerm      bool
+		wantSucceeded bool
+	}{
+		{
+			name:     "no init containers",
+			pod:      podWithInit(0, 1),
+			wantTerm: false,
+		},
+		{
+			name: "init still running",
+			pod: func() *corev1.Pod {
+				p := podWithInit(1, 1)
+				p.Status.InitContainerStatuses = []corev1.ContainerStatus{runningStatus()}
+				return p
+			}(),
+			wantTerm: false,
+		},
+		{
+			name: "status not yet populated",
+			pod: func() *corev1.Pod {
+				p := podWithInit(2, 1)
+				p.Status.InitContainerStatuses = []corev1.ContainerStatus{termStatus(0)}
+				return p
+			}(),
+			wantTerm: false,
+		},
+		{
+			name: "all terminated exit 0",
+			pod: func() *corev1.Pod {
+				p := podWithInit(2, 1)
+				p.Status.InitContainerStatuses = []corev1.ContainerStatus{termStatus(0), termStatus(0)}
+				return p
+			}(),
+			wantTerm:      true,
+			wantSucceeded: true,
+		},
+		{
+			name: "terminated non-zero",
+			pod: func() *corev1.Pod {
+				p := podWithInit(1, 1)
+				p.Status.InitContainerStatuses = []corev1.ContainerStatus{termStatus(1)}
+				return p
+			}(),
+			wantTerm:      true,
+			wantSucceeded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InitContainersAllTerminated(tt.pod); got != tt.wantTerm {
+				t.Errorf("InitContainersAllTerminated = %v, want %v", got, tt.wantTerm)
+			}
+			if got := InitContainersAllSucceeded(tt.pod); got != tt.wantSucceeded {
+				t.Errorf("InitContainersAllSucceeded = %v, want %v", got, tt.wantSucceeded)
+			}
+		})
+	}
+}

--- a/pkg/device/initcontainer_usage_test.go
+++ b/pkg/device/initcontainer_usage_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package device
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// TestInitContainerUsageLifecycle walks a pod with an init container that
+// requests more memory than its app container through the accounting
+// lifecycle, mirroring design Cases 3 and 4 (docs/develop/initContainer-design.md):
+//
+//   - init requests 20 on uuid1, app requests 10 on uuid1
+//   - recorded usage while init runs = max(sum(app)=10, max(init)=20) = 20 (Case 3)
+//   - once the init container terminates with exit 0, usage shrinks to
+//     app-only = 10, and the quota delta is applied symmetrically (Case 4)
+func TestInitContainerUsageLifecycle(t *testing.T) {
+	initTest()
+	const (
+		ns      = "default"
+		memName = "nvidia.com/gpumem"
+	)
+
+	// Raw per-container device list: index 0 = init (20), index 1 = app (10),
+	// both on uuid1. DecodePodDevices preserves this init-first ordering.
+	rawDevices := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			ContainerDevices{{UUID: "uuid1", Type: "NVIDIA", Usedmem: 20}},
+			ContainerDevices{{UUID: "uuid1", Type: "NVIDIA", Usedmem: 10}},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "p", UID: k8stypes.UID("uid-1")},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init"}},
+			Containers:     []corev1.Container{{Name: "app"}},
+		},
+	}
+
+	pm := NewPodManager()
+	qm := NewQuotaManager()
+	qm.Quotas[ns] = &DeviceQuota{memName: &Quota{Used: 0, Limit: 24}}
+
+	// --- bind time: record collapsed usage ---
+	collapsed := CollapseInitContainerUsage(pod, rawDevices)
+	if pm.AddPod(pod, "node1", collapsed) {
+		qm.AddUsage(pod, collapsed)
+	}
+	if got := (*qm.Quotas[ns])[memName].Used; got != 20 {
+		t.Fatalf("Case 3: recorded mem usage = %d, want 20 (max(app 10, init 20))", got)
+	}
+
+	// --- init container not yet finished: no shrink ---
+	if InitContainersAllSucceeded(pod) {
+		t.Fatal("init container has no status yet; should not be considered succeeded")
+	}
+
+	// --- init container terminates with exit 0: shrink to app-only ---
+	pod.Status.InitContainerStatuses = []corev1.ContainerStatus{
+		{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+	}
+	if !InitContainersAllSucceeded(pod) {
+		t.Fatal("init container terminated exit 0 should be considered succeeded")
+	}
+	appOnly := AppContainersOnly(pod, rawDevices)
+	old, didShrink := pm.ShrinkToAppOnly(pod, appOnly)
+	if !didShrink {
+		t.Fatal("expected shrink to occur on first call after init success")
+	}
+	qm.RmUsage(pod, old)
+	qm.AddUsage(pod, appOnly)
+	if got := (*qm.Quotas[ns])[memName].Used; got != 10 {
+		t.Fatalf("Case 4: shrunk mem usage = %d, want 10 (app only)", got)
+	}
+
+	// --- shrink is idempotent ---
+	if _, again := pm.ShrinkToAppOnly(pod, appOnly); again {
+		t.Fatal("shrink should be idempotent; second call must be a no-op")
+	}
+
+	// --- a routine informer update must not clobber the shrunk value ---
+	pm.AddPod(pod, "node1", collapsed)
+	pi, _ := pm.GetPod(pod)
+	if got := pi.Devices["NVIDIA"][0][0].Usedmem; got != 10 {
+		t.Fatalf("post-shrink update clobbered usage: mem = %d, want 10", got)
+	}
+
+	// --- deletion subtracts exactly the currently-stored (shrunk) value ---
+	taken, ok := pm.TakeAndDeletePod(pod)
+	if !ok {
+		t.Fatal("expected pod present for deletion")
+	}
+	qm.RmUsage(pod, taken.Devices)
+	if got := (*qm.Quotas[ns])[memName].Used; got != 0 {
+		t.Fatalf("after delete mem usage = %d, want 0 (no drift)", got)
+	}
+}

--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -30,6 +30,11 @@ type PodInfo struct {
 	*corev1.Pod
 	NodeID  string
 	Devices PodDevices
+	// InitContainerResourceReleased guards the one-time shrink of recorded
+	// usage from max(sum(app), max(init)) down to app-containers-only, once
+	// the pod's init containers are confirmed finished. Default false. See
+	// docs/develop/initContainer-design.md.
+	InitContainerResourceReleased bool
 }
 
 // PodUseDeviceStat counts pod use device info.
@@ -69,14 +74,47 @@ func (m *PodManager) AddPod(pod *corev1.Pod, nodeID string, devices PodDevices) 
 			"devices", devices,
 		)
 	} else {
-		m.pods[pod.UID].Devices = devices
-		klog.V(5).InfoS("Pod devices updated",
-			"pod", klog.KRef(pod.Namespace, pod.Name),
-			"devices", devices,
-		)
+		// Once init-container usage has been released (shrunk to app-only), the
+		// annotation-derived collapsed value would be larger again, so do not let
+		// a routine update clobber the shrunk value. The shrink is applied only by
+		// ShrinkToAppOnly.
+		if !m.pods[pod.UID].InitContainerResourceReleased {
+			m.pods[pod.UID].Devices = devices
+			klog.V(5).InfoS("Pod devices updated",
+				"pod", klog.KRef(pod.Namespace, pod.Name),
+				"devices", devices,
+			)
+		}
 	}
 
 	return !exists
+}
+
+// ShrinkToAppOnly performs the one-time shrink of a pod's recorded device usage
+// from max(sum(app), max(init)) down to app-containers-only, once its init
+// containers are confirmed finished. It is idempotent: the first call swaps the
+// stored Devices to appOnly, sets InitContainerResourceReleased, and returns the
+// previously-stored devices (old), the new devices, and true. Subsequent calls
+// (or calls for an unknown pod) return didShrink=false and touch nothing. The
+// caller applies the quota delta as RmUsage(old)+AddUsage(new) so add and remove
+// always operate on the same stored value.
+func (m *PodManager) ShrinkToAppOnly(pod *corev1.Pod, appOnly PodDevices) (old PodDevices, didShrink bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	pi, ok := m.pods[pod.UID]
+	if !ok || pi.InitContainerResourceReleased {
+		return nil, false
+	}
+	old = pi.Devices
+	pi.Devices = appOnly
+	pi.InitContainerResourceReleased = true
+	klog.InfoS("Init container usage released, shrinking recorded usage to app-only",
+		"pod", klog.KRef(pod.Namespace, pod.Name),
+		"old", old,
+		"new", appOnly,
+	)
+	return old, true
 }
 
 func (m *PodManager) UpdatePod(pod *corev1.Pod) {
@@ -172,9 +210,10 @@ func (p *PodInfo) DeepCopy() *PodInfo {
 		return nil
 	}
 	return &PodInfo{
-		Pod:     p.Pod.DeepCopy(),
-		NodeID:  p.NodeID,
-		Devices: p.Devices.DeepCopy(),
+		Pod:                           p.Pod.DeepCopy(),
+		NodeID:                        p.NodeID,
+		Devices:                       p.Devices.DeepCopy(),
+		InitContainerResourceReleased: p.InitContainerResourceReleased,
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -162,8 +162,22 @@ func (s *Scheduler) onAddPod(obj any) {
 		klog.ErrorS(err, "failed to decode pod devices", "pod", klog.KObj(pod))
 		return
 	}
-	if s.podManager.AddPod(pod, nodeID, podDev) {
-		s.quotaManager.AddUsage(pod, podDev)
+	// Record the effective footprint max(sum(app), max(init)) rather than the raw
+	// per-container sum, so quota and node-capacity accounting are not inflated by
+	// init containers that never run concurrently with app containers.
+	collapsed := device.CollapseInitContainerUsage(pod, podDev)
+	if s.podManager.AddPod(pod, nodeID, collapsed) {
+		s.quotaManager.AddUsage(pod, collapsed)
+	}
+	// Once the pod's init containers are confirmed finished (all terminated with
+	// exit code 0, pod not yet terminal), shrink recorded usage to app-only. The
+	// shrink is one-time and guarded inside ShrinkToAppOnly.
+	if device.InitContainersAllSucceeded(pod) {
+		appOnly := device.AppContainersOnly(pod, podDev)
+		if old, didShrink := s.podManager.ShrinkToAppOnly(pod, appOnly); didShrink {
+			s.quotaManager.RmUsage(pod, old)
+			s.quotaManager.AddUsage(pod, appOnly)
+		}
 	}
 }
 
@@ -967,16 +981,21 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		val.PatchAnnotations(args.Pod, &annotations, m.Devices)
 	}
 
-	added := s.podManager.AddPod(args.Pod, m.NodeID, m.Devices)
+	// Annotations keep the full per-container device list (the device plugin
+	// needs it), but recorded usage is the effective collapsed view:
+	// per device UUID, max(sum(app), max(init)). See
+	// docs/develop/initContainer-design.md.
+	collapsed := device.CollapseInitContainerUsage(args.Pod, m.Devices)
+	added := s.podManager.AddPod(args.Pod, m.NodeID, collapsed)
 	if added {
-		s.quotaManager.AddUsage(args.Pod, m.Devices)
+		s.quotaManager.AddUsage(args.Pod, collapsed)
 	}
 
 	err = util.PatchPodAnnotations(args.Pod, annotations)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
 		if added {
-			s.quotaManager.RmUsage(args.Pod, m.Devices)
+			s.quotaManager.RmUsage(args.Pod, collapsed)
 		}
 		s.podManager.DelPod(args.Pod)
 		return nil, err

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -144,10 +144,27 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 				}
 			}
 
+			// Init containers run sequentially to completion before any app
+			// container starts, so an init container never uses GPU at the same
+			// instant as an app container (or another init container). The correct
+			// per-device footprint is max(sum(app requests), max(init request)),
+			// which fits the node iff the app containers fit cumulatively AND each
+			// init container fits independently. resourceReqs is ordered init-first
+			// (see device.Resourcereqs), so entries with index < numInit are init
+			// containers. App containers accumulate on the real node copy as before;
+			// each init container is checked against a fresh copy of the node's
+			// entry state so its usage never piles onto the app containers'.
+			numInit := len(task.Spec.InitContainers)
+			var pristine *NodeUsage
+			if numInit > 0 {
+				pristine = node.DeepCopy()
+			}
+
 			// Assume the node is a fit by default. This handles pods with no device
 			// requests, which should be schedulable on any node.
 			ctrfit := true
 			deviceType := ""
+			appDevices := make(device.PodDevices)
 			//This loop is for different container request
 			for ctrid, n := range resourceReqs {
 				sums := 0
@@ -160,8 +177,26 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 					score.Devices[deviceType] = append(score.Devices[deviceType], device.ContainerDevices{})
 					continue
 				}
+				// Init containers fit independently against a fresh copy of the
+				// node's entry state; app containers accumulate on the real node.
+				fitNode := node
+				fitDevices := &appDevices
+				if ctrid < numInit {
+					fitNode = pristine.DeepCopy()
+					tmpDevices := make(device.PodDevices)
+					fitDevices = &tmpDevices
+				}
+				beforeLens := make(map[string]int, len(*fitDevices))
+				for devType, podSingleDevice := range *fitDevices {
+					beforeLens[devType] = len(podSingleDevice)
+				}
 				klog.V(5).InfoS("fitInDevices", "pod", klog.KObj(task), "node", nodeID)
-				fit, reason := fitInDevices(node, n, task, nodeInfo, &score.Devices)
+				fit, reason := fitInDevices(fitNode, n, task, nodeInfo, fitDevices)
+				if fit {
+					for devType, podSingleDevice := range *fitDevices {
+						score.Devices[devType] = append(score.Devices[devType], podSingleDevice[beforeLens[devType]:]...)
+					}
+				}
 				// found certain deviceType, fill missing empty allocation for containers before this
 				for idx := range score.Devices {
 					deviceType = idx

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -2658,6 +2658,82 @@ func Test_calcScore(t *testing.T) {
 	}
 }
 
+func TestCalcScoreInitContainerDoesNotPolluteAppAllocatedContext(t *testing.T) {
+	qm := device.NewQuotaManager()
+	qm.Quotas["default"] = &device.DeviceQuota{
+		"hami.io/gpumem": &device.Quota{Used: 0, Limit: 24},
+	}
+	t.Cleanup(func() {
+		delete(qm.Quotas, "default")
+	})
+
+	nodes := &map[string]*NodeUsage{
+		"node1": {
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			NodeInfo: &device.NodeInfo{
+				ID:   "node1",
+				Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			},
+			Devices: policy.DeviceUsageList{
+				Policy: util.GPUSchedulerPolicySpread.String(),
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "uuid1",
+							Index:     0,
+							Used:      0,
+							Count:     10,
+							Usedmem:   0,
+							Totalmem:  24,
+							Totalcore: 100,
+							Usedcores: 0,
+							Numa:      0,
+							Type:      nvidia.NvidiaGPUDevice,
+							Health:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+	resourceReqs := device.PodDeviceRequests{
+		{
+			"hami.io/vgpu-devices-to-allocate": device.ContainerDeviceRequest{
+				Nums:   1,
+				Type:   nvidia.NvidiaGPUDevice,
+				Memreq: 20,
+			},
+		},
+		{
+			"hami.io/vgpu-devices-to-allocate": device.ContainerDeviceRequest{
+				Nums:   1,
+				Type:   nvidia.NvidiaGPUDevice,
+				Memreq: 10,
+			},
+		},
+	}
+	task := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-init-app-quota", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init"}},
+			Containers:     []corev1.Container{{Name: "app"}},
+		},
+	}
+
+	got, err := NewScheduler().calcScore(nodes, resourceReqs, task, map[string]string{})
+	assert.NilError(t, err)
+	if len(got.NodeList) != 1 {
+		t.Fatalf("node should fit init(20)+app(10) under 24Gi effective quota; got %d nodes", len(got.NodeList))
+	}
+	devs := got.NodeList[0].Devices[nvidia.NvidiaGPUDevice]
+	if len(devs) != 2 {
+		t.Fatalf("expected full init+app annotation devices, got %#v", devs)
+	}
+	if devs[0][0].Usedmem != 20 || devs[1][0].Usedmem != 10 {
+		t.Fatalf("unexpected per-container devices: %#v", devs)
+	}
+}
+
 func Test_fitInCertainDevice(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -69,22 +69,39 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 	}
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	hasResource := false
-	for idx, ctr := range pod.Spec.Containers {
-		c := &pod.Spec.Containers[idx]
-		if ctr.SecurityContext != nil {
-			if ctr.SecurityContext.Privileged != nil && *ctr.SecurityContext.Privileged {
-				klog.Warningf(template+" - Denying admission as container %s is privileged", pod.Namespace, pod.Name, pod.UID, c.Name)
-				continue
-			}
+	// Init containers can request GPU resources too, so they must go through
+	// MutateAdmission alongside app containers to have their device annotations
+	// applied. See docs/develop/initContainer-design.md.
+	mutate := func(c *corev1.Container) (bool, error) {
+		if c.SecurityContext != nil && c.SecurityContext.Privileged != nil && *c.SecurityContext.Privileged {
+			klog.Warningf(template+" - Denying admission as container %s is privileged", pod.Namespace, pod.Name, pod.UID, c.Name)
+			return false, nil
 		}
+		found := false
 		for _, val := range device.GetDevices() {
-			found, err := val.MutateAdmission(c, pod)
+			f, err := val.MutateAdmission(c, pod)
 			if err != nil {
-				klog.Errorf("validating pod failed:%s", err.Error())
-				return admission.Errored(http.StatusInternalServerError, err)
+				return false, err
 			}
-			hasResource = hasResource || found
+			found = found || f
 		}
+		return found, nil
+	}
+	for idx := range pod.Spec.InitContainers {
+		found, err := mutate(&pod.Spec.InitContainers[idx])
+		if err != nil {
+			klog.Errorf("validating pod failed:%s", err.Error())
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		hasResource = hasResource || found
+	}
+	for idx := range pod.Spec.Containers {
+		found, err := mutate(&pod.Spec.Containers[idx])
+		if err != nil {
+			klog.Errorf("validating pod failed:%s", err.Error())
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		hasResource = hasResource || found
 	}
 
 	if !hasResource {
@@ -133,17 +150,38 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 			}
 			return 0, false
 		}
-		for _, ctr := range pod.Spec.Containers {
-			req, ok := getRequest(&ctr, resourceName)
-			if ok {
-				if memReq, ok := getRequest(&ctr, memResourceName); ok {
-					memoryReq += memReq * req
-				}
-				if coreReq, ok := getRequest(&ctr, coreResourceName); ok {
-					coresReq += coreReq * req
-				}
+		// containerReq returns this container's total memory and cores request
+		// (per-GPU value multiplied by the requested GPU count).
+		containerReq := func(ctr *corev1.Container) (mem int64, cores int64) {
+			req, ok := getRequest(ctr, resourceName)
+			if !ok {
+				return 0, 0
 			}
+			if memReq, ok := getRequest(ctr, memResourceName); ok {
+				mem = memReq * req
+			}
+			if coreReq, ok := getRequest(ctr, coreResourceName); ok {
+				cores = coreReq * req
+			}
+			return mem, cores
 		}
+		// Init containers run sequentially to completion before app containers
+		// start, so a pod's real GPU footprint at any instant is
+		// max(sum(app requests), max(single init request)) per resource. See
+		// docs/develop/initContainer-design.md.
+		var initMemReq, initCoresReq int64
+		for i := range pod.Spec.InitContainers {
+			mem, cores := containerReq(&pod.Spec.InitContainers[i])
+			initMemReq = max(initMemReq, mem)
+			initCoresReq = max(initCoresReq, cores)
+		}
+		for i := range pod.Spec.Containers {
+			mem, cores := containerReq(&pod.Spec.Containers[i])
+			memoryReq += mem
+			coresReq += cores
+		}
+		memoryReq = max(memoryReq, initMemReq)
+		coresReq = max(coresReq, initCoresReq)
 		if memoryFactor > 1 {
 			oriMemReq := memoryReq
 			memoryReq = memoryReq * int64(memoryFactor)

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -412,6 +412,80 @@ func TestFitResourceQuota(t *testing.T) {
 			},
 			fit: true,
 		},
+		{
+			// Design Case 1: an init container that could never fit is caught.
+			// effective mem = max(app 100, init 1500) = 1500; 1000 used + 1500 > 2000.
+			name: "init container exceeds quota",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: "hami-scheduler",
+					InitContainers: []corev1.Container{
+						{
+							Name: "init1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":    resource.MustParse("1"),
+									"nvidia.com/gpumem": resource.MustParse("1500"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":    resource.MustParse("1"),
+									"nvidia.com/gpumem": resource.MustParse("100"),
+								},
+							},
+						},
+					},
+				},
+			},
+			fit: false,
+		},
+		{
+			// init(500) + app(600): naive sum 1100 -> 1000+1100=2100 > 2000 would
+			// wrongly deny; effective max(600, 500) = 600 -> 1000+600=1600 <= 2000 fits.
+			name: "init container within quota via max formula",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: "hami-scheduler",
+					InitContainers: []corev1.Container{
+						{
+							Name: "init1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":    resource.MustParse("1"),
+									"nvidia.com/gpumem": resource.MustParse("500"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu":    resource.MustParse("1"),
+									"nvidia.com/gpumem": resource.MustParse("600"),
+								},
+							},
+						},
+					},
+				},
+			},
+			fit: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind feature

-->

**What this PR does / why we need it**:
Implements GPU resource accounting for init containers, following the design in
  [`docs/develop/initContainer-design.md`](https://github.com/Project-HAMi/HAMi/blob/master/docs/develop/initContainer-design.md) (#2064).

  Init containers run sequentially to completion before app containers start, so their
  GPU usage should never be summed with app usage. The effective per-device footprint is:

  effective = max( sum(app requests), max(init request) )

  This is applied consistently across the three accounting paths:

  - **Admission** (`webhook.go`): quota check uses the effective value; `MutateAdmission`
    now also runs over init containers.
  - **Scheduling** (`score.go`): each init container is fit independently against a fresh
    node copy with an isolated allocation context; app containers accumulate on the real
    node. Init allocations no longer pollute app quota/filter checks.
  - **Usage recording** (`scheduler.go`, `pods.go`): stores the collapsed view, and shrinks
    to app-only once init containers finish (one-time, with symmetric quota delta).

  ## Context

  Follow-up to my earlier attempt in #1278, which only touched the webhook and was
  incomplete. This PR implements the full model per the merged design doc.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved GPU resource accounting for pods with init containers using init-aware effective usage semantics.
  - Added automatic transition from init-inclusive usage to app-only usage once init containers complete successfully.
  - GPU admission, scheduling, and scoring/fit now consistently account for both init and app containers.

- **Bug Fixes**
  - Prevented init-container device allocations from polluting app container allocation/footprints.
  - Fixed quota usage tracking to remain consistent across pod updates, shrink transitions, and deletion.

- **Tests**
  - Added coverage for init-container accounting, quota evaluation, and allocation separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->