### PR TITLE
refactor(device-plugin): pass driverRoot to GetPlugins instead of rec…

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -393,7 +393,7 @@ func startPlugins(c *cli.Context, o *options) ([]plugin.Interface, bool, error) 
 
 	// Get the set of plugins.
 	klog.Info("Retrieving plugins.")
-	plugins, err := GetPlugins(c.Context, infolib, nvmllib, devicelib, &devConfig)
+	plugins, err := GetPlugins(c.Context, infolib, nvmllib, devicelib, string(driverRoot), &devConfig)
 	if err != nil {
 		return nil, false, fmt.Errorf("error getting plugins: %v", err)
 	}

--- a/cmd/device-plugin/nvidia/plugin-manager.go
+++ b/cmd/device-plugin/nvidia/plugin-manager.go
@@ -32,24 +32,23 @@ import (
 )
 
 // GetPlugins returns a set of plugins for the specified configuration.
-func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *nvidia.DeviceConfig) ([]plugin.Interface, error) {
-	// TODO: We could consider passing this as an argument since it should already be used to construct nvmllib.
-	driverRoot := root(*config.Flags.Plugin.ContainerDriverRoot)
+func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, driverRoot string, config *nvidia.DeviceConfig) ([]plugin.Interface, error) {
+	dr := root(driverRoot)
 
 	deviceListStrategies, err := spec.NewDeviceListStrategies(*config.Flags.Plugin.DeviceListStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("invalid device list strategy: %v", err)
 	}
 
-	imexChannels, err := imex.GetChannels(config.Config, driverRoot.getDevRoot())
+	imexChannels, err := imex.GetChannels(config.Config, dr.getDevRoot())
 	if err != nil {
 		return nil, fmt.Errorf("error querying IMEX channels: %w", err)
 	}
 
 	cdiHandler, err := cdi.New(infolib, nvmllib, devicelib,
 		cdi.WithDeviceListStrategies(deviceListStrategies),
-		cdi.WithDriverRoot(string(driverRoot)),
-		cdi.WithDevRoot(driverRoot.getDevRoot()),
+		cdi.WithDriverRoot(driverRoot),
+		cdi.WithDevRoot(dr.getDevRoot()),
 		cdi.WithTargetDriverRoot(*config.Flags.NvidiaDriverRoot),
 		cdi.WithTargetDevRoot(*config.Flags.NvidiaDevRoot),
 		cdi.WithNvidiaCTKPath(*config.Flags.Plugin.NvidiaCTKPath),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves a specific `TODO` in `cmd/device-plugin/nvidia/plugin-manager.go`. The `driverRoot` was being reconstructed inside `GetPlugins` even though it was already instantiated inside `main.go` right before calling `GetPlugins`. 

This refactor updates the `GetPlugins` signature to accept the `driverRoot` string directly from the caller, cleaning up the NVIDIA plugin manager initialization pipeline.

**Which issue(s) this PR fixes**:
Fixes #2496

**Special notes for your reviewer**:
Tested the build and verified the initialization pipeline remains functionally equivalent.

**Release note**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA device plugin handling of custom driver root paths.
  * Ensured device discovery and CDI configuration consistently use the specified driver and device roots.
  * Preserved existing plugin setup and device list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->