### PR TITLE
fix(enflame): bound profile values before int32 conversion in Fit

### DIFF
--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -391,11 +391,6 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		reason[common.ModeNotFit]++
 		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
-	// Reject rather than clamp: these come from strconv.Atoi on a profile name,
-	// so an out of range value means the profile is malformed, and clamping
-	// would let it through with a plausible looking size. MemoryGB is bounded
-	// before the multiply, otherwise the product wraps in int on its way to the
-	// conversion.
 	if profile.Size <= 0 || profile.Size > math.MaxInt32 {
 		reason[common.ModeNotFit]++
 		return false, tmpDevs, common.GenReason(reason, len(devices))
@@ -409,14 +404,7 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
 	profileMemoryMiB := int32(profile.MemoryGB * 1024)
-	// Clamp before the conversion, not after, so both bounds are established
-	// on the int value. Same result either way, since the clamp only ever
-	// raises a non-positive value to 1.
-	corePercent := profile.CorePercent
-	if corePercent <= 0 {
-		corePercent = 1
-	}
-	profileCorePercent := int32(corePercent)
+	profileCorePercent := int32(profile.CorePercent)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
@@ -672,7 +660,6 @@ func parseDRSCapacity(raw any) (int32, error) {
 	}
 }
 
-// clampToInt32 bounds v to the int32 range instead of letting the cast wrap silently.
 func clampToInt32(v int) int32 {
 	if v > math.MaxInt32 {
 		return math.MaxInt32

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -391,20 +391,32 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		reason[common.ModeNotFit]++
 		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
-	requiredSlice := int32(profile.Size)
-	if requiredSlice <= 0 {
+	// Reject rather than clamp: these come from strconv.Atoi on a profile name,
+	// so an out of range value means the profile is malformed, and clamping
+	// would let it through with a plausible looking size. MemoryGB is bounded
+	// before the multiply, otherwise the product wraps in int on its way to the
+	// conversion.
+	if profile.Size <= 0 || profile.Size > math.MaxInt32 {
+		reason[common.ModeNotFit]++
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
+	if profile.MemoryGB <= 0 || profile.MemoryGB > math.MaxInt32/1024 {
+		reason[common.ModeNotFit]++
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
+	if profile.CorePercent > math.MaxInt32 {
 		reason[common.ModeNotFit]++
 		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
 	profileMemoryMiB := int32(profile.MemoryGB * 1024)
-	if profileMemoryMiB <= 0 {
-		reason[common.ModeNotFit]++
-		return false, tmpDevs, common.GenReason(reason, len(devices))
+	// Clamp before the conversion, not after, so both bounds are established
+	// on the int value. Same result either way, since the clamp only ever
+	// raises a non-positive value to 1.
+	corePercent := profile.CorePercent
+	if corePercent <= 0 {
+		corePercent = 1
 	}
-	profileCorePercent := int32(profile.CorePercent)
-	if profileCorePercent <= 0 {
-		profileCorePercent = 1
-	}
+	profileCorePercent := int32(corePercent)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)

--- a/pkg/device/enflame/device_test.go
+++ b/pkg/device/enflame/device_test.go
@@ -421,3 +421,37 @@ func TestAddResourceUsage_ClampsOversizedSliceString(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, n.Used, int32(math.MaxInt32))
 }
+
+func TestFit_OversizedProfileRejected(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	// A profile name parsed with strconv.Atoi can carry a value far beyond
+	// int32; without a bound the conversion wraps into a small or negative
+	// slice count and the profile looks usable.
+	devices := []*device.DeviceUsage{
+		{
+			ID:       "node-a-enflame-drs-0",
+			Index:    0,
+			Count:    6,
+			Used:     0,
+			Totalmem: 40960,
+			Type:     EnflameVGCUDevice,
+			CustomInfo: map[string]any{
+				"minor": "0",
+				"index": "0",
+				// 2^32+3 wraps to a plausible-looking 3 slices and 3072 MiB.
+				"profiles": map[string]string{"4294967299g.4294967299gb": "0"},
+			},
+		},
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 3, MemPercentagereq: 101}
+	fit, result, _ := dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)
+
+	// A sane memory size clears the memory bound, so this pins the slice bound
+	// on its own and keeps the raw value out of the drsSlice annotation.
+	devices[0].CustomInfo["profiles"] = map[string]string{"4294967299g.20gb": "0"}
+	fit, result, _ = dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)
+}

--- a/pkg/device/enflame/device_test.go
+++ b/pkg/device/enflame/device_test.go
@@ -377,7 +377,6 @@ func TestAddResourceUsage_ClampsOnOverflow(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, n.Used, int32(math.MaxInt32))
 
-	// A second oversized slice must saturate, not wrap negative.
 	err = dev.AddResourceUsage(&corev1.Pod{}, n, ctr)
 	assert.NilError(t, err)
 	assert.Equal(t, n.Used, int32(math.MaxInt32))
@@ -424,9 +423,6 @@ func TestAddResourceUsage_ClampsOversizedSliceString(t *testing.T) {
 
 func TestFit_OversizedProfileRejected(t *testing.T) {
 	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
-	// A profile name parsed with strconv.Atoi can carry a value far beyond
-	// int32; without a bound the conversion wraps into a small or negative
-	// slice count and the profile looks usable.
 	devices := []*device.DeviceUsage{
 		{
 			ID:       "node-a-enflame-drs-0",
@@ -436,9 +432,8 @@ func TestFit_OversizedProfileRejected(t *testing.T) {
 			Totalmem: 40960,
 			Type:     EnflameVGCUDevice,
 			CustomInfo: map[string]any{
-				"minor": "0",
-				"index": "0",
-				// 2^32+3 wraps to a plausible-looking 3 slices and 3072 MiB.
+				"minor":    "0",
+				"index":    "0",
 				"profiles": map[string]string{"4294967299g.4294967299gb": "0"},
 			},
 		},
@@ -448,9 +443,18 @@ func TestFit_OversizedProfileRejected(t *testing.T) {
 	assert.Equal(t, fit, false)
 	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)
 
-	// A sane memory size clears the memory bound, so this pins the slice bound
-	// on its own and keeps the raw value out of the drsSlice annotation.
 	devices[0].CustomInfo["profiles"] = map[string]string{"4294967299g.20gb": "0"}
+	fit, result, _ = dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)
+
+	devices[0].CustomInfo["profiles"] = map[string]string{"2g.4294967299gb": "0"}
+	fit, result, _ = dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)
+
+	devices[0].CustomInfo["maxSlice"] = "1"
+	devices[0].CustomInfo["profiles"] = map[string]string{"2147483647g.20gb": "0"}
 	fit, result, _ = dev.Fit(devices, req, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}, &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, false)
 	assert.Equal(t, len(result[EnflameVGCUDevice]), 0)


### PR DESCRIPTION
/kind bug
`Fit` in `pkg/device/enflame/device.go` converts three profile fields to `int32` without an upper bound. All three trace back to `strconv.Atoi` in `parseProfile`, so a profile name such as `4294967299g.4294967299gb` wraps to 3 slices and 3072 MiB and the profile is accepted. The bogus `drsSlice` also reaches the container annotation. This is CodeQL alert `go/incorrect-integer-conversion` at `pkg/device/enflame/device.go:394`. #2145 added `clampToInt32` and applied it elsewhere in the file but left these three sites.