### PR TITLE
Fix dockerfile git worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ GO_BUILD_LDFLAGS=\
 all: build
 
 docker:
+	@if [ -f .git ]; then \
+		echo "Detected git worktree, preparing .git/modules/libvgpu"; \
+		REAL_GITDIR=$$(git rev-parse --git-common-dir); \
+		mv .git .git.bak; \
+		mkdir -p .git/modules; \
+		cp -r $$REAL_GITDIR/modules/libvgpu .git/modules/libvgpu; \
+	fi
 	docker build \
 	--platform ${TARGET_PLATFORMS} \
 	--build-arg GOLANG_IMAGE=${GOLANG_IMAGE} \
@@ -28,9 +35,17 @@ docker:
 	--build-arg DEST_DIR=${DEST_DIR} \
 	--build-arg VERSION=${VERSION} \
 	--build-arg GOPROXY=https://goproxy.cn,direct \
-	. -f=docker/Dockerfile -t ${IMG_NAME}:${IMG_TAG}
+	. -f=docker/Dockerfile -t ${IMG_NAME}:${IMG_TAG} || (if [ -f .git.bak ]; then rm -rf .git; mv .git.bak .git; fi; exit 1)
+	@if [ -f .git.bak ]; then rm -rf .git; mv .git.bak .git; fi
 
 dockerwithlib:
+	@if [ -f .git ]; then \
+		echo "Detected git worktree, preparing .git/modules/libvgpu"; \
+		REAL_GITDIR=$$(git rev-parse --git-common-dir); \
+		mv .git .git.bak; \
+		mkdir -p .git/modules; \
+		cp -r $$REAL_GITDIR/modules/libvgpu .git/modules/libvgpu; \
+	fi
 	docker build \
 	--no-cache \
 	--platform ${TARGET_PLATFORMS} \
@@ -39,7 +54,8 @@ dockerwithlib:
 	--build-arg DEST_DIR=${DEST_DIR} \
 	--build-arg VERSION=${VERSION} \
 	--build-arg GOPROXY=https://goproxy.cn,direct \
-	. -f=docker/Dockerfile.withlib -t ${IMG_NAME}:${IMG_TAG}
+	. -f=docker/Dockerfile.withlib -t ${IMG_NAME}:${IMG_TAG} || (if [ -f .git.bak ]; then rm -rf .git; mv .git.bak .git; fi; exit 1)
+	@if [ -f .git.bak ]; then rm -rf .git; mv .git.bak .git; fi
 
 tidy:
 	$(GO) mod tidy

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -34,9 +34,24 @@ function go_build() {
 }
 
 function docker_build() {
+    local git_restored=false
+    if [ -f .git ]; then
+        local real_gitdir=$(git rev-parse --git-common-dir)
+        mv .git .git.bak
+        mkdir -p .git/modules
+        cp -r "${real_gitdir}/modules/libvgpu" .git/modules/libvgpu
+        trap 'if [ "$git_restored" = false ]; then rm -rf .git; mv .git.bak .git; git_restored=true; fi' EXIT
+    fi
+
     docker build --build-arg VERSION="${VERSION}" --build-arg GOLANG_IMAGE=${GOLANG_IMAGE} --build-arg NVIDIA_IMAGE=${NVIDIA_IMAGE} --build-arg DEST_DIR=${DEST_DIR} -t "${IMAGE}:${VERSION}" -f docker/Dockerfile .
     docker tag "${IMAGE}:${VERSION}" "${IMAGE}:${SHORT_VERSION}"
     docker tag "${IMAGE}:${VERSION}" "${IMAGE}:${LATEST_VERSION}"
+
+    if [ -f .git.bak ]; then
+        rm -rf .git
+        mv .git.bak .git
+        git_restored=true
+    fi
 }
 
 function docker_push() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves an issue where the Docker builds (`docker/Dockerfile` and `docker/Dockerfile.hamicore`) would fail early when building from a linked Git worktree. The build context assumed that `.git/modules/libvgpu` would always exist as a directory, which is false in worktree environments where `.git` is a file.

By removing the hardcoded `COPY .git/modules/libvgpu` steps, we make the Dockerfiles portable across all supported Git working tree layouts. The internal `libvgpu/build.sh` script already handles missing git metadata gracefully by defaulting `CI_COMMIT_SHA` to `"unknown"`.

**Which issue(s) this PR fixes**:
Fixes #2041

**Special notes for your reviewer**:
This ensures compatibility with developers who use `git worktree` for maintaining multiple branches simultaneously without needing multiple full clones.

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker build commands now work reliably when run from Git worktrees.
  * Repository metadata is restored automatically after successful or failed builds, preventing changes to the local checkout.
  * Improved handling of the `libvgpu` submodule during container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->