### PR TITLE
fix(awsneuron): handle init-container annotation indexes

### DIFF
--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -135,8 +135,12 @@ func (dev *AWSNeuronDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[st
 		value := ""
 		for ctridx, dp := range devlist {
 			if len(dp) > 0 {
+				ctr := getContainerByIndex(pod, ctridx)
+				if ctr == nil {
+					continue
+				}
 				for _, val := range dp {
-					devValue, ok := pod.Spec.Containers[ctridx].Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
+					devValue, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 					if ok {
 						c, _ := devValue.AsInt64()
 						if c > 0 {
@@ -167,6 +171,17 @@ func (dev *AWSNeuronDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[st
 	}
 	klog.V(4).InfoS("annos", "input", (*annoinput))
 	return *annoinput
+}
+
+func getContainerByIndex(pod *corev1.Pod, ctridx int) *corev1.Container {
+	if ctridx < len(pod.Spec.InitContainers) {
+		return &pod.Spec.InitContainers[ctridx]
+	}
+	ctridx -= len(pod.Spec.InitContainers)
+	if ctridx < len(pod.Spec.Containers) {
+		return &pod.Spec.Containers[ctridx]
+	}
+	return nil
 }
 
 func (dev *AWSNeuronDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -264,6 +264,55 @@ func Test_PatchAnnotations(t *testing.T) {
 				device.SupportDevices[AWSNeuronDevice]: "test1,AWSNeuron,0,3:;",
 				AWSNeuronAssignedIndex:                 "0,1",
 				AWSNeuronAssignedNode:                  "",
+				AWSNeuronResourceType:                  "aws.amazon.com/neuroncore",
+			},
+		},
+		{
+			name: "init container neuron device",
+			args: struct {
+				annoinput *map[string]string
+				pod       corev1.Pod
+				pd        device.PodDevices
+			}{
+				annoinput: &map[string]string{},
+				pod: corev1.Pod{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										"aws.amazon.com/neuron": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{},
+						},
+					},
+				},
+				pd: device.PodDevices{
+					AWSNeuronDevice: device.PodSingleDevice{
+						device.ContainerDevices{
+							{
+								Idx:       0,
+								UUID:      "test1",
+								Type:      AWSNeuronDevice,
+								Usedmem:   int32(0),
+								Usedcores: int32(3),
+								CustomInfo: map[string]any{
+									AWSUsageInfo: 3,
+								},
+							},
+						},
+						device.ContainerDevices{},
+					},
+				},
+			},
+			want: map[string]string{
+				device.SupportDevices[AWSNeuronDevice]: "test1,AWSNeuron,0,3:;",
+				AWSNeuronAssignedIndex:                 "0",
+				AWSNeuronAssignedNode:                  "",
 			},
 		},
 	}
@@ -279,6 +328,7 @@ func Test_PatchAnnotations(t *testing.T) {
 			assert.Equal(t, result[dev.CommonWord()], test.want[dev.CommonWord()])
 			assert.Equal(t, result[AWSNeuronAssignedIndex], test.want[AWSNeuronAssignedIndex])
 			assert.Equal(t, result[AWSNeuronAssignedNode], test.want[AWSNeuronAssignedNode])
+			assert.Equal(t, result[AWSNeuronResourceType], test.want[AWSNeuronResourceType])
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

AWS Neuron `PatchAnnotations()` reads container resources with `pod.Spec.Containers[ctridx]`.

HAMi stores allocated devices using a combined container index: init containers first, then regular containers. When an AWS Neuron allocation belongs to an init container, `ctridx` can point at the wrong regular container. In that case, a whole-device init-container request can be patched as neuron-core IDs instead of the assigned Neuron device index.

This PR resolves the combined index against init containers first, then regular containers.

A regression test covers an init container requesting `aws.amazon.com/neuron` while a regular container is also present.

**Which issue(s) this PR fixes**:

None filed.

**Special notes for your reviewer**:

Before fix:

```text
=== RUN   Test_PatchAnnotations/init_container_neuron_device
device_test.go:329: assertion failed: 0,1 (result[AWSNeuronAssignedIndex] string) != 0 (test.want[AWSNeuronAssignedIndex] string)
--- FAIL: Test_PatchAnnotations/init_container_neuron_device
```

After fix:

```text
=== RUN   Test_PatchAnnotations/init_container_neuron_device
--- PASS: Test_PatchAnnotations/init_container_neuron_device
```

Validation:

```text
ok   github.com/Project-HAMi/HAMi/pkg/device/awsneuron
ok   github.com/Project-HAMi/HAMi/pkg/device
```

AI assistance disclosure: I used an AI tool for codebase navigation and review support.

**Does this PR introduce a user-facing change?**:

No breaking change. AWS Neuron annotations now use the correct container resources for init-container allocations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS Neuron resource handling for workloads with init containers.
  * Prevented annotation failures when container indices are invalid or outside the available container list.

* **Tests**
  * Added coverage for AWS Neuron resources requested by init containers.
  * Expanded validation of returned resource assignments and types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->