### PR TITLE
ci: replace write-all with per-job permissions in auto-release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -21,7 +21,7 @@ on:
         description: 'Tag'
         required: true
         default: v1.0.0
-permissions: write-all
+permissions: read-all
 
 jobs:
   pre-release:
@@ -53,6 +53,9 @@ jobs:
   ensure-tag:
     runs-on: ubuntu-latest
     needs: pre-release
+    # creates the release-vX.Y branch
+    permissions:
+      contents: write
     outputs:
       tag: ${{ env.RUN_TAG }}
     steps:
@@ -103,6 +106,11 @@ jobs:
 
   release-image-hamicore:
     needs: ensure-tag
+    # pushes to ghcr and signs with keyless cosign
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/call-release-image-hamicore.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
@@ -110,6 +118,11 @@ jobs:
 
   release-image:
     needs: [ensure-tag,release-image-hamicore]
+    # pushes to ghcr and signs with keyless cosign
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/call-release-image.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
@@ -117,6 +130,9 @@ jobs:
 
   release-chart:
     needs: [ensure-tag]
+    # pushes to github_pages with API_TOKEN_GITHUB, not GITHUB_TOKEN
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-release-helm.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
@@ -125,19 +141,26 @@ jobs:
 
   # generate changelog and update to github releases pages
   release-notes:
-    needs: [release-chart,release-image]
+    needs: [ensure-tag,release-chart,release-image]
+    # updates the github release page
+    permissions:
+      contents: write
     uses: ./.github/workflows/call-release-notes.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
   
   release-website:
-    needs: [release-notes]
+    needs: [ensure-tag,release-notes]
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-release-website.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
   # excute a full e2e test when hami release
   release-e2e:
-    needs: [release-notes]
+    needs: [ensure-tag,release-notes]
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-e2e.yaml
     with:
       ref: ${{ needs.ensure-tag.outputs.tag }}
@@ -145,7 +168,9 @@ jobs:
 
   # excute a compatibility test when hami release
   release-e2e-upgrade:
-      needs: [release-notes]
+      needs: [ensure-tag,release-notes]
+      permissions:
+        contents: read
       uses: ./.github/workflows/call-e2e-upgrade.yaml
       with:
         ref: ${{ needs.ensure-tag.outputs.tag }}


### PR DESCRIPTION
/kind cleanup

`.github/workflows/auto-release.yaml` sets `permissions: write-all`, so every job in the release pipeline runs with the full token even though most only read. This is Scorecard alert #1058 (Token-Permissions, line 24).

The default drops to `read-all` and each job declares what it uses:

| job | permissions | why |
| --- | --- | --- |
| `pre-release` | `contents: write` | already declared, creates the prerelease |
| `ensure-tag` | `contents: write` | creates the `release-vX.Y` branch |
| `release-image`, `release-image-hamicore` | `contents: read`, `packages: write`, `id-token: write` | ghcr push plus keyless cosign signing |
| `release-chart` | `contents: read` | pushes with `API_TOKEN_GITHUB`, not `GITHUB_TOKEN` |
| `release-notes` | `contents: write` | `action-gh-release` with `GITHUB_TOKEN` |
| `release-website`, `release-e2e`, `release-e2e-upgrade` | `contents: read` | no writes |

Called workflows can only downgrade what the caller grants, so the per-job values above are the effective ceiling. The reusable workflows themselves still say `permissions: write-all` (`call-release-image.yaml`, `call-release-helm.yaml`, `call-release-notes.yaml`, `call-release-website.yaml`, `call-e2e-upgrade.yaml`); tightening those is a separate change and is not needed for this alert.

This path only runs on a tag, so CI here cannot exercise it. Worth a second pair of eyes from someone who has watched a release go through, particularly on `release-chart`: it is set to `contents: read` because the push uses the `API_TOKEN_GITHUB` PAT.