### PR TITLE
refactor: upgrade health check config from env vars to top-level options

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/factory.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/factory.go
@@ -35,6 +35,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
@@ -128,9 +129,14 @@ func (o *options) getResourceManagers() ([]rm.ResourceManager, error) {
 			_ = o.nvmllib.Shutdown()
 		}()
 
-		return rm.NewNVMLResourceManagers(o.infolib, o.nvmllib, o.devicelib, o.config.Config)
+		disableHealthChecks := os.Getenv("DP_DISABLE_HEALTHCHECKS")
+		enableHealthChecks := os.Getenv("DP_ENABLE_HEALTHCHECKS")
+
+		return rm.NewNVMLResourceManagers(o.infolib, o.nvmllib, o.devicelib, o.config.Config, disableHealthChecks, enableHealthChecks)
 	case "tegra":
-		return rm.NewTegraResourceManagers(o.config.Config)
+		disableHealthChecks := os.Getenv("DP_DISABLE_HEALTHCHECKS")
+		enableHealthChecks := os.Getenv("DP_ENABLE_HEALTHCHECKS")
+		return rm.NewTegraResourceManagers(o.config.Config, disableHealthChecks, enableHealthChecks)
 	default:
 		klog.Errorf("Incompatible strategy detected %v", strategy)
 		klog.Error("If this is a GPU node, did you configure the NVIDIA Container Toolkit?")

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -58,7 +58,7 @@ const (
 
 // CheckHealth performs health checks on a set of devices, writing to the 'unhealthy' channel with any unhealthy devices
 func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devices, unhealthy chan<- *Device, disableNVML <-chan bool) error {
-	xids := getHealthCheckXids()
+	xids := getHealthCheckXids(r.disableHealthChecks, r.enableHealthChecks)
 	if xids.IsAllDisabled() {
 		return nil
 	}
@@ -228,23 +228,18 @@ func (h disabledXIDs) IsDisabled(xid uint64) bool {
 }
 
 // getHealthCheckXids returns the XIDs that are considered fatal.
-// Here we combine the following (in order of precedence):
-// * A list of explicitly disabled XIDs (including all XIDs)
-// * A list of hardcoded disabled XIDs
-// * A list of explicitly enabled XIDs (including all XIDs)
-//
-// Note that if an XID is explicitly enabled, this takes precedence over it
-// having been disabled either explicitly or implicitly.
-func getHealthCheckXids() disabledXIDs {
+// Healthchecks can be disabled by specifying an explicit list of XIDs to ignore.
+// This list is defined by the DP_DISABLE_HEALTHCHECKS and DP_ENABLE_HEALTHCHECKS configuration options.
+// If DP_DISABLE_HEALTHCHECKS="all", all healthchecks are disabled.
+// An XID that is present in the "enabled" list will override the "disabled" list.
+// The list of ignored XIDs returned contains the predefined list of application errors
+// in addition to the specified list, minus the XIDs from the "enabled" list.
+func getHealthCheckXids(disableHealthChecks, enableHealthChecks string) disabledXIDs {
 	disabled := newHealthCheckXIDs(
-		// TODO: We should not read the envvar here directly, but instead
-		// "upgrade" this to a top-level config option.
-		strings.Split(strings.ToLower(os.Getenv(envDisableHealthChecks)), ",")...,
+		strings.Split(strings.ToLower(disableHealthChecks), ",")...,
 	)
 	enabled := newHealthCheckXIDs(
-		// TODO: We should not read the envvar here directly, but instead
-		// "upgrade" this to a top-level config option.
-		strings.Split(strings.ToLower(os.Getenv(envEnableHealthChecks)), ",")...,
+		strings.Split(strings.ToLower(enableHealthChecks), ",")...,
 	)
 
 	// Add the list of hardcoded disabled (ignored) XIDs:

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_checkhealth_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_checkhealth_test.go
@@ -26,9 +26,11 @@ import (
 // example DP_DISABLE_HEALTHCHECKS=all). CheckHealth must not dereference that
 // nil error.
 func TestCheckHealthNilErrorDoesNotPanic(t *testing.T) {
-	t.Setenv(envDisableHealthChecks, "all")
-
-	r := &nvmlResourceManager{}
+	r := &nvmlResourceManager{
+		resourceManager: resourceManager{
+			disableHealthChecks: "all",
+		},
+	}
 	stop := make(chan interface{})
 	unhealthy := make(chan *Device, 1)
 	disableNVML := make(chan bool, 1)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_test.go
@@ -225,10 +225,7 @@ func TestGetHealthCheckXids(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Setenv(envDisableHealthChecks, tc.disabled)
-			t.Setenv(envEnableHealthChecks, tc.enabled)
-
-			xids := getHealthCheckXids()
+			xids := getHealthCheckXids(tc.disabled, tc.enabled)
 			require.EqualValues(t, tc.expectedContents, xids)
 			require.Equal(t, tc.expectedAllDisabled, xids.IsAllDisabled())
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -53,7 +53,7 @@ type nvmlResourceManager struct {
 var _ ResourceManager = (*nvmlResourceManager)(nil)
 
 // NewNVMLResourceManagers returns a set of ResourceManagers, one for each NVML resource in 'config'.
-func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]ResourceManager, error) {
+func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config, disableHealthChecks, enableHealthChecks string) ([]ResourceManager, error) {
 	ret := nvmllib.Init()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
@@ -83,9 +83,11 @@ func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, dev
 		}
 		r := &nvmlResourceManager{
 			resourceManager: resourceManager{
-				config:   config,
-				resource: resourceName,
-				devices:  devices,
+				config:              config,
+				resource:            resourceName,
+				devices:             devices,
+				disableHealthChecks: disableHealthChecks,
+				enableHealthChecks:  enableHealthChecks,
 			},
 			nvml: nvmllib,
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm.go
@@ -47,9 +47,11 @@ import (
 
 // resourceManager forms the base type for specific resource manager implementations
 type resourceManager struct {
-	config   *spec.Config
-	resource spec.ResourceName
-	devices  Devices
+	config              *spec.Config
+	resource            spec.ResourceName
+	devices             Devices
+	disableHealthChecks string
+	enableHealthChecks  string
 }
 
 // ResourceManager provides an interface for listing a set of Devices and checking health on them

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/tegra_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/tegra_manager.go
@@ -44,8 +44,8 @@ type tegraResourceManager struct {
 
 var _ ResourceManager = (*tegraResourceManager)(nil)
 
-// NewTegraResourceManagers returns a set of ResourceManagers for tegra resources
-func NewTegraResourceManagers(config *spec.Config) ([]ResourceManager, error) {
+// NewTegraResourceManagers returns a set of ResourceManagers, one for each Tegra resource in 'config'.
+func NewTegraResourceManagers(config *spec.Config, disableHealthChecks, enableHealthChecks string) ([]ResourceManager, error) {
 	deviceMap, err := buildTegraDeviceMap(config)
 	if err != nil {
 		return nil, fmt.Errorf("error building Tegra device map: %v", err)
@@ -63,9 +63,11 @@ func NewTegraResourceManagers(config *spec.Config) ([]ResourceManager, error) {
 		}
 		r := &tegraResourceManager{
 			resourceManager: resourceManager{
-				config:   config,
-				resource: resourceName,
-				devices:  devices,
+				config:              config,
+				resource:            resourceName,
+				devices:             devices,
+				disableHealthChecks: disableHealthChecks,
+				enableHealthChecks:  enableHealthChecks,
 			},
 		}
 		if len(devices) != 0 {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind cleanup

**What this PR does / why we need it**:
This PR resolves the `// TODO` technical debt in `pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go` by upgrading the health check configuration so it no longer dynamically reads environment variables (`DP_DISABLE_HEALTHCHECKS` and `DP_ENABLE_HEALTHCHECKS`) on the fly via `os.Getenv()`.

Instead, the configuration is now parsed exactly once at startup during plugin initialization (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/factory.go`) and explicitly passed down into the `rm.ResourceManager` instances as state variables. This eliminates hidden dependencies on `os.Getenv()` deep within the business logic and makes testing and mocking significantly cleaner. The test suite (`health_test.go` and `health_checkhealth_test.go`) has also been refactored to inject the configuration into the mock structs rather than relying on `t.Setenv()`.

**Which issue(s) this PR fixes**:
Fixes #2150 

**Special notes for your reviewer**:
The commit is signed-off (DCO) and all associated tests have been successfully updated to natively test the new configuration injection logic without environment variable mocking!

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based configuration for enabling or disabling device health checks.
  * Health-check settings now apply consistently across supported NVIDIA and Tegra devices.
  * Explicitly enabled checks take precedence over disabled checks when both settings overlap.

* **Bug Fixes**
  * Improved health-check configuration handling to avoid relying on process-wide state during device monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->