### PR TITLE
fix(scheduler): deny privileged containers in webhook

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -74,7 +74,7 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		if ctr.SecurityContext != nil {
 			if ctr.SecurityContext.Privileged != nil && *ctr.SecurityContext.Privileged {
 				klog.Warningf(template+" - Denying admission as container %s is privileged", pod.Namespace, pod.Name, pod.UID, c.Name)
-				continue
+				return admission.Denied("privileged containers are not allowed")
 			}
 		}
 		for _, val := range device.GetDevices() {

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -545,6 +545,91 @@ func TestEmptyContainersDenied(t *testing.T) {
 	}
 }
 
+func TestPrivilegedContainerDeniedAdmission(t *testing.T) {
+	prevSchedulerName := config.SchedulerName
+	prevForceOverwrite := config.ForceOverwriteDefaultScheduler
+	t.Cleanup(func() {
+		config.SchedulerName = prevSchedulerName
+		config.ForceOverwriteDefaultScheduler = prevForceOverwrite
+	})
+
+	config.SchedulerName = "hami-scheduler"
+	config.ForceOverwriteDefaultScheduler = true
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+		},
+	}
+
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		klog.Fatalf("Failed to initialize devices with config: %v", err)
+	}
+
+	privileged := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "privileged-gpu-mixed",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "privileged-sidecar",
+					Image: "busybox",
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+				},
+				{
+					Name:  "gpu-workload",
+					Image: "busybox",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hami.io/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+	podBytes, err := runtime.Encode(codec, pod)
+	if err != nil {
+		t.Fatalf("Error encoding pod: %v", err)
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:       "privileged-gpu-mixed-uid",
+			Namespace: "default",
+			Name:      "privileged-gpu-mixed",
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+		},
+	}
+
+	wh, err := NewWebHook()
+	if err != nil {
+		t.Fatalf("Error creating WebHook: %v", err)
+	}
+
+	resp := wh.Handle(context.Background(), req)
+	if resp.Allowed {
+		t.Fatalf("Expected pod with privileged container to be denied, but got allowed")
+	}
+}
+
 func TestSchedulerNameEmptyNoOverwrite(t *testing.T) {
 	prevSchedulerName := config.SchedulerName
 	prevForceOverwrite := config.ForceOverwriteDefaultScheduler


### PR DESCRIPTION
## What changed

- Return a denied admission response as soon as the webhook sees a privileged container.
- Add a regression test for a pod that combines a privileged sidecar with a GPU-requesting workload container.

## Why

The webhook previously logged that it was denying privileged containers but then continued processing the pod. If another container requested GPU resources, the webhook could still allow and mutate the pod.

Fixes #2138.

## Validation

- `go test ./pkg/scheduler`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod admission is now denied when any container is configured as privileged.
  * Prevents privileged containers from bypassing admission checks while other containers continue processing.

* **Tests**
  * Added coverage verifying that pods containing privileged containers are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->