### PR TITLE
refactor(device-plugin): pass driverRoot to GetPlugins instead of rec…

### DIFF
--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -393,7 +393,7 @@ func startPlugins(c *cli.Context, o *options) ([]plugin.Interface, bool, error) 
 
 	// Get the set of plugins.
 	klog.Info("Retrieving plugins.")
-	plugins, err := GetPlugins(c.Context, infolib, nvmllib, devicelib, &devConfig)
+	plugins, err := GetPlugins(c.Context, infolib, nvmllib, devicelib, &devConfig, driverRoot)
 	if err != nil {
 		return nil, false, fmt.Errorf("error getting plugins: %v", err)
 	}

--- a/cmd/device-plugin/nvidia/plugin-manager.go
+++ b/cmd/device-plugin/nvidia/plugin-manager.go
@@ -32,9 +32,7 @@ import (
 )
 
 // GetPlugins returns a set of plugins for the specified configuration.
-func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *nvidia.DeviceConfig) ([]plugin.Interface, error) {
-	// TODO: We could consider passing this as an argument since it should already be used to construct nvmllib.
-	driverRoot := root(*config.Flags.Plugin.ContainerDriverRoot)
+func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *nvidia.DeviceConfig, driverRoot root) ([]plugin.Interface, error) {
 
 	deviceListStrategies, err := spec.NewDeviceListStrategies(*config.Flags.Plugin.DeviceListStrategy)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- Resolves a TODO in `GetPlugins` where `driverRoot` was being re-constructed
  from `config.Flags.Plugin.ContainerDriverRoot`, even though the caller in
  `main.go` already derives it before passing it to NVML library initialization.
- Removes the redundant call and accepts `driverRoot root` as a parameter
  instead.
- The caller in `startPlugins()` already constructs `driverRoot` on line 363
  for NVML library path resolution, so re-deriving it from the same source is
  unnecessary coupling to the config struct.

**Which issue(s) this PR fixes**:
Fixes #2196

**Special notes for your reviewer**:

Zero-behavior-change refactor — `driverRoot` has the same value either way,
since both call sites read from `*config.Flags.Plugin.ContainerDriverRoot`.

**Does this PR introduce a user-facing change?**:

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA device plugin configuration by consistently applying the detected driver root when setting up device handlers.
  * Helps ensure IMEX and CDI device paths are resolved correctly across driver installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->