### PR TITLE
fix(monitor): use atomic load/store for shared memory access

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v0
 
-import "unsafe"
+import (
+	"sync/atomic"
+	"unsafe"
+)
 
 const maxDevices = 16
 
@@ -130,10 +133,9 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
-		s.sr.smLimit[idx] = l
-		idx += 1
+	n := s.sr.num
+	for idx := uint64(0); idx < n; idx++ {
+		atomic.StoreUint64(&s.sr.smLimit[idx], l)
 	}
 }
 
@@ -146,14 +148,13 @@ func (s Spec) DeviceUUID(idx int) string {
 }
 
 func (s Spec) DeviceMemoryLimit(idx int) uint64 {
-	return s.sr.limit[idx]
+	return atomic.LoadUint64(&s.sr.limit[idx])
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
-		s.sr.limit[idx] = l
-		idx += 1
+	n := s.sr.num
+	for idx := uint64(0); idx < n; idx++ {
+		atomic.StoreUint64(&s.sr.limit[idx], l)
 	}
 }
 
@@ -176,17 +177,17 @@ func (s Spec) GetPriority() int {
 }
 
 func (s Spec) GetRecentKernel() int32 {
-	return s.sr.recentKernel
+	return atomic.LoadInt32(&s.sr.recentKernel)
 }
 
 func (s Spec) SetRecentKernel(v int32) {
-	s.sr.recentKernel = v
+	atomic.StoreInt32(&s.sr.recentKernel, v)
 }
 
 func (s Spec) GetUtilizationSwitch() int32 {
-	return s.sr.utilizationSwitch
+	return atomic.LoadInt32(&s.sr.utilizationSwitch)
 }
 
 func (s Spec) SetUtilizationSwitch(v int32) {
-	s.sr.utilizationSwitch = v
+	atomic.StoreInt32(&s.sr.utilizationSwitch, v)
 }

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -18,7 +18,9 @@ package v0
 
 import (
 	"reflect"
+	"sync"
 	"testing"
+	"unsafe"
 )
 
 type specTest struct {
@@ -566,4 +568,37 @@ func TestSpec_LastKernelTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSpec_ConcurrentAtomicAccess(t *testing.T) {
+	data := make([]byte, unsafe.Sizeof(sharedRegionT{}))
+	sr := (*sharedRegionT)(unsafe.Pointer(&data[0]))
+	sr.num = 4
+
+	s := Spec{sr: sr}
+
+	var wg sync.WaitGroup
+	goroutines := 50
+	iterations := 200
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				val := uint64(id*iterations + j)
+				s.SetDeviceMemoryLimit(val)
+				s.SetDeviceSmLimit(val)
+				s.SetRecentKernel(int32(j))
+				s.SetUtilizationSwitch(int32(j))
+
+				_ = s.DeviceMemoryLimit(0)
+				_ = s.DeviceMemoryLimit(1)
+				_ = s.GetRecentKernel()
+				_ = s.GetUtilizationSwitch()
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1
 
-import "unsafe"
+import (
+	"sync/atomic"
+	"unsafe"
+)
 
 const maxDevices = 16
 
@@ -137,10 +140,9 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
-		s.sr.smLimit[idx] = l
-		idx += 1
+	n := s.sr.num
+	for idx := uint64(0); idx < n; idx++ {
+		atomic.StoreUint64(&s.sr.smLimit[idx], l)
 	}
 }
 
@@ -153,19 +155,18 @@ func (s Spec) DeviceUUID(idx int) string {
 }
 
 func (s Spec) DeviceMemoryLimit(idx int) uint64 {
-	return s.sr.limit[idx]
+	return atomic.LoadUint64(&s.sr.limit[idx])
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
-		s.sr.limit[idx] = l
-		idx += 1
+	n := s.sr.num
+	for idx := uint64(0); idx < n; idx++ {
+		atomic.StoreUint64(&s.sr.limit[idx], l)
 	}
 }
 
 func (s Spec) LastKernelTime() int64 {
-	return s.sr.lastKernelTime
+	return atomic.LoadInt64(&s.sr.lastKernelTime)
 }
 
 func CastSpec(data []byte) Spec {
@@ -183,17 +184,17 @@ func (s Spec) GetPriority() int {
 }
 
 func (s Spec) GetRecentKernel() int32 {
-	return s.sr.recentKernel
+	return atomic.LoadInt32(&s.sr.recentKernel)
 }
 
 func (s Spec) SetRecentKernel(v int32) {
-	s.sr.recentKernel = v
+	atomic.StoreInt32(&s.sr.recentKernel, v)
 }
 
 func (s Spec) GetUtilizationSwitch() int32 {
-	return s.sr.utilizationSwitch
+	return atomic.LoadInt32(&s.sr.utilizationSwitch)
 }
 
 func (s Spec) SetUtilizationSwitch(v int32) {
-	s.sr.utilizationSwitch = v
+	atomic.StoreInt32(&s.sr.utilizationSwitch, v)
 }

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"gotest.tools/v3/assert"
 )
@@ -1082,4 +1085,39 @@ func Test_SetUtilizationSwitch(t *testing.T) {
 			assert.Equal(t, result, test.want)
 		})
 	}
+}
+
+func TestSpec_ConcurrentAtomicAccess(t *testing.T) {
+	data := make([]byte, unsafe.Sizeof(sharedRegionT{}))
+	sr := (*sharedRegionT)(unsafe.Pointer(&data[0]))
+	sr.num = 4
+
+	s := Spec{sr: sr}
+
+	var wg sync.WaitGroup
+	goroutines := 50
+	iterations := 200
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				val := uint64(id*iterations + j)
+				s.SetDeviceMemoryLimit(val)
+				s.SetDeviceSmLimit(val)
+				s.SetRecentKernel(int32(j))
+				s.SetUtilizationSwitch(int32(j))
+				atomic.StoreInt64(&sr.lastKernelTime, int64(j))
+
+				_ = s.DeviceMemoryLimit(0)
+				_ = s.DeviceMemoryLimit(1)
+				_ = s.GetRecentKernel()
+				_ = s.GetUtilizationSwitch()
+				_ = s.LastKernelTime()
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## What this PR does / why we need it

The vGPUmonitor writes GPU memory limits, SM limits, utilization switch, and recent kernel values to shared memory using ordinary Go assignments. When multiple container processes on the same node read/write these values concurrently, this causes torn reads and stale cache values on multi-core systems.

This PR replaces all direct shared-memory assignments with \sync/atomic\ load/store operations, ensuring memory visibility guarantees across goroutines and preventing data races on the mmap'd shared region.

## Which issue(s) this PR fixes

Fixes #2127

## Does this PR introduce a user-facing change?

No. This is an internal correctness fix with no API or behavioral change.

## How has this been tested?

- [x] \go test -race ./pkg/monitor/nvidia/v0/...\ passes
- [x] \go test -race ./pkg/monitor/nvidia/v1/...\ passes
- [x] \go vet ./pkg/monitor/nvidia/...\ passes
- [x] Added \TestSpec_ConcurrentAtomicAccess\ with 50 goroutines x 200 iterations to verify race-free concurrent access

## AI Assistance Disclosure

This PR description was generated with the assistance of an AI coding tool. The author reviewed and verified all changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when NVIDIA monitoring values are read or updated concurrently.
  - Prevented inconsistent device memory, SM limits, recent kernel timing, and utilization settings during simultaneous operations.
  - Enhanced stability for multithreaded access to shared GPU monitoring data.
- **Tests**
  - Added concurrency coverage that exercises parallel setters/getters to verify consistent behavior under load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->