### PR TITLE
fix leader election hostname prefix matching

### DIFF
--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -166,7 +166,7 @@ func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
+	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname+"_")
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {

--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -162,11 +163,23 @@ func (m *leaderManager) onDelete(obj any) {
 }
 
 func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
-	// kube-scheduler lease id take format of `hostname + "_" + string(uuid.NewUUID())`
+	// Kubernetes leader election holder identities use hostname_<uuid>.
+	// The trailing "_" is required so one hostname cannot match another whose
+	// name extends the local prefix (e.g. "dev" must not match "dev-server_<uuid>").
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname+"_")
+	holder := *lease.Spec.HolderIdentity
+	prefix := m.hostname + "_"
+	if !strings.HasPrefix(holder, prefix) {
+		return false
+	}
+	suffix := strings.TrimPrefix(holder, prefix)
+	if suffix == "" {
+		return false
+	}
+	_, err := uuid.Parse(suffix)
+	return err == nil
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -451,7 +451,7 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 					Namespace: namespace,
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       func() *string { s := hostname; return &s }(),
+					HolderIdentity:       func() *string { s := generateHolderIdentity(hostname); return &s }(),
 					LeaseDurationSeconds: nil, // nil duration
 				},
 			}
@@ -487,6 +487,16 @@ var _ = ginkgo.Describe("isHolderOf hostname prefix boundary", func() {
 			},
 		}
 		g.Expect(lm.isHolderOf(lease)).Should(g.BeTrue())
+	})
+
+	ginkgo.It("should not match a bare hostname without uuid suffix", func() {
+		bareHolder := "dev"
+		lease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &bareHolder,
+			},
+		}
+		g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
 	})
 })
 

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -462,6 +462,34 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 	})
 })
 
+var _ = ginkgo.Describe("isHolderOf hostname prefix boundary", func() {
+	var lm *leaderManager
+
+	ginkgo.BeforeEach(func() {
+		lm = NewLeaderManager("dev", "kube-system", "hami-scheduler", LeaderCallbacks{})
+	})
+
+	ginkgo.It("should not match when another hostname extends the local prefix", func() {
+		otherHolder := "dev-server_" + string(uuid.NewUUID())
+		lease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &otherHolder,
+			},
+		}
+		g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
+	})
+
+	ginkgo.It("should match the local hostname holder identity", func() {
+		localHolder := generateHolderIdentity("dev")
+		lease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &localHolder,
+			},
+		}
+		g.Expect(lm.isHolderOf(lease)).Should(g.BeTrue())
+	})
+})
+
 var _ = ginkgo.Describe("DummyLeaderManager", func() {
 	var lm LeaderManager
 	var elected bool

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -498,6 +498,26 @@ var _ = ginkgo.Describe("isHolderOf hostname prefix boundary", func() {
 		}
 		g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
 	})
+
+	ginkgo.It("should not match a holder with an empty uuid suffix", func() {
+		emptySuffixHolder := "dev_"
+		lease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &emptySuffixHolder,
+			},
+		}
+		g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
+	})
+
+	ginkgo.It("should not match a holder with a malformed uuid suffix", func() {
+		invalidHolder := "dev_not-a-uuid"
+		lease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &invalidHolder,
+			},
+		}
+		g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
+	})
 })
 
 var _ = ginkgo.Describe("DummyLeaderManager", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`isHolderOf` in `pkg/util/leaderelection/leaderelection.go` used `strings.HasPrefix(holder, hostname)` to match lease holder identities. Kubernetes holder IDs use the format `hostname_<uuid>`, but the check did not require the `_` separator.

This caused false positives when one node's hostname is a prefix of another's (e.g. `dev` matching `dev-server_<uuid>`). A node could incorrectly believe it holds the lease, trigger leader callbacks, and run leader-only scheduler work on a non-leader replica.

This PR matches holder identities with `hostname + "_"` and adds regression tests for prefix collision and valid local holder cases.

**Which issue(s) this PR fixes**:
Fixes #2154 

**Special notes for your reviewer**:

- One-line logic change in `isHolderOf`
- Tests added in existing ginkgo suite (`27` specs pass)
- No GPU hardware required
- `make verify` passes locally

**Does this PR introduce a user-facing change?**:

Yes, when scheduler leader election is enabled. Nodes whose hostnames are prefixes of other node hostnames will no longer falsely report as leader. This improves HA correctness in clusters with names like `dev` / `dev-server` or `worker` / `worker2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader detection so a host is recognized only when the lease holder identity exactly matches the expected hostname and valid UUID suffix, preventing false matches and malformed identities.

* **Tests**
  * Expanded leader-detection coverage for valid identities, hostname-prefix collisions, missing suffixes, malformed UUIDs, and nil lease fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->