### PR TITLE
fix(metrics): update scheduler metric descriptors label key from node to node_name

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -77,42 +77,46 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodevGPUMemoryLimitDesc := prometheus.NewDesc(
 		"hami_gpu_memory_limit_bytes",
 		"Device memory limit for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodevGPUCoreLimitDesc := prometheus.NewDesc(
 		"hami_gpu_core_limit_ratio",
 		"Device core limit for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodevGPUMemoryAllocatedDesc := prometheus.NewDesc(
 		"hami_gpu_memory_allocated_bytes",
 		"Device memory allocated for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_cores", "device_type"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "device_cores", "device_type"}, nil,
 	)
 	nodevGPUSharedNumDesc := prometheus.NewDesc(
 		"hami_gpu_shared_count",
 		"Number of containers sharing this GPU",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodeGPUCoreAllocatedDesc := prometheus.NewDesc(
 		"hami_gpu_core_allocated_ratio",
 		"Device core allocated for a certain GPU",
-		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodeGPUOverview := prometheus.NewDesc(
 		"hami_node_gpu_overview",
 		"GPU overview on a certain node",
+<<<<<<< HEAD
 		[]string{"node", "device_uuid", "device_index", "device_cores", "device_memory_limit", "device_type"}, nil,
+=======
+		[]string{"node_name", "device_uuid", "device_index", "device_cores", "shared_containers", "device_memory_limit", "device_type"}, nil,
+>>>>>>> 793c056 (fix(metrics): update scheduler metric descriptors label key from node to node_name)
 	)
 	nodeGPUMemoryPercentage := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
 		"GPU Memory Allocated Percentage on a certain GPU",
-		[]string{"node", "device_uuid", "device_index"}, nil,
+		[]string{"node_name", "device_uuid", "device_index"}, nil,
 	)
 	nodeGPUMigInstance := prometheus.NewDesc(
 		"hami_node_gpu_mig_instance_info",
 		"GPU Sharing mode. 0 for hami-core, 1 for mig, 2 for mps",
-		[]string{"node", "device_uuid", "device_index", "mig_name"}, nil,
+		[]string{"node_name", "device_uuid", "device_index", "mig_name"}, nil,
 	)
 
 	// Legacy metric descriptors (only created when legacy mode is enabled)
@@ -187,7 +191,15 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
+<<<<<<< HEAD
 	nu := cc.metricsProvider.InspectAllNodesUsage()
+=======
+	if sher == nil {
+		return
+	}
+
+	nu := sher.InspectAllNodesUsage()
+>>>>>>> 793c056 (fix(metrics): update scheduler metric descriptors label key from node to node_name)
 	for nodeID, val := range *nu {
 		for _, devs := range val.Devices.DeviceLists {
 			coreLimit, coreAllocated := normalizeAMDCoreMetrics(devs.Device.Type, devs.Device.Totalcore, devs.Device.Usedcores)
@@ -313,12 +325,12 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	ctrvGPUdeviceAllocatedMemoryDesc := prometheus.NewDesc(
 		"hami_vgpu_memory_allocated_bytes",
 		"vGPU memory allocated from a container",
-		[]string{"namespace", "node", "pod", "container_index", "device_uuid"}, nil,
+		[]string{"namespace", "node_name", "pod", "container_index", "device_uuid"}, nil,
 	)
 	ctrvGPUdeviceAllocatedCoreDesc := prometheus.NewDesc(
 		"hami_vgpu_core_allocated_ratio",
 		"vGPU core allocated from a container",
-		[]string{"namespace", "node", "pod", "container_index", "device_uuid"}, nil,
+		[]string{"namespace", "node_name", "pod", "container_index", "device_uuid"}, nil,
 	)
 	quotaUsedDesc := prometheus.NewDesc(
 		"hami_resource_quota_used",

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
 Copyright 2026 The HAMi Authors.
+=======
+Copyright 2024 The HAMi Authors.
+>>>>>>> 793c056 (fix(metrics): update scheduler metric descriptors label key from node to node_name)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+<<<<<<< HEAD
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -116,5 +121,66 @@ nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"
 		"nodeGPUMemoryPercentage",
 	); err != nil {
 		t.Fatalf("unexpected collecting result:\n%s", err)
+=======
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestSchedulerMetricDescriptors(t *testing.T) {
+	cm := &ClusterManager{
+		Zone:          "test-zone",
+		LegacyMetrics: false,
+	}
+	collector := ClusterManagerCollector{
+		ClusterManager: cm,
+	}
+
+	ch := make(chan *prometheus.Desc, 50)
+	collector.Describe(ch)
+	close(ch)
+
+	foundDescriptors := 0
+	for desc := range ch {
+		foundDescriptors++
+		descStr := desc.String()
+		// Ensure standard descriptors contain node_name
+		if strings.Contains(descStr, "fqName: \"hami_") {
+			if !strings.Contains(descStr, "node_name") {
+				t.Errorf("standard descriptor %s does not contain node_name label", descStr)
+			}
+		}
+	}
+
+	if foundDescriptors == 0 {
+		t.Error("expected at least 1 descriptor from scheduler collector")
+	}
+}
+
+func TestSchedulerMetricDescriptorsLegacyMode(t *testing.T) {
+	cm := &ClusterManager{
+		Zone:          "test-zone",
+		LegacyMetrics: true,
+	}
+	collector := ClusterManagerCollector{
+		ClusterManager: cm,
+	}
+
+	ch := make(chan *prometheus.Desc, 50)
+	collector.Describe(ch)
+	close(ch)
+
+	foundDescriptors := 0
+	for desc := range ch {
+		foundDescriptors++
+		descStr := desc.String()
+		if strings.Contains(descStr, "fqName: \"hami_") {
+			if !strings.Contains(descStr, "node_name") {
+				t.Errorf("standard descriptor %s does not contain node_name label", descStr)
+			}
+		}
+	}
+
+	if foundDescriptors == 0 {
+		t.Error("expected at least 1 descriptor from scheduler collector in legacy mode")
+>>>>>>> 793c056 (fix(metrics): update scheduler metric descriptors label key from node to node_name)
 	}
 }

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -142,8 +142,8 @@ func TestSchedulerMetricDescriptors(t *testing.T) {
 	for desc := range ch {
 		foundDescriptors++
 		descStr := desc.String()
-		// Ensure standard descriptors contain node_name
-		if strings.Contains(descStr, "fqName: \"hami_") {
+		// Ensure standard GPU descriptors (excluding namespace-scoped quota metrics) contain node_name
+		if strings.Contains(descStr, "fqName: \"hami_") && !strings.Contains(descStr, "hami_resource_quota_used") {
 			if !strings.Contains(descStr, "node_name") {
 				t.Errorf("standard descriptor %s does not contain node_name label", descStr)
 			}
@@ -172,7 +172,7 @@ func TestSchedulerMetricDescriptorsLegacyMode(t *testing.T) {
 	for desc := range ch {
 		foundDescriptors++
 		descStr := desc.String()
-		if strings.Contains(descStr, "fqName: \"hami_") {
+		if strings.Contains(descStr, "fqName: \"hami_") && !strings.Contains(descStr, "hami_resource_quota_used") {
 			if !strings.Contains(descStr, "node_name") {
 				t.Errorf("standard descriptor %s does not contain node_name label", descStr)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
In `cmd/vGPUmonitor/metrics.go`, host and container GPU metrics export standard Prometheus labels using key `node_name`. However, `cmd/scheduler/metrics.go` exported its metric descriptors with label key `"node"`. This label inconsistency prevents the operators from performing PromQL metric joins across components in Prometheus or Grafana (e.g., joining `vGPUmonitor` metrics with `scheduler` metrics on node name).

In this PR we update `"node"` to `"node_name"` across all standard scheduler metric descriptors to align them with `vGPUmonitor` and added unit test coverage. We also added a nil-guard for `sher` inside `ClusterManagerCollector.Collect()` to safely allow unit tests and uninitialized collector calls to execute without panicking.


**Which issue(s) this PR fixes**:
Fixes #2161 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU and container allocation metrics to consistently identify nodes by name.
  * Prevented invalid memory-ratio metrics from being emitted when total memory is zero or negative.
  * Preserved core-limit metrics in these conditions.

* **Tests**
  * Added coverage for standard and legacy metric descriptors.
  * Added validation that expected scheduler metrics are emitted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->