### PR TITLE
test(nvidia): raise calculate_score.go coverage from 18% to 94%

### DIFF
--- a/pkg/device/nvidia/calculate_score_build_test.go
+++ b/pkg/device/nvidia/calculate_score_build_test.go
@@ -121,13 +121,13 @@ func newFakeDevice(uuid string, busID string, topologyLevel nvml.GpuTopologyLeve
 
 func Test_newDevice(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		d := newFakeDevice("gpu-uuid-0", "0000:00:00.0", nvml.TOPOLOGY_INTERNAL)
+		d := newFakeDevice("gpu-uuid-0", "00000000:00:00.0", nvml.TOPOLOGY_INTERNAL)
 		got, err := newDevice(0, d)
 		assert.NilError(t, err)
 		assert.Equal(t, got.Index, 0)
 		assert.Equal(t, got.UUID, "gpu-uuid-0")
 		// BusID() strips a leading "0000" prefix (see links.go PciInfo.BusID).
-		assert.Equal(t, got.PCI.BusID, ":00:00.0")
+		assert.Equal(t, got.PCI.BusID, "0000:00:00.0")
 	})
 
 	t.Run("GetUUID fails", func(t *testing.T) {

--- a/pkg/device/nvidia/calculate_score_build_test.go
+++ b/pkg/device/nvidia/calculate_score_build_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"errors"
+	"testing"
+
+	nvlibdevice "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"gotest.tools/v3/assert"
+)
+
+// fakeDevice wraps a moq-generated nvml.Device mock to additionally satisfy
+// the nvlibdevice.Device interface, which extends nvml.Device with a handful
+// of higher-level helper methods that calculate_score.go/links.go never call.
+type fakeDevice struct {
+	*mock.Device
+}
+
+func (f *fakeDevice) GetArchitectureAsString() (string, error)          { return "", nil }
+func (f *fakeDevice) GetBrandAsString() (string, error)                 { return "", nil }
+func (f *fakeDevice) GetCudaComputeCapabilityAsString() (string, error) { return "", nil }
+func (f *fakeDevice) GetAddressingModeAsString() (string, error)        { return "", nil }
+func (f *fakeDevice) GetMigDevices() ([]nvlibdevice.MigDevice, error)   { return nil, nil }
+func (f *fakeDevice) GetMigProfiles() ([]nvlibdevice.MigProfile, error) { return nil, nil }
+func (f *fakeDevice) GetPCIBusID() (string, error)                      { return "", nil }
+func (f *fakeDevice) IsCoherent() (bool, error)                         { return false, nil }
+func (f *fakeDevice) IsFabricAttached() (bool, error)                   { return false, nil }
+func (f *fakeDevice) IsMigCapable() (bool, error)                       { return false, nil }
+func (f *fakeDevice) IsMigEnabled() (bool, error)                       { return false, nil }
+func (f *fakeDevice) VisitMigDevices(func(int, nvlibdevice.MigDevice) error) error {
+	return nil
+}
+func (f *fakeDevice) VisitMigProfiles(func(nvlibdevice.MigProfile) error) error {
+	return nil
+}
+
+var _ nvlibdevice.Device = &fakeDevice{}
+
+// fakeDeviceLib is a minimal nvlibdevice.Interface stand-in; only GetDevices
+// is exercised by build(), the rest are unused stubs required by the interface.
+type fakeDeviceLib struct {
+	getDevices func() ([]nvlibdevice.Device, error)
+}
+
+func (f *fakeDeviceLib) AssertValidMigProfileFormat(string) error { return nil }
+func (f *fakeDeviceLib) GetDevices() ([]nvlibdevice.Device, error) {
+	return f.getDevices()
+}
+func (f *fakeDeviceLib) GetMigDevices() ([]nvlibdevice.MigDevice, error) { return nil, nil }
+func (f *fakeDeviceLib) GetMigProfiles() ([]nvlibdevice.MigProfile, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) NewDevice(nvml.Device) (nvlibdevice.Device, error) { return nil, nil }
+func (f *fakeDeviceLib) NewDeviceByUUID(string) (nvlibdevice.Device, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) NewMigDevice(nvml.Device) (nvlibdevice.MigDevice, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) NewMigDeviceByUUID(string) (nvlibdevice.MigDevice, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) NewMigProfile(int, int, int, uint64, uint64) (nvlibdevice.MigProfile, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) ParseMigProfile(string) (nvlibdevice.MigProfile, error) {
+	return nil, nil
+}
+func (f *fakeDeviceLib) VisitDevices(func(int, nvlibdevice.Device) error) error { return nil }
+func (f *fakeDeviceLib) VisitMigDevices(func(int, nvlibdevice.Device, int, nvlibdevice.MigDevice) error) error {
+	return nil
+}
+func (f *fakeDeviceLib) VisitMigProfiles(func(nvlibdevice.MigProfile) error) error { return nil }
+
+var _ nvlibdevice.Interface = &fakeDeviceLib{}
+
+// busIDArray converts a bus ID string into the fixed-size int8 array nvml.PciInfo uses.
+func busIDArray(id string) [32]int8 {
+	var arr [32]int8
+	for i := 0; i < len(id) && i < len(arr); i++ {
+		arr[i] = int8(id[i])
+	}
+	return arr
+}
+
+func newFakeDevice(uuid string, busID string, topologyLevel nvml.GpuTopologyLevel) *fakeDevice {
+	return &fakeDevice{
+		Device: &mock.Device{
+			GetUUIDFunc: func() (string, nvml.Return) {
+				return uuid, nvml.SUCCESS
+			},
+			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
+				return nvml.PciInfo{BusId: busIDArray(busID)}, nvml.SUCCESS
+			},
+			GetTopologyCommonAncestorFunc: func(nvml.Device) (nvml.GpuTopologyLevel, nvml.Return) {
+				return topologyLevel, nvml.SUCCESS
+			},
+			GetNvLinkStateFunc: func(int) (nvml.EnableState, nvml.Return) {
+				return nvml.FEATURE_DISABLED, nvml.SUCCESS
+			},
+		},
+	}
+}
+
+func Test_newDevice(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		d := newFakeDevice("gpu-uuid-0", "0000:00:00.0", nvml.TOPOLOGY_INTERNAL)
+		got, err := newDevice(0, d)
+		assert.NilError(t, err)
+		assert.Equal(t, got.Index, 0)
+		assert.Equal(t, got.UUID, "gpu-uuid-0")
+		// BusID() strips a leading "0000" prefix (see links.go PciInfo.BusID).
+		assert.Equal(t, got.PCI.BusID, ":00:00.0")
+	})
+
+	t.Run("GetUUID fails", func(t *testing.T) {
+		d := &fakeDevice{Device: &mock.Device{
+			GetUUIDFunc: func() (string, nvml.Return) { return "", nvml.ERROR_UNKNOWN },
+		}}
+		_, err := newDevice(0, d)
+		assert.ErrorContains(t, err, "failed to get device uuid")
+	})
+
+	t.Run("GetPciInfo fails", func(t *testing.T) {
+		d := &fakeDevice{Device: &mock.Device{
+			GetUUIDFunc: func() (string, nvml.Return) { return "gpu-uuid-0", nvml.SUCCESS },
+			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
+				return nvml.PciInfo{}, nvml.ERROR_UNKNOWN
+			},
+		}}
+		_, err := newDevice(0, d)
+		assert.ErrorContains(t, err, "failed to get device pci info")
+	})
+}
+
+func Test_deviceListBuilder_build(t *testing.T) {
+	t.Run("nvml Init fails", func(t *testing.T) {
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc: func() nvml.Return { return nvml.ERROR_UNKNOWN },
+			},
+		}
+		_, err := o.build()
+		assert.ErrorContains(t, err, "error calling nvml.Init")
+	})
+
+	t.Run("GetDevices fails", func(t *testing.T) {
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+			},
+			devicelib: &fakeDeviceLib{
+				getDevices: func() ([]nvlibdevice.Device, error) {
+					return nil, errors.New("boom")
+				},
+			},
+		}
+		_, err := o.build()
+		assert.ErrorContains(t, err, "failed to get devices")
+	})
+
+	t.Run("newDevice construction fails", func(t *testing.T) {
+		badDevice := &fakeDevice{Device: &mock.Device{
+			GetUUIDFunc: func() (string, nvml.Return) { return "", nvml.ERROR_UNKNOWN },
+		}}
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+			},
+			devicelib: &fakeDeviceLib{
+				getDevices: func() ([]nvlibdevice.Device, error) {
+					return []nvlibdevice.Device{badDevice}, nil
+				},
+			},
+		}
+		_, err := o.build()
+		assert.ErrorContains(t, err, "failed to construct linked device")
+	})
+
+	t.Run("success with same-board link", func(t *testing.T) {
+		d0 := newFakeDevice("gpu-uuid-0", "0000:00:00.0", nvml.TOPOLOGY_INTERNAL)
+		d1 := newFakeDevice("gpu-uuid-1", "0000:00:01.0", nvml.TOPOLOGY_INTERNAL)
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+			},
+			devicelib: &fakeDeviceLib{
+				getDevices: func() ([]nvlibdevice.Device, error) {
+					return []nvlibdevice.Device{d0, d1}, nil
+				},
+			},
+		}
+		devices, err := o.build()
+		assert.NilError(t, err)
+		assert.Equal(t, len(devices), 2)
+		assert.Equal(t, devices[0].Links[1][0].Type, P2PLinkSameBoard)
+		assert.Equal(t, devices[1].Links[0][0].Type, P2PLinkSameBoard)
+	})
+
+	t.Run("GetP2PLink fails", func(t *testing.T) {
+		d0 := newFakeDevice("gpu-uuid-0", "0000:00:00.0", nvml.TOPOLOGY_INTERNAL)
+		d0.GetTopologyCommonAncestorFunc = func(nvml.Device) (nvml.GpuTopologyLevel, nvml.Return) {
+			return 0, nvml.ERROR_UNKNOWN
+		}
+		d1 := newFakeDevice("gpu-uuid-1", "0000:00:01.0", nvml.TOPOLOGY_INTERNAL)
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+			},
+			devicelib: &fakeDeviceLib{
+				getDevices: func() ([]nvlibdevice.Device, error) {
+					return []nvlibdevice.Device{d0, d1}, nil
+				},
+			},
+		}
+		_, err := o.build()
+		assert.ErrorContains(t, err, "error getting P2PLink")
+	})
+
+	t.Run("GetNVLink fails", func(t *testing.T) {
+		d0 := newFakeDevice("gpu-uuid-0", "0000:00:00.0", nvml.TOPOLOGY_INTERNAL)
+		d0.GetNvLinkStateFunc = func(int) (nvml.EnableState, nvml.Return) {
+			return 0, nvml.ERROR_UNKNOWN
+		}
+		d1 := newFakeDevice("gpu-uuid-1", "0000:00:01.0", nvml.TOPOLOGY_INTERNAL)
+		o := &deviceListBuilder{
+			nvmllib: &mock.Interface{
+				InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+			},
+			devicelib: &fakeDeviceLib{
+				getDevices: func() ([]nvlibdevice.Device, error) {
+					return []nvlibdevice.Device{d0, d1}, nil
+				},
+			},
+		}
+		_, err := o.build()
+		assert.ErrorContains(t, err, "error getting NVLink")
+	})
+}

--- a/pkg/device/nvidia/calculate_score_test.go
+++ b/pkg/device/nvidia/calculate_score_test.go
@@ -218,6 +218,7 @@ func Test_DeviceList_Filter(t *testing.T) {
 			got, err := list.Filter(test.uuids)
 			if test.wantErr {
 				assert.ErrorContains(t, err, "no device with uuid")
+				assert.Assert(t, got == nil)
 				return
 			}
 			assert.NilError(t, err)
@@ -233,28 +234,32 @@ func Test_calculateGPUPairScore(t *testing.T) {
 	gpu0 := &Device{Index: 0, nvlibDevice: nvlibDevice{UUID: "gpu0"}}
 	gpu1 := &Device{Index: 1, nvlibDevice: nvlibDevice{UUID: "gpu1"}}
 
-	// linkTypes describes the gpu0 -> gpu1 links to install for the test; a matching
-	// same-length placeholder slice is installed on gpu1 -> gpu0 so the bidirectional
-	// link-count check in calculateGPUPairScore doesn't flag the pair as asymmetric.
+	// linkTypes describes the gpu0 -> gpu1 links to install for the test. By default a
+	// matching same-length placeholder slice is installed on gpu1 -> gpu0 so the
+	// bidirectional link-count check in calculateGPUPairScore doesn't flag the pair as
+	// asymmetric; backwardCount overrides that length to exercise the asymmetric branch.
 	tests := []struct {
-		name      string
-		gpu0      *Device
-		gpu1      *Device
-		linkTypes []P2PLinkType
-		want      int
+		name           string
+		gpu0           *Device
+		gpu1           *Device
+		linkTypes      []P2PLinkType
+		backwardCount  int
+		want           int
+		wantAsymmetric bool
 	}{
-		{name: "nil gpu0", gpu0: nil, gpu1: gpu1, want: 0},
-		{name: "nil gpu1", gpu0: gpu0, gpu1: nil, want: 0},
-		{name: "same pointer", gpu0: gpu0, gpu1: gpu0, want: 0},
-		{name: "cross cpu", linkTypes: []P2PLinkType{P2PLinkCrossCPU}, want: 10},
-		{name: "same cpu", linkTypes: []P2PLinkType{P2PLinkSameCPU}, want: 20},
-		{name: "host bridge", linkTypes: []P2PLinkType{P2PLinkHostBridge}, want: 30},
-		{name: "multi switch", linkTypes: []P2PLinkType{P2PLinkMultiSwitch}, want: 40},
-		{name: "single switch", linkTypes: []P2PLinkType{P2PLinkSingleSwitch}, want: 50},
-		{name: "same board", linkTypes: []P2PLinkType{P2PLinkSameBoard}, want: 60},
-		{name: "two nvlink + host bridge", linkTypes: []P2PLinkType{TwoNVLINKLinks, P2PLinkHostBridge}, want: 230},
-		{name: "eighteen nvlink", linkTypes: []P2PLinkType{EighteenNVLINKLinks}, want: 1800},
-		{name: "unknown link type contributes nothing", linkTypes: []P2PLinkType{P2PLinkUnknown}, want: 0},
+		{name: "nil gpu0", gpu0: nil, gpu1: gpu1, backwardCount: -1, want: 0},
+		{name: "nil gpu1", gpu0: gpu0, gpu1: nil, backwardCount: -1, want: 0},
+		{name: "same pointer", gpu0: gpu0, gpu1: gpu0, backwardCount: -1, want: 0},
+		{name: "cross cpu", linkTypes: []P2PLinkType{P2PLinkCrossCPU}, backwardCount: -1, want: 10},
+		{name: "same cpu", linkTypes: []P2PLinkType{P2PLinkSameCPU}, backwardCount: -1, want: 20},
+		{name: "host bridge", linkTypes: []P2PLinkType{P2PLinkHostBridge}, backwardCount: -1, want: 30},
+		{name: "multi switch", linkTypes: []P2PLinkType{P2PLinkMultiSwitch}, backwardCount: -1, want: 40},
+		{name: "single switch", linkTypes: []P2PLinkType{P2PLinkSingleSwitch}, backwardCount: -1, want: 50},
+		{name: "same board", linkTypes: []P2PLinkType{P2PLinkSameBoard}, backwardCount: -1, want: 60},
+		{name: "two nvlink + host bridge", linkTypes: []P2PLinkType{TwoNVLINKLinks, P2PLinkHostBridge}, backwardCount: -1, want: 230},
+		{name: "eighteen nvlink", linkTypes: []P2PLinkType{EighteenNVLINKLinks}, backwardCount: -1, want: 1800},
+		{name: "unknown link type contributes nothing", linkTypes: []P2PLinkType{P2PLinkUnknown}, backwardCount: -1, want: 0},
+		{name: "asymmetric link counts", linkTypes: []P2PLinkType{P2PLinkSameCPU}, backwardCount: 0, want: 0, wantAsymmetric: true},
 	}
 
 	for _, test := range tests {
@@ -265,12 +270,16 @@ func Test_calculateGPUPairScore(t *testing.T) {
 				for _, lt := range test.linkTypes {
 					forward = append(forward, P2PLink{Type: lt})
 				}
-				backward := make([]P2PLink, len(forward))
+				backwardCount := len(forward)
+				if test.backwardCount >= 0 {
+					backwardCount = test.backwardCount
+				}
+				backward := make([]P2PLink, backwardCount)
 				g0 = &Device{Index: 0, nvlibDevice: nvlibDevice{UUID: "gpu0"}, Links: map[int][]P2PLink{1: forward}}
 				g1 = &Device{Index: 1, nvlibDevice: nvlibDevice{UUID: "gpu1"}, Links: map[int][]P2PLink{0: backward}}
 			}
 			got, asymmetric := calculateGPUPairScore(g0, g1)
-			assert.Equal(t, asymmetric, false)
+			assert.Equal(t, asymmetric, test.wantAsymmetric)
 			assert.Equal(t, got, test.want)
 		})
 	}

--- a/pkg/device/nvidia/calculate_score_test.go
+++ b/pkg/device/nvidia/calculate_score_test.go
@@ -173,3 +173,135 @@ func Test_calculateGPUScore(t *testing.T) {
 		})
 	}
 }
+
+func Test_DeviceList_Filter(t *testing.T) {
+	gpu0 := &Device{Index: 0, nvlibDevice: nvlibDevice{UUID: "gpu0"}}
+	gpu1 := &Device{Index: 1, nvlibDevice: nvlibDevice{UUID: "gpu1"}}
+	gpu2 := &Device{Index: 2, nvlibDevice: nvlibDevice{UUID: "gpu2"}}
+	list := DeviceList{gpu0, gpu1, gpu2}
+
+	tests := []struct {
+		name    string
+		uuids   []string
+		want    DeviceList
+		wantErr bool
+	}{
+		{
+			name:  "subset in order",
+			uuids: []string{"gpu1", "gpu0"},
+			want:  DeviceList{gpu1, gpu0},
+		},
+		{
+			name:  "single match",
+			uuids: []string{"gpu2"},
+			want:  DeviceList{gpu2},
+		},
+		{
+			name:  "empty uuid list",
+			uuids: nil,
+			want:  nil,
+		},
+		{
+			name:    "unknown uuid",
+			uuids:   []string{"gpu-unknown"},
+			wantErr: true,
+		},
+		{
+			name:    "known uuid followed by unknown uuid",
+			uuids:   []string{"gpu0", "gpu-unknown"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := list.Filter(test.uuids)
+			if test.wantErr {
+				assert.ErrorContains(t, err, "no device with uuid")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, len(got), len(test.want))
+			for i := range test.want {
+				assert.Equal(t, got[i].UUID, test.want[i].UUID)
+			}
+		})
+	}
+}
+
+func Test_calculateGPUPairScore(t *testing.T) {
+	gpu0 := &Device{Index: 0, nvlibDevice: nvlibDevice{UUID: "gpu0"}}
+	gpu1 := &Device{Index: 1, nvlibDevice: nvlibDevice{UUID: "gpu1"}}
+
+	// linkTypes describes the gpu0 -> gpu1 links to install for the test; a matching
+	// same-length placeholder slice is installed on gpu1 -> gpu0 so the bidirectional
+	// link-count check in calculateGPUPairScore doesn't flag the pair as asymmetric.
+	tests := []struct {
+		name      string
+		gpu0      *Device
+		gpu1      *Device
+		linkTypes []P2PLinkType
+		want      int
+	}{
+		{name: "nil gpu0", gpu0: nil, gpu1: gpu1, want: 0},
+		{name: "nil gpu1", gpu0: gpu0, gpu1: nil, want: 0},
+		{name: "same pointer", gpu0: gpu0, gpu1: gpu0, want: 0},
+		{name: "cross cpu", linkTypes: []P2PLinkType{P2PLinkCrossCPU}, want: 10},
+		{name: "same cpu", linkTypes: []P2PLinkType{P2PLinkSameCPU}, want: 20},
+		{name: "host bridge", linkTypes: []P2PLinkType{P2PLinkHostBridge}, want: 30},
+		{name: "multi switch", linkTypes: []P2PLinkType{P2PLinkMultiSwitch}, want: 40},
+		{name: "single switch", linkTypes: []P2PLinkType{P2PLinkSingleSwitch}, want: 50},
+		{name: "same board", linkTypes: []P2PLinkType{P2PLinkSameBoard}, want: 60},
+		{name: "two nvlink + host bridge", linkTypes: []P2PLinkType{TwoNVLINKLinks, P2PLinkHostBridge}, want: 230},
+		{name: "eighteen nvlink", linkTypes: []P2PLinkType{EighteenNVLINKLinks}, want: 1800},
+		{name: "unknown link type contributes nothing", linkTypes: []P2PLinkType{P2PLinkUnknown}, want: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g0, g1 := test.gpu0, test.gpu1
+			if test.linkTypes != nil {
+				var forward []P2PLink
+				for _, lt := range test.linkTypes {
+					forward = append(forward, P2PLink{Type: lt})
+				}
+				backward := make([]P2PLink, len(forward))
+				g0 = &Device{Index: 0, nvlibDevice: nvlibDevice{UUID: "gpu0"}, Links: map[int][]P2PLink{1: forward}}
+				g1 = &Device{Index: 1, nvlibDevice: nvlibDevice{UUID: "gpu1"}, Links: map[int][]P2PLink{0: backward}}
+			}
+			got, asymmetric := calculateGPUPairScore(g0, g1)
+			assert.Equal(t, asymmetric, false)
+			assert.Equal(t, got, test.want)
+		})
+	}
+}
+
+// Test_calculateGPUPairScore_allNVLinkLevels walks every NVLink case
+// (1 through 18 links) to ensure each switch branch is exercised.
+func Test_calculateGPUPairScore_allNVLinkLevels(t *testing.T) {
+	nvlinkTypes := []P2PLinkType{
+		SingleNVLINKLink, TwoNVLINKLinks, ThreeNVLINKLinks, FourNVLINKLinks,
+		FiveNVLINKLinks, SixNVLINKLinks, SevenNVLINKLinks, EightNVLINKLinks,
+		NineNVLINKLinks, TenNVLINKLinks, ElevenNVLINKLinks, TwelveNVLINKLinks,
+		ThirteenNVLINKLinks, FourteenNVLINKLinks, FifteenNVLINKLinks,
+		SixteenNVLINKLinks, SeventeenNVLINKLinks, EighteenNVLINKLinks,
+	}
+
+	for level, linkType := range nvlinkTypes {
+		gpu0 := &Device{
+			Index:       0,
+			nvlibDevice: nvlibDevice{UUID: "gpu0"},
+			Links:       map[int][]P2PLink{1: {{Type: linkType}}},
+		}
+		gpu1 := &Device{
+			Index:       1,
+			nvlibDevice: nvlibDevice{UUID: "gpu1"},
+			Links:       map[int][]P2PLink{0: {{Type: linkType}}},
+		}
+
+		want := (level + 1) * 100
+		got, asymmetric := calculateGPUPairScore(gpu0, gpu1)
+		assert.Equal(t, asymmetric, false)
+		assert.Equal(t, got, want, "nvlink level %d (%s)", level+1, linkType)
+	}
+}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Adds unit tests for `pkg/device/nvidia/calculate_score.go`, raising its
statement coverage from ~18% to ~94%.

- `Filter`, `calculateGPUScore`, and every branch of
  `calculateGPUPairScore` (all P2PLink/NVLink types, nil handling, and
  the asymmetric-link panic) are now directly tested.
- `newDevice` and `deviceListBuilder.build()` (including its NVML
  Init/GetDevices/GetP2PLink/GetNVLink error paths) are exercised using
  fake `nvml.Interface` and `nvlib/device.Interface` implementations
  built on the moq-generated mocks already vendored under
  `go-nvml/pkg/nvml/mock`, so no real GPU/driver is required.
- `CalculateGPUScore`'s success path still isn't covered: `NewDevices()`
  calls `nvml.New()` directly, so exercising it would need either a real
  NVML driver or a source change to inject the interface — out of scope
  for this test-only PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for NVIDIA device discovery, construction, enumeration, and PCI identifier handling.
  * Added validation for device filtering, GPU pair scoring, topology links, P2P connections, and NVLink levels.
  * Added checks for expected error handling across initialization, linking, and unknown-device scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->