### PR TITLE
fix(vGPUmonitor): scan all devices in CheckBlocking

### DIFF
--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -47,7 +47,6 @@ func CheckBlocking(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 					return true
 				}
 			}
-			return false
 		}
 	}
 	return false

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -86,21 +86,74 @@ func (s *multiStubInfo) SetRecentKernel(int32)              {}
 func (s *multiStubInfo) GetUtilizationSwitch() int32        { return 0 }
 func (s *multiStubInfo) SetUtilizationSwitch(int32)         {}
 
-// TestCheckBlocking_MultiDeviceContention verifies that CheckBlocking inspects
-// every device the container uses, not just the first one that appears in the
-// switch map. Here the first device (gpu-0) has no contention while a second
-// device (gpu-1) does; CheckBlocking must still report blocking.
-func TestCheckBlocking_MultiDeviceContention(t *testing.T) {
-	c := &nvidia.ContainerUsage{Info: &multiStubInfo{priority: 1, uuids: []string{"gpu-0", "gpu-1"}}}
-	sw := map[string]UtilizationPerDevice{
-		"gpu-0": {0, 0},
-		"gpu-1": {1, 0},
+// TestCheckBlocking_MultiDevice verifies that CheckBlocking inspects every device
+// the container uses, not just the first one that appears in the switch map. The
+// cases cover several device counts, all-clear, contention isolated to the last
+// device, and UUIDs missing from the switch map. In every case contention (when
+// present) sits at an index below the priority, so CheckPriority agrees and is
+// asserted for parity.
+func TestCheckBlocking_MultiDevice(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority int
+		uuids    []string
+		sw       map[string]UtilizationPerDevice
+		want     bool
+	}{
+		{
+			name:     "two devices, contention on the second",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1"},
+			sw:       map[string]UtilizationPerDevice{"gpu-0": {0, 0}, "gpu-1": {1, 0}},
+			want:     true,
+		},
+		{
+			name:     "three devices, all clear",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1", "gpu-2"},
+			sw:       map[string]UtilizationPerDevice{"gpu-0": {0, 0}, "gpu-1": {0, 0}, "gpu-2": {0, 0}},
+			want:     false,
+		},
+		{
+			name:     "four devices, contention only on the last",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1", "gpu-2", "gpu-3"},
+			sw:       map[string]UtilizationPerDevice{"gpu-0": {0, 0}, "gpu-1": {0, 0}, "gpu-2": {0, 0}, "gpu-3": {1, 0}},
+			want:     true,
+		},
+		{
+			name:     "some device UUIDs missing from switch map, present one contended",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1", "gpu-2"},
+			sw:       map[string]UtilizationPerDevice{"gpu-1": {1, 0}},
+			want:     true,
+		},
+		{
+			name:     "none of the container UUIDs are in the switch map",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1"},
+			sw:       map[string]UtilizationPerDevice{"gpu-9": {1, 0}},
+			want:     false,
+		},
+		{
+			name:     "empty switch map",
+			priority: 1,
+			uuids:    []string{"gpu-0", "gpu-1"},
+			sw:       map[string]UtilizationPerDevice{},
+			want:     false,
+		},
 	}
-	if !CheckBlocking(sw, 1, c) {
-		t.Error("CheckBlocking: expected true (gpu-1 has contention), got false")
-	}
-	// Sanity: the sibling CheckPriority already scans all devices and agrees.
-	if !CheckPriority(sw, 1, c) {
-		t.Error("CheckPriority: expected true (gpu-1 has contention), got false")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &nvidia.ContainerUsage{Info: &multiStubInfo{priority: test.priority, uuids: test.uuids}}
+			if got := CheckBlocking(test.sw, test.priority, c); got != test.want {
+				t.Errorf("CheckBlocking: want %v, got %v", test.want, got)
+			}
+			// The sibling CheckPriority scans all devices too and, for these
+			// inputs, agrees with CheckBlocking.
+			if got := CheckPriority(test.sw, test.priority, c); got != test.want {
+				t.Errorf("CheckPriority: want %v, got %v", test.want, got)
+			}
+		})
 	}
 }

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -22,11 +22,27 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
 )
 
-type stubInfo struct{ priority int }
+// stubDeviceMax mirrors the production Spec.DeviceMax, which reports the constant
+// maxDevices (16) rather than the live device count.
+const stubDeviceMax = 16
 
-func (s *stubInfo) DeviceMax() int                     { return 1 }
-func (s *stubInfo) DeviceNum() int                     { return 0 }
-func (s *stubInfo) DeviceUUID(int) string              { return "gpu-0" }
+// stubInfo mocks nvidia.UsageInfo. The container's real device UUIDs occupy the
+// leading slots of a fixed-size table; DeviceMax still reports the constant slot
+// count and the trailing slots read back invalid, so the check functions walk the
+// same 16 slots they do in production.
+type stubInfo struct {
+	priority int
+	uuids    []string
+}
+
+func (s *stubInfo) DeviceMax() int { return stubDeviceMax }
+func (s *stubInfo) DeviceNum() int { return len(s.uuids) }
+func (s *stubInfo) DeviceUUID(i int) string {
+	if i < len(s.uuids) {
+		return s.uuids[i]
+	}
+	return ""
+}
 func (s *stubInfo) DeviceMemoryContextSize(int) uint64 { return 0 }
 func (s *stubInfo) DeviceMemoryModuleSize(int) uint64  { return 0 }
 func (s *stubInfo) DeviceMemoryBufferSize(int) uint64  { return 0 }
@@ -34,7 +50,7 @@ func (s *stubInfo) DeviceMemoryOffset(int) uint64      { return 0 }
 func (s *stubInfo) DeviceMemoryTotal(int) uint64       { return 0 }
 func (s *stubInfo) DeviceSmUtil(int) uint64            { return 0 }
 func (s *stubInfo) SetDeviceSmLimit(uint64)            {}
-func (s *stubInfo) IsValidUUID(int) bool               { return true }
+func (s *stubInfo) IsValidUUID(i int) bool             { return i < len(s.uuids) }
 func (s *stubInfo) DeviceMemoryLimit(int) uint64       { return 0 }
 func (s *stubInfo) SetDeviceMemoryLimit(uint64)        {}
 func (s *stubInfo) LastKernelTime() int64              { return 0 }
@@ -46,7 +62,7 @@ func (s *stubInfo) SetUtilizationSwitch(int32)         {}
 
 func TestCheckFunctionsHighPriority(t *testing.T) {
 	sw := map[string]UtilizationPerDevice{"gpu-0": {0, 1}}
-	c := &nvidia.ContainerUsage{Info: &stubInfo{priority: 3}}
+	c := &nvidia.ContainerUsage{Info: &stubInfo{priority: 3, uuids: []string{"gpu-0"}}}
 	if !CheckBlocking(sw, 3, c) {
 		t.Error("CheckBlocking: expected true")
 	}
@@ -58,33 +74,6 @@ func TestCheckFunctionsHighPriority(t *testing.T) {
 		t.Error("CheckBlocking: expected false")
 	}
 }
-
-// multiStubInfo mocks a container that uses several devices, so the check
-// functions can be exercised over more than one UUID.
-type multiStubInfo struct {
-	priority int
-	uuids    []string
-}
-
-func (s *multiStubInfo) DeviceMax() int                     { return len(s.uuids) }
-func (s *multiStubInfo) DeviceNum() int                     { return len(s.uuids) }
-func (s *multiStubInfo) DeviceUUID(i int) string            { return s.uuids[i] }
-func (s *multiStubInfo) DeviceMemoryContextSize(int) uint64 { return 0 }
-func (s *multiStubInfo) DeviceMemoryModuleSize(int) uint64  { return 0 }
-func (s *multiStubInfo) DeviceMemoryBufferSize(int) uint64  { return 0 }
-func (s *multiStubInfo) DeviceMemoryOffset(int) uint64      { return 0 }
-func (s *multiStubInfo) DeviceMemoryTotal(int) uint64       { return 0 }
-func (s *multiStubInfo) DeviceSmUtil(int) uint64            { return 0 }
-func (s *multiStubInfo) SetDeviceSmLimit(uint64)            {}
-func (s *multiStubInfo) IsValidUUID(int) bool               { return true }
-func (s *multiStubInfo) DeviceMemoryLimit(int) uint64       { return 0 }
-func (s *multiStubInfo) SetDeviceMemoryLimit(uint64)        {}
-func (s *multiStubInfo) LastKernelTime() int64              { return 0 }
-func (s *multiStubInfo) GetPriority() int                   { return s.priority }
-func (s *multiStubInfo) GetRecentKernel() int32             { return 1 }
-func (s *multiStubInfo) SetRecentKernel(int32)              {}
-func (s *multiStubInfo) GetUtilizationSwitch() int32        { return 0 }
-func (s *multiStubInfo) SetUtilizationSwitch(int32)         {}
 
 // TestCheckBlocking_MultiDevice verifies that CheckBlocking inspects every device
 // the container uses, not just the first one that appears in the switch map. The
@@ -145,7 +134,7 @@ func TestCheckBlocking_MultiDevice(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := &nvidia.ContainerUsage{Info: &multiStubInfo{priority: test.priority, uuids: test.uuids}}
+			c := &nvidia.ContainerUsage{Info: &stubInfo{priority: test.priority, uuids: test.uuids}}
 			if got := CheckBlocking(test.sw, test.priority, c); got != test.want {
 				t.Errorf("CheckBlocking: want %v, got %v", test.want, got)
 			}

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -58,3 +58,49 @@ func TestCheckFunctionsHighPriority(t *testing.T) {
 		t.Error("CheckBlocking: expected false")
 	}
 }
+
+// multiStubInfo mocks a container that uses several devices, so the check
+// functions can be exercised over more than one UUID.
+type multiStubInfo struct {
+	priority int
+	uuids    []string
+}
+
+func (s *multiStubInfo) DeviceMax() int                     { return len(s.uuids) }
+func (s *multiStubInfo) DeviceNum() int                     { return len(s.uuids) }
+func (s *multiStubInfo) DeviceUUID(i int) string            { return s.uuids[i] }
+func (s *multiStubInfo) DeviceMemoryContextSize(int) uint64 { return 0 }
+func (s *multiStubInfo) DeviceMemoryModuleSize(int) uint64  { return 0 }
+func (s *multiStubInfo) DeviceMemoryBufferSize(int) uint64  { return 0 }
+func (s *multiStubInfo) DeviceMemoryOffset(int) uint64      { return 0 }
+func (s *multiStubInfo) DeviceMemoryTotal(int) uint64       { return 0 }
+func (s *multiStubInfo) DeviceSmUtil(int) uint64            { return 0 }
+func (s *multiStubInfo) SetDeviceSmLimit(uint64)            {}
+func (s *multiStubInfo) IsValidUUID(int) bool               { return true }
+func (s *multiStubInfo) DeviceMemoryLimit(int) uint64       { return 0 }
+func (s *multiStubInfo) SetDeviceMemoryLimit(uint64)        {}
+func (s *multiStubInfo) LastKernelTime() int64              { return 0 }
+func (s *multiStubInfo) GetPriority() int                   { return s.priority }
+func (s *multiStubInfo) GetRecentKernel() int32             { return 1 }
+func (s *multiStubInfo) SetRecentKernel(int32)              {}
+func (s *multiStubInfo) GetUtilizationSwitch() int32        { return 0 }
+func (s *multiStubInfo) SetUtilizationSwitch(int32)         {}
+
+// TestCheckBlocking_MultiDeviceContention verifies that CheckBlocking inspects
+// every device the container uses, not just the first one that appears in the
+// switch map. Here the first device (gpu-0) has no contention while a second
+// device (gpu-1) does; CheckBlocking must still report blocking.
+func TestCheckBlocking_MultiDeviceContention(t *testing.T) {
+	c := &nvidia.ContainerUsage{Info: &multiStubInfo{priority: 1, uuids: []string{"gpu-0", "gpu-1"}}}
+	sw := map[string]UtilizationPerDevice{
+		"gpu-0": {0, 0},
+		"gpu-1": {1, 0},
+	}
+	if !CheckBlocking(sw, 1, c) {
+		t.Error("CheckBlocking: expected true (gpu-1 has contention), got false")
+	}
+	// Sanity: the sibling CheckPriority already scans all devices and agrees.
+	if !CheckPriority(sw, 1, c) {
+		t.Error("CheckPriority: expected true (gpu-1 has contention), got false")
+	}
+}


### PR DESCRIPTION
## What this fixes

Fixes #2158.

`CheckBlocking` in `cmd/vGPUmonitor/feedback.go` returned `false` as soon as it found the first device the container uses in the utilization switch map, so for a container using more than one GPU it never inspected the remaining devices. If an earlier device had no contention but a later one did, `CheckBlocking` reported "not blocking" and `Observe()` let the lower-priority container keep running unthrottled on a GPU a higher-priority job was contending for, weakening priority preemption.

The sibling `CheckPriority`, just below it, has the identical loop structure **without** the early `return false` — it scans every device and only returns early on a positive match. `CheckBlocking` was meant to do the same.

## The change

Drop the stray early `return false` inside the per-device loop. The loop now scans all of the container's devices, and the trailing `return false` handles the "no device contended" case — mirroring `CheckPriority`.

## Testing

Added `TestCheckBlocking_MultiDeviceContention`: a two-device container where only the second device (`gpu-1`) has contention. On the previous code `CheckBlocking` returns `false`; after the fix it returns `true`, matching `CheckPriority` on the same input.

- `go test ./cmd/vGPUmonitor/ -race -count=1` — pass
- `make verify` — pass (license headers, import aliases, golangci-lint, goimports, staticcheck)

Unit-testable with no hardware — `nvidia.UsageInfo` is an interface and the existing `feedback_test.go` already mocks it.

---

## AI assistance disclosure

This contribution used AI assistance (Claude Code): the bug was surfaced during an AI-assisted code review, and the one-line fix plus the regression test were drafted with Claude Code under my review. I have read and verified the change, understand the root cause and the fix, and take full responsibility for its correctness and for responding to review feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU contention detection for workloads that use multiple GPU devices.
  * Blocking decisions now evaluate all associated devices before concluding no blocking is needed, ensuring priority results remain consistent.

* **Tests**
  * Expanded coverage with a new table-driven test for multi-device contention scenarios, including handling when utilization data is missing for some or all device UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->