### PR TITLE
fix(nvidia): treat gpumem-percentage of 0 as unset

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -561,11 +561,17 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 			if ok {
 				mempnums, ok := mem.AsInt64()
 				if ok {
-					if mempnums < 0 || mempnums > 100 {
+					if mempnums > 100 {
 						klog.ErrorS(nil, "memory percentage request out of range, clamping to 100", "container", ctr.Name, "requested", mempnums)
 						mempnums = 100
 					}
-					mempnum = int32(mempnums)
+					if mempnums > 0 {
+						mempnum = int32(mempnums)
+					} else {
+						// 0 would inject CUDA_DEVICE_MEMORY_LIMIT=0m, which hami-core reads as "no limit", so keep the "unset" sentinel and let the default below apply, like nvidia.com/gpumem: 0.
+						klog.ErrorS(nil, "memory percentage request is not positive, ignoring it", "container", ctr.Name, "requested", mempnums)
+						mempnum = 101
+					}
 				}
 			}
 			if mempnum == 101 && memnum == 0 {

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1940,6 +1940,79 @@ func TestGenerateResourceRequests(t *testing.T) {
 				Coresreq:         0,
 			},
 		},
+		{
+			name: "gpu count + memory percentage of 0 — treated as unset",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
+				Coresreq:         0,
+			},
+		},
+		{
+			name: "memory percentage of 0 in Requests — treated as unset",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
+				Coresreq:         0,
+			},
+		},
+		{
+			name: "negative memory percentage — treated as unset",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(-1, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           0,
+				MemPercentagereq: 100,
+				Coresreq:         0,
+			},
+		},
+		{
+			name: "memory percentage of 0 + explicit memory — explicit memory wins",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem":            *resource.NewQuantity(2000, resource.DecimalSI),
+						"nvidia.com/gpumem-percentage": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             1,
+				Type:             NvidiaGPUDevice,
+				Memreq:           2000,
+				MemPercentagereq: 101,
+				Coresreq:         0,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1991,6 +2064,59 @@ func TestGenerateResourceRequests_DefaultMemory(t *testing.T) {
 	result := dev.GenerateResourceRequests(ctr)
 	assert.Equal(t, result.Memreq, int32(512))
 	assert.Equal(t, result.MemPercentagereq, int32(101))
+
+	// a percentage of 0 is unset, so it lands on defaultMemory just like nvidia.com/gpumem: 0
+	ctr.Resources.Limits["nvidia.com/gpumem-percentage"] = *resource.NewQuantity(0, resource.DecimalSI)
+	result = dev.GenerateResourceRequests(ctr)
+	assert.Equal(t, result.Memreq, int32(512))
+	assert.Equal(t, result.MemPercentagereq, int32(101))
+
+	delete(ctr.Resources.Limits, "nvidia.com/gpumem-percentage")
+	ctr.Resources.Limits["nvidia.com/gpumem"] = *resource.NewQuantity(0, resource.DecimalSI)
+	control := dev.GenerateResourceRequests(ctr)
+	assert.DeepEqual(t, result, control)
+}
+
+// A gpumem-percentage of 0 used to reach Fit as memreq=0: the pod fitted any card and was booked
+// with 0 memory, so the device plugin injected CUDA_DEVICE_MEMORY_LIMIT=0m ("no limit").
+func TestZeroMemoryPercentageIsAccountedAsWholeCard(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+	}
+	dev := InitNvidiaDevice(config)
+	ctr := &corev1.Container{
+		Name: "test",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"nvidia.com/gpu":               *resource.NewQuantity(1, resource.BinarySI),
+				"nvidia.com/gpumem-percentage": *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "zero-percentage", Namespace: "zero-percentage-ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{*ctr}},
+	}
+	newCard := func(usedmem int32) []*device.DeviceUsage {
+		return []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Used: 0, Count: 10,
+			Usedmem: usedmem, Totalmem: 11264, Totalcore: 100, Usedcores: 0,
+			Type: NvidiaGPUDevice, Health: true,
+		}}
+	}
+	req := dev.GenerateResourceRequests(ctr)
+
+	fit, result, reason := dev.Fit(newCard(0), req, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Assert(t, fit, "empty card should fit, reason: %s", reason)
+	// must book the whole card, not 0
+	assert.Equal(t, int32(11264), result[NvidiaGPUDevice][0].Usedmem)
+
+	fit, _, reason = dev.Fit(newCard(11260), req, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Assert(t, !fit, "an almost full card must not fit")
+	assert.Assert(t, strings.Contains(reason, "CardInsufficientMemory"), "reason: %s", reason)
 }
 
 func TestMigNeedsReset(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`nvidia.com/gpumem-percentage: 0` is accepted today, so the scheduler computes `memreq = Totalmem * 0 / 100 = 0`: the pod fits any card however full it is, is booked with 0 memory, and the device plugin injects `CUDA_DEVICE_MEMORY_LIMIT_0=0m`, which hami-core reads as "no limit". The container can then use the whole card while the scheduler still thinks it is free.

`nvidia.com/gpumem: 0` is fine because it leaves the percentage unset and falls through to the defaultMemory / whole-card branch below. This makes a non-positive percentage take the same path.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

Clamping to 100 instead would also stop the 0-memory booking, but it skips that defaultMemory branch, and unlike the 101 sentinel, 100 is not excluded in `ComputeScore`, so scoring would count a whole card.

On a V100-32GB node, a pod with `gpumem-percentage: 0` got `0m` and allocated 8 GiB while still booked as 0; a second pod asking for `gpumem: 30000` on the same card was then admitted and died with `cuMemoryAllocate failed res=2`. I also ran a before/after A/B on an A100-80GB node with two shadow schedulers differing only in this change: an empty card is now booked as 81920 instead of 0, with 80000/81920 already booked the same request goes Pending with `CardInsufficientMemory`, and with `defaultMemory: 512` it is booked as 512 and the container gets `512m` instead of `0m`.

The tests added for a zero percentage fail on master and pass here. This PR was written primarily by Claude Code, and I reviewed and tested it.

**Does this PR introduce a user-facing change?**:

A `nvidia.com/gpumem-percentage` of 0 is now treated as unset: the container gets the whole card, or `defaultMemory` when one is configured, instead of running with no GPU memory limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NVIDIA GPU memory requests with zero or negative percentages now use the default full-card allocation.
  * Percentage values above 100 remain capped at 100, while positive values are honored.
  * Explicit GPU memory requests continue to take precedence over percentage settings.
  * Resource accounting now correctly reserves full GPU memory for zero-percentage requests, preventing allocation when insufficient memory remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->