### PR TITLE
fix(scheduler): preserve concurrent node locks

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -140,6 +140,7 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 	if _, ok := node.Annotations[NodeLockKey]; ok {
 		return fmt.Errorf("node %s is locked: %w", nodeName, ErrNodeLockContention)
 	}
+	lockOwner := NodeLockSep + GeneratePodNamespaceName(pods, NodeLockSep)
 	err = retry.OnError(DefaultStrategy, func(err error) bool {
 		return !IsNodeLockContention(err)
 	}, func() error {
@@ -148,7 +149,11 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
 		}
-		if _, ok := node.Annotations[NodeLockKey]; ok {
+		lockStr, ok := node.Annotations[NodeLockKey]
+		if ok && strings.Contains(lockStr, NodeLockSep) && strings.HasSuffix(lockStr, lockOwner) {
+			return nil
+		}
+		if ok {
 			return fmt.Errorf("node %s is locked: %w", nodeName, ErrNodeLockContention)
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
@@ -207,10 +212,11 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 		if !ok {
 			return nil
 		}
-		if skipNodeLockOwnerCheck && currentLock != lockStr {
-			return nil
-		}
-		if !skipNodeLockOwnerCheck && strings.Contains(currentLock, NodeLockSep) && !strings.HasSuffix(currentLock, lockOwner) {
+		if skipNodeLockOwnerCheck || !strings.Contains(currentLock, NodeLockSep) {
+			if currentLock != lockStr {
+				return nil
+			}
+		} else if !strings.HasSuffix(currentLock, lockOwner) {
 			return nil
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -186,8 +186,9 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 	if !ok {
 		return nil
 	}
+	lockOwner := NodeLockSep + GeneratePodNamespaceName(pod, NodeLockSep)
 	// Keep backward compatibility with the legacy format, which is simply a timestamp
-	if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, NodeLockSep+GeneratePodNamespaceName(pod, NodeLockSep)) {
+	if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, lockOwner) {
 		klog.InfoS("NodeLock is not set by this pod", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
 		return nil
 	}
@@ -203,7 +204,13 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 			return err
 		}
 		currentLock, ok := node.Annotations[NodeLockKey]
-		if !ok || currentLock != lockStr {
+		if !ok {
+			return nil
+		}
+		if skipNodeLockOwnerCheck && currentLock != lockStr {
+			return nil
+		}
+		if !skipNodeLockOwnerCheck && strings.Contains(currentLock, NodeLockSep) && !strings.HasSuffix(currentLock, lockOwner) {
 			return nil
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -138,16 +138,18 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 		return err
 	}
 	if _, ok := node.Annotations[NodeLockKey]; ok {
-		return fmt.Errorf("node %s is locked", nodeName)
+		return fmt.Errorf("node %s is locked: %w", nodeName, ErrNodeLockContention)
 	}
 	err = retry.OnError(DefaultStrategy, func(err error) bool {
-		// Retry on any error
-		return true
+		return !IsNodeLockContention(err)
 	}, func() error {
 		node, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
+		}
+		if _, ok := node.Annotations[NodeLockKey]; ok {
+			return fmt.Errorf("node %s is locked: %w", nodeName, ErrNodeLockContention)
 		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
@@ -190,6 +192,7 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 		return nil
 	}
 
+	released := false
 	err = retry.OnError(DefaultStrategy, func(err error) bool {
 		// Retry on any error
 		return true
@@ -199,19 +202,26 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
 		}
+		currentLock, ok := node.Annotations[NodeLockKey]
+		if !ok || currentLock != lockStr {
+			return nil
+		}
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
 			klog.ErrorS(err, "Failed to patch node when retry to patch", "node", nodeName)
 			return err
 		}
+		released = true
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to release node lock (node=%s, retry strategy=%+v): %w", nodeName, DefaultStrategy, err)
 	}
 
-	klog.InfoS("Node lock released", "node", nodeName, "podName", pod.Name)
+	if released {
+		klog.InfoS("Node lock released", "node", nodeName, "podName", pod.Name)
+	}
 	return nil
 }
 

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -18,17 +18,109 @@ package nodelock
 
 import (
 	"context" // Added for the new test
+	"errors"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1" // Added for the new test
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
+
+func TestSetNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "node-set-conflict"
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns"}}
+	holderB := GenerateNodeLockKeyByPod(podB)
+	clientSet := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}})
+	client.KubeClient = clientSet
+
+	getCalls := 0
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getCalls++
+		if getCalls < 3 {
+			return false, nil, nil
+		}
+		return true, &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{NodeLockKey: holderB},
+		}}, nil
+	})
+	patchCalls := 0
+	clientSet.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, nodeName, errors.New("simulated concurrent lock"))
+	})
+
+	err := SetNodeLock(nodeName, "", podA)
+	if !IsNodeLockContention(err) {
+		t.Fatalf("SetNodeLock() error = %v, want node lock contention", err)
+	}
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got := node.Annotations[NodeLockKey]; got != holderB {
+		t.Fatalf("node lock = %q, want concurrent holder %q", got, holderB)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("patch calls = %d, want 1", patchCalls)
+	}
+}
+
+func TestReleaseNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "node-release-conflict"
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns"}}
+	holderA := GenerateNodeLockKeyByPod(podA)
+	holderB := GenerateNodeLockKeyByPod(podB)
+	clientSet := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        nodeName,
+		Annotations: map[string]string{NodeLockKey: holderA},
+	}})
+	client.KubeClient = clientSet
+
+	getCalls := 0
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getCalls++
+		if getCalls < 3 {
+			return false, nil, nil
+		}
+		return true, &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{NodeLockKey: holderB},
+		}}, nil
+	})
+	patchCalls := 0
+	clientSet.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, nodeName, errors.New("simulated concurrent lock"))
+	})
+
+	if err := ReleaseNodeLock(nodeName, "", podA, false); err != nil {
+		t.Fatalf("ReleaseNodeLock() error = %v, want nil", err)
+	}
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got := node.Annotations[NodeLockKey]; got != holderB {
+		t.Fatalf("node lock = %q, want concurrent holder %q", got, holderB)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("patch calls = %d, want 1", patchCalls)
+	}
+}
 
 func Test_LockNode(t *testing.T) {
 	client.KubeClient = fake.NewClientset()

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -77,6 +77,39 @@ func TestSetNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
 	}
 }
 
+func TestSetNodeLockSucceedsAfterLostPatchResponse(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "node-set-lost-response"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns"}}
+	lockStr := "2026-08-01T06:00:00Z,ns,pod-a"
+	clientSet := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}})
+	client.KubeClient = clientSet
+
+	getCalls := 0
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getCalls++
+		if getCalls < 3 {
+			return false, nil, nil
+		}
+		return true, &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{NodeLockKey: lockStr},
+		}}, nil
+	})
+	patchCalls := 0
+	clientSet.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCalls++
+		return true, nil, errors.New("simulated lost patch response")
+	})
+
+	if err := SetNodeLock(nodeName, "", pod); err != nil {
+		t.Fatalf("SetNodeLock() error = %v, want nil", err)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("patch calls = %d, want 1", patchCalls)
+	}
+}
+
 func TestReleaseNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
 	nodeLocks = newNodeLockManager()
 	nodeName := "node-release-conflict"
@@ -116,6 +149,50 @@ func TestReleaseNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
 	}
 	if got := node.Annotations[NodeLockKey]; got != holderB {
 		t.Fatalf("node lock = %q, want concurrent holder %q", got, holderB)
+	}
+	if patchCalls != 1 {
+		t.Fatalf("patch calls = %d, want 1", patchCalls)
+	}
+}
+
+func TestReleaseNodeLockPreservesReplacedLegacyLockAfterConflict(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "node-release-legacy-conflict"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns"}}
+	initialLock := "2026-08-01T06:00:00Z"
+	replacedLock := "2026-08-01T06:00:01Z"
+	clientSet := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        nodeName,
+		Annotations: map[string]string{NodeLockKey: initialLock},
+	}})
+	client.KubeClient = clientSet
+
+	getCalls := 0
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getCalls++
+		if getCalls < 3 {
+			return false, nil, nil
+		}
+		return true, &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{NodeLockKey: replacedLock},
+		}}, nil
+	})
+	patchCalls := 0
+	clientSet.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, nodeName, errors.New("simulated concurrent legacy lock"))
+	})
+
+	if err := ReleaseNodeLock(nodeName, "", pod, false); err != nil {
+		t.Fatalf("ReleaseNodeLock() error = %v, want nil", err)
+	}
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got := node.Annotations[NodeLockKey]; got != replacedLock {
+		t.Fatalf("node lock = %q, want concurrent legacy lock %q", got, replacedLock)
 	}
 	if patchCalls != 1 {
 		t.Fatalf("patch calls = %d, want 1", patchCalls)

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nodelock
 
 import (
-	"context" // Added for the new test
+	"context"
 	"errors"
 	"runtime"
 	"strings"
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1" // Added for the new test
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
@@ -119,6 +119,53 @@ func TestReleaseNodeLockPreservesConcurrentLockAfterConflict(t *testing.T) {
 	}
 	if patchCalls != 1 {
 		t.Fatalf("patch calls = %d, want 1", patchCalls)
+	}
+}
+
+func TestReleaseNodeLockReleasesRestampedLockForSamePod(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "node-release-restamped"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns"}}
+	initialLock := "2026-07-29T13:00:00Z,ns,pod-a"
+	restampedLock := "2026-07-29T13:00:01Z,ns,pod-a"
+	clientSet := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:        nodeName,
+		Annotations: map[string]string{NodeLockKey: initialLock},
+	}})
+	client.KubeClient = clientSet
+
+	getCalls := 0
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getCalls++
+		if getCalls != 3 {
+			return false, nil, nil
+		}
+		return true, &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{NodeLockKey: restampedLock},
+		}}, nil
+	})
+	patchCalls := 0
+	clientSet.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCalls++
+		if patchCalls == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, nodeName, errors.New("simulated restamp"))
+		}
+		return false, nil, nil
+	})
+
+	if err := ReleaseNodeLock(nodeName, "", pod, false); err != nil {
+		t.Fatalf("ReleaseNodeLock() error = %v, want nil", err)
+	}
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if _, ok := node.Annotations[NodeLockKey]; ok {
+		t.Fatalf("node lock = %q, want removed", node.Annotations[NodeLockKey])
+	}
+	if patchCalls != 2 {
+		t.Fatalf("patch calls = %d, want 2", patchCalls)
 	}
 }
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Prevents concurrent scheduler replicas from replacing or clearing a node lock after a Kubernetes API conflict retry.

**Which issue(s) this PR fixes**:

Fixes none.

**Special notes for your reviewer**:

`SetNodeLock` and `ReleaseNodeLock` previously checked the annotation before entering `retry.OnError`. After a conflict, the retry fetched a newer Node and patched it without rechecking the lock. An acquisition could overwrite a concurrent holder; a release could remove it.

The retry now treats the annotation observed before patching as a compare-and-set target. Acquisition returns `ErrNodeLockContention` when a refreshed Node is locked. Release only removes the exact lock value it originally observed. Focused fake-client regression tests cover both conflict paths.

Validation:

- `make verify`
- `make test`
- `go test ./pkg/util/nodelock -run 'Test(SetNodeLockPreservesConcurrentLockAfterConflict|ReleaseNodeLockPreservesConcurrentLockAfterConflict)$' -count=1 -v -timeout=60s`

This is scheduler-only; no device-allocation or in-container isolation path changed.

**Does this PR introduce a user-facing change?**:

No.

**AI assistance disclosure**:

AI assistance was used for repository exploration, race analysis, and drafting the focused implementation and tests. I reviewed the affected scheduler path and the validation results, and take responsibility for this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node lock contention handling with clearer contention errors and no unnecessary retries.
  * Revalidated lock ownership before acquiring or releasing locks to prevent overwriting concurrent changes.
  * Preserved active locks during conflicting updates and improved compatibility with legacy lock records.
  * Updated release reporting so it occurs only when a lock is successfully removed.

* **Tests**
  * Expanded coverage for concurrent lock acquisition, release conflicts, restamped locks, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->