### PR TITLE
ci: scope reusable workflow permissions, pin build.sh images, stop persisting checkout credentials, bump mig-parted

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ env.RUN_TAG }}
+          persist-credentials: false
         # if branch exists, the action will no fail, and it output created=false
       - name: release Y branch
         uses: peterjgrainger/action-create-branch@4b81ce657e255acd677cc6c55c9c763654be3aef # v4.0.0

--- a/.github/workflows/call-e2e-upgrade.yaml
+++ b/.github/workflows/call-e2e-upgrade.yaml
@@ -6,7 +6,8 @@ on:
       ref:
         required: true
         type: string
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   upgrade-e2e:

--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Acquire shared e2e runner lock
         run: bash hack/e2e-runner-lock.sh acquire

--- a/.github/workflows/call-release-helm.yaml
+++ b/.github/workflows/call-release-helm.yaml
@@ -28,7 +28,9 @@ on:
         required: true
         default: v1.0.0
 
-permissions: write-all
+# the github_pages push uses API_TOKEN_GITHUB, not GITHUB_TOKEN
+permissions:
+  contents: read
 
 jobs:
   get_ref:

--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -21,7 +21,11 @@ on:
       tagoverride:
         required: false
         type: string
-permissions: write-all
+# id-token is needed for keyless cosign signing
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   docker-build:

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -21,7 +21,11 @@ on:
       tagoverride:
         required: false
         type: string
-permissions: write-all
+# id-token is needed for keyless cosign signing
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   docker-build:

--- a/.github/workflows/call-release-notes.yaml
+++ b/.github/workflows/call-release-notes.yaml
@@ -32,6 +32,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: master
+        persist-credentials: false
 
     - name: Create release notes markdown
       run: |

--- a/.github/workflows/call-release-notes.yaml
+++ b/.github/workflows/call-release-notes.yaml
@@ -8,7 +8,9 @@ on:
         required: true
         type: string
 
-permissions: write-all
+# updates the github release page
+permissions:
+  contents: write
 
 jobs:
   generate-release-notes:

--- a/.github/workflows/call-release-website.yaml
+++ b/.github/workflows/call-release-website.yaml
@@ -6,7 +6,8 @@ on:
       ref:
         required: true
         type: string
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   build-website:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Checkout submodule
         uses: Mushus/checkout-submodule@f6a7fddc9798c8f8728b252594243ced3b56e550 # v1.0.1
         with:

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5

--- a/benchmarks/ai-benchmark/Dockerfile.client
+++ b/benchmarks/ai-benchmark/Dockerfile.client
@@ -1,8 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
-    && pip install requests==2.34.2
-
 COPY benchmark.py /benchmark.py
 
 RUN cat > /run_client.sh <<'SCRIPT' && chmod +x /run_client.sh
@@ -11,7 +8,7 @@ set -e
 echo "Waiting for vLLM to be ready..."
 MAX_RETRIES=30
 COUNT=0
-while ! curl -s http://127.0.0.1:8000/v1/models > /dev/null 2>&1; do
+while ! python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/v1/models', timeout=2)" 2>/dev/null; do
   if [ $COUNT -ge $MAX_RETRIES ]; then
     echo "Timeout waiting for vLLM"
     exit 1

--- a/benchmarks/ai-benchmark/benchmark.py
+++ b/benchmarks/ai-benchmark/benchmark.py
@@ -2,24 +2,26 @@ import time
 import json
 import uuid
 import argparse
-import requests
+import urllib.request
 from datetime import datetime
 
 def now():
     return time.time()
 
-def send_request(url, model, prompt, stream):
+def send_request(url, model, prompt, stream, timeout):
     t0 = now()
-    r = requests.post(
-        url,
-        json={
-            "model": model,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": stream,
-        },
-        stream=stream,
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": stream,
+    }).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
     )
-    r.raise_for_status()
+    # urlopen raises HTTPError on a non-2xx status and does not read the body
+    # up front, so lines arrive as the server sends them. The timeout applies
+    # per read, so it bounds the gap between tokens rather than the whole run.
+    r = urllib.request.urlopen(req, timeout=timeout)
     if not stream:
         raise RuntimeError("Use stream=True for token timestamps")
 
@@ -27,7 +29,8 @@ def send_request(url, model, prompt, stream):
     token_times = []
     usage = None
 
-    for line in r.iter_lines():
+    for raw in r:
+        line = raw.strip()
         if not line:
             continue
         if not line.startswith(b"data: "):
@@ -70,6 +73,8 @@ def main():
                         help="Number of warmup requests (default: 30)")
     parser.add_argument("--runs", type=int, default=200,
                         help="Number of benchmark requests (default: 200)")
+    parser.add_argument("--timeout", type=float, default=60.0,
+                        help="Seconds to wait for the next chunk before giving up (default: 60)")
     parser.add_argument("--output", default=None,
                         help="Output file path (default: auto-generated)")
     args = parser.parse_args()
@@ -85,14 +90,14 @@ def main():
 
     print("warmup...")
     for i in range(args.warmup):
-        send_request(args.vllm_url, args.model, args.prompt, stream=True)
+        send_request(args.vllm_url, args.model, args.prompt, stream=True, timeout=args.timeout)
         if (i + 1) % 10 == 0:
             print(f"  {i + 1}/{args.warmup}")
 
     print("running...")
     with open(fname, "w") as f:
         for i in range(args.runs):
-            data = send_request(args.vllm_url, args.model, args.prompt, stream=True)
+            data = send_request(args.vllm_url, args.model, args.prompt, stream=True, timeout=args.timeout)
             f.write(json.dumps(data) + "\n")
             if (i + 1) % 10 == 0:
                 print(f"  {i + 1}/{args.runs}")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ADD . /k8s-vgpu
 #RUN --mount=type=cache,target=/go/pkg/mod \
 #    cd /k8s-vgpu && make all
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.14.4
 
 FROM $NVIDIA_IMAGE AS nvbuild
 RUN dnf install -y cmake git && dnf clean all

--- a/docker/Dockerfile.hamimaster
+++ b/docker/Dockerfile.hamimaster
@@ -8,7 +8,7 @@ ADD . /k8s-vgpu
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.14.4
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04@sha256:e08868e73d2045f1cbe0c39222441d670f8245d6d98e0434bcc9453c7cdb6a31
 RUN apt-get update && \

--- a/docker/Dockerfile.withlib
+++ b/docker/Dockerfile.withlib
@@ -8,7 +8,7 @@ ARG GOPROXY=https://goproxy.cn,direct
 ARG VERSION
 RUN go env -w GO111MODULE=on
 RUN cd /k8s-vgpu && make all VERSION=$VERSION
-RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.12.2
+RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@v0.14.4
 
 FROM nvidia/cuda:13.3.0-base-ubuntu22.04@sha256:e08868e73d2045f1cbe0c39222441d670f8245d6d98e0434bcc9453c7cdb6a31
 RUN apt-get update && \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -22,8 +22,14 @@ export SHORT_VERSION
 export COMMIT_CODE
 export VERSION="${SHORT_VERSION}-${COMMIT_CODE}"
 export LATEST_VERSION="latest"
-export GOLANG_IMAGE="golang:1.26.5-bookworm"
-export NVIDIA_IMAGE="nvidia/cuda:13.3.0-cudnn-devel-ubi8"
+# Read the digest-pinned values from version.mk so this stays the single
+# source of truth; hardcoding the tags here silently dropped the pinning.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GOLANG_IMAGE=$(sed -n 's/^GOLANG_IMAGE=//p' "${REPO_ROOT}/version.mk")
+NVIDIA_IMAGE=$(sed -n 's/^NVIDIA_IMAGE=//p' "${REPO_ROOT}/version.mk")
+[[ -z ${GOLANG_IMAGE} || -z ${NVIDIA_IMAGE} ]] && echo "failed to read image pins from version.mk" && exit 1
+export GOLANG_IMAGE
+export NVIDIA_IMAGE
 export DEST_DIR="/usr/local"
 
 IMAGE=${IMAGE-"projecthami/hami"}


### PR DESCRIPTION
/kind cleanup
Closes four gaps in the build/CI path: five read-only workflows no longer persist the job token via `actions/checkout`, the six reusable workflows called by `auto-release.yaml` now declare the scope their caller already grants instead of `write-all`, `hack/build.sh` reads its base images from the digest-pinned values in `version.mk` instead of keeping a second unpinned copy, and `nvidia-mig-parted` moves from v0.12.2 to v0.14.4 to drop the `golang.org/x/sys` CVE it pulled in. The benchmark client image also drops `requests` and `curl`, which removes the unpinned `pip install` and covers both call sites with `urllib.request`.
The reusable-workflow scopes were copied from the existing per-job `permissions` blocks in `auto-release.yaml`, its only caller, so the effective token is unchanged. HAMi only shells out to mig-parted `export` and `apply -f`, and neither subcommand nor the config schema changed across 0.13 and 0.14.
