### PR TITLE
fix(nvidia): handle zero-score topology combinations

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -937,8 +937,9 @@ func getDevicePairScoreMap(nodeInfo *device.NodeInfo) map[string]*device.DeviceP
 }
 
 func computeWorstSingleCard(nodeInfo *device.NodeInfo, request device.ContainerDeviceRequest, tmpDevs map[string]device.ContainerDevices) device.ContainerDevices {
-	worstScore := -1
+	worstScore := 0
 	worstDevices := device.ContainerDevices{}
+	found := false
 	deviceScoreMap := getDevicePairScoreMap(nodeInfo)
 	// Iterate through all devices to find the one with the lowest score
 	devices := tmpDevs[request.Type]
@@ -952,7 +953,8 @@ func computeWorstSingleCard(nodeInfo *device.NodeInfo, request device.ContainerD
 			}
 			totalScore += scoreMapDev1.Scores[dev2.UUID]
 		}
-		if totalScore < worstScore || worstScore == -1 {
+		if !found || totalScore < worstScore {
+			found = true
 			worstScore = totalScore
 			worstDevices = device.ContainerDevices{dev1}
 		}
@@ -961,8 +963,9 @@ func computeWorstSingleCard(nodeInfo *device.NodeInfo, request device.ContainerD
 }
 
 func computeBestCombination(nodeInfo *device.NodeInfo, combinations []device.ContainerDevices) device.ContainerDevices {
-	bestScore := 0
+	bestScore := -1
 	bestCombination := device.ContainerDevices{}
+	found := false
 	deviceScoreMap := getDevicePairScoreMap(nodeInfo)
 	// Iterate through all combinations to find the one with the highest score
 	for _, partition := range combinations {
@@ -977,7 +980,8 @@ func computeBestCombination(nodeInfo *device.NodeInfo, combinations []device.Con
 			}
 		}
 
-		if totalScore > bestScore {
+		if !found || totalScore > bestScore {
+			found = true
 			bestScore = totalScore
 			bestCombination = partition
 		}

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2783,3 +2783,86 @@ func TestFit_TopologyBestCombination(t *testing.T) {
 	assert.Assert(t, uuids["dev-0"])
 	assert.Assert(t, uuids["dev-2"])
 }
+
+func TestFit_TopologyBestCombinationZeroScores(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+	}
+	nv := InitNvidiaDevice(config)
+	devices := []*device.DeviceUsage{
+		{ID: "dev-0", Index: 0, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+		{ID: "dev-1", Index: 1, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+		{ID: "dev-2", Index: 2, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+	}
+	nodeInfo := &device.NodeInfo{
+		Devices: map[string][]device.DeviceInfo{
+			NvidiaGPUDevice: {
+				{ID: "dev-0", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-1": 0, "dev-2": 0}}},
+				{ID: "dev-1", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-0": 0, "dev-2": 0}}},
+				{ID: "dev-2", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-0": 0, "dev-1": 0}}},
+			},
+		},
+	}
+	req := device.ContainerDeviceRequest{Nums: 2, Memreq: 100, Coresreq: 10, Type: NvidiaGPUDevice}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{util.GPUSchedulerPolicyAnnotationKey: util.GPUSchedulerPolicyTopology.String()},
+		},
+	}
+	fit, result, _ := nv.Fit(devices, req, pod, nodeInfo, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, len(result[NvidiaGPUDevice]), 2)
+}
+
+func TestFit_TopologyNegativeScores(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+	}
+	nv := InitNvidiaDevice(config)
+	devices := []*device.DeviceUsage{
+		{ID: "dev-0", Index: 0, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+		{ID: "dev-1", Index: 1, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+		{ID: "dev-2", Index: 2, Used: 0, Count: 10, Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true},
+	}
+	nodeInfo := &device.NodeInfo{
+		Devices: map[string][]device.DeviceInfo{
+			NvidiaGPUDevice: {
+				{ID: "dev-0", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-1": -5, "dev-2": -3}}},
+				{ID: "dev-1", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-0": -5, "dev-2": -1}}},
+				{ID: "dev-2", DevicePairScore: device.DevicePairScore{Scores: map[string]int{"dev-0": -3, "dev-1": -1}}},
+			},
+		},
+	}
+
+	// Test single-GPU request (exercises computeWorstSingleCard)
+	t.Run("SingleGPU", func(t *testing.T) {
+		req := device.ContainerDeviceRequest{Nums: 1, Memreq: 100, Coresreq: 10, Type: NvidiaGPUDevice}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{util.GPUSchedulerPolicyAnnotationKey: util.GPUSchedulerPolicyTopology.String()},
+			},
+		}
+		fit, result, _ := nv.Fit(devices, req, pod, nodeInfo, &device.PodDevices{})
+		assert.Equal(t, fit, true)
+		assert.Equal(t, len(result[NvidiaGPUDevice]), 1)
+	})
+
+	// Test multi-GPU request (exercises computeBestCombination)
+	t.Run("MultiGPU", func(t *testing.T) {
+		req := device.ContainerDeviceRequest{Nums: 2, Memreq: 100, Coresreq: 10, Type: NvidiaGPUDevice}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{util.GPUSchedulerPolicyAnnotationKey: util.GPUSchedulerPolicyTopology.String()},
+			},
+		}
+		fit, result, _ := nv.Fit(devices, req, pod, nodeInfo, &device.PodDevices{})
+		assert.Equal(t, fit, true)
+		assert.Equal(t, len(result[NvidiaGPUDevice]), 2)
+	})
+}

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2851,6 +2851,7 @@ func TestFit_TopologyNegativeScores(t *testing.T) {
 		fit, result, _ := nv.Fit(devices, req, pod, nodeInfo, &device.PodDevices{})
 		assert.Equal(t, fit, true)
 		assert.Equal(t, len(result[NvidiaGPUDevice]), 1)
+		assert.Equal(t, result[NvidiaGPUDevice][0].UUID, "dev-0")
 	})
 
 	// Test multi-GPU request (exercises computeBestCombination)
@@ -2864,5 +2865,11 @@ func TestFit_TopologyNegativeScores(t *testing.T) {
 		fit, result, _ := nv.Fit(devices, req, pod, nodeInfo, &device.PodDevices{})
 		assert.Equal(t, fit, true)
 		assert.Equal(t, len(result[NvidiaGPUDevice]), 2)
+		uuids := map[string]bool{}
+		for _, d := range result[NvidiaGPUDevice] {
+			uuids[d.UUID] = true
+		}
+		assert.Assert(t, uuids["dev-1"])
+		assert.Assert(t, uuids["dev-2"])
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`computeBestCombination()` initializes `bestScore` to `0` and only records a device combination when `totalScore > bestScore`.

When topology-aware scheduling evaluates valid NVIDIA GPU combinations and every pair score is `0`, no combination is selected. The scheduler can return an empty allocation even though the request can be satisfied.

This PR initializes `bestScore` to `-1` so a valid zero-score combination can still be selected.

A regression test covers a 2-GPU topology-aware request where all available GPU pair scores are `0`.

**Which issue(s) this PR fixes**:

None filed.

**Special notes for your reviewer**:

Before fix:

```text
=== RUN   TestFit_TopologyBestCombinationZeroScores
device_test.go:2817: assertion failed: 0 (int) != 2 (int)
--- FAIL: TestFit_TopologyBestCombinationZeroScores
```

After fix:

```text
=== RUN   TestFit_TopologyBestCombinationZeroScores
--- PASS: TestFit_TopologyBestCombinationZeroScores
PASS
ok   github.com/Project-HAMi/HAMi/pkg/device/nvidia
```

Broader validation:

```text
ok   github.com/Project-HAMi/HAMi/pkg/device/nvidia
ok   github.com/Project-HAMi/HAMi/pkg/scheduler
ok   github.com/Project-HAMi/HAMi/pkg/scheduler/config
ok   github.com/Project-HAMi/HAMi/pkg/scheduler/policy
ok   github.com/Project-HAMi/HAMi/pkg/scheduler/routes
```

`make verify` was attempted in a Linux Go 1.26.5 Docker environment, but Docker Desktop returned `unexpected EOF` before the command completed.

AI assistance disclosure: I used an AI tool for codebase navigation and review support.

**Does this PR introduce a user-facing change?**:

No breaking change. Topology-aware NVIDIA scheduling now selects a valid GPU combination when all valid pair scores are zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA topology-based scheduling to handle edge scoring cases more reliably, including when pair scores are zero or negative.
  * Corrected device combination selection for both single-GPU and multi-GPU requests so allocations match expected “best/worst” outcomes.
* **Tests**
  * Added unit coverage verifying two-GPU requests succeed when all topology pair scores are zero.
  * Added unit coverage verifying single- and two-GPU requests succeed with negative pair scores, with expected device UUIDs selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->