### PR TITLE
fix: resolve go vet sync.Mutex copy-by-value errors

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -250,7 +250,7 @@ func TestCDIAllocateResponse(t *testing.T) {
 	}
 
 	for i := range testCases {
-		tc := testCases[i]
+		tc := &testCases[i]
 		t.Run(tc.description, func(t *testing.T) {
 			deviceListStrategies, _ := v1.NewDeviceListStrategies(tc.deviceListStrategies)
 			plugin := NvidiaDevicePlugin{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -39,10 +39,10 @@ import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"k8s.io/klog/v2"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"google.golang.org/protobuf/proto"
-
 )
 
 type deviceMapBuilder struct {
@@ -344,13 +344,13 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 				annotatedID := string(NewAnnotatedID(id, i))
 				orig := oDevices[r.Name][id]
 				replicatedDevice := &Device{
+					Device:            *proto.Clone(&orig.Device).(*kubeletdevicepluginv1beta1.Device),
 					Paths:             orig.Paths,
 					Index:             orig.Index,
 					TotalMemory:       orig.TotalMemory,
 					ComputeCapability: orig.ComputeCapability,
 					Replicas:          r.Replicas,
 				}
-				proto.Merge(&replicatedDevice.Device, &orig.Device)
 				replicatedDevice.ID = annotatedID
 				devices.insert(name, replicatedDevice)
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -41,7 +41,8 @@ import (
 	"k8s.io/klog/v2"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
-	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	"google.golang.org/protobuf/proto"
+
 )
 
 type deviceMapBuilder struct {
@@ -343,17 +344,14 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 				annotatedID := string(NewAnnotatedID(id, i))
 				orig := oDevices[r.Name][id]
 				replicatedDevice := &Device{
-					Device: kubeletdevicepluginv1beta1.Device{
-						ID:       annotatedID,
-						Health:   orig.Health,
-						Topology: orig.Topology,
-					},
 					Paths:             orig.Paths,
 					Index:             orig.Index,
 					TotalMemory:       orig.TotalMemory,
 					ComputeCapability: orig.ComputeCapability,
 					Replicas:          r.Replicas,
 				}
+				proto.Merge(&replicatedDevice.Device, &orig.Device)
+				replicatedDevice.ID = annotatedID
 				devices.insert(name, replicatedDevice)
 			}
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/klog/v2"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 type deviceMapBuilder struct {
@@ -340,10 +341,20 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 		for _, id := range ids {
 			for i := 0; i < r.Replicas; i++ {
 				annotatedID := string(NewAnnotatedID(id, i))
-				replicatedDevice := *(oDevices[r.Name][id])
-				replicatedDevice.ID = annotatedID
-				replicatedDevice.Replicas = r.Replicas
-				devices.insert(name, &replicatedDevice)
+				orig := oDevices[r.Name][id]
+				replicatedDevice := &Device{
+					Device: kubeletdevicepluginv1beta1.Device{
+						ID:       annotatedID,
+						Health:   orig.Health,
+						Topology: orig.Topology,
+					},
+					Paths:             orig.Paths,
+					Index:             orig.Index,
+					TotalMemory:       orig.TotalMemory,
+					ComputeCapability: orig.ComputeCapability,
+					Replicas:          r.Replicas,
+				}
+				devices.insert(name, replicatedDevice)
 			}
 		}
 	}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map_test.go
@@ -40,6 +40,7 @@ import (
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -127,8 +128,22 @@ func TestDeviceMapInsert(t *testing.T) {
 }
 
 func TestUpdateDeviceMapWithReplicas(t *testing.T) {
-	device0 := Device{Device: kubeletdevicepluginv1beta1.Device{ID: "0"}, Index: "0"}
-	device1 := Device{Device: kubeletdevicepluginv1beta1.Device{ID: "1"}}
+	device0 := Device{
+		Device: kubeletdevicepluginv1beta1.Device{ID: "0", Health: "Healthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 0}}}},
+		Index: "0",
+		Paths: []string{"/dev/nvidia0"},
+		TotalMemory: 1024,
+		ComputeCapability: "8.0",
+		Replicas: 1,
+	}
+	device1 := Device{
+		Device: kubeletdevicepluginv1beta1.Device{ID: "1", Health: "Unhealthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 1}}}},
+		Index: "1",
+		Paths: []string{"/dev/nvidia1"},
+		TotalMemory: 2048,
+		ComputeCapability: "8.6",
+		Replicas: 1,
+	}
 	device2 := Device{Device: kubeletdevicepluginv1beta1.Device{ID: "2"}}
 	device3 := Device{Device: kubeletdevicepluginv1beta1.Device{ID: "3"}}
 
@@ -179,10 +194,38 @@ func TestUpdateDeviceMapWithReplicas(t *testing.T) {
 			},
 			expectedDeviceMap: DeviceMap{
 				"replicated-resource1": Devices{
-					"0::0": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "0::0"}, Index: "0", Replicas: 2},
-					"0::1": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "0::1"}, Index: "0", Replicas: 2},
-					"1::0": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "1::0"}, Replicas: 2},
-					"1::1": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "1::1"}, Replicas: 2},
+					"0::0": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "0::0", Health: "Healthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 0}}}},
+						Index: "0",
+						Paths: []string{"/dev/nvidia0"},
+						TotalMemory: 1024,
+						ComputeCapability: "8.0",
+						Replicas: 2,
+					},
+					"0::1": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "0::1", Health: "Healthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 0}}}},
+						Index: "0",
+						Paths: []string{"/dev/nvidia0"},
+						TotalMemory: 1024,
+						ComputeCapability: "8.0",
+						Replicas: 2,
+					},
+					"1::0": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "1::0", Health: "Unhealthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 1}}}},
+						Index: "1",
+						Paths: []string{"/dev/nvidia1"},
+						TotalMemory: 2048,
+						ComputeCapability: "8.6",
+						Replicas: 2,
+					},
+					"1::1": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "1::1", Health: "Unhealthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 1}}}},
+						Index: "1",
+						Paths: []string{"/dev/nvidia1"},
+						TotalMemory: 2048,
+						ComputeCapability: "8.6",
+						Replicas: 2,
+					},
 				},
 				"resource2": Devices{
 					"2::0": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "2::0"}, Replicas: 1},
@@ -220,8 +263,22 @@ func TestUpdateDeviceMapWithReplicas(t *testing.T) {
 			},
 			expectedDeviceMap: DeviceMap{
 				"replicated-resource1": Devices{
-					"0::0": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "0::0"}, Index: "0", Replicas: 2},
-					"0::1": &Device{Device: kubeletdevicepluginv1beta1.Device{ID: "0::1"}, Index: "0", Replicas: 2},
+					"0::0": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "0::0", Health: "Healthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 0}}}},
+						Index: "0",
+						Paths: []string{"/dev/nvidia0"},
+						TotalMemory: 1024,
+						ComputeCapability: "8.0",
+						Replicas: 2,
+					},
+					"0::1": &Device{
+						Device: kubeletdevicepluginv1beta1.Device{ID: "0::1", Health: "Healthy", Topology: &kubeletdevicepluginv1beta1.TopologyInfo{Nodes: []*kubeletdevicepluginv1beta1.NUMANode{{ID: 0}}}},
+						Index: "0",
+						Paths: []string{"/dev/nvidia0"},
+						TotalMemory: 1024,
+						ComputeCapability: "8.0",
+						Replicas: 2,
+					},
 				},
 				"resource1": Devices{
 					"1": &device1,
@@ -233,7 +290,21 @@ func TestUpdateDeviceMapWithReplicas(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			devices, _ := updateDeviceMapWithReplicas(&tc.config.Config.Sharing.TimeSlicing, tc.devices)
-			require.EqualValues(t, tc.expectedDeviceMap, devices)
+			require.Equal(t, len(tc.expectedDeviceMap), len(devices))
+			for resourceName, expectedDevices := range tc.expectedDeviceMap {
+				actualDevices := devices[resourceName]
+				require.Equal(t, len(expectedDevices), len(actualDevices))
+				for id, expectedDevice := range expectedDevices {
+					actualDevice := actualDevices[id]
+					require.NotNil(t, actualDevice)
+					require.Equal(t, expectedDevice.Index, actualDevice.Index)
+					require.Equal(t, expectedDevice.Paths, actualDevice.Paths)
+					require.Equal(t, expectedDevice.TotalMemory, actualDevice.TotalMemory)
+					require.Equal(t, expectedDevice.ComputeCapability, actualDevice.ComputeCapability)
+					require.Equal(t, expectedDevice.Replicas, actualDevice.Replicas)
+					require.True(t, proto.Equal(&expectedDevice.Device, &actualDevice.Device), "proto fields should match")
+				}
+			}
 		})
 	}
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
@@ -253,7 +253,7 @@ func (ds Devices) AlignedAllocationSupported() bool {
 }
 
 // AlignedAllocationSupported checks whether the device supports an aligned allocation
-func (d Device) AlignedAllocationSupported() bool {
+func (d *Device) AlignedAllocationSupported() bool {
 	if d.IsMigDevice() {
 		return false
 	}
@@ -268,12 +268,12 @@ func (d Device) AlignedAllocationSupported() bool {
 }
 
 // IsMigDevice returns checks whether d is a MIG device or not.
-func (d Device) IsMigDevice() bool {
+func (d *Device) IsMigDevice() bool {
 	return strings.Contains(d.Index, ":")
 }
 
 // GetUUID returns the UUID for the device from the annotated ID.
-func (d Device) GetUUID() string {
+func (d *Device) GetUUID() string {
 	return AnnotatedID(d.ID).GetID()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves several `go vet` violations where a `sync.Mutex` was inadvertently copied by value. 

In `devices.go`, passing `Device` by value in receiver methods triggered a lock copy of the embedded protobuf `MessageState` mutex. I've updated these to use pointer receivers. 

In `device_map.go`, `updateDeviceMapWithReplicas` was dereferencing the device struct to create a replica. I replaced this with an explicit struct initialization that safely copies fields without copying the embedded mutex.

In `server_test.go`, the loop assigned `tc := testCases[i]`. Because `expectedResponse` is a `ContainerAllocateResponse` containing a protobuf mutex, this triggered `go vet`. I changed this to a pointer reference `tc := &testCases[i]`.

These changes ensure `go vet ./...` passes cleanly on master.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
*Note: This PR was prepared with AI assistance; the solution was reviewed and tested manually.*

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replicated device handling so replicas consistently preserve health, topology, paths, memory, and compute capability details.
  * Improved device allocation checks for more reliable capability and UUID handling.
* **Tests**
  * Expanded replication coverage to validate complete device details.
  * Improved test case handling for more consistent per-case assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->