### PR TITLE
fix: process init containers in admission mutation and quota checks

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -71,6 +71,17 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false
+	for idx := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[idx]
+		for _, val := range device.GetDevices() {
+			found, err := val.MutateAdmission(c, pod)
+			if err != nil {
+				klog.Errorf("validating pod failed:%s", err.Error())
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			hasResource = hasResource || found
+		}
+	}
 	for idx := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[idx]
 		for _, val := range device.GetDevices() {
@@ -152,6 +163,17 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 				}
 			}
 			return 0, false
+		}
+		for _, ctr := range pod.Spec.InitContainers {
+			req, ok := getRequest(&ctr, resourceName)
+			if ok {
+				if memReq, ok := getRequest(&ctr, memResourceName); ok {
+					memoryReq += memReq * req
+				}
+				if coreReq, ok := getRequest(&ctr, coreResourceName); ok {
+					coresReq += coreReq * req
+				}
+			}
 		}
 		for _, ctr := range pod.Spec.Containers {
 			req, ok := getRequest(&ctr, resourceName)

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -811,3 +811,104 @@ func TestPrivilegedContainerDenied(t *testing.T) {
 		})
 	}
 }
+
+func TestInitContainerOnlyGPUAdmission(t *testing.T) {
+	prevSchedulerName := config.SchedulerName
+	prevForceOverwrite := config.ForceOverwriteDefaultScheduler
+	t.Cleanup(func() {
+		config.SchedulerName = prevSchedulerName
+		config.ForceOverwriteDefaultScheduler = prevForceOverwrite
+	})
+
+	config.SchedulerName = "hami-scheduler"
+	config.ForceOverwriteDefaultScheduler = false
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+		},
+	}
+
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("Failed to initialize devices with config: %v", err)
+	}
+
+	// Pod with GPU resource in init container only
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "init-gpu-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:  "gpu-init",
+					Image: "cuda-init",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hami.io/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "cpu-app",
+					Image: "busybox",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+	podBytes, err := runtime.Encode(codec, pod)
+	if err != nil {
+		t.Fatalf("Error encoding pod: %v", err)
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:       "init-gpu-uid",
+			Namespace: "default",
+			Name:      "init-gpu-pod",
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+		},
+	}
+
+	wh, err := NewWebHook()
+	if err != nil {
+		t.Fatalf("Error creating WebHook: %v", err)
+	}
+
+	resp := wh.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Fatalf("Expected init GPU pod to be allowed, but got denied: %+v", resp.Result)
+	}
+
+	// Verify that schedulerName was patched to hami-scheduler for init container GPU request
+	found := false
+	for _, patch := range resp.Patches {
+		if patch.Path == "/spec/schedulerName" && patch.Value == config.SchedulerName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Expected schedulerName patch to %q for init container GPU request, got patches: %+v", config.SchedulerName, resp.Patches)
+	}
+}


### PR DESCRIPTION
### Summary
While `pkg/device/devices.go` accounts for both `InitContainers` and `Containers` during scheduling and resource allocation fitting, the mutating admission webhook (`pkg/scheduler/webhook.go`) and resource quota checks (`fitResourceQuota`) previously only iterated `pod.Spec.Containers`.

When a Pod requested accelerator resources (e.g., `nvidia.com/gpu` or `hami.io/gpu`) exclusively inside an init container:
1. The webhook failed to mutate admission for the init container.
2. The HAMi custom scheduler name (`config.SchedulerName`) was not assigned to the Pod.
3. `fitResourceQuota()` skipped init container resource limits/requests.

This PR updates `pkg/scheduler/webhook.go` to iterate over `pod.Spec.InitContainers` in both `MutateAdmission` and `fitResourceQuota()`, ensuring consistent resource mutation, scheduler injection, and quota enforcement.

### Changes
- Updated `Handle()` in `pkg/scheduler/webhook.go` to process `pod.Spec.InitContainers`.
- Updated `fitResourceQuota()` in `pkg/scheduler/webhook.go` to calculate init container resource requests.
- Added unit test `TestInitContainerOnlyGPUAdmission` in `pkg/scheduler/webhook_test.go`.

Fixes #2167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU and device resource requests in init containers are now recognized during pod admission.
  * Scheduler assignment, quota checks, and resource mutations now account for init-container requirements.

* **Bug Fixes**
  * Pods requesting GPU resources exclusively through init containers are correctly admitted and assigned to the configured scheduler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->