### PR TITLE
ci: run CodeQL on pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,13 @@ on:
       - "**/*.md"
       - "**/*.txt"
       - "**/*.yml"
+  pull_request:
+    branches: ["master","dev"]
+    paths-ignore:
+      - "**/*.json"
+      - "**/*.md"
+      - "**/*.txt"
+      - "**/*.yml"
   schedule:
     - cron: "0 4 * * 6"
 


### PR DESCRIPTION
/kind cleanup
CodeQL only runs on push to `master` and `dev` and on the weekly cron, so a finding is first seen after merge. #2190 is an example: the conversion it fixes has been open as alert #1031 since May. This adds the same trigger for pull requests targeting those branches, reusing the existing `paths-ignore` list. It also closes Scorecard alert #1149 (SAST), which checks whether a SAST tool runs on pull requests.