### PR TITLE
feat(nvidia): support RTX PRO 6000 Blackwell dynamic MIG

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -230,6 +230,23 @@ data:
               core: 100
               memory: 184320
               count: 1
+      - models: [ "RTX PRO 6000 Blackwell Server Edition" ]
+        allowedGeometries:
+          -
+            - name: 1g.24gb
+              core: 25
+              memory: 24576
+              count: 4
+          -
+            - name: 2g.48gb
+              core: 50
+              memory: 49152
+              count: 2
+          -
+            - name: 4g.96gb
+              core: 100
+              memory: 98304
+              count: 1
     cambricon:
       resourceCountName: {{ .Values.mluResourceName }}
       resourceMemoryName: {{ .Values.mluResourceMem }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ADD . /k8s-vgpu
 #RUN --mount=type=cache,target=/go/pkg/mod \
 #    cd /k8s-vgpu && make all
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.3
 
 FROM $NVIDIA_IMAGE AS nvbuild
 RUN dnf install -y cmake git && dnf clean all

--- a/docker/Dockerfile.hamimaster
+++ b/docker/Dockerfile.hamimaster
@@ -8,7 +8,7 @@ ADD . /k8s-vgpu
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.3
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \

--- a/docker/Dockerfile.withlib
+++ b/docker/Dockerfile.withlib
@@ -8,7 +8,7 @@ ARG GOPROXY=https://goproxy.cn,direct
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.3
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04
 RUN apt-get update && \

--- a/docs/develop/dynamic-mig.md
+++ b/docs/develop/dynamic-mig.md
@@ -87,6 +87,20 @@ data:
             - name: 7g.79gb
               memory: 80896
               count: 1
+      - models: [ "RTX PRO 6000 Blackwell Server Edition" ]
+        allowedGeometries:
+          -
+            - name: 1g.24gb
+              memory: 24576
+              count: 4
+          -
+            - name: 2g.48gb
+              memory: 49152
+              count: 2
+          -
+            - name: 4g.96gb
+              memory: 98304
+              count: 1
       nodeconfig: 
           - name: nodeA
             operatingmode: hami-core

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -60,6 +60,14 @@ func TestGenerateMigTemplate(t *testing.T) {
 					{device.MigTemplate{Name: "7g.80gb", Core: 100, Memory: 81920, Count: 1}},
 				},
 			},
+			{
+				Models: []string{"RTX PRO 6000 Blackwell Server Edition"},
+				Geometries: []device.Geometry{
+					{device.MigTemplate{Name: "1g.24gb", Core: 25, Memory: 24576, Count: 4}},
+					{device.MigTemplate{Name: "2g.48gb", Core: 50, Memory: 49152, Count: 2}},
+					{device.MigTemplate{Name: "4g.96gb", Core: 100, Memory: 98304, Count: 1}},
+				},
+			},
 		},
 	}
 
@@ -132,6 +140,23 @@ func TestGenerateMigTemplate(t *testing.T) {
 			expectedReset: false,
 			expectedMig: map[string]int32{
 				"1g.5gb": 7,
+			},
+		},
+		{
+			// The full NVML model string must match the shorter configured
+			// model via substring matching (RTX PRO 6000 Blackwell Server Edition).
+			name:      "rtx pro 6000 blackwell 1g.24gb template",
+			model:     "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+			deviceIdx: 0,
+			containerDev: device.ContainerDevice{
+				Idx:     0,
+				UUID:    "ccccdddd[0-3]",
+				Usedmem: 20000,
+			},
+			expectedPos:   3,
+			expectedReset: true,
+			expectedMig: map[string]int32{
+				"1g.24gb": 4,
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Why this is needed:

1. HAMi currently bundles `nvidia-mig-parted` v0.12.2, which uses `go-nvlib` v0.7.3 and `go-nvml` v0.12.9.
2. That `go-nvlib` version does not recognize the newer Blackwell MIG profile IDs. PCI device ID 2bb5 (vendor ID 10DE) belongs to the [NVIDIA Corporation](https://devicehunt.com/view/type/pci/vendor/10DE) [RTX PRO 6000 Blackwell / GB202GL](1.2.1, 1.2.3) professional graphics card.
3. Parsing profiles such as `1g.24gb` and `2g.48gb` therefore fails. No MIG devices are created, but `nvidia-mig-parted` still returns successfully and prints `MIG configuration applied successfully`.

This PR:

- Adds dynamic MIG geometries for the NVIDIA RTX PRO 6000 Blackwell Server Edition:
  - `1g.24gb` × 4
  - `2g.48gb` × 2
  - `4g.96gb` × 1
- Adds the model and geometries to the default Helm device configuration.
- Documents the supported profiles and covers matching the full NVML model name.
- Updates the bundled `nvidia-mig-parted` to v0.12.3, which includes native MIG profile support for this GPU.

**Which issue(s) this PR fixes**:

Fixes Project-HAMi/HAMi#2131

**Special notes for your reviewer**:

Validated with:

```text
go test -count=1 ./pkg/device-plugin/nvidiadevice/nvinternal/plugin
```

The native MIG configuration was also exercised on RTX PRO 6000 Blackwell Server Edition hardware.

Cursor AI assisted with investigation, implementation, tests, documentation, and drafting this pull request. The resulting changes were reviewed and validated locally.

**Does this PR introduce a user-facing change?**:

HAMi dynamic MIG now supports NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs with their native `1g.24gb`, `2g.48gb`, and `4g.96gb` profiles.