### PR TITLE
fix(metrics): resolve high-cardinality leak in memory_allocated_bytes

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -65,7 +65,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodevGPUMemoryAllocatedDesc := prometheus.NewDesc(
 		"hami_gpu_memory_allocated_bytes",
 		"Device memory allocated for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_cores", "device_type"}, nil,
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodevGPUSharedNumDesc := prometheus.NewDesc(
 		"hami_gpu_shared_count",
@@ -80,7 +80,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodeGPUOverview := prometheus.NewDesc(
 		"hami_node_gpu_overview",
 		"GPU overview on a certain node",
-		[]string{"node", "device_uuid", "device_index", "device_cores", "shared_containers", "device_memory_limit", "device_type"}, nil,
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodeGPUMemoryPercentage := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
@@ -121,7 +121,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		legacyMemoryAllocatedDesc = prometheus.NewDesc(
 			"GPUDeviceMemoryAllocated",
 			"Device memory allocated for a certain GPU",
-			[]string{"nodeid", "deviceuuid", "deviceidx", "devicecores", "devicetype"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
 		)
 		legacySharedNumDesc = prometheus.NewDesc(
 			"GPUDeviceSharedNum",
@@ -136,7 +136,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		legacyOverview = prometheus.NewDesc(
 			"nodeGPUOverview",
 			"GPU overview on a certain node",
-			[]string{"nodeid", "deviceuuid", "deviceidx", "devicecores", "sharedcontainers", "devicememorylimit", "devicetype"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
 		)
 		legacyMemoryPercentage = prometheus.NewDesc(
 			"nodeGPUMemoryPercentage",
@@ -208,7 +208,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodevGPUMemoryAllocatedDesc,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodevGPUSharedNumDesc,
@@ -226,7 +226,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodeGPUOverview,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodeGPUMemoryPercentage,
@@ -252,7 +252,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyMemoryAllocatedDesc,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacySharedNumDesc,
@@ -270,7 +270,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyOverview,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacyMemoryPercentage,

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -65,7 +65,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodevGPUMemoryAllocatedDesc := prometheus.NewDesc(
 		"hami_gpu_memory_allocated_bytes",
 		"Device memory allocated for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node", "device_uuid", "device_index", "device_cores", "device_type"}, nil,
 	)
 	nodevGPUSharedNumDesc := prometheus.NewDesc(
 		"hami_gpu_shared_count",
@@ -80,7 +80,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodeGPUOverview := prometheus.NewDesc(
 		"hami_node_gpu_overview",
 		"GPU overview on a certain node",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node", "device_uuid", "device_index", "device_cores", "device_memory_limit", "device_type"}, nil,
 	)
 	nodeGPUMemoryPercentage := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
@@ -121,7 +121,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		legacyMemoryAllocatedDesc = prometheus.NewDesc(
 			"GPUDeviceMemoryAllocated",
 			"Device memory allocated for a certain GPU",
-			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx", "devicecores", "devicetype"}, nil,
 		)
 		legacySharedNumDesc = prometheus.NewDesc(
 			"GPUDeviceSharedNum",
@@ -136,7 +136,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		legacyOverview = prometheus.NewDesc(
 			"nodeGPUOverview",
 			"GPU overview on a certain node",
-			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx", "devicecores", "devicememorylimit", "devicetype"}, nil,
 		)
 		legacyMemoryPercentage = prometheus.NewDesc(
 			"nodeGPUMemoryPercentage",
@@ -208,7 +208,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodevGPUMemoryAllocatedDesc,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodevGPUSharedNumDesc,
@@ -226,7 +226,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodeGPUOverview,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodeGPUMemoryPercentage,
@@ -252,7 +252,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyMemoryAllocatedDesc,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacySharedNumDesc,
@@ -270,7 +270,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyOverview,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacyMemoryPercentage,

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -208,7 +208,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodevGPUMemoryAllocatedDesc,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Usedcores), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodevGPUSharedNumDesc,
@@ -226,7 +226,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				nodeGPUOverview,
 				prometheus.GaugeValue,
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Usedcores), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
+				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				nodeGPUMemoryPercentage,
@@ -252,7 +252,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyMemoryAllocatedDesc,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Usedcores), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacySharedNumDesc,
@@ -270,7 +270,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					legacyOverview,
 					prometheus.GaugeValue,
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Usedcores), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Used), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					legacyMemoryPercentage,

--- a/skill/hami-vgpu-metrics-summary/SKILL.md
+++ b/skill/hami-vgpu-metrics-summary/SKILL.md
@@ -245,10 +245,12 @@ These are emitted in **bytes**, even though internal scheduler state stores memo
 These are emitted directly from quota manager `q.Used` and should be interpreted as **MiB-like GPU memory units**, not bytes.
 
 **Overview labels**
+- `hami_node_gpu_overview.device_cores`
 - `hami_node_gpu_overview.device_memory_limit`
+- legacy `nodeGPUOverview.devicecores`
 - legacy `nodeGPUOverview.devicememorylimit`
 
-These label values are also in **MiB-like units**.
+These label values are static. Memory limits are in **MiB-like units**, and cores are integers.
 
 Use these conversions when needed:
 


### PR DESCRIPTION
## What happened
The `hami_gpu_memory_allocated_bytes` metric (and its legacy counterpart `GPUDeviceMemoryAllocated`) defines a `device_cores` label but incorrectly injects `fmt.Sprint(devs.Device.Usedcores)` as its value instead of `Totalcore`. 

Because `Usedcores` is a dynamic state variable (changing every time a pod is scheduled or unscheduled), this causes a severe **Prometheus High Cardinality Leak**. Every time the used cores change, Prometheus is forced to create a completely new time series, abandoning the old one. On a cluster with high pod churn, this combinatorial explosion of stale time series will eventually cause Prometheus OOMs.

## What you expected to happen
Prometheus best practices dictate that labels must represent stable identity attributes, not dynamic state. The `device_cores` label should represent the static core capacity of the device (`Totalcore`), while the dynamic state should remain as metric values (e.g., via `hami_gpu_core_allocated_ratio`). 

## How to reproduce
1. Deploy HAMi and scrape `:31993/metrics`.
2. Schedule a pod that requests GPU cores.
3. Observe `hami_gpu_memory_allocated_bytes`.
4. Delete the pod.
5. Observe that a **new** time series is created for `hami_gpu_memory_allocated_bytes` with a different `device_cores` label, instead of updating the existing series. 

## Root cause
In `cmd/scheduler/metrics.go`:
```go
ch <- prometheus.MustNewConstMetric(
    nodevGPUMemoryAllocatedDesc,
    prometheus.GaugeValue,
    float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
    nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), 
    fmt.Sprint(devs.Device.Usedcores), // <-- BUG: Injecting dynamic state into label
    devs.Device.Type,
)
```

## Fix
Changed `devs.Device.Usedcores` to `devs.Device.Totalcore` when populating the `device_cores` label, stabilizing the time series identity.

**Note:** This aligns directly with the gap analysis currently open in #2126 regarding metric cardinality risks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU-related Prometheus metrics to align label definitions and semantics across both current and legacy formats.
  * For GPU memory allocation, the `device_cores` label now reflects total device cores (while the underlying memory allocation value remains based on used memory).
  * For GPU node overview, the label set was simplified by removing the container-sharing dimension, and the `device_cores` / `device_memory_limit` labels now report total cores and memory limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->