### PR TITLE
enforce resource quota for all device backends

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -31,6 +31,7 @@ import (
 )
 
 type AMDDevices struct {
+	device.DefaultMemoryFactor
 	resourceCountName  string
 	resourceMemoryName string
 }
@@ -63,10 +64,6 @@ func InitAMDGPUDevice(config AMDConfig) *AMDDevices {
 
 func (dev *AMDDevices) CommonWord() string {
 	return AMDCommonWord
-}
-
-func (dev *AMDDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -65,6 +65,10 @@ func (dev *AMDDevices) CommonWord() string {
 	return AMDCommonWord
 }
 
+func (dev *AMDDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 	if !ok {

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -115,6 +115,10 @@ func (dev *Devices) CommonWord() string {
 	return dev.config.CommonWord
 }
 
+func (dev *Devices) MemoryFactor() int32 {
+	return dev.config.MemoryFactor
+}
+
 func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceName)]
 	if !ok {
@@ -516,6 +520,11 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		if k.MemPercentagereq != 101 && k.Memreq == 0 {
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
+		}
+		if !device.FitAllocationQuota(pod.Namespace, k.Type, npu.config.MemoryFactor, int64(memreq), int64(k.Coresreq), tmpDevs, allocated) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
 		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2107,6 +2107,58 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+func TestDevices_Fit_ResourceQuotaExceeded(t *testing.T) {
+	configStr := `- chipName: 910A
+  commonWord: Ascend910A
+  resourceName: huawei.com/Ascend910A
+  resourceMemoryName: huawei.com/Ascend910A-memory
+  memoryAllocatable: 32768
+  memoryCapacity: 32768
+  aiCore: 30
+  templates:
+    - name: vir02
+      memory: 2184
+      aiCore: 2
+`
+	var config []VNPUConfig
+	if err := yaml.Unmarshal([]byte(configStr), &config); err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+	enableAscend = true
+	devs := InitDevices(VNPUs{Configs: config})
+	if len(devs) != 1 {
+		t.Fatalf("expected one ascend device, got %d", len(devs))
+	}
+	dev := devs[0]
+	oldMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldMap })
+	device.DevicesMap = map[string]device.Devices{
+		dev.config.CommonWord: dev,
+	}
+	memName := "huawei.com/Ascend910A-memory"
+	qm := device.NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, "default") })
+	qm.Quotas["default"] = &device.DeviceQuota{
+		memName: &device.Quota{Used: 9000, Limit: 10000},
+	}
+
+	devices := []*device.DeviceUsage{{
+		ID: "dev-0", Used: 0, Count: 100, Usedmem: 0, Totalmem: 1280,
+		Totalcore: 100, Usedcores: 0, Type: dev.config.CommonWord, Health: true,
+	}}
+	request := device.ContainerDeviceRequest{
+		Nums: 1, Memreq: 2000, Coresreq: 50, Type: dev.config.CommonWord,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}
+	fit, _, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	if fit {
+		t.Fatal("Fit should fail when namespace memory quota is exceeded")
+	}
+	if reason != "1/1 ResourceQuotaNotFit" {
+		t.Fatalf("expected ResourceQuotaNotFit, got %q", reason)
+	}
+}
+
 func TestDevices_Fit_910C(t *testing.T) {
 	configStr := `- chipName: Ascend910
   commonWord: Ascend910C

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2361,3 +2361,8 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestMemoryFactor(t *testing.T) {
+	dev := &Devices{config: VNPUConfig{MemoryFactor: 10}}
+	assert.Equal(t, dev.MemoryFactor(), int32(10))
+}

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -33,6 +33,7 @@ import (
 )
 
 type AWSNeuronDevices struct {
+	device.DefaultMemoryFactor
 	resourceCountName string
 	resourceCoreName  string
 	coresPerAWSNeuron uint
@@ -74,10 +75,6 @@ func InitAWSNeuronDevice(config AWSNeuronConfig) *AWSNeuronDevices {
 
 func (dev *AWSNeuronDevices) CommonWord() string {
 	return AWSNeuronCommonWord
-}
-
-func (dev *AWSNeuronDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -76,6 +76,10 @@ func (dev *AWSNeuronDevices) CommonWord() string {
 	return AWSNeuronCommonWord
 }
 
+func (dev *AWSNeuronDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 	if !ok {

--- a/pkg/device/biren/device.go
+++ b/pkg/device/biren/device.go
@@ -68,6 +68,10 @@ func (dev *BirenDevices) CommonWord() string {
 	return BirenCommonWord
 }
 
+func (dev *BirenDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *BirenDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
 	devEncoded, ok := n.Annotations[RegisterAnnos]
 	if !ok {

--- a/pkg/device/biren/device.go
+++ b/pkg/device/biren/device.go
@@ -31,6 +31,7 @@ import (
 )
 
 type BirenDevices struct {
+	device.DefaultMemoryFactor
 }
 
 const (
@@ -66,10 +67,6 @@ func InitBirenDevice(config BirenConfig) *BirenDevices {
 
 func (dev *BirenDevices) CommonWord() string {
 	return BirenCommonWord
-}
-
-func (dev *BirenDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *BirenDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -69,6 +69,7 @@ type CambriconConfig struct {
 }
 
 type CambriconDevices struct {
+	device.DefaultMemoryFactor
 }
 
 func ParseConfig(fs *flag.FlagSet) {
@@ -91,10 +92,6 @@ func InitMLUDevice(config CambriconConfig) *CambriconDevices {
 
 func (dev *CambriconDevices) CommonWord() string {
 	return CambriconMLUCommonWord
-}
-
-func (dev *CambriconDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -93,6 +93,10 @@ func (dev *CambriconDevices) CommonWord() string {
 	return CambriconMLUCommonWord
 }
 
+func (dev *CambriconDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {
 	ctx := context.Background()
 	if _, ok := node.Annotations[DsmluLockTime]; ok {
@@ -374,6 +378,11 @@ func (cam *CambriconDevices) Fit(devices []*device.DeviceUsage, request device.C
 		if k.MemPercentagereq != 101 && k.Memreq == 0 {
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
+		}
+		if !device.FitAllocationQuota(pod.Namespace, k.Type, cam.MemoryFactor(), int64(memreq), int64(k.Coresreq), tmpDevs, allocated) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
 		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -1071,6 +1071,42 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+func TestDevices_Fit_ResourceQuotaExceeded(t *testing.T) {
+	config := CambriconConfig{
+		ResourceCountName:  "cambricon.com/mlu",
+		ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+		ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+	}
+	dev := InitMLUDevice(config)
+	oldMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldMap })
+	device.DevicesMap = map[string]device.Devices{
+		CambriconMLUDevice: dev,
+	}
+	memName := "cambricon.com/mlu.smlu.vmemory"
+	qm := device.NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, "default") })
+	qm.Quotas["default"] = &device.DeviceQuota{
+		memName: &device.Quota{Used: 9000, Limit: 10000},
+	}
+
+	devices := []*device.DeviceUsage{{
+		ID: "dev-0", Used: 0, Count: 100, Usedmem: 0, Totalmem: 1280,
+		Totalcore: 100, Usedcores: 0, Type: CambriconMLUDevice, Health: true,
+	}}
+	request := device.ContainerDeviceRequest{
+		Nums: 1, Memreq: 2000, Coresreq: 50, Type: CambriconMLUDevice,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}
+	fit, _, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	if fit {
+		t.Fatal("Fit should fail when namespace memory quota is exceeded")
+	}
+	if reason != "1/1 ResourceQuotaNotFit" {
+		t.Fatalf("expected ResourceQuotaNotFit, got %q", reason)
+	}
+}
+
 func TestDevices_AddResourceUsage(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -35,6 +35,7 @@ import (
 
 type Devices interface {
 	CommonWord() string
+	MemoryFactor() int32
 	MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error)
 	CheckHealth(devType string, n *corev1.Node) (bool, bool)
 	NodeCleanUp(nn string) error

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -50,6 +50,13 @@ type Devices interface {
 	Fit(devices []*DeviceUsage, request ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *NodeInfo, allocated *PodDevices) (bool, map[string]ContainerDevices, string)
 }
 
+// DefaultMemoryFactor provides MemoryFactor() for backends without memory scaling.
+type DefaultMemoryFactor struct{}
+
+func (DefaultMemoryFactor) MemoryFactor() int32 {
+	return 1
+}
+
 type MigTemplate struct {
 	Name   string `yaml:"name"`
 	Core   int32  `yaml:"core"`

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1011,7 +1011,8 @@ type mockDevices struct {
 	resourceRequest ContainerDeviceRequest
 }
 
-func (m *mockDevices) CommonWord() string { return "mock" }
+func (m *mockDevices) CommonWord() string  { return "mock" }
+func (m *mockDevices) MemoryFactor() int32 { return 1 }
 func (m *mockDevices) MutateAdmission(_ *corev1.Container, _ *corev1.Pod) (bool, error) {
 	return false, nil
 }

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -110,6 +110,10 @@ func (dev *EnflameDevices) CommonWord() string {
 	return EnflameVGCUCommonWord
 }
 
+func (dev *EnflameDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *EnflameDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	resourceCount := corev1.ResourceName(EnflameResourceNameDRSGCU)
 	count, ok := ctr.Resources.Limits[resourceCount]

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -35,7 +35,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type EnflameDevices struct{}
+type EnflameDevices struct {
+	device.DefaultMemoryFactor
+}
 
 const (
 	EnflameVGCUDevice     = "Enflame"
@@ -108,10 +110,6 @@ func InitEnflameDevice(config EnflameConfig) *EnflameDevices {
 
 func (dev *EnflameDevices) CommonWord() string {
 	return EnflameVGCUCommonWord
-}
-
-func (dev *EnflameDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *EnflameDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/enflame/gcu.go
+++ b/pkg/device/enflame/gcu.go
@@ -50,6 +50,10 @@ func (dev *GCUDevices) CommonWord() string {
 	return EnflameGCUCommonWord
 }
 
+func (dev *GCUDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *GCUDevices) MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(EnflameResourceNameGCU)]
 	return ok, nil

--- a/pkg/device/enflame/gcu.go
+++ b/pkg/device/enflame/gcu.go
@@ -34,6 +34,7 @@ const (
 )
 
 type GCUDevices struct {
+	device.DefaultMemoryFactor
 }
 
 func InitGCUDevice(config EnflameConfig) *GCUDevices {
@@ -48,10 +49,6 @@ func InitGCUDevice(config EnflameConfig) *GCUDevices {
 
 func (dev *GCUDevices) CommonWord() string {
 	return EnflameGCUCommonWord
-}
-
-func (dev *GCUDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *GCUDevices) MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error) {

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -84,6 +84,10 @@ func (dev *DCUDevices) CommonWord() string {
 	return HygonDCUCommonWord
 }
 
+func (dev *DCUDevices) MemoryFactor() int32 {
+	return MemoryFactor
+}
+
 func ParseConfig(fs *flag.FlagSet) {
 	fs.StringVar(&HygonResourceCount, "dcu-name", "hygon.com/dcunum", "dcu resource count")
 	fs.StringVar(&HygonResourceMemory, "dcu-memory", "hygon.com/dcumem", "dcu memory resource")
@@ -300,6 +304,11 @@ func (dcu *DCUDevices) Fit(devices []*device.DeviceUsage, request device.Contain
 		if k.MemPercentagereq != 101 && k.Memreq == 0 {
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
+		}
+		if !device.FitAllocationQuota(pod.Namespace, k.Type, MemoryFactor, int64(memreq), int64(k.Coresreq), tmpDevs, allocated) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
 		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -1164,6 +1164,16 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+func TestMemoryFactor(t *testing.T) {
+	dev := InitDCUDevice(HygonConfig{
+		ResourceCountName:  "hygon.com/dcunum",
+		ResourceMemoryName: "hygon.com/dcumem",
+		ResourceCoreName:   "hygon.com/dcucores",
+		MemoryFactor:       5,
+	})
+	assert.Equal(t, dev.MemoryFactor(), int32(5))
+}
+
 func TestDevices_Fit_ResourceQuotaExceeded(t *testing.T) {
 	config := HygonConfig{
 		ResourceCountName:  "hygon.com/dcunum",

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -1164,6 +1164,42 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+func TestDevices_Fit_ResourceQuotaExceeded(t *testing.T) {
+	config := HygonConfig{
+		ResourceCountName:  "hygon.com/dcunum",
+		ResourceMemoryName: "hygon.com/dcumem",
+		ResourceCoreName:   "hygon.com/dcucores",
+	}
+	dev := InitDCUDevice(config)
+	oldMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldMap })
+	device.DevicesMap = map[string]device.Devices{
+		HygonDCUDevice: dev,
+	}
+	memName := "hygon.com/dcumem"
+	qm := device.NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, "default") })
+	qm.Quotas["default"] = &device.DeviceQuota{
+		memName: &device.Quota{Used: 9000, Limit: 10000},
+	}
+
+	devices := []*device.DeviceUsage{{
+		ID: "dev-0", Used: 0, Count: 100, Usedmem: 0, Totalmem: 1280,
+		Totalcore: 100, Usedcores: 0, Type: HygonDCUDevice, Health: true,
+	}}
+	request := device.ContainerDeviceRequest{
+		Nums: 1, Memreq: 2000, Coresreq: 50, Type: HygonDCUDevice,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}
+	fit, _, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	if fit {
+		t.Fatal("Fit should fail when namespace memory quota is exceeded")
+	}
+	if reason != "1/1 ResourceQuotaNotFit" {
+		t.Fatalf("expected ResourceQuotaNotFit, got %q", reason)
+	}
+}
+
 func TestDevices_AddResourceUsage(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -38,6 +38,7 @@ var (
 )
 
 type IluvatarDevices struct {
+	device.DefaultMemoryFactor
 	config           IluvatarConfig
 	nodeRegisterAnno string
 	useUUIDAnno      string
@@ -78,10 +79,6 @@ func InitIluvatarDevice(config []IluvatarConfig) []*IluvatarDevices {
 
 func (dev *IluvatarDevices) CommonWord() string {
 	return dev.config.CommonWord
-}
-
-func (dev *IluvatarDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func ParseConfig(fs *flag.FlagSet) {

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -80,6 +80,10 @@ func (dev *IluvatarDevices) CommonWord() string {
 	return dev.config.CommonWord
 }
 
+func (dev *IluvatarDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func ParseConfig(fs *flag.FlagSet) {
 	fs.BoolVar(&enableIluvatar, "enable-iluvatar", false, "enable iluvatar device")
 }

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -55,6 +55,10 @@ func (dev *KunlunDevices) CommonWord() string {
 	return KunlunGPUCommonWord
 }
 
+func (dev *KunlunDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *KunlunDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(KunlunResourceCount)]
 	return ok, nil

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -40,6 +40,7 @@ const (
 )
 
 type KunlunDevices struct {
+	device.DefaultMemoryFactor
 }
 
 func InitKunlunDevice(config KunlunConfig) *KunlunDevices {
@@ -53,10 +54,6 @@ func InitKunlunDevice(config KunlunConfig) *KunlunDevices {
 
 func (dev *KunlunDevices) CommonWord() string {
 	return KunlunGPUCommonWord
-}
-
-func (dev *KunlunDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *KunlunDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -74,6 +74,10 @@ func (dev *KunlunVDevices) CommonWord() string {
 	return XPUDevice
 }
 
+func (dev *KunlunVDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *KunlunVDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(KunlunResourceVCount)]
 	if !ok {

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -46,6 +46,7 @@ const (
 )
 
 type KunlunVDevices struct {
+	device.DefaultMemoryFactor
 }
 
 func InitKunlunVDevice(config KunlunConfig) *KunlunVDevices {
@@ -72,10 +73,6 @@ func (dev *KunlunVDevices) trimMemory(m int64) int64 {
 
 func (dev *KunlunVDevices) CommonWord() string {
 	return XPUDevice
-}
-
-func (dev *KunlunVDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *KunlunVDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -32,6 +32,7 @@ import (
 )
 
 type MetaxDevices struct {
+	device.DefaultMemoryFactor
 }
 
 const (
@@ -57,10 +58,6 @@ func InitMetaxDevice(config MetaxConfig) *MetaxDevices {
 
 func (dev *MetaxDevices) CommonWord() string {
 	return MetaxGPUCommonWord
-}
-
-func (dev *MetaxDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *MetaxDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -59,6 +59,10 @@ func (dev *MetaxDevices) CommonWord() string {
 	return MetaxGPUCommonWord
 }
 
+func (dev *MetaxDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *MetaxDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(MetaxResourceCount)]
 	return ok, nil

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -57,6 +57,7 @@ var (
 )
 
 type MetaxSDevices struct {
+	device.DefaultMemoryFactor
 	jqCache *JitteryQosCache
 }
 
@@ -79,10 +80,6 @@ func InitMetaxSDevice(config MetaxConfig) *MetaxSDevices {
 
 func (sdev *MetaxSDevices) CommonWord() string {
 	return MetaxSGPUCommonWord
-}
-
-func (sdev *MetaxSDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (sdev *MetaxSDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -81,6 +81,10 @@ func (sdev *MetaxSDevices) CommonWord() string {
 	return MetaxSGPUCommonWord
 }
 
+func (sdev *MetaxSDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (sdev *MetaxSDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(MetaxResourceNameVCount)]
 	if !ok {

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -36,6 +36,7 @@ import (
 )
 
 type MthreadsDevices struct {
+	device.DefaultMemoryFactor
 }
 
 const (
@@ -80,10 +81,6 @@ func InitMthreadsDevice(config MthreadsConfig) *MthreadsDevices {
 
 func (dev *MthreadsDevices) CommonWord() string {
 	return MthreadsGPUCommonWord
-}
-
-func (dev *MthreadsDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func ParseConfig(fs *flag.FlagSet) {

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -82,6 +82,10 @@ func (dev *MthreadsDevices) CommonWord() string {
 	return MthreadsGPUCommonWord
 }
 
+func (dev *MthreadsDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func ParseConfig(fs *flag.FlagSet) {
 	fs.StringVar(&MthreadsResourceCount, "mthreads-name", "mthreads.com/vgpu", "mthreads resource count")
 	fs.StringVar(&MthreadsResourceMemory, "mthreads-memory", "mthreads.com/sgpu-memory", "mthreads memory resource")

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -188,6 +188,10 @@ func (dev *NvidiaGPUDevices) CommonWord() string {
 	return NvidiaGPUDevice
 }
 
+func (dev *NvidiaGPUDevices) MemoryFactor() int32 {
+	return MemoryFactor
+}
+
 func ParseConfig(fs *flag.FlagSet) {
 }
 
@@ -723,24 +727,7 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 }
 
 func fitQuota(tmpDevs map[string]device.ContainerDevices, allocated *device.PodDevices, ns string, memreq int64, coresreq int64) bool {
-	mem := memreq
-	core := coresreq
-	for _, val := range tmpDevs[NvidiaGPUDevice] {
-		mem += int64(val.Usedmem)
-		core += int64(val.Usedcores)
-	}
-	if allocated != nil {
-		if podSingleDevice, exists := (*allocated)[NvidiaGPUDevice]; exists {
-			for _, containerDevices := range podSingleDevice {
-				for _, val := range containerDevices {
-					mem += int64(val.Usedmem)
-					core += int64(val.Usedcores)
-				}
-			}
-		}
-	}
-	klog.V(4).Infoln("Allocating...", mem, "cores", core)
-	return device.GetLocalCache().FitQuota(ns, mem, MemoryFactor, core, NvidiaGPUDevice)
+	return device.FitAllocationQuota(ns, NvidiaGPUDevice, MemoryFactor, memreq, coresreq, tmpDevs, allocated)
 }
 
 func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1907,6 +1907,14 @@ func TestGenerateResourceRequests(t *testing.T) {
 	}
 }
 
+func TestMemoryFactor(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{
+		ResourceCountName: "nvidia.com/gpu",
+		MemoryFactor:      3,
+	})
+	assert.Equal(t, dev.MemoryFactor(), int32(3))
+}
+
 func TestGenerateResourceRequests_MemoryFactor(t *testing.T) {
 	config := NvidiaConfig{
 		ResourceCountName:            "nvidia.com/gpu",

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -88,6 +88,79 @@ func (q *QuotaManager) FitQuota(ns string, memreq int64, memoryFactor int32, cor
 	return true
 }
 
+func containerResourceRequest(ctr *corev1.Container, resName corev1.ResourceName) (int64, bool) {
+	v, ok := ctr.Resources.Limits[resName]
+	if !ok {
+		v, ok = ctr.Resources.Requests[resName]
+	}
+	if ok {
+		if n, ok := v.AsInt64(); ok {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func PodQuotaRequests(pod *corev1.Pod, deviceName string) (memoryReq int64, coresReq int64) {
+	devs, ok := GetDevices()[deviceName]
+	if !ok {
+		return 0, 0
+	}
+	resourceNames := devs.GetResourceNames()
+	if resourceNames.ResourceCountName == "" {
+		return 0, 0
+	}
+	resourceName := corev1.ResourceName(resourceNames.ResourceCountName)
+	memResourceName := corev1.ResourceName(resourceNames.ResourceMemoryName)
+	coreResourceName := corev1.ResourceName(resourceNames.ResourceCoreName)
+
+	for _, ctr := range pod.Spec.Containers {
+		req, ok := containerResourceRequest(&ctr, resourceName)
+		if !ok {
+			continue
+		}
+		if memReq, ok := containerResourceRequest(&ctr, memResourceName); ok {
+			memoryReq += memReq * req
+		}
+		if coreReq, ok := containerResourceRequest(&ctr, coreResourceName); ok {
+			coresReq += coreReq * req
+		}
+	}
+	return memoryReq, coresReq
+}
+
+func FitPodQuota(pod *corev1.Pod, deviceName string, memoryFactor int32) bool {
+	memoryReq, coresReq := PodQuotaRequests(pod, deviceName)
+	if memoryReq == 0 && coresReq == 0 {
+		return true
+	}
+	if memoryFactor > 1 {
+		memoryReq *= int64(memoryFactor)
+	}
+	return GetLocalCache().FitQuota(pod.Namespace, memoryReq, memoryFactor, coresReq, deviceName)
+}
+
+func FitAllocationQuota(ns, deviceType string, memoryFactor int32, memreq, coresreq int64, tmpDevs map[string]ContainerDevices, allocated *PodDevices) bool {
+	mem := memreq
+	core := coresreq
+	for _, val := range tmpDevs[deviceType] {
+		mem += int64(val.Usedmem)
+		core += int64(val.Usedcores)
+	}
+	if allocated != nil {
+		if podSingleDevice, exists := (*allocated)[deviceType]; exists {
+			for _, containerDevices := range podSingleDevice {
+				for _, val := range containerDevices {
+					mem += int64(val.Usedmem)
+					core += int64(val.Usedcores)
+				}
+			}
+		}
+	}
+	klog.V(4).InfoS("Allocating quota", "device", deviceType, "mem", mem, "cores", core)
+	return GetLocalCache().FitQuota(ns, mem, memoryFactor, core, deviceType)
+}
+
 func countPodDevices(podDev PodDevices) map[string]int64 {
 	res := make(map[string]int64)
 	for deviceName, podSingle := range podDev {

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -32,6 +32,10 @@ func (m *MockDevices) CommonWord() string {
 	return "mock"
 }
 
+func (m *MockDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (m *MockDevices) MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error) {
 	return true, nil
 }
@@ -86,6 +90,13 @@ type PodDeviceInfo struct {
 }
 
 type TestPodDevices map[string]map[string][]PodDeviceInfo
+
+func cleanupNamespaceQuota(t *testing.T, ns string) {
+	t.Helper()
+	t.Cleanup(func() {
+		delete(NewQuotaManager().Quotas, ns)
+	})
+}
 
 func initTest() {
 	DevicesMap = make(map[string]Devices)
@@ -157,6 +168,184 @@ func TestFitQuota(t *testing.T) {
 	// Should fit if device not present
 	if !qm.FitQuota(ns, 1000, 1, 100, "unknown-device") {
 		t.Error("FitQuota should return true if device not present")
+	}
+}
+
+func TestPodQuotaRequests(t *testing.T) {
+	initTest()
+	DevicesMap["Ascend910B"] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceCountName:  "huawei.com/Ascend910B",
+			ResourceMemoryName: "huawei.com/Ascend910B-memory",
+			ResourceCoreName:   "huawei.com/Ascend910B-core",
+		},
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B":        resource.MustParse("1"),
+						"huawei.com/Ascend910B-memory": resource.MustParse("2000"),
+					},
+				},
+			}},
+		},
+	}
+	mem, cores := PodQuotaRequests(pod, "Ascend910B")
+	if mem != 2000 || cores != 0 {
+		t.Fatalf("PodQuotaRequests() = (%d, %d), want (2000, 0)", mem, cores)
+	}
+}
+
+func TestPodQuotaRequestsUnknownDevice(t *testing.T) {
+	initTest()
+	mem, cores := PodQuotaRequests(&corev1.Pod{}, "unknown")
+	if mem != 0 || cores != 0 {
+		t.Fatalf("PodQuotaRequests() = (%d, %d), want (0, 0)", mem, cores)
+	}
+}
+
+func TestFitPodQuotaNoDeviceRequest(t *testing.T) {
+	initTest()
+	cleanupNamespaceQuota(t, "default")
+	if !FitPodQuota(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}}, "NVIDIA", 1) {
+		t.Fatal("FitPodQuota should allow pods with no device requests")
+	}
+}
+
+func TestFitPodQuotaMemoryFactor(t *testing.T) {
+	initTest()
+	deviceName := "NVIDIA"
+	memName := "nvidia.com/gpumem"
+	cleanupNamespaceQuota(t, "default")
+	qm := NewQuotaManager()
+	qm.Quotas["default"] = &DeviceQuota{
+		memName: &Quota{Used: 0, Limit: 1000},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":    resource.MustParse("1"),
+						"nvidia.com/gpumem": resource.MustParse("1500"),
+					},
+				},
+			}},
+		},
+	}
+	DevicesMap[deviceName] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceCountName:  "nvidia.com/gpu",
+			ResourceMemoryName: memName,
+			ResourceCoreName:   "nvidia.com/gpucore",
+		},
+	}
+	if FitPodQuota(pod, deviceName, 2) {
+		t.Fatal("FitPodQuota should reject request when memoryFactor doubles usage over limit")
+	}
+}
+
+func TestFitAllocationQuota(t *testing.T) {
+	initTest()
+	cleanupNamespaceQuota(t, "default")
+	deviceName := "NVIDIA"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+	DevicesMap[deviceName] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceCountName:  "nvidia.com/gpu",
+			ResourceMemoryName: memName,
+			ResourceCoreName:   coreName,
+		},
+	}
+	qm := NewQuotaManager()
+	qm.Quotas["default"] = &DeviceQuota{
+		memName:  &Quota{Used: 0, Limit: 2048},
+		coreName: &Quota{Used: 0, Limit: 100},
+	}
+
+	tests := []struct {
+		name      string
+		tmpDevs   map[string]ContainerDevices
+		allocated *PodDevices
+		memreq    int64
+		coresreq  int64
+		want      bool
+	}{
+		{
+			name:     "within quota",
+			memreq:   100,
+			coresreq: 1,
+			want:     true,
+		},
+		{
+			name:   "request exceeds quota",
+			memreq: 3000,
+			want:   false,
+		},
+		{
+			name: "tmpdev exceeds quota",
+			tmpDevs: map[string]ContainerDevices{
+				deviceName: {{Usedmem: 1024, Usedcores: 5}},
+			},
+			memreq: 2000,
+			want:   false,
+		},
+		{
+			name: "allocated devs exceed quota",
+			allocated: &PodDevices{
+				deviceName: PodSingleDevice{
+					ContainerDevices{{Usedmem: 1024, Usedcores: 2}},
+				},
+			},
+			memreq: 2000,
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FitAllocationQuota("default", deviceName, 1, tt.memreq, tt.coresreq, tt.tmpDevs, tt.allocated)
+			if got != tt.want {
+				t.Fatalf("FitAllocationQuota() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFitPodQuotaNonNvidia(t *testing.T) {
+	initTest()
+	cleanupNamespaceQuota(t, "default")
+	deviceName := "Ascend910B"
+	memName := "huawei.com/Ascend910B-memory"
+	DevicesMap[deviceName] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceCountName:  "huawei.com/Ascend910B",
+			ResourceMemoryName: memName,
+			ResourceCoreName:   "huawei.com/Ascend910B-core",
+		},
+	}
+	qm := NewQuotaManager()
+	qm.Quotas["default"] = &DeviceQuota{
+		memName: &Quota{Used: 9000, Limit: 10000},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B":        resource.MustParse("1"),
+						"huawei.com/Ascend910B-memory": resource.MustParse("2000"),
+					},
+				},
+			}},
+		},
+	}
+	if FitPodQuota(pod, deviceName, 1) {
+		t.Fatal("FitPodQuota should reject over-limit non-NVIDIA request")
 	}
 }
 

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -206,6 +206,55 @@ func TestPodQuotaRequestsUnknownDevice(t *testing.T) {
 	}
 }
 
+func TestPodQuotaRequestsEmptyCountName(t *testing.T) {
+	initTest()
+	DevicesMap["empty"] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceMemoryName: "nvidia.com/gpumem",
+		},
+	}
+	mem, cores := PodQuotaRequests(&corev1.Pod{}, "empty")
+	if mem != 0 || cores != 0 {
+		t.Fatalf("PodQuotaRequests() = (%d, %d), want (0, 0)", mem, cores)
+	}
+}
+
+func TestPodQuotaRequestsWithCores(t *testing.T) {
+	initTest()
+	deviceName := "NVIDIA"
+	DevicesMap[deviceName] = &MockDevices{
+		resourceNames: ResourceNames{
+			ResourceCountName:  "nvidia.com/gpu",
+			ResourceMemoryName: "nvidia.com/gpumem",
+			ResourceCoreName:   "nvidia.com/gpucore",
+		},
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"nvidia.com/gpu":     resource.MustParse("2"),
+						"nvidia.com/gpumem":  resource.MustParse("1000"),
+						"nvidia.com/gpucore": resource.MustParse("50"),
+					},
+				},
+			}},
+		},
+	}
+	mem, cores := PodQuotaRequests(pod, deviceName)
+	if mem != 2000 || cores != 100 {
+		t.Fatalf("PodQuotaRequests() = (%d, %d), want (2000, 100)", mem, cores)
+	}
+}
+
+func TestDefaultMemoryFactor(t *testing.T) {
+	var d DefaultMemoryFactor
+	if got := d.MemoryFactor(); got != 1 {
+		t.Fatalf("DefaultMemoryFactor.MemoryFactor() = %d, want 1", got)
+	}
+}
+
 func TestFitPodQuotaNoDeviceRequest(t *testing.T) {
 	initTest()
 	cleanupNamespaceQuota(t, "default")

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -33,6 +33,7 @@ import (
 )
 
 type VastaiDevices struct {
+	device.DefaultMemoryFactor
 }
 
 const (
@@ -68,10 +69,6 @@ func InitVastaiDevice(config VastaiConfig) *VastaiDevices {
 
 func (dev *VastaiDevices) CommonWord() string {
 	return VastaiCommonWord
-}
-
-func (dev *VastaiDevices) MemoryFactor() int32 {
-	return 1
 }
 
 func (dev *VastaiDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -70,6 +70,10 @@ func (dev *VastaiDevices) CommonWord() string {
 	return VastaiCommonWord
 }
 
+func (dev *VastaiDevices) MemoryFactor() int32 {
+	return 1
+}
+
 func (dev *VastaiDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
 	devEncoded, ok := n.Annotations[RegisterAnnos]
 	if !ok {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1154,7 +1154,8 @@ type registerMockDevice struct {
 	nodeCleanedUp int
 }
 
-func (m *registerMockDevice) CommonWord() string { return "mock-vendor" }
+func (m *registerMockDevice) CommonWord() string  { return "mock-vendor" }
+func (m *registerMockDevice) MemoryFactor() int32 { return 1 }
 func (m *registerMockDevice) MutateAdmission(_ *corev1.Container, _ *corev1.Pod) (bool, error) {
 	return false, nil
 }

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3580,7 +3580,8 @@ type fitMockDevice struct {
 	uuid     string
 }
 
-func (m *fitMockDevice) CommonWord() string { return m.typeName }
+func (m *fitMockDevice) CommonWord() string  { return m.typeName }
+func (m *fitMockDevice) MemoryFactor() int32 { return 1 }
 func (m *fitMockDevice) MutateAdmission(_ *corev1.Container, _ *corev1.Pod) (bool, error) {
 	return false, nil
 }

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
-	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
 
@@ -130,47 +129,8 @@ func isPrivilegedContainer(ctr *corev1.Container) bool {
 
 func fitResourceQuota(pod *corev1.Pod) bool {
 	for deviceName, dev := range device.GetDevices() {
-		// Only supports NVIDIA
-		if deviceName != nvidia.NvidiaGPUDevice {
-			continue
-		}
-		memoryFactor := nvidia.MemoryFactor
-		resourceNames := dev.GetResourceNames()
-		resourceName := corev1.ResourceName(resourceNames.ResourceCountName)
-		memResourceName := corev1.ResourceName(resourceNames.ResourceMemoryName)
-		coreResourceName := corev1.ResourceName(resourceNames.ResourceCoreName)
-		var memoryReq int64 = 0
-		var coresReq int64 = 0
-		getRequest := func(ctr *corev1.Container, resName corev1.ResourceName) (int64, bool) {
-			v, ok := ctr.Resources.Limits[resName]
-			if !ok {
-				v, ok = ctr.Resources.Requests[resName]
-			}
-			if ok {
-				if n, ok := v.AsInt64(); ok {
-					return n, true
-				}
-			}
-			return 0, false
-		}
-		for _, ctr := range pod.Spec.Containers {
-			req, ok := getRequest(&ctr, resourceName)
-			if ok {
-				if memReq, ok := getRequest(&ctr, memResourceName); ok {
-					memoryReq += memReq * req
-				}
-				if coreReq, ok := getRequest(&ctr, coreResourceName); ok {
-					coresReq += coreReq * req
-				}
-			}
-		}
-		if memoryFactor > 1 {
-			oriMemReq := memoryReq
-			memoryReq = memoryReq * int64(memoryFactor)
-			klog.V(5).Infof("Adjusting memory request for quota check: oriMemReq %d, memoryReq %d, factor %d", oriMemReq, memoryReq, memoryFactor)
-		}
-		if !device.GetLocalCache().FitQuota(pod.Namespace, memoryReq, memoryFactor, coresReq, deviceName) {
-			klog.Infof(template+" - Denying admission", pod.Namespace, pod.Name, pod.UID)
+		if !device.FitPodQuota(pod, deviceName, dev.MemoryFactor()) {
+			klog.Infof(template+" - Denying admission, device %s exceeds quota", pod.Namespace, pod.Name, pod.UID, deviceName)
 			return false
 		}
 	}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -272,6 +272,7 @@ func TestFitResourceQuota(t *testing.T) {
 		memName:  &device.Quota{Used: 1000, Limit: 2000},
 		coreName: &device.Quota{Used: 200, Limit: 400},
 	}
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
 
 	testCases := []struct {
 		name string
@@ -422,6 +423,80 @@ func TestFitResourceQuota(t *testing.T) {
 				t.Errorf("Expected %v, but got %v", tc.fit, result)
 			}
 		})
+	}
+}
+
+type quotaWebhookDevice struct {
+	names device.ResourceNames
+	word  string
+}
+
+func (d *quotaWebhookDevice) CommonWord() string  { return d.word }
+func (d *quotaWebhookDevice) MemoryFactor() int32 { return 1 }
+func (d *quotaWebhookDevice) MutateAdmission(*corev1.Container, *corev1.Pod) (bool, error) {
+	return false, nil
+}
+func (d *quotaWebhookDevice) CheckHealth(string, *corev1.Node) (bool, bool) { return true, true }
+func (d *quotaWebhookDevice) NodeCleanUp(string) error                      { return nil }
+func (d *quotaWebhookDevice) GetResourceNames() device.ResourceNames        { return d.names }
+func (d *quotaWebhookDevice) GetNodeDevices(corev1.Node) ([]*device.DeviceInfo, error) {
+	return nil, nil
+}
+func (d *quotaWebhookDevice) LockNode(*corev1.Node, *corev1.Pod) error        { return nil }
+func (d *quotaWebhookDevice) ReleaseNodeLock(*corev1.Node, *corev1.Pod) error { return nil }
+func (d *quotaWebhookDevice) GenerateResourceRequests(*corev1.Container) device.ContainerDeviceRequest {
+	return device.ContainerDeviceRequest{}
+}
+func (d *quotaWebhookDevice) PatchAnnotations(*corev1.Pod, *map[string]string, device.PodDevices) map[string]string {
+	return nil
+}
+func (d *quotaWebhookDevice) ScoreNode(*corev1.Node, device.PodSingleDevice, []*device.DeviceUsage, string) float32 {
+	return 0
+}
+func (d *quotaWebhookDevice) AddResourceUsage(*corev1.Pod, *device.DeviceUsage, *device.ContainerDevice) error {
+	return nil
+}
+func (d *quotaWebhookDevice) Fit([]*device.DeviceUsage, device.ContainerDeviceRequest, *corev1.Pod, *device.NodeInfo, *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
+	return false, nil, ""
+}
+
+func TestFitResourceQuotaNonNvidiaExceeded(t *testing.T) {
+	oldMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldMap })
+	t.Cleanup(func() { delete(device.GetLocalCache().Quotas, "default") })
+
+	deviceName := "Ascend910B"
+	memName := "huawei.com/Ascend910B-memory"
+	device.DevicesMap = map[string]device.Devices{
+		deviceName: &quotaWebhookDevice{
+			word: deviceName,
+			names: device.ResourceNames{
+				ResourceCountName:  "huawei.com/Ascend910B",
+				ResourceMemoryName: memName,
+				ResourceCoreName:   "huawei.com/Ascend910B-core",
+			},
+		},
+	}
+	qm := device.NewQuotaManager()
+	qm.Quotas["default"] = &device.DeviceQuota{
+		memName: &device.Quota{Used: 9000, Limit: 10000},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B":        resource.MustParse("1"),
+						"huawei.com/Ascend910B-memory": resource.MustParse("2000"),
+					},
+				},
+			}},
+		},
+	}
+	if fitResourceQuota(pod) {
+		t.Fatal("fitResourceQuota should deny non-NVIDIA pod exceeding memory quota")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

HAMi's `QuotaManager` tracks namespace memory and core usage in a device agnostic way, but quota enforcement was wired only for NVIDIA. The admission webhook skipped all non-NVIDIA devices, and only NVIDIA's `Fit()` path called `FitQuota()` during scheduling.

This PR adds shared quota helpers in `pkg/device/quota.go` and enforces namespace ResourceQuota for all registered device backends at admission time. It also adds pre-allocation quota checks in the scheduler `Fit()` path for Cambricon, Ascend, and Hygon, matching the existing NVIDIA behavior.

**Which issue(s) this PR fixes**:
Fixes #2157

**Special notes for your reviewer**:

- Shared helpers: `PodQuotaRequests`, `FitPodQuota`, `FitAllocationQuota`
- Webhook `fitResourceQuota()` now iterates all devices in `DevicesMap`
- NVIDIA `fitQuota()` refactored to use `FitAllocationQuota`
- Added quota checks in `Fit()` for Cambricon, Ascend, and Hygon
- New tests cover non-NVIDIA webhook denial and quota request calculation
- `make test` and `make verify` pass locally
- No GPU hardware required

**Does this PR introduce a user-facing change?**:

Yes. In multi-vendor clusters, pods requesting Cambricon, Ascend, Hygon, or other registered backends can now be denied at admission or scheduler Filter time when namespace ResourceQuota limits for vendor memory or core resources would be exceeded. Previously, only NVIDIA quota enforcement was active.

**AI assistance disclosure:**
I used AI assistance to understand the codebase and explore the quota enforcement flow. All code changes, tests, and verification were written and run by me. I reviewed and understand the full diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced namespace quota validation to account for pod memory and compute requests across supported device types.
  * Applied device-specific memory scaling when calculating quota consumption.
* **Bug Fixes**
  * Prevented allocations that exceed namespace quotas, including pending and already allocated resources.
  * Extended quota enforcement to non-NVIDIA device types.
* **Tests**
  * Added coverage for quota calculations, memory scaling, allocation rejection, and scheduler admission enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->