### PR TITLE
Fix/multi device quota enforcement

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -130,11 +130,10 @@ func isPrivilegedContainer(ctr *corev1.Container) bool {
 
 func fitResourceQuota(pod *corev1.Pod) bool {
 	for deviceName, dev := range device.GetDevices() {
-		// Only supports NVIDIA
-		if deviceName != nvidia.NvidiaGPUDevice {
-			continue
+		memoryFactor := int32(1)
+		if deviceName == nvidia.NvidiaGPUDevice {
+			memoryFactor = nvidia.MemoryFactor
 		}
-		memoryFactor := nvidia.MemoryFactor
 		resourceNames := dev.GetResourceNames()
 		resourceName := corev1.ResourceName(resourceNames.ResourceCountName)
 		memResourceName := corev1.ResourceName(resourceNames.ResourceMemoryName)

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -35,6 +35,40 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
 
+type mockDevices struct {
+	resourceNames device.ResourceNames
+}
+
+func (m *mockDevices) CommonWord() string                                   { return "mock" }
+func (m *mockDevices) MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error) {
+	return true, nil
+}
+func (m *mockDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) {
+	return true, true
+}
+func (m *mockDevices) NodeCleanUp(nn string) error                      { return nil }
+func (m *mockDevices) GetResourceNames() device.ResourceNames           { return m.resourceNames }
+func (m *mockDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
+	return []*device.DeviceInfo{}, nil
+}
+func (m *mockDevices) LockNode(n *corev1.Node, p *corev1.Pod) error       { return nil }
+func (m *mockDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error { return nil }
+func (m *mockDevices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {
+	return device.ContainerDeviceRequest{}
+}
+func (m *mockDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]string, pd device.PodDevices) map[string]string {
+	return map[string]string{}
+}
+func (m *mockDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
+	return 1.0
+}
+func (m *mockDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
+	return nil
+}
+func (m *mockDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
+	return true, nil, ""
+}
+
 func TestHandle(t *testing.T) {
 	// create a Pod object
 	pod := &corev1.Pod{
@@ -263,14 +297,27 @@ func TestFitResourceQuota(t *testing.T) {
 		klog.Fatalf("Failed to initialize devices with config: %v", err)
 	}
 
+	ascendCountName := "huawei.com/Ascend910B"
+	ascendMemName := "huawei.com/Ascend910B-memory"
+	device.DevicesMap["Ascend910B"] = &mockDevices{
+		resourceNames: device.ResourceNames{
+			ResourceCountName:  ascendCountName,
+			ResourceMemoryName: ascendMemName,
+		},
+	}
+	defer func() {
+		delete(device.DevicesMap, "Ascend910B")
+	}()
+
 	qm := device.NewQuotaManager()
 	ns := "default"
-	memName := "nvidia.com/gpumem"
-	coreName := "nvidia.com/gpucores"
+	nvidiaMemName := "nvidia.com/gpumem"
+	nvidiaCoreName := "nvidia.com/gpucores"
 
 	qm.Quotas[ns] = &device.DeviceQuota{
-		memName:  &device.Quota{Used: 1000, Limit: 2000},
-		coreName: &device.Quota{Used: 200, Limit: 400},
+		nvidiaMemName:  &device.Quota{Used: 1000, Limit: 2000},
+		nvidiaCoreName: &device.Quota{Used: 200, Limit: 400},
+		ascendMemName:  &device.Quota{Used: 0, Limit: 1000},
 	}
 
 	testCases := []struct {
@@ -387,7 +434,7 @@ func TestFitResourceQuota(t *testing.T) {
 			fit: true,
 		},
 		{
-			name: "request ascend",
+			name: "request ascend exceeded quota",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
@@ -405,6 +452,59 @@ func TestFitResourceQuota(t *testing.T) {
 								Limits: corev1.ResourceList{
 									"huawei.com/Ascend910B":        resource.MustParse("1"),
 									"huawei.com/Ascend910B-memory": resource.MustParse("1024"),
+								},
+							},
+						},
+					},
+				},
+			},
+			fit: false,
+		},
+		{
+			name: "request ascend within quota",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: "hami-scheduler",
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: nil,
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"huawei.com/Ascend910B":        resource.MustParse("1"),
+									"huawei.com/Ascend910B-memory": resource.MustParse("500"),
+								},
+							},
+						},
+					},
+				},
+			},
+			fit: true,
+		},
+		{
+			name: "request ascend memory only no count",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					SchedulerName: "hami-scheduler",
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: nil,
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"huawei.com/Ascend910B-memory": resource.MustParse("2000"),
 								},
 							},
 						},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fitResourceQuota had a hard skip for every device except NVIDIA. Pods
requesting Ascend, Cambricon, Hygon or any other backend could blow right
past namespace ResourceQuota at admission time.

Removed the guard. Non-NVIDIA devices use memoryFactor=1, NVIDIA keeps
nvidia.MemoryFactor as before.

**Which issue(s) this PR fixes**:
Fixes #2157

**Special notes for your reviewer**:

FitQuota in pkg/device/quota.go was already device-agnostic — call it with
an Ascend device name and it returns the right answer. The gap was purely
in fitResourceQuota skipping the call for non-NVIDIA.

Test setup registers a stub Ascend device with a 1000mb quota (0 used) and
verifies deny/allow for over/under-quota requests plus a no-count-resource
edge case.

**Does this PR introduce a user-facing change?**:

Pods requesting non-NVIDIA accelerator memory or core resources are now
checked against namespace ResourceQuota at admission time, same as NVIDIA.
Previously they were silently excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota checks now account for all supported device types, not only NVIDIA GPUs.
  * Improved handling of device-specific memory quotas, including Ascend devices.
* **Tests**
  * Expanded quota validation coverage for mixed device types and memory-only requests.
  * Added scenarios for exceeded and successfully fitted Ascend quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->