### PR TITLE
fix(workflow): skip non-translatable issue comments

### DIFF
--- a/.github/workflows/issue-translate.yaml
+++ b/.github/workflows/issue-translate.yaml
@@ -10,6 +10,13 @@ permissions:
 
 jobs:
   translate: # make sure the action works on a clean machine without building
+    if: >-
+      github.event_name == 'issues' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        !startsWith(github.event.comment.body, '/')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: tomsun28/issues-translate-action@b41f55ddc81d7d54bd542a4f289fe28ec081898e # v2.7


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add a job-level condition to the `issue-translate` workflow so it continues translating newly opened issues and genuine human comments, while skipping:

- slash-command comments such as `/assign`, `/kind`, and `/close`
- comments created by GitHub bot accounts

Because the condition is evaluated at job level, skipped comments do not allocate an Actions runner.

**Which issue(s) this PR fixes**:
Fixes #2205 

**Special notes for your reviewer**:
The `/assign` comment on #2186 triggered workflow run 30476472696 even though it was an automation command and not translatable content.

The `Bad credentials` error observed in that run is a separate issue with `TRANSLATE_ROBOT_TOKEN`. Genuine non-English comments also fail when the action attempts to use this token, so the repository secret likely requires maintainer-side rotation. This PR intentionally does not modify token ownership or bot identity.

The slash-command check only matches comments beginning with `/`, consistent with HAMi's documented command format. Handling arbitrary leading whitespace is outside the scope of this workflow-only fix.
Validated with:

- `actionlint` v1.7.12
- `git diff --check`
- `make verify`

**Does this PR introduce a user-facing change?**:
No, this only changes when the GitHub Actions translation workflow runs.

**AI assistance disclosure**:
I personally authored this change and used OpenAI Codex for the overall review and testing purpose. I fully understand the final implementation and have manually verified the job-level conditions and slash-command filtering in my fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated issue translation triggers.
  * Translation now runs for newly created or updated issues and for qualifying human comments that do not begin with a command prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->