### PR TITLE
perf: remove unused all-device scan in metrics collector

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -355,25 +354,6 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 							float64(ctrdevval.Usedcores),
 							val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
 					}
-					var totaldev int32
-					found := false
-					for _, ni := range *nu {
-						for _, nodedev := range ni.Devices.DeviceLists {
-							if strings.Compare(nodedev.Device.ID, ctrdevval.UUID) == 0 {
-								totaldev = nodedev.Device.Totalmem
-								found = true
-								break
-							}
-						}
-						if found {
-							break
-						}
-					}
-					klog.V(4).InfoS("Total memory for device",
-						"deviceUUID", ctrdevval.UUID,
-						"totalMemory", totaldev,
-						"nodeID", val.NodeID,
-					)
 				}
 			}
 		}


### PR DESCRIPTION
### Summary
Fixes #2165.

During Prometheus metrics collection in `cmd/scheduler/metrics.go`, an nested loop was iterating over all cluster nodes and node devices to calculate `totaldev` for every scheduled container device. This computed `totaldev` value was only logged at `klog.V(4)` and never used in any emitted metric or calculation.

This PR removes the redundant $O(A \times D)$ device scan loop and unused `strings` package import, eliminating unnecessary CPU and memory allocation overhead during Prometheus scrapes.

### Changes
- Removed unneeded nested node/device search loop in `cmd/scheduler/metrics.go`.
- Removed unused `strings` import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Refactor**
  - Streamlined scheduler metrics collection by removing legacy device memory lookup and its associated logging.
  - Improved scheduled pod snapshot isolation: returned pod/device data is now deep-copied so callers can’t mutate cached state, with custom metadata intentionally omitted from the returned copies.

- **Tests**
  - Updated pod and deep-copy tests to match the new snapshot and metadata omission behavior.

- **Chores**
  - Removed unused imports and simplified internal collection/copying logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->