### PR TITLE
test: add tests for predicate and bind routes, including error handling

### DIFF
--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -17,13 +17,63 @@ limitations under the License.
 package routes
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/scheduler"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
+
+func setUnexportedField(target interface{}, fieldName string, value interface{}) {
+	rv := reflect.ValueOf(target).Elem()
+	field := rv.FieldByName(fieldName)
+	if !field.IsValid() {
+		panic(fmt.Sprintf("no such field %q on %T", fieldName, target))
+	}
+	addr := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+	addr.Set(reflect.ValueOf(value))
+}
+
+func setSynced(s *scheduler.Scheduler, synced bool) {
+	setUnexportedField(s, "synced", synced)
+}
+
+func setPodLister(s *scheduler.Scheduler, pl listerscorev1.PodLister) {
+	setUnexportedField(s, "podLister", pl)
+}
+
+// fakePodLister/fakePodNamespaceLister let us simulate "pod not found" from
+// Scheduler.Bind without wiring up a full informer + fake clientset.
+type fakePodLister struct{}
+
+func (fakePodLister) List(_ labels.Selector) ([]*corev1.Pod, error) { return nil, nil }
+func (fakePodLister) Pods(_ string) listerscorev1.PodNamespaceLister {
+	return fakePodNamespaceLister{}
+}
+
+type fakePodNamespaceLister struct{}
+
+func (fakePodNamespaceLister) List(_ labels.Selector) ([]*corev1.Pod, error) { return nil, nil }
+func (fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
+	return nil, fmt.Errorf("pod %q not found", name)
+}
+
+// ---------------------------------------------------------------------------
+// Existing tests (unchanged)
+// ---------------------------------------------------------------------------
 
 func TestMaxRequestSize(t *testing.T) {
 	hugePayload := strings.Repeat(" ", maxRequestSize+100)
@@ -42,6 +92,7 @@ func TestMaxRequestSize(t *testing.T) {
 		t.Logf("Success! Caught expected error: %s", respBody)
 	}
 }
+
 func TestHealthzRoute(t *testing.T) {
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	w := httptest.NewRecorder()
@@ -133,5 +184,163 @@ func TestCheckBodyNil(t *testing.T) {
 
 	if w.Code != 400 {
 		t.Errorf("Expected status 400 for nil body, got %d", w.Code)
+	}
+}
+
+func TestPredicateRoute_DecodeError(t *testing.T) {
+	req := httptest.NewRequest("POST", "/predicate", strings.NewReader("{not-json"))
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := PredicateRoute(s)
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200 (error reported in body, not status), got %d", w.Code)
+	}
+
+	var result extenderv1.ExtenderFilterResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Error == "" {
+		t.Error("expected a decode error to be reported in the filter result")
+	}
+}
+
+// TestPredicateRoute_CacheNotSynced exercises the "cache not synced" branch:
+// a valid, decodable request but a context that is already cancelled, so
+// WaitForCacheSync returns false quickly instead of blocking.
+func TestPredicateRoute_CacheNotSynced(t *testing.T) {
+	args := extenderv1.ExtenderArgs{Pod: &corev1.Pod{}}
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so WaitForCacheSync fails fast instead of polling forever
+
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body)).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{} // zero value: synced defaults to false
+	handler := PredicateRoute(s)
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var result extenderv1.ExtenderFilterResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if !strings.Contains(result.Error, "context cancelled") {
+		t.Errorf("expected 'context cancelled' error, got %q", result.Error)
+	}
+}
+
+// TestPredicateRoute_FilterSuccess exercises the successful decode + synced +
+// Filter() + marshal path end-to-end. A pod with no device resource requests
+// takes the early-return branch inside Scheduler.Filter, which needs no
+// podLister/nodeLister/kubeClient, so only "synced" has to be forced to true.
+func TestPredicateRoute_FilterSuccess(t *testing.T) {
+	s := scheduler.NewScheduler()
+	setSynced(s, true)
+
+	nodeNames := []string{"node1"}
+	args := extenderv1.ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
+			},
+		},
+		NodeNames: &nodeNames,
+	}
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler := PredicateRoute(s)
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result extenderv1.ExtenderFilterResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Error != "" {
+		t.Errorf("expected no error from Filter, got %q", result.Error)
+	}
+}
+
+// TestBind_DecodeError exercises Bind's JSON-decode-failure branch with a
+// well-formed (small) request, complementing the existing oversized-payload
+// EOF test.
+func TestBind_DecodeError(t *testing.T) {
+	req := httptest.NewRequest("POST", "/bind", strings.NewReader("{not-json"))
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := Bind(s)
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200 (error reported in body, not status), got %d", w.Code)
+	}
+
+	var result extenderv1.ExtenderBindingResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Error == "" {
+		t.Error("expected a decode error to be reported in the bind result")
+	}
+}
+
+// TestBind_PodNotFound exercises Scheduler.Bind's "pod not found" error path,
+// which flows back through routes.Bind's success-marshal branch with a
+// populated Error field. It only requires a fake podLister, since that error
+// return happens before anything else (node lookup, locking, kube client)
+// is touched.
+func TestBind_PodNotFound(t *testing.T) {
+	s := scheduler.NewScheduler()
+	setPodLister(s, fakePodLister{})
+
+	args := extenderv1.ExtenderBindingArgs{
+		PodName:      "missing-pod",
+		PodNamespace: "default",
+		Node:         "node1",
+	}
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/bind", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler := Bind(s)
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result extenderv1.ExtenderBindingResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Error == "" {
+		t.Error("expected Bind to report a pod-not-found error")
 	}
 }

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -71,10 +71,6 @@ func (fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
 	return nil, fmt.Errorf("pod %q not found", name)
 }
 
-// ---------------------------------------------------------------------------
-// Existing tests (unchanged)
-// ---------------------------------------------------------------------------
-
 func TestMaxRequestSize(t *testing.T) {
 	hugePayload := strings.Repeat(" ", maxRequestSize+100)
 

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -20,56 +20,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
-	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	listerscorev1 "k8s.io/client-go/listers/core/v1"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/scheduler"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
-
-func setUnexportedField(target any, fieldName string, value any) {
-	rv := reflect.ValueOf(target).Elem()
-	field := rv.FieldByName(fieldName)
-	if !field.IsValid() {
-		panic(fmt.Sprintf("no such field %q on %T", fieldName, target))
-	}
-	addr := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
-	addr.Set(reflect.ValueOf(value))
-}
-
-func setSynced(s *scheduler.Scheduler, synced bool) {
-	setUnexportedField(s, "synced", synced)
-}
-
-func setPodLister(s *scheduler.Scheduler, pl listerscorev1.PodLister) {
-	setUnexportedField(s, "podLister", pl)
-}
-
-// fakePodLister/fakePodNamespaceLister let us simulate "pod not found" from
-// Scheduler.Bind without wiring up a full informer + fake clientset.
-type fakePodLister struct{}
-
-func (fakePodLister) List(_ labels.Selector) ([]*corev1.Pod, error) { return nil, nil }
-func (fakePodLister) Pods(_ string) listerscorev1.PodNamespaceLister {
-	return fakePodNamespaceLister{}
-}
-
-type fakePodNamespaceLister struct{}
-
-func (fakePodNamespaceLister) List(_ labels.Selector) ([]*corev1.Pod, error) { return nil, nil }
-func (fakePodNamespaceLister) Get(name string) (*corev1.Pod, error) {
-	return nil, fmt.Errorf("pod %q not found", name)
-}
 
 func TestMaxRequestSize(t *testing.T) {
 	hugePayload := strings.Repeat(" ", maxRequestSize+100)
@@ -122,14 +82,12 @@ func TestWebHookRoute(t *testing.T) {
 		t.Fatal("WebHookRoute returned nil handler")
 	}
 
-	// Send a request to the webhook handler - even an invalid request exercises the handler path
 	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	handler(w, req, nil)
 
-	// The webhook handler should respond (any status is fine - we're testing the route layer)
 	if w.Code == 0 {
 		t.Error("Expected a non-zero status code from webhook handler")
 	}
@@ -204,9 +162,6 @@ func TestPredicateRoute_DecodeError(t *testing.T) {
 	}
 }
 
-// TestPredicateRoute_CacheNotSynced exercises the "cache not synced" branch:
-// a valid, decodable request but a context that is already cancelled, so
-// WaitForCacheSync returns false quickly instead of blocking.
 func TestPredicateRoute_CacheNotSynced(t *testing.T) {
 	args := extenderv1.ExtenderArgs{Pod: &corev1.Pod{}}
 	body, err := json.Marshal(args)
@@ -237,59 +192,6 @@ func TestPredicateRoute_CacheNotSynced(t *testing.T) {
 	}
 }
 
-// TestPredicateRoute_FilterSuccess exercises the successful decode + synced +
-// Filter() + marshal path end-to-end. A pod with no device resource requests
-// takes the early-return branch inside Scheduler.Filter, which needs no
-// podLister/nodeLister/kubeClient, so only "synced" has to be forced to true.
-func TestPredicateRoute_FilterSuccess(t *testing.T) {
-	s := scheduler.NewScheduler()
-	setSynced(s, true)
-
-	nodeNames := []string{"node1"}
-	args := extenderv1.ExtenderArgs{
-		Pod: &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
-			},
-		},
-		NodeNames: &nodeNames,
-	}
-	body, err := json.Marshal(args)
-	if err != nil {
-		t.Fatalf("failed to marshal args: %v", err)
-	}
-
-	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	handler := PredicateRoute(s)
-	handler(w, req, nil)
-
-	if w.Code != 200 {
-		t.Fatalf("expected 200, got %d, body: %s", w.Code, w.Body.String())
-	}
-
-	var result extenderv1.ExtenderFilterResult
-	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
-		t.Fatalf("failed to unmarshal response: %v", err)
-	}
-
-	if result.Error != "" {
-		t.Errorf("expected no error from Filter, got %q", result.Error)
-	}
-
-	if result.NodeNames == nil {
-		t.Fatal("expected NodeNames to be non-nil in successful filter result")
-	}
-	if !reflect.DeepEqual(*result.NodeNames, nodeNames) {
-		t.Errorf("expected NodeNames %v, got %v", nodeNames, *result.NodeNames)
-	}
-}
-
-// TestBind_DecodeError exercises Bind's JSON-decode-failure branch with a
-// well-formed (small) request, complementing the existing oversized-payload
-// EOF test.
 func TestBind_DecodeError(t *testing.T) {
 	req := httptest.NewRequest("POST", "/bind", strings.NewReader("{not-json"))
 	w := httptest.NewRecorder()
@@ -308,43 +210,5 @@ func TestBind_DecodeError(t *testing.T) {
 	}
 	if result.Error == "" {
 		t.Error("expected a decode error to be reported in the bind result")
-	}
-}
-
-// TestBind_PodNotFound exercises Scheduler.Bind's "pod not found" error path,
-// which flows back through routes.Bind's success-marshal branch with a
-// populated Error field. It only requires a fake podLister, since that error
-// return happens before anything else (node lookup, locking, kube client)
-// is touched.
-func TestBind_PodNotFound(t *testing.T) {
-	s := scheduler.NewScheduler()
-	setPodLister(s, fakePodLister{})
-
-	args := extenderv1.ExtenderBindingArgs{
-		PodName:      "missing-pod",
-		PodNamespace: "default",
-		Node:         "node1",
-	}
-	body, err := json.Marshal(args)
-	if err != nil {
-		t.Fatalf("failed to marshal args: %v", err)
-	}
-
-	req := httptest.NewRequest("POST", "/bind", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	handler := Bind(s)
-	handler(w, req, nil)
-
-	if w.Code != 200 {
-		t.Fatalf("expected 200, got %d, body: %s", w.Code, w.Body.String())
-	}
-
-	var result extenderv1.ExtenderBindingResult
-	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
-		t.Fatalf("failed to unmarshal response: %v", err)
-	}
-	if result.Error == "" {
-		t.Error("expected Bind to report a pod-not-found error")
 	}
 }

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
 
-func setUnexportedField(target interface{}, fieldName string, value interface{}) {
+func setUnexportedField(target any, fieldName string, value any) {
 	rv := reflect.ValueOf(target).Elem()
 	field := rv.FieldByName(fieldName)
 	if !field.IsValid() {

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -278,8 +278,16 @@ func TestPredicateRoute_FilterSuccess(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+
 	if result.Error != "" {
 		t.Errorf("expected no error from Filter, got %q", result.Error)
+	}
+
+	if result.NodeNames == nil {
+		t.Fatal("expected NodeNames to be non-nil in successful filter result")
+	}
+	if !reflect.DeepEqual(*result.NodeNames, nodeNames) {
+		t.Errorf("expected NodeNames %v, got %v", nodeNames, *result.NodeNames)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind feature

**What this PR does / why we need it**:

- This PR improves the unit testing coverage of the Router Component up to 80 Percent .
<img width="1088" height="73" alt="image" src="https://github.com/user-attachments/assets/ca557e50-4e0c-42b2-a95c-315cd37dc3bf" />

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded route-layer coverage for malformed request handling.
  * Added new tests for `/predicate` and `/bind` to verify responses include decode errors when given invalid JSON.
  * Added a test for `/predicate` to ensure cache sync failure due to an immediately cancelled request context is surfaced in the response error details.
  * Strengthened assertions that these endpoints consistently return HTTP 200 while providing relevant error information in the response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->