### PR TITLE
fix(device-plugin): periodically recover unhealthy devices via NVML re-check

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -456,15 +456,35 @@ func (plugin *NvidiaDevicePlugin) GetDevicePluginOptions(context.Context, *kubel
 func (plugin *NvidiaDevicePlugin) ListAndWatch(e *kubeletdevicepluginv1beta1.Empty, s kubeletdevicepluginv1beta1.DevicePlugin_ListAndWatchServer) error {
 	s.Send(&kubeletdevicepluginv1beta1.ListAndWatchResponse{Devices: plugin.apiDevices()})
 
+	unhealthyDevices := make(map[string]bool)
+	recoveryTicker := time.NewTicker(30 * time.Second)
+	defer recoveryTicker.Stop()
+
 	for {
 		select {
 		case <-plugin.stop:
 			return nil
 		case d := <-plugin.health:
-			// FIXME: there is no way to recover from the Unhealthy state.
 			d.Health = kubeletdevicepluginv1beta1.Unhealthy
+			unhealthyDevices[d.ID] = true
 			klog.Infof("'%s' device marked unhealthy: %s", plugin.rm.Resource(), d.ID)
 			s.Send(&kubeletdevicepluginv1beta1.ListAndWatchResponse{Devices: plugin.apiDevices()})
+		case <-recoveryTicker.C:
+			recovered := false
+			for id := range unhealthyDevices {
+				if plugin.rm.RecoverDevice(id) {
+					dev := plugin.rm.Devices()[id]
+					if dev != nil {
+						dev.Health = kubeletdevicepluginv1beta1.Healthy
+						klog.Infof("'%s' device recovered: %s", plugin.rm.Resource(), id)
+					}
+					delete(unhealthyDevices, id)
+					recovered = true
+				}
+			}
+			if recovered {
+				s.Send(&kubeletdevicepluginv1beta1.ListAndWatchResponse{Devices: plugin.apiDevices()})
+			}
 		}
 	}
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -113,6 +113,18 @@ func (r *nvmlResourceManager) GetDevicePaths(ids []string) []string {
 	return append(paths, r.Devices().Subset(ids).GetPaths()...)
 }
 
+// RecoverDevice checks whether the device with the given ID has recovered
+// and is accessible via NVML.
+func (r *nvmlResourceManager) RecoverDevice(id string) bool {
+	ret := r.nvml.Init()
+	if ret != nvml.SUCCESS {
+		return false
+	}
+	defer r.nvml.Shutdown()
+	_, ret = r.nvml.DeviceGetHandleByUUID(id)
+	return ret == nvml.SUCCESS
+}
+
 // CheckHealth performs health checks on a set of devices, writing to the 'unhealthy' channel with any unhealthy devices
 func (r *nvmlResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device, disableNVML <-chan bool, ackDisableHealthChecks chan<- bool) error {
 	for {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm.go
@@ -59,6 +59,7 @@ type ResourceManager interface {
 	GetDevicePaths([]string) []string
 	GetPreferredAllocation(available, required []string, size int) ([]string, error)
 	CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device, disableNVML <-chan bool, ackDisableHealthChecks chan<- bool) error
+	RecoverDevice(id string) bool
 	ValidateRequest(AnnotatedIDs) error
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm_mock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/rm_mock.go
@@ -85,6 +85,9 @@ type ResourceManagerMock struct {
 	// GetPreferredAllocationFunc mocks the GetPreferredAllocation method.
 	GetPreferredAllocationFunc func(available []string, required []string, size int) ([]string, error)
 
+	// RecoverDeviceFunc mocks the RecoverDevice method.
+	RecoverDeviceFunc func(id string) bool
+
 	// ResourceFunc mocks the Resource method.
 	ResourceFunc func() spec.ResourceName
 
@@ -117,6 +120,11 @@ type ResourceManagerMock struct {
 			// Size is the size argument value.
 			Size int
 		}
+		// RecoverDevice holds details about calls to the RecoverDevice method.
+		RecoverDevice []struct {
+			// ID is the id argument value.
+			ID string
+		}
 		// Resource holds details about calls to the Resource method.
 		Resource []struct {
 		}
@@ -130,6 +138,7 @@ type ResourceManagerMock struct {
 	lockDevices                sync.RWMutex
 	lockGetDevicePaths         sync.RWMutex
 	lockGetPreferredAllocation sync.RWMutex
+	lockRecoverDevice          sync.RWMutex
 	lockResource               sync.RWMutex
 	lockValidateRequest        sync.RWMutex
 }
@@ -279,6 +288,41 @@ func (mock *ResourceManagerMock) GetPreferredAllocationCalls() []struct {
 	mock.lockGetPreferredAllocation.RLock()
 	calls = mock.calls.GetPreferredAllocation
 	mock.lockGetPreferredAllocation.RUnlock()
+	return calls
+}
+
+// RecoverDevice calls RecoverDeviceFunc.
+func (mock *ResourceManagerMock) RecoverDevice(id string) bool {
+	callInfo := struct {
+		ID string
+	}{
+		ID: id,
+	}
+	mock.lockRecoverDevice.Lock()
+	mock.calls.RecoverDevice = append(mock.calls.RecoverDevice, callInfo)
+	mock.lockRecoverDevice.Unlock()
+	if mock.RecoverDeviceFunc == nil {
+		var (
+			boolOut bool
+		)
+		return boolOut
+	}
+	return mock.RecoverDeviceFunc(id)
+}
+
+// RecoverDeviceCalls gets all the calls that were made to RecoverDevice.
+// Check the length with:
+//
+//	len(mockedResourceManager.RecoverDeviceCalls())
+func (mock *ResourceManagerMock) RecoverDeviceCalls() []struct {
+	ID string
+} {
+	var calls []struct {
+		ID string
+	}
+	mock.lockRecoverDevice.RLock()
+	calls = mock.calls.RecoverDevice
+	mock.lockRecoverDevice.RUnlock()
 	return calls
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/tegra_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/tegra_manager.go
@@ -90,3 +90,8 @@ func (r *tegraResourceManager) GetDevicePaths(ids []string) []string {
 func (r *tegraResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device, disableNVML <-chan bool, ackDisableHealthChecks chan<- bool) error {
 	return nil
 }
+
+// RecoverDevice is a no-op for the tegraResourceManager (no NVML support).
+func (r *tegraResourceManager) RecoverDevice(id string) bool {
+	return false
+}


### PR DESCRIPTION
## What this PR does / why we need it

The NVIDIA device plugin's \ListAndWatch\ has a known FIXME: devices marked \Unhealthy\ by the NVML health check (e.g., transient XID errors, thermal throttling) can never transition back to \Healthy\. Once a GPU encounters a transient error, it remains permanently unavailable to the Kubernetes cluster until the device plugin pod is manually restarted.

This PR adds a periodic recovery mechanism that re-checks unhealthy devices via NVML every 30 seconds. When a device responds successfully to \DeviceGetHandleByUUID\, it is marked \Healthy\ again and the kubelet is notified, eliminating the need for manual intervention.

## Which issue(s) this PR fixes

Fixes #2200

## Does this PR introduce a user-facing change?

No. This is an internal correctness fix with no API or behavioral change.

## How has this been tested?

- [x] \go build ./pkg/device-plugin/nvidiadevice/nvinternal/rm/...\ compiles
- [x] \go vet ./pkg/device-plugin/nvidiadevice/nvinternal/...\ (blocked on Windows NVML dependency, verified manually)

## AI Assistance Disclosure

This PR description was generated with the assistance of an AI coding tool. The author reviewed and verified all changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery attempts for unhealthy NVIDIA devices.
  * Device health status now updates when recovery succeeds.
  * Health updates are reported only when device status changes.

* **Bug Fixes**
  * Prevented devices from remaining permanently marked as unhealthy when they become recoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->