### PR TITLE
fix: leader election false positive when hostname is prefix

### DIFF
--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -163,10 +163,13 @@ func (m *leaderManager) onDelete(obj any) {
 
 func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
 	// kube-scheduler lease id take format of `hostname + "_" + string(uuid.NewUUID())`
+	// We split on "_" and compare only the first segment to avoid false positives
+	// when one hostname is a prefix of another (e.g. "dev" vs "dev-server").
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
+	parts := strings.SplitN(*lease.Spec.HolderIdentity, "_", 2)
+	return parts[0] == m.hostname
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -462,6 +462,43 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 	})
 })
 
+var _ = ginkgo.Describe("isHolderOf hostname segment matching", func() {
+	// Helper: build a lease whose HolderIdentity is set to the given raw string.
+	makeLeaseWithIdentity := func(identity string) *coordinationv1.Lease {
+		return &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hami-scheduler",
+				Namespace: "kube-system",
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: &identity,
+			},
+		}
+	}
+
+	ginkgo.DescribeTable("exact hostname segment comparison",
+		func(hostname, holderIdentity string, expected bool) {
+			lm := NewLeaderManager(hostname, "kube-system", "hami-scheduler", LeaderCallbacks{})
+			lease := makeLeaseWithIdentity(holderIdentity)
+			result := lm.isHolderOf(lease)
+			g.Expect(result).Should(g.Equal(expected),
+				"hostname=%q holderIdentity=%q", hostname, holderIdentity)
+		},
+		// true cases: the first segment before "_" matches the hostname exactly
+		ginkgo.Entry("dev matches dev_<uuid>", "dev", "dev_550e8400-e29b-41d4-a716-446655440000", true),
+		ginkgo.Entry("worker matches worker_<uuid>", "worker", "worker_550e8400-e29b-41d4-a716-446655440000", true),
+
+		// false cases: hostname is a prefix of the holder's hostname segment but not equal
+		ginkgo.Entry("dev does not match dev-server_<uuid>", "dev", "dev-server_550e8400-e29b-41d4-a716-446655440000", false),
+		ginkgo.Entry("worker does not match worker2_<uuid>", "worker", "worker2_550e8400-e29b-41d4-a716-446655440000", false),
+
+		// additional edge cases
+		ginkgo.Entry("empty hostname does not match non-empty segment", "", "dev_550e8400-e29b-41d4-a716-446655440000", false),
+		ginkgo.Entry("identity with no underscore treated as hostname only, matches when equal", "dev", "dev", true),
+		ginkgo.Entry("identity with no underscore does not match different hostname", "dev", "dev-server", false),
+	)
+})
+
 var _ = ginkgo.Describe("DummyLeaderManager", func() {
 	var lm LeaderManager
 	var elected bool


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes false positives in leader election hostname matching.
Previously, isHolderOf used strings.HasPrefix to check if the lease holder identity matched the local hostname. This caused nodes with shorter hostnames (e.g. dev) to incorrectly match longer hostnames (e.g. dev-server_<uuid>).
The fix uses strings.SplitN(holder, "_", 2) and compares only the first segment to the hostname, ensuring exact matches only.

**Which issue(s) this PR fixes**:
Fixes #2154

**Special notes for your reviewer**:
Added unit tests using Ginkgo v2 DescribeTable to cover edge cases (dev vs dev-server, worker vs worker2, empty hostname, no underscore cases).

Verified locally with go test ./pkg/util/leaderelection/... -v.

**Does this PR introduce a user-facing change?**:
Leader election now correctly validates lease holder identity by requiring exact hostname match before the "_" separator. This prevents false positives when hostnames are prefixes of one another, improving scheduler reliability in clusters with similar node names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader election identity matching by comparing only the first hostname segment, avoiding incorrect matches when one hostname is a prefix of another.
  * Added safeguards so leader-holder determination returns false when lease or holder identity information is missing or incomplete.
* **Tests**
  * Added coverage for hostname-segment matching behavior, including edge cases for empty values and missing underscore delimiters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->