### PR TITLE
test: add native fuzz test for DecodeContainerDevices

### DIFF
--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1619,3 +1619,14 @@ func TestMigInUseDeepCopy(t *testing.T) {
 		})
 	}
 }
+
+func FuzzDecodeContainerDevices(f *testing.F) {
+	f.Add("")
+	f.Add("GPU-uuid,NVIDIA,1024,10:")
+	f.Add("GPU-uuid,NVIDIA,1024,10:GPU-uuid2,NVIDIA,2048,20:")
+	f.Add(",,,")
+	f.Fuzz(func(t *testing.T, str string) {
+		// Must never panic on arbitrary pod-annotation input.
+		_, _ = DecodeContainerDevices(str)
+	})
+}


### PR DESCRIPTION
/kind failing-test

OpenSSF Scorecard flagged this repo as not fuzzed. DecodeContainerDevices parses pod annotation strings (untrusted input) and had no fuzz test. Added a native Go fuzz test with a few seed corpus entries.
