### PR TITLE
fix: remove PR template fields from enhancement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -8,15 +8,6 @@ labels: kind/feature
 
 **What would you like to be added**:
 
-**What type of PR is this?**
+**Why is this needed**:
 
-/kind feature
-
-**What this PR does / why we need it**:
-
-**Which issue(s) this PR fixes**:
-Fixes #
-
-**Special notes for your reviewer**:
-
-**Does this PR introduce a user-facing change?**:
+**Anything else we need to know?**:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `Enhancement Request` issue template contains the body of `.github/PULL_REQUEST_TEMPLATE.md`. Anyone opening a feature request is asked which issue their PR fixes, for notes to their reviewer, and whether the PR introduces a user-facing change. None of that applies to an issue.

Before:

```
**What would you like to be added**:

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```

After:

```
**What would you like to be added**:

**Why is this needed**:

**Anything else we need to know?**:
```

This matches the shape of the other issue templates in the repo and the upstream Kubernetes enhancement template. Also adds the missing trailing newline.

The `kind/feature` label still comes from the template front matter, so the `/kind feature` line is not needed.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Only `enhancement.md` was affected. `bug-report.md`, `question.md` and `good-first.md` are fine.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the enhancement request template with prompts for the request’s rationale and additional relevant context.
  - Simplified the template by removing outdated instructional sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->