### PR TITLE
fix(monitor): fix use-after-unmap crash in loadCache + raise cudevshr.go coverage to 90%

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -440,6 +440,15 @@ func (cc ClusterManagerCollector) collectPodAndContainerInfo(ch chan<- prometheu
 		return fmt.Errorf("failed to list pods: %w", err)
 	}
 
+	// Update() can run concurrently on its own resync timer and munmap a
+	// container's backing memory while removing it from the map. c.Info is
+	// backed by that same mmap'd memory, so holding the lister's lock for
+	// the whole read-and-scrape below keeps it alive for as long as we
+	// dereference it - the same use-after-unmap hazard loadCache's error
+	// path guards against, just on the read side instead of the write side.
+	cc.ClusterManager.containerLister.Lock()
+	defer cc.ClusterManager.containerLister.UnLock()
+
 	containers := cc.ClusterManager.containerLister.ListContainers()
 	containerMap := make(map[string][]*nvidia.ContainerUsage) // podUID -> containers
 	for _, c := range containers {

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -277,7 +277,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	if info.Size() == 1197897 {
 		klog.Infoln("casting......v0")
 		usage.Info = v0.CastSpec(usage.data)
-	} else if head.majorVersion == 1 {
+	} else if head.majorVersion == 1 && info.Size() >= int64(v1.MinSize()) {
 		klog.Infoln("casting......v1")
 		usage.Info = v1.CastSpec(usage.data)
 	} else {

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -281,8 +281,9 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		klog.Infoln("casting......v1")
 		usage.Info = v1.CastSpec(usage.data)
 	} else {
+		majorVersion, minorVersion := head.majorVersion, head.minorVersion
 		_ = syscall.Munmap(usage.data)
-		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), head.majorVersion, head.minorVersion)
+		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), majorVersion, minorVersion)
 	}
 	return usage, nil
 }

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -35,8 +35,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	v1 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v1"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
+
+// v1CacheFileSize is large enough for v1.CastSpec to safely dereference
+// every field of the real v1 sharedRegionT; using a smaller fixture would
+// leave usage.Info backed by an out-of-bounds pointer.
+var v1CacheFileSize = v1.MinSize()
 
 // fakePodLister is a minimal corelisters.PodLister used to drive Update()'s
 // error path without touching a real (or fake) Kubernetes API server.
@@ -112,6 +118,7 @@ func Test_NewContainerLister_errors(t *testing.T) {
 	t.Run("NODE_NAME not set", func(t *testing.T) {
 		t.Setenv("HOOK_PATH", t.TempDir())
 		t.Setenv("KUBECONFIG", writeKubeconfig(t, "http://localhost:8080"))
+		t.Setenv(util.NodeNameEnvName, "")
 		os.Unsetenv(util.NodeNameEnvName)
 		_, err := NewContainerLister()
 		assert.ErrorContains(t, err, "env "+util.NodeNameEnvName+" not set")
@@ -246,9 +253,16 @@ func Test_loadCache(t *testing.T) {
 		assert.ErrorContains(t, err, "unknown cache file size")
 	})
 
-	t.Run("v1 cache file", func(t *testing.T) {
+	t.Run("v1 header but file too small for the v1 spec", func(t *testing.T) {
 		dir := t.TempDir()
 		writeCacheFile(t, dir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		_, err := loadCache(dir)
+		assert.ErrorContains(t, err, "unknown cache file size")
+	})
+
+	t.Run("v1 cache file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
 		usage, err := loadCache(dir)
 		assert.NilError(t, err)
 		assert.Assert(t, usage != nil)
@@ -267,6 +281,9 @@ func Test_loadCache(t *testing.T) {
 	})
 
 	t.Run("open file fails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("running as root bypasses file permission checks")
+		}
 		dir := t.TempDir()
 		path := writeCacheFile(t, dir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
 		assert.NilError(t, os.Chmod(path, 0000))
@@ -332,7 +349,7 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.NilError(t, os.Chtimes(ctrDir, old, old))
 
 		cacheDir := t.TempDir()
-		writeCacheFile(t, cacheDir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		writeCacheFile(t, cacheDir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
 		usage, err := loadCache(cacheDir)
 		assert.NilError(t, err)
 
@@ -402,7 +419,7 @@ func Test_ContainerLister_Update(t *testing.T) {
 		entryName := "uid4_mycontainer"
 		ctrDir := filepath.Join(dir, entryName)
 		assert.NilError(t, os.Mkdir(ctrDir, 0755))
-		writeCacheFile(t, ctrDir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		writeCacheFile(t, ctrDir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
 		l := &ContainerLister{
 			containerPath: dir,
 			containers:    map[string]*ContainerUsage{},

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -1,0 +1,418 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// fakePodLister is a minimal corelisters.PodLister used to drive Update()'s
+// error path without touching a real (or fake) Kubernetes API server.
+type fakePodLister struct {
+	pods    []*corev1.Pod
+	listErr error
+}
+
+func (f *fakePodLister) List(labels.Selector) ([]*corev1.Pod, error) {
+	return f.pods, f.listErr
+}
+
+func (f *fakePodLister) Pods(string) corelisters.PodNamespaceLister {
+	return nil
+}
+
+func newTestPodLister(pods ...*corev1.Pod) corelisters.PodLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, p := range pods {
+		_ = indexer.Add(p)
+	}
+	return corelisters.NewPodLister(indexer)
+}
+
+func headerBytes(size int, magic, major, minor int32) []byte {
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(magic))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(major))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(minor))
+	return buf
+}
+
+func writeCacheFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	assert.NilError(t, os.WriteFile(p, content, 0666))
+	return p
+}
+
+func Test_ContainerLister_Accessors(t *testing.T) {
+	l := &ContainerLister{
+		containers: map[string]*ContainerUsage{"a": {}},
+	}
+	assert.Equal(t, len(l.ListContainers()), 1)
+	assert.Assert(t, l.Clientset() == nil)
+
+	l.Lock()
+	l.UnLock()
+}
+
+func Test_NewContainerLister_errors(t *testing.T) {
+	t.Run("HOOK_PATH not set", func(t *testing.T) {
+		t.Setenv("HOOK_PATH", "")
+		os.Unsetenv("HOOK_PATH")
+		_, err := NewContainerLister()
+		assert.ErrorContains(t, err, "HOOK_PATH not set")
+	})
+
+	t.Run("invalid KUBECONFIG", func(t *testing.T) {
+		t.Setenv("HOOK_PATH", t.TempDir())
+		t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+		_, err := NewContainerLister()
+		assert.Assert(t, err != nil)
+	})
+
+	t.Run("clientset construction fails", func(t *testing.T) {
+		t.Setenv("HOOK_PATH", t.TempDir())
+		t.Setenv("KUBECONFIG", writeKubeconfig(t, "http://[::1]:namedport"))
+		_, err := NewContainerLister()
+		assert.ErrorContains(t, err, "host must be a URL or a host:port pair")
+	})
+
+	t.Run("NODE_NAME not set", func(t *testing.T) {
+		t.Setenv("HOOK_PATH", t.TempDir())
+		t.Setenv("KUBECONFIG", writeKubeconfig(t, "http://localhost:8080"))
+		os.Unsetenv(util.NodeNameEnvName)
+		_, err := NewContainerLister()
+		assert.ErrorContains(t, err, "env "+util.NodeNameEnvName+" not set")
+	})
+}
+
+func writeKubeconfig(t *testing.T, server string) string {
+	t.Helper()
+	kubeconfig := filepath.Join(t.TempDir(), "kubeconfig.yaml")
+	content := `apiVersion: v1
+clusters:
+- cluster:
+    server: ` + server + `
+  name: local-server
+contexts:
+- context:
+    cluster: local-server
+    namespace: the-right-prefix
+    user: myself
+  name: default-context
+current-context: default-context
+kind: Config
+preferences: {}
+users:
+- name: myself
+  user:
+    password: secret
+    username: admin
+`
+	assert.NilError(t, os.WriteFile(kubeconfig, []byte(content), 0644))
+	return kubeconfig
+}
+
+// unreachableClientset builds a real *kubernetes.Clientset pointed at a port
+// nothing is listening on, so any request fails fast with connection refused
+// instead of hanging.
+func unreachableClientset(t *testing.T) *kubernetes.Clientset {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	addr := ln.Addr().String()
+	assert.NilError(t, ln.Close())
+
+	cs, err := kubernetes.NewForConfig(&rest.Config{Host: "http://" + addr})
+	assert.NilError(t, err)
+	return cs
+}
+
+func Test_initInformerWithConfig_syncTimeout(t *testing.T) {
+	l := &ContainerLister{
+		clientset: unreachableClientset(t),
+		nodeName:  "test-node",
+		stopCh:    make(chan struct{}),
+	}
+	time.AfterFunc(200*time.Millisecond, func() { close(l.stopCh) })
+
+	err := l.initInformerWithConfig(50 * time.Millisecond)
+	assert.ErrorContains(t, err, "failed to sync pod informer cache")
+}
+
+func Test_onPodDelete(t *testing.T) {
+	l := &ContainerLister{}
+
+	t.Run("plain pod", func(t *testing.T) {
+		l.onPodDelete(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}})
+	})
+
+	t.Run("tombstone wrapping a pod", func(t *testing.T) {
+		l.onPodDelete(cache.DeletedFinalStateUnknown{
+			Key: "default/p2",
+			Obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "default"}},
+		})
+	})
+
+	t.Run("tombstone wrapping a non-pod", func(t *testing.T) {
+		l.onPodDelete(cache.DeletedFinalStateUnknown{Key: "x", Obj: "not-a-pod"})
+	})
+
+	t.Run("neither pod nor tombstone", func(t *testing.T) {
+		l.onPodDelete("garbage")
+	})
+}
+
+func Test_loadCache(t *testing.T) {
+	t.Run("directory missing", func(t *testing.T) {
+		_, err := loadCache(filepath.Join(t.TempDir(), "missing"))
+		assert.Assert(t, err != nil)
+	})
+
+	t.Run("too many files", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "a.cache", []byte("x"))
+		writeCacheFile(t, dir, "b.cache", []byte("x"))
+		writeCacheFile(t, dir, "c.cache", []byte("x"))
+		_, err := loadCache(dir)
+		assert.ErrorContains(t, err, "cache num not matched")
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		usage, err := loadCache(t.TempDir())
+		assert.NilError(t, err)
+		assert.Assert(t, usage == nil)
+	})
+
+	t.Run("no matching cache file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "libvgpu.so", []byte("x"))
+		writeCacheFile(t, dir, "notes.txt", []byte("x"))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage == nil)
+	})
+
+	t.Run("cache file too small", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", []byte("tiny"))
+		_, err := loadCache(dir)
+		assert.ErrorContains(t, err, "too small")
+	})
+
+	t.Run("magic flag mismatch", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(64, 0, 1, 0))
+		_, err := loadCache(dir)
+		assert.ErrorContains(t, err, "magic flag not matched")
+	})
+
+	t.Run("unknown version and size", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 99, 0))
+		_, err := loadCache(dir)
+		assert.ErrorContains(t, err, "unknown cache file size")
+	})
+
+	t.Run("v1 cache file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
+	t.Run("v0 cache file (exact legacy size)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(1197897, SharedRegionMagicFlag, 0, 0))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
+	t.Run("open file fails", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeCacheFile(t, dir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		assert.NilError(t, os.Chmod(path, 0000))
+		defer os.Chmod(path, 0666)
+		_, err := loadCache(dir)
+		assert.Assert(t, err != nil)
+	})
+}
+
+func Test_ContainerLister_Update(t *testing.T) {
+	t.Run("container path missing", func(t *testing.T) {
+		l := &ContainerLister{
+			containerPath: filepath.Join(t.TempDir(), "missing"),
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(),
+		}
+		err := l.Update()
+		assert.Assert(t, err != nil)
+	})
+
+	t.Run("podLister error propagates", func(t *testing.T) {
+		l := &ContainerLister{
+			containerPath: t.TempDir(),
+			containers:    map[string]*ContainerUsage{},
+			podLister:     &fakePodLister{listErr: errors.New("boom")},
+		}
+		err := l.Update()
+		assert.ErrorContains(t, err, "failed to list pods")
+	})
+
+	t.Run("skips non-directory entries", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "stray-file"), []byte("x"), 0644))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(),
+		}
+		assert.NilError(t, l.Update())
+		assert.Equal(t, len(l.containers), 0)
+	})
+
+	t.Run("recently modified stale dir is kept", func(t *testing.T) {
+		dir := t.TempDir()
+		ctrDir := filepath.Join(dir, "missing-pod-uid_ctr")
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(),
+		}
+		assert.NilError(t, l.Update())
+		_, err := os.Stat(ctrDir)
+		assert.NilError(t, err)
+	})
+
+	t.Run("old stale dir with tracked mapping is removed and unmapped", func(t *testing.T) {
+		dir := t.TempDir()
+		entryName := "missing-pod-uid_ctr"
+		ctrDir := filepath.Join(dir, entryName)
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		old := time.Now().Add(-2 * resyncInterval)
+		assert.NilError(t, os.Chtimes(ctrDir, old, old))
+
+		cacheDir := t.TempDir()
+		writeCacheFile(t, cacheDir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		usage, err := loadCache(cacheDir)
+		assert.NilError(t, err)
+
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{entryName: usage},
+			podLister:     newTestPodLister(),
+		}
+		assert.NilError(t, l.Update())
+		_, ok := l.containers[entryName]
+		assert.Equal(t, ok, false)
+		_, err = os.Stat(ctrDir)
+		assert.Assert(t, os.IsNotExist(err))
+	})
+
+	t.Run("already tracked entry is left untouched", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid1"}}
+		entryName := "uid1_ctr"
+		assert.NilError(t, os.Mkdir(filepath.Join(dir, entryName), 0755))
+		existing := &ContainerUsage{PodUID: "uid1", ContainerName: "ctr"}
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{entryName: existing},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		assert.Assert(t, l.containers[entryName] == existing)
+	})
+
+	t.Run("loadCache error is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid2"}}
+		entryName := "uid2_ctr"
+		ctrDir := filepath.Join(dir, entryName)
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		writeCacheFile(t, ctrDir, "a.cache", []byte("x"))
+		writeCacheFile(t, ctrDir, "b.cache", []byte("x"))
+		writeCacheFile(t, ctrDir, "c.cache", []byte("x"))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		assert.Equal(t, len(l.containers), 0)
+	})
+
+	t.Run("no cuInit yet is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid3"}}
+		entryName := "uid3_ctr"
+		ctrDir := filepath.Join(dir, entryName)
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		assert.Equal(t, len(l.containers), 0)
+	})
+
+	t.Run("new container is added with PodUID and ContainerName set", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid4"}}
+		entryName := "uid4_mycontainer"
+		ctrDir := filepath.Join(dir, entryName)
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		writeCacheFile(t, ctrDir, "x.cache", headerBytes(64, SharedRegionMagicFlag, 1, 0))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		got, ok := l.containers[entryName]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, got.PodUID, "uid4")
+		assert.Equal(t, got.ContainerName, "mycontainer")
+		defer func() { _ = syscall.Munmap(got.data) }()
+	})
+}

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -174,6 +174,12 @@ func CastSpec(data []byte) Spec {
 	}
 }
 
+// MinSize returns the minimum byte length data must have for CastSpec to be
+// memory-safe.
+func MinSize() int {
+	return int(unsafe.Sizeof(sharedRegionT{}))
+}
+
 //	func (s *SharedRegionT) UsedMemory(idx int) (uint64, error) {
 //		return 0, nil
 //	}

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -59,10 +59,17 @@ type sharedRegionT struct {
 	majorVersion    int32
 	minorVersion    int32
 	smInitFlag      int32
-	ownerPid        uint32
-	sem             semT
-	num             uint64
-	uuids           [16]uuid
+	// ownerPid mirrors libvgpu's `_Atomic size_t owner_pid`, which is 8
+	// bytes on the 64-bit Linux ABI this cache format targets. It was
+	// previously typed uint32 (4 bytes); every field after it still lined
+	// up with the C layout only because Go's own 8-byte alignment padding
+	// ahead of `num` happened to absorb the missing 4 bytes. Typing it
+	// uint64 makes the two layouts match for the actual reason instead of
+	// by accident. See TestSharedRegionTLayoutMatchesCABI.
+	ownerPid uint64
+	sem      semT
+	num      uint64
+	uuids    [16]uuid
 
 	limit   [16]uint64
 	smLimit [16]uint64

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -18,9 +18,20 @@ package v1
 
 import (
 	"testing"
+	"unsafe"
 
 	"gotest.tools/v3/assert"
 )
+
+func Test_MinSize(t *testing.T) {
+	assert.Equal(t, MinSize(), int(unsafe.Sizeof(sharedRegionT{})))
+}
+
+func Test_CastSpec(t *testing.T) {
+	data := make([]byte, MinSize())
+	spec := CastSpec(data)
+	assert.Assert(t, spec.sr != nil)
+}
 
 func Test_DeviceMax(t *testing.T) {
 	tests := []struct {

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -27,6 +27,47 @@ func Test_MinSize(t *testing.T) {
 	assert.Equal(t, MinSize(), int(unsafe.Sizeof(sharedRegionT{})))
 }
 
+// TestSharedRegionTLayoutMatchesCABI locks sharedRegionT's field offsets to
+// libvgpu's C `shared_region_t` (multiprocess_memory_limit.h), computed with
+// C's offsetof on linux/amd64 glibc (sizeof(sem_t) == 32 there). MinSize only
+// checks the total size, which is not enough: two structs can have the same
+// total size while individual fields sit at different offsets, in which case
+// CastSpec would silently read the wrong bytes for every field after the
+// first mismatch. If this test fails, the Go mirror has drifted from the C
+// struct and needs to be brought back in line with it, not just have this
+// test's expectations bumped.
+func TestSharedRegionTLayoutMatchesCABI(t *testing.T) {
+	var s sharedRegionT
+	cases := []struct {
+		field string
+		got   uintptr
+		want  uintptr
+	}{
+		{"initializedFlag", unsafe.Offsetof(s.initializedFlag), 0},
+		{"majorVersion", unsafe.Offsetof(s.majorVersion), 4},
+		{"minorVersion", unsafe.Offsetof(s.minorVersion), 8},
+		{"smInitFlag", unsafe.Offsetof(s.smInitFlag), 12},
+		{"ownerPid", unsafe.Offsetof(s.ownerPid), 16},
+		{"sem", unsafe.Offsetof(s.sem), 24},
+		{"num", unsafe.Offsetof(s.num), 56},
+		{"uuids", unsafe.Offsetof(s.uuids), 64},
+		{"limit", unsafe.Offsetof(s.limit), 1600},
+		{"smLimit", unsafe.Offsetof(s.smLimit), 1728},
+		{"procs", unsafe.Offsetof(s.procs), 1856},
+		{"procnum", unsafe.Offsetof(s.procnum), 2008896},
+		{"utilizationSwitch", unsafe.Offsetof(s.utilizationSwitch), 2008900},
+		{"recentKernel", unsafe.Offsetof(s.recentKernel), 2008904},
+		{"priority", unsafe.Offsetof(s.priority), 2008908},
+		{"lastKernelTime", unsafe.Offsetof(s.lastKernelTime), 2008912},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("field %s at offset %d, want %d (libvgpu shared_region_t layout has drifted)", c.field, c.got, c.want)
+		}
+	}
+	assert.Equal(t, int(unsafe.Sizeof(s)), 2008952)
+}
+
 func Test_CastSpec(t *testing.T) {
 	data := make([]byte, MinSize())
 	spec := CastSpec(data)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Fixes a crash bug and adds tests for `pkg/monitor/nvidia/cudevshr.go`.

**Bug fix:** `loadCache()` unmapped `usage.data` and then read from it afterward to build an error message — a use-after-unmap that crashes the whole vGPU monitor process whenever a cache file has a valid magic flag but an unknown version/size. Fixed by reading the values before unmapping.

**Tests:** Added unit tests covering `ContainerLister` and `loadCache`, raising `cudevshr.go` coverage from 0% to ~91%. Covers the constructor's error paths, `Update()`'s directory-scanning logic, and `loadCache`'s cache-file parsing (using real mmap'd temp files since the code reads raw memory via `unsafe.Pointer`).

<img width="1347" height="284" alt="image" src="https://github.com/user-attachments/assets/e2ba62e5-e839-456c-aecc-654d9137cc19" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache loading safety by requiring both the expected version and minimum file size before parsing modern formats.
  * Preserved detected version details in unsupported-format errors.
  * Prevented concurrent container memory cleanup while metrics are being collected.
  * Corrected cache memory layout compatibility for 64-bit process identifiers.
* **New Features**
  * Added a `MinSize()` helper to define the minimum safe cache size.
* **Tests**
  * Expanded coverage for cache parsing, container discovery, informer timeouts, pod events, and directory reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->