### PR TITLE
fix: bound int32 conversion in enflame device parsing

### DIFF
--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -255,7 +255,7 @@ func (dev *EnflameDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[stri
 				continue
 			}
 			chosen := ctrDevices[0]
-			slice := int32(readCustomInfoInt(chosen.CustomInfo, "drsSlice"))
+			slice := clampToInt32(readCustomInfoInt(chosen.CustomInfo, "drsSlice"))
 			if slice <= 0 {
 				slice = 1
 			}
@@ -369,11 +369,11 @@ func (dev *EnflameDevices) ScoreNode(node *corev1.Node, podDevices device.PodSin
 }
 
 func (dev *EnflameDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
-	slice := int32(readCustomInfoInt(ctr.CustomInfo, "drsSlice"))
+	slice := clampToInt32(readCustomInfoInt(ctr.CustomInfo, "drsSlice"))
 	if slice <= 0 {
 		slice = 1
 	}
-	n.Used += slice
+	n.Used = clampToInt32(int(n.Used) + int(slice))
 	n.Usedcores += ctr.Usedcores
 	n.Usedmem += ctr.Usedmem
 	return nil
@@ -639,22 +639,36 @@ func normalizeMemoryRequestToGB(rawMemory int32, maxProfileMemoryGB int) int {
 func parseDRSCapacity(raw any) (int32, error) {
 	switch typed := raw.(type) {
 	case float64:
+		if math.IsNaN(typed) || typed > math.MaxInt32 || typed < math.MinInt32 {
+			return 0, fmt.Errorf("invalid capacity value: %v", typed)
+		}
 		return int32(typed), nil
 	case int:
-		return int32(typed), nil
+		return clampToInt32(typed), nil
 	case int32:
 		return typed, nil
 	case int64:
-		return int32(typed), nil
+		return clampToInt32(int(typed)), nil
 	case string:
 		capacity, err := strconv.Atoi(strings.TrimSpace(typed))
 		if err != nil {
 			return 0, err
 		}
-		return int32(capacity), nil
+		return clampToInt32(capacity), nil
 	default:
 		return 0, fmt.Errorf("unknown capacity type: %T", raw)
 	}
+}
+
+// clampToInt32 bounds v to the int32 range instead of letting the cast wrap silently.
+func clampToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
 }
 
 func containerNameByIndex(pod *corev1.Pod, index int) string {
@@ -712,6 +726,9 @@ func readCustomInfoInt(customInfo map[string]any, key string) int {
 	case int64:
 		return int(typed)
 	case float64:
+		if math.IsNaN(typed) || typed > math.MaxInt32 || typed < math.MinInt32 {
+			return 0
+		}
 		return int(typed)
 	case string:
 		v, err := strconv.Atoi(strings.TrimSpace(typed))

--- a/pkg/device/enflame/device_test.go
+++ b/pkg/device/enflame/device_test.go
@@ -18,6 +18,7 @@ package enflame
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -357,4 +358,66 @@ func TestPatchAnnotations_DRSFields(t *testing.T) {
 	assert.Equal(t, assigned["pod-gcu-example1"].Request, int32(3))
 	assert.Equal(t, assigned["pod-gcu-example1"].ProfileName, "3g.20gb")
 	assert.Equal(t, assigned["pod-gcu-example1"].ProfileID, "1")
+}
+
+func TestClampToInt32(t *testing.T) {
+	assert.Equal(t, clampToInt32(5), int32(5))
+	assert.Equal(t, clampToInt32(math.MaxInt64), int32(math.MaxInt32))
+	assert.Equal(t, clampToInt32(math.MinInt64), int32(math.MinInt32))
+}
+
+func TestAddResourceUsage_ClampsOnOverflow(t *testing.T) {
+	dev := &EnflameDevices{}
+	n := &device.DeviceUsage{}
+	ctr := &device.ContainerDevice{
+		CustomInfo: map[string]any{"drsSlice": math.MaxInt32},
+	}
+
+	err := dev.AddResourceUsage(&corev1.Pod{}, n, ctr)
+	assert.NilError(t, err)
+	assert.Equal(t, n.Used, int32(math.MaxInt32))
+
+	// A second oversized slice must saturate, not wrap negative.
+	err = dev.AddResourceUsage(&corev1.Pod{}, n, ctr)
+	assert.NilError(t, err)
+	assert.Equal(t, n.Used, int32(math.MaxInt32))
+}
+
+func TestParseDRSCapacity_RejectsNaNAndInf(t *testing.T) {
+	_, err := parseDRSCapacity(math.NaN())
+	assert.Assert(t, err != nil)
+
+	_, err = parseDRSCapacity(math.Inf(1))
+	assert.Assert(t, err != nil)
+
+	_, err = parseDRSCapacity(1e300)
+	assert.Assert(t, err != nil)
+
+	capacity, err := parseDRSCapacity(float64(42))
+	assert.NilError(t, err)
+	assert.Equal(t, capacity, int32(42))
+
+	capacity, err = parseDRSCapacity("2147483648")
+	assert.NilError(t, err)
+	assert.Equal(t, capacity, int32(math.MaxInt32))
+}
+
+func TestReadCustomInfoInt_RejectsNaNAndInf(t *testing.T) {
+	assert.Equal(t, readCustomInfoInt(map[string]any{"k": math.NaN()}, "k"), 0)
+	assert.Equal(t, readCustomInfoInt(map[string]any{"k": math.Inf(-1)}, "k"), 0)
+	assert.Equal(t, readCustomInfoInt(map[string]any{"k": 1e300}, "k"), 0)
+	assert.Equal(t, readCustomInfoInt(map[string]any{"k": float64(7)}, "k"), 7)
+	assert.Equal(t, readCustomInfoInt(map[string]any{"k": "7"}, "k"), 7)
+}
+
+func TestAddResourceUsage_ClampsOversizedSliceString(t *testing.T) {
+	dev := &EnflameDevices{}
+	n := &device.DeviceUsage{}
+	ctr := &device.ContainerDevice{
+		CustomInfo: map[string]any{"drsSlice": "2147483648"},
+	}
+
+	err := dev.AddResourceUsage(&corev1.Pod{}, n, ctr)
+	assert.NilError(t, err)
+	assert.Equal(t, n.Used, int32(math.MaxInt32))
 }


### PR DESCRIPTION
/kind bug

CodeQL flagged 4 spots in pkg/device/enflame/device.go where strconv.Atoi results were cast to int32 with no range check. A large value could silently wrap into a wrong or negative number. Added a clamp helper and used it everywhere the conversion happens.
