### PR TITLE
refactor: replace deprecated grpc.DialContext with grpc.NewClient

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/imdario/mergo"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
@@ -833,21 +834,28 @@ func (plugin *NvidiaDevicePlugin) PreStartContainer(context.Context, *kubeletdev
 	return &kubeletdevicepluginv1beta1.PreStartContainerResponse{}, nil
 }
 
-// dial establishes the gRPC communication with the registered device plugin.
 func (plugin *NvidiaDevicePlugin) dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error) {
-	ctx, cancel := context.WithTimeout(plugin.ctx, timeout)
-	defer cancel()
-	//nolint:staticcheck  // TODO: Switch to grpc.NewClient
-	c, err := grpc.DialContext(ctx, unixSocketPath,
+	c, err := grpc.NewClient("unix://"+unixSocketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		//nolint:staticcheck  // TODO: WithBlock is deprecated.
-		grpc.WithBlock(),
-		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
-		}),
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(plugin.ctx, timeout)
+	defer cancel()
+
+	// Wait for the connection to be ready (replaces the deprecated grpc.WithBlock())
+	c.Connect() // Trigger connection attempt
+	for {
+		state := c.GetState()
+		if state == connectivity.Ready {
+			break
+		}
+		if !c.WaitForStateChange(ctx, state) {
+			c.Close()
+			return nil, fmt.Errorf("timeout waiting for connection to %s", unixSocketPath)
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
This PR resolves the `// TODO` comments in `pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go` by upgrading the deprecated `grpc.DialContext` and `grpc.WithBlock()` functions to the modern `grpc.NewClient` standard.

Because the previous implementation used `grpc.WithBlock()` specifically as a blocking readiness probe (to ensure the local gRPC socket was listening before proceeding), simply dropping it would cause the readiness check to become a no-op due to `grpc.NewClient`'s lazy dial behavior. To preserve the exact readiness-check behavior using modern grpc-go practices, this PR implements an explicit state-checking loop utilizing `conn.Connect()`, `conn.GetState()`, and `conn.WaitForStateChange()`. 

**Which issue(s) this PR fixes**:
Fixes #2149 

**Special notes for your reviewer**:
The commit is signed-off (DCO) and correctly imports `google.golang.org/grpc/connectivity` to handle the replacement logic for `WithBlock()`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device plugin connection handling by waiting until the connection is ready before proceeding.
  * Added timeout-aware connection behavior to prevent indefinite waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->