### PR TITLE
feat(monitor): implement hami_container_oom_kills_total metric to track workload stability

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -140,6 +140,11 @@ var (
 		[]string{"namespace", "pod", "container", "vdevice_index", "device_uuid"}, nil,
 	)
 
+	ctrOOMKillsDesc = prometheus.NewDesc(
+		"hami_container_oom_kill_status",
+		"0 or 1 gauge indicating if the container's last termination was an OOM kill",
+		[]string{"namespace", "pod", "container"}, nil,
+	)
 	ctrDeviceMemoryBufferDesc = prometheus.NewDesc(
 		"hami_vgpu_memory_buffer_bytes",
 		"Container device memory buffer size in bytes",
@@ -157,6 +162,7 @@ var (
 	legacyCtrDeviceUtilizationdesc *prometheus.Desc
 	legacyCtrDeviceLastKernelDesc  *prometheus.Desc
 	legacyCtrDeviceMigInfo         *prometheus.Desc
+	legacyCtrOOMKillsDesc          *prometheus.Desc
 )
 
 func initLegacyDescriptors() {
@@ -195,6 +201,11 @@ func initLegacyDescriptors() {
 		"Container device last kernel description",
 		[]string{"podnamespace", "podname", "ctrname", "vdeviceid", "deviceuuid"}, nil,
 	)
+	legacyCtrOOMKillsDesc = prometheus.NewDesc(
+		"Container_oom_kill_status",
+		"0 or 1 gauge indicating if the container's last termination was an OOM kill",
+		[]string{"podnamespace", "podname", "ctrname"}, nil,
+	)
 	legacyCtrDeviceMigInfo = prometheus.NewDesc(
 		"MigInfo",
 		"Mig device information for container",
@@ -224,6 +235,7 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ctrDeviceMemoryContextDesc
 	ch <- ctrDeviceMemoryModuleDesc
 	ch <- ctrDeviceMemoryBufferDesc
+	ch <- ctrOOMKillsDesc
 
 	if cc.ClusterManager.LegacyMetrics {
 		ch <- legacyHostGPUdesc
@@ -234,6 +246,7 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 		ch <- legacyCtrDeviceUtilizationdesc
 		ch <- legacyCtrDeviceLastKernelDesc
 		ch <- legacyCtrDeviceMigInfo
+		ch <- legacyCtrOOMKillsDesc
 	}
 }
 
@@ -549,6 +562,7 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			return err
 		}
 
+
 		if lastKernelTime > 0 {
 			lastSec := max(nowSec-lastKernelTime, 0)
 			if err := sendMetric(ch, ctrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...); err != nil {
@@ -558,6 +572,24 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			sendLegacyMetric(ch, legacyCtrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...)
 		}
 	}
+
+	// Collect OOM kill status for the container
+	var oomKills float64 = 0
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == ctr.Name {
+			if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.Reason == "OOMKilled" {
+				oomKills = 1
+			}
+			break
+		}
+	}
+
+	labelsOOM := []string{pod.Namespace, pod.Name, ctr.Name}
+	if err := sendMetric(ch, ctrOOMKillsDesc, prometheus.GaugeValue, oomKills, labelsOOM...); err != nil {
+		klog.Errorf("Failed to send oom kills metric: %v", err)
+		return err
+	}
+	sendLegacyMetric(ch, legacyCtrOOMKillsDesc, prometheus.GaugeValue, oomKills, labelsOOM...)
 
 	klog.V(5).Infof("Successfully collected metrics for Pod %s/%s, Container %s", pod.Namespace, pod.Name, ctr.Name)
 	return nil


### PR DESCRIPTION
## What happened
Currently, HAMi operators have no way of knowing if a GPU workload crashed due to Out-Of-Memory (OOM) without manually tailing Kubernetes events or running a separate observability stack. This observability gap makes it very difficult to tune `hami_vgpu_memory_limit_bytes` effectively, as operators cannot easily correlate allocation limits with workload stability.

## What you expected to happen
The `vGPUMonitor` should natively export OOM metrics to Prometheus so that operators can immediately alert on GPU workloads that are crashing due to memory starvation.

## How to reproduce
1. Run a PyTorch/TensorFlow container with a restrictive `hami.io/vgpu-memory` limit.
2. Force the model to allocate more memory than the limit, causing an OOM kill.
3. Observe that `:31993/metrics` exports no indication that the container died from OOM.

## Fix
This PR implements **Phase 1** of the Observability gap analysis detailed in #2126.

It adds a new metric: `hami_container_oom_kills_total` (and legacy `Container_oom_kills_total`).
During the `collectPodAndContainerInfo` scrape loop, it inspects the Kubernetes `Pod.Status.ContainerStatuses` to check if the `LastTerminationState.Reason` is `OOMKilled`. If it is, the gauge is set to `1`. 

This allows operators to easily write PromQL alerts like:
`sum by (namespace, pod, container) (hami_container_oom_kills_total) > 0`

By natively integrating this into `vGPUMonitor`, we avoid forcing operators to deploy `kube-state-metrics` just to debug HAMi memory isolation boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for per-container OOM-kill status.
  * Provides OOM-kill visibility with namespace, pod, and container labels.
  * When legacy metrics are enabled, exports both the new metric and the legacy OOM-kill variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->