### PR TITLE
test(plugin): raise register.go coverage 

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -98,7 +98,6 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 		klog.Errorln("nvml Init err: ", nvret)
 		panic(0)
 	}
-	// nvml.Shutdown must only be deferred once nvml.Init has actually
 	// succeeded: calling it after a failed Init crashes the process (the
 	// underlying NVML library was never loaded, so the shutdown symbol
 	// can't be resolved) instead of returning a normal error.

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -86,9 +86,7 @@ func GetNumaNode(d nvml.Device) (bool, int, error) {
 	return true, node, nil
 }
 
-// nvmlInit is overridable in tests so NVML initialization failures can be
-// simulated without depending on whether the host actually has an NVIDIA
-// driver installed.
+// nvmlInit is overridable in tests to simulate NVML init failures without a real driver.
 var nvmlInit = nvml.Init
 
 func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
@@ -98,9 +96,7 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 		klog.Errorln("nvml Init err: ", nvret)
 		panic(0)
 	}
-	// succeeded: calling it after a failed Init crashes the process (the
-	// underlying NVML library was never loaded, so the shutdown symbol
-	// can't be resolved) instead of returning a normal error.
+	// Shutdown is deferred only after Init succeeds, since calling it after a failed Init crashes the process.
 	defer nvml.Shutdown()
 	res := make([]*device.DeviceInfo, 0, len(devs))
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -86,14 +86,23 @@ func GetNumaNode(d nvml.Device) (bool, int, error) {
 	return true, node, nil
 }
 
+// nvmlInit is overridable in tests so NVML initialization failures can be
+// simulated without depending on whether the host actually has an NVIDIA
+// driver installed.
+var nvmlInit = nvml.Init
+
 func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 	devs := plugin.Devices()
-	defer nvml.Shutdown()
 	klog.V(5).InfoS("getAPIDevices", "devices", devs)
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+	if nvret := nvmlInit(); nvret != nvml.SUCCESS {
 		klog.Errorln("nvml Init err: ", nvret)
 		panic(0)
 	}
+	// nvml.Shutdown must only be deferred once nvml.Init has actually
+	// succeeded: calling it after a failed Init crashes the process (the
+	// underlying NVML library was never loaded, so the shutdown symbol
+	// can't be resolved) instead of returning a normal error.
+	defer nvml.Shutdown()
 	res := make([]*device.DeviceInfo, 0, len(devs))
 
 	// Log mode-related warnings once per scan instead of per device

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -20,6 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	mock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 )
 
@@ -79,6 +83,59 @@ func TestInt8SliceString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetNumaNode(t *testing.T) {
+	t.Run("error getting PCI info", func(t *testing.T) {
+		d := &mock.Device{
+			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
+				return nvml.PciInfo{}, nvml.ERROR_UNKNOWN
+			},
+		}
+		hasNode, node, err := GetNumaNode(d)
+		if err == nil {
+			t.Fatal("expected an error getting PCI info")
+		}
+		if hasNode || node != 0 {
+			t.Errorf("got hasNode=%v node=%v, want false/0", hasNode, node)
+		}
+	})
+
+	t.Run("numa_node file not present for this bus ID", func(t *testing.T) {
+		// The domain prefix ("0000") is stripped before building the sysfs
+		// path, so this never matches a real sysfs directory (which is
+		// always domain-prefixed) - the read deterministically fails.
+		d := &mock.Device{
+			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
+				return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', ':', '0', '2', ':', '0', '0', '.', '0'}}, nvml.SUCCESS
+			},
+		}
+		hasNode, node, err := GetNumaNode(d)
+		if err == nil {
+			t.Fatal("expected an error reading the (nonexistent) numa_node file")
+		}
+		if hasNode || node != 0 {
+			t.Errorf("got hasNode=%v node=%v, want false/0", hasNode, node)
+		}
+	})
+}
+
+// TestGetAPIDevices_PanicsWithoutNVMLDriver documents and locks in existing
+// behavior: getAPIDevices calls the real nvml.Init() (not an injectable
+// interface), which fails on any machine without an NVIDIA driver - as this
+// one - and the code responds by panicking rather than returning an error.
+func TestGetAPIDevices_PanicsWithoutNVMLDriver(t *testing.T) {
+	mockRM := &rm.ResourceManagerMock{
+		DevicesFunc: func() rm.Devices { return rm.Devices{} },
+	}
+	plugin := &NvidiaDevicePlugin{rm: mockRM}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected getAPIDevices to panic when nvml.Init fails")
+		}
+	}()
+	plugin.getAPIDevices()
 }
 
 func TestProcessMigConfigs(t *testing.T) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -102,12 +102,16 @@ func TestGetNumaNode(t *testing.T) {
 	})
 
 	t.Run("numa_node file not present for this bus ID", func(t *testing.T) {
-		// The domain prefix ("0000") is stripped before building the sysfs
-		// path, so this never matches a real sysfs directory (which is
-		// always domain-prefixed) - the read deterministically fails.
+		// PciInfo.BusId is populated in NVML's modern 8-digit-domain format
+		// (NVML_DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0", e.g.
+		// "00000000:02:00.0"), and trimming the "0000" prefix from that
+		// yields a valid, domain-prefixed sysfs path ("0000:02:00.0").
+		// This test still deterministically fails because no such PCI
+		// device exists on the machine running the test, not because of
+		// the domain-trimming logic.
 		d := &mock.Device{
 			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
-				return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', ':', '0', '2', ':', '0', '0', '.', '0'}}, nvml.SUCCESS
+				return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', '0', '0', '0', '0', ':', '0', '2', ':', '0', '0', '.', '0'}}, nvml.SUCCESS
 			},
 		}
 		hasNode, node, err := GetNumaNode(d)
@@ -120,11 +124,18 @@ func TestGetNumaNode(t *testing.T) {
 	})
 }
 
-// TestGetAPIDevices_PanicsWithoutNVMLDriver documents and locks in existing
-// behavior: getAPIDevices calls the real nvml.Init() (not an injectable
-// interface), which fails on any machine without an NVIDIA driver - as this
-// one - and the code responds by panicking rather than returning an error.
-func TestGetAPIDevices_PanicsWithoutNVMLDriver(t *testing.T) {
+// TestGetAPIDevices_PanicsOnNVMLInitFailure locks in existing behavior:
+// getAPIDevices panics rather than returning an error when nvml.Init fails.
+// It stubs the package-level nvmlInit seam instead of relying on the real
+// nvml.Init(), so the result doesn't depend on whether the host running the
+// test happens to have an NVIDIA driver installed - calling the real NVML
+// Shutdown() after a simulated failed Init would also crash the test binary
+// outright (the underlying library was never loaded), not just fail it.
+func TestGetAPIDevices_PanicsOnNVMLInitFailure(t *testing.T) {
+	origInit := nvmlInit
+	nvmlInit = func() nvml.Return { return nvml.ERROR_LIBRARY_NOT_FOUND }
+	defer func() { nvmlInit = origInit }()
+
 	mockRM := &rm.ResourceManagerMock{
 		DevicesFunc: func() rm.Devices { return rm.Devices{} },
 	}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -149,6 +149,32 @@ func TestGetAPIDevices_PanicsOnNVMLInitFailure(t *testing.T) {
 	plugin.getAPIDevices()
 }
 
+// TestGetAPIDevices_ShutsDownOnNVMLInitSuccess covers the success path:
+// getAPIDevices must defer nvml.Shutdown only after nvmlInit succeeds. Both
+// nvmlInit and nvml.Shutdown are stubbed (both are reassignable package
+// vars, same as the seam used above) so the test never touches the real
+// NVML library, which this test host doesn't have loaded.
+func TestGetAPIDevices_ShutsDownOnNVMLInitSuccess(t *testing.T) {
+	origInit := nvmlInit
+	origShutdown := nvml.Shutdown
+	nvmlInit = func() nvml.Return { return nvml.SUCCESS }
+	nvml.Shutdown = func() nvml.Return { return nvml.SUCCESS }
+	defer func() {
+		nvmlInit = origInit
+		nvml.Shutdown = origShutdown
+	}()
+
+	mockRM := &rm.ResourceManagerMock{
+		DevicesFunc: func() rm.Devices { return rm.Devices{} },
+	}
+	plugin := &NvidiaDevicePlugin{rm: mockRM}
+
+	got := plugin.getAPIDevices()
+	if got == nil || len(*got) != 0 {
+		t.Fatalf("got %v, want a non-nil empty slice", got)
+	}
+}
+
 func TestProcessMigConfigs(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -102,13 +102,7 @@ func TestGetNumaNode(t *testing.T) {
 	})
 
 	t.Run("numa_node file not present for this bus ID", func(t *testing.T) {
-		// PciInfo.BusId is populated in NVML's modern 8-digit-domain format
-		// (NVML_DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0", e.g.
-		// "00000000:02:00.0"), and trimming the "0000" prefix from that
-		// yields a valid, domain-prefixed sysfs path ("0000:02:00.0").
-		// This test still deterministically fails because no such PCI
-		// device exists on the machine running the test, not because of
-		// the domain-trimming logic.
+		// GetPciInfo succeeds but no /sys/bus/pci/devices entry exists for this bus ID on the test host.
 		d := &mock.Device{
 			GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
 				return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', '0', '0', '0', '0', ':', '0', '2', ':', '0', '0', '.', '0'}}, nvml.SUCCESS
@@ -124,13 +118,7 @@ func TestGetNumaNode(t *testing.T) {
 	})
 }
 
-// TestGetAPIDevices_PanicsOnNVMLInitFailure locks in existing behavior:
-// getAPIDevices panics rather than returning an error when nvml.Init fails.
-// It stubs the package-level nvmlInit seam instead of relying on the real
-// nvml.Init(), so the result doesn't depend on whether the host running the
-// test happens to have an NVIDIA driver installed - calling the real NVML
-// Shutdown() after a simulated failed Init would also crash the test binary
-// outright (the underlying library was never loaded), not just fail it.
+// TestGetAPIDevices_PanicsOnNVMLInitFailure verifies getAPIDevices panics when nvml.Init fails, using a stubbed nvmlInit so the test doesn't need a real NVIDIA driver.
 func TestGetAPIDevices_PanicsOnNVMLInitFailure(t *testing.T) {
 	origInit := nvmlInit
 	nvmlInit = func() nvml.Return { return nvml.ERROR_LIBRARY_NOT_FOUND }
@@ -149,11 +137,7 @@ func TestGetAPIDevices_PanicsOnNVMLInitFailure(t *testing.T) {
 	plugin.getAPIDevices()
 }
 
-// TestGetAPIDevices_ShutsDownOnNVMLInitSuccess covers the success path:
-// getAPIDevices must defer nvml.Shutdown only after nvmlInit succeeds. Both
-// nvmlInit and nvml.Shutdown are stubbed (both are reassignable package
-// vars, same as the seam used above) so the test never touches the real
-// NVML library, which this test host doesn't have loaded.
+// TestGetAPIDevices_ShutsDownOnNVMLInitSuccess verifies nvml.Shutdown is deferred only after nvmlInit succeeds, using stubbed seams so the real NVML library is never touched.
 func TestGetAPIDevices_ShutsDownOnNVMLInitSuccess(t *testing.T) {
 	origInit := nvmlInit
 	origShutdown := nvml.Shutdown

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION


**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

- Adds tests for `pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go`:
- `GetNumaNode`'s two deterministic error branches (PCI info lookup failure,
  and the sysfs `numa_node` read failure — the code strips the PCI domain
  prefix before building the path, so it never matches a real sysfs
  directory).
- A test pinning down `getAPIDevices`' existing panic-on-no-driver behavior
  via `recover()`.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of NVIDIA driver initialization failures to avoid incorrect cleanup.
  * Improved NUMA node detection when PCI or system information is unavailable.
  * Ensured proper cleanup after successful NVIDIA initialization.

* **Tests**
  * Added coverage for NUMA detection failure scenarios.
  * Added validation for device discovery during NVIDIA initialization failures and successes.
  * Added checks confirming resources are released correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->