### PR TITLE
fix(metrics): prevent invalid memory ratios for unknown total memory

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -139,7 +139,7 @@ func start() error {
 	defer sher.Stop()
 
 	// start monitor metrics
-	go initMetrics(config.MetricsBindAddress, legacyMetrics)
+	go initMetrics(config.MetricsBindAddress, sher, legacyMetrics)
 
 	// start http server
 	router := httprouter.New()

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -27,7 +27,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	klog "k8s.io/klog/v2"
 
+	"github.com/Project-HAMi/HAMi/pkg/device"
 	versionmetrics "github.com/Project-HAMi/HAMi/pkg/metrics"
+	schedulerpkg "github.com/Project-HAMi/HAMi/pkg/scheduler"
 )
 
 type ClusterManager struct {
@@ -35,9 +37,16 @@ type ClusterManager struct {
 	LegacyMetrics bool
 }
 
+type schedulerMetricsProvider interface {
+	InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage
+	GetQuotaManager() *device.QuotaManager
+	GetPodManager() *device.PodManager
+}
+
 // ClusterManagerCollector implements the Collector interface.
 type ClusterManagerCollector struct {
-	ClusterManager *ClusterManager
+	ClusterManager  *ClusterManager
+	metricsProvider schedulerMetricsProvider
 }
 
 // Describe is implemented with DescribeByCollect. That's possible because the
@@ -165,7 +174,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
-	nu := sher.InspectAllNodesUsage()
+	nu := cc.metricsProvider.InspectAllNodesUsage()
 	for nodeID, val := range *nu {
 		for _, devs := range val.Devices.DeviceLists {
 			if devs.Device.Mode == "mig" {
@@ -228,12 +237,15 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
 				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 			)
-			ch <- prometheus.MustNewConstMetric(
-				nodeGPUMemoryPercentage,
-				prometheus.GaugeValue,
-				float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
-			)
+
+			if devs.Device.Totalmem > 0 {
+				ch <- prometheus.MustNewConstMetric(
+					nodeGPUMemoryPercentage,
+					prometheus.GaugeValue,
+					float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
+					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
+				)
+			}
 
 			if legacy {
 				ch <- prometheus.MustNewConstMetric(
@@ -272,12 +284,14 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
 					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
 				)
-				ch <- prometheus.MustNewConstMetric(
-					legacyMemoryPercentage,
-					prometheus.GaugeValue,
-					float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
-				)
+				if devs.Device.Totalmem > 0 {
+					ch <- prometheus.MustNewConstMetric(
+						legacyMemoryPercentage,
+						prometheus.GaugeValue,
+						float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
+						nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
+					)
+				}
 			}
 		}
 	}
@@ -297,7 +311,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 		"resourcequota usage for a certain device",
 		[]string{"namespace", "quota_name", "limit"}, nil,
 	)
-	for ns, val := range sher.GetQuotaManager().GetResourceQuota() {
+	for ns, val := range cc.metricsProvider.GetQuotaManager().GetResourceQuota() {
 		for quotaname, q := range *val {
 			ch <- prometheus.MustNewConstMetric(
 				quotaUsedDesc,
@@ -315,7 +329,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 	}
-	schedpods, _ := sher.GetPodManager().GetScheduledPods()
+	schedpods, _ := cc.metricsProvider.GetPodManager().GetScheduledPods()
 	for _, val := range schedpods {
 		for _, podSingleDevice := range val.Devices {
 			for ctridx, ctrdevs := range podSingleDevice {
@@ -386,7 +400,10 @@ func NewClusterManager(zone string, reg prometheus.Registerer, legacyMetrics boo
 		Zone:          zone,
 		LegacyMetrics: legacyMetrics,
 	}
-	cc := ClusterManagerCollector{ClusterManager: c}
+	cc := ClusterManagerCollector{
+		ClusterManager:  c,
+		metricsProvider: sher,
+	}
 	prometheus.WrapRegistererWith(prometheus.Labels{"zone": zone}, reg).MustRegister(cc)
 	return c
 }

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -395,25 +395,25 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // NewClusterManager creates a ClusterManager and registers its collector.
-func NewClusterManager(zone string, reg prometheus.Registerer, legacyMetrics bool) *ClusterManager {
+func NewClusterManager(zone string, reg prometheus.Registerer, metricsProvider schedulerMetricsProvider, legacyMetrics bool) *ClusterManager {
 	c := &ClusterManager{
 		Zone:          zone,
 		LegacyMetrics: legacyMetrics,
 	}
 	cc := ClusterManagerCollector{
 		ClusterManager:  c,
-		metricsProvider: sher,
+		metricsProvider: metricsProvider,
 	}
 	prometheus.WrapRegistererWith(prometheus.Labels{"zone": zone}, reg).MustRegister(cc)
 	return c
 }
 
-func initMetrics(bindAddress string, legacyMetrics bool) {
+func initMetrics(bindAddress string, metricsProvider schedulerMetricsProvider, legacyMetrics bool) {
 	klog.Info("Initializing metrics for scheduler")
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(versionmetrics.NewBuildInfoCollector())
 
-	NewClusterManager("vGPU", reg, legacyMetrics)
+	NewClusterManager("vGPU", reg, metricsProvider, legacyMetrics)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	schedulerpkg "github.com/Project-HAMi/HAMi/pkg/scheduler"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+)
+
+type fakeSchedulerMetricsProvider struct {
+	nodeUsage    map[string]*schedulerpkg.NodeUsage
+	quotaManager *device.QuotaManager
+	podManager   *device.PodManager
+}
+
+func (f *fakeSchedulerMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage {
+	return &f.nodeUsage
+}
+
+func (f *fakeSchedulerMetricsProvider) GetQuotaManager() *device.QuotaManager {
+	return f.quotaManager
+}
+
+func (f *fakeSchedulerMetricsProvider) GetPodManager() *device.PodManager {
+	return f.podManager
+}
+
+func TestClusterManagerCollectorSkipsMemoryRatioWithNonPositiveTotalMemory(t *testing.T) {
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "zero-memory",
+							Index:     0,
+							Totalmem:  0,
+							Totalcore: 2,
+							Type:      "AWSNeuron",
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "negative-memory",
+							Index:     1,
+							Totalmem:  -1,
+							Totalcore: 2,
+							Type:      "test-device",
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "normal-memory",
+							Index:     2,
+							Usedmem:   1,
+							Totalmem:  4,
+							Totalcore: 2,
+							Type:      "NVIDIA",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{
+			LegacyMetrics: true,
+		},
+		metricsProvider: &fakeSchedulerMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: device.NewQuotaManager(),
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_gpu_core_limit_ratio Device core limit for a certain GPU
+# TYPE hami_gpu_core_limit_ratio gauge
+hami_gpu_core_limit_ratio{device_index="0",device_type="AWSNeuron",device_uuid="zero-memory",node="node-1"} 2
+hami_gpu_core_limit_ratio{device_index="1",device_type="test-device",device_uuid="negative-memory",node="node-1"} 2
+hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 2
+# HELP hami_node_gpu_memory_allocated_ratio GPU Memory Allocated Percentage on a certain GPU
+# TYPE hami_node_gpu_memory_allocated_ratio gauge
+hami_node_gpu_memory_allocated_ratio{device_index="2",device_uuid="normal-memory",node="node-1"} 0.25
+# HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU
+# TYPE nodeGPUMemoryPercentage gauge
+nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"} 0.25
+`
+
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_gpu_core_limit_ratio",
+		"hami_node_gpu_memory_allocated_ratio",
+		"nodeGPUMemoryPercentage",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR skips the current and legacy memory-allocation ratio metrics when `Totalmem <= 0`. Some device backends, such as AWS Neuron, do not report memory capacity, which previously caused the collector to export `NaN` from a `0/0` calculation.

It also adds collector-level regression coverage for nonpositive total memory while verifying that normal ratios and unrelated device metrics remain unchanged.

**Which issue(s) this PR fixes**:
Fixes #2186 

**Special notes for your reviewer**:

The collector now receives its scheduler metrics provider through a small interface instead of reading the global scheduler directly. Production still injects the same scheduler instance; the interface allows the real collector to be tested with controlled device usage.

Validation performed:

- `go test ./cmd/scheduler ./pkg/scheduler/... ./pkg/device/awsneuron -short -count=1`
- `make verify`

No accelerator hardware was used because this change is limited to scheduler metric collection and is covered using synthetic scheduler state.

**Does this PR introduce a user-facing change?**:
Yes. When a device does not report a positive total memory capacity, HAMi no longer exports the current or legacy memory-allocation ratio for that device. All other device metrics continue to be exported.

AI assistance disclosure: I used OpenAI Codex while exploring the repository to trace the affected metrics path, discuss how to make the collector testable, and review the test coverage and final diff. 
Rest, I, Mr.Human manually implemented the changes, reproduced the failure, iterated through the failing and passing collector test, ran the relevant scheduler and AWS Neuron tests, and completed `make verify`. 
I understand the implementation and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented GPU memory allocation ratio metrics from being emitted when total GPU memory is zero or negative, avoiding invalid calculations (including the legacy metric).
  * Continued emitting GPU core limit ratio metrics for those devices.
* **Refactor**
  * Improved metrics collection by sourcing node usage, quota, and scheduled-pod data through a pluggable provider.
  * Updated metrics initialization to use the active scheduler instance at startup.
* **Tests**
  * Added unit coverage to confirm memory-ratio metrics are skipped only for non-positive total GPU memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->