### PR TITLE
fix(util): re-evaluate lock state in optimistic locking retry loop

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -45,6 +45,9 @@ const (
 // valid pod. Callers may retry this error when the caller is a PodGroup member.
 var ErrNodeLockContention = errors.New("node lock contention")
 
+// ErrNodeLockAborted indicates the lock operation was safely aborted to avoid blindly overwriting state.
+var ErrNodeLockAborted = errors.New("node lock operation aborted")
+
 func IsNodeLockContention(err error) bool {
 	return errors.Is(err, ErrNodeLockContention)
 }
@@ -141,14 +144,24 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 		return fmt.Errorf("node %s is locked", nodeName)
 	}
 	err = retry.OnError(DefaultStrategy, func(err error) bool {
-		// Retry on any error
-		return true
+		// Retry on any error except our own contention error
+		return !IsNodeLockContention(err)
 	}, func() error {
 		node, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
 		}
+
+		// Re-evaluate lock status after fetching latest state
+		if lockStr, ok := node.Annotations[NodeLockKey]; ok {
+			// If our first patch succeeded but the resp was lost, this retry sees our own lock.
+			if strings.Contains(lockStr, NodeLockSep) && strings.HasSuffix(lockStr, NodeLockSep+GeneratePodNamespaceName(pods, NodeLockSep)) {
+				return nil
+			}
+			return fmt.Errorf("node %s is locked: %w", nodeName, ErrNodeLockContention)
+		}
+
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"},"resourceVersion":"%s"}}`, NodeLockKey, GenerateNodeLockKeyByPod(pods), node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
@@ -191,14 +204,25 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 	}
 
 	err = retry.OnError(DefaultStrategy, func(err error) bool {
-		// Retry on any error
-		return true
+		// Retry on any error except our own abort signal
+		return !errors.Is(err, ErrNodeLockAborted)
 	}, func() error {
 		node, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node when retry to patch", "node", nodeName)
 			return err
 		}
+
+		// Re-evaluate lock ownership after fetching latest state
+		lockStr, ok := node.Annotations[NodeLockKey]
+		if !ok {
+			return nil // Already released
+		}
+		if !skipNodeLockOwnerCheck && strings.Contains(lockStr, NodeLockSep) && !strings.HasSuffix(lockStr, NodeLockSep+GeneratePodNamespaceName(pod, NodeLockSep)) {
+			klog.InfoS("NodeLock is not set by this pod during retry", NodeLockKey, lockStr, "podName", pod.Name, "podNamespace", pod.Namespace)
+			return ErrNodeLockAborted // Abort retry
+		}
+
 		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null},"resourceVersion":"%s"}}`, NodeLockKey, node.ResourceVersion)
 		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
@@ -207,6 +231,9 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 		}
 		return nil
 	})
+	if errors.Is(err, ErrNodeLockAborted) {
+		return nil // Gracefully handled abort
+	}
 	if err != nil {
 		return fmt.Errorf("failed to release node lock (node=%s, retry strategy=%+v): %w", nodeName, DefaultStrategy, err)
 	}

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -24,8 +24,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1" // Added for the new test
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
@@ -613,5 +616,118 @@ func TestSetupNodeLockTimeout(t *testing.T) {
 				t.Errorf("got %v, want %v", NodeLockTimeout, tt.want)
 			}
 		})
+	}
+}
+
+func TestSetNodeLock_RetryOwnLock(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeName := "retry-node"
+	podName := "retry-pod"
+	podNamespace := "retry-ns"
+
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	}, metav1.CreateOptions{})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+		},
+	}
+
+	fakeClient := client.KubeClient.(*fake.Clientset)
+	patchAttempts := 0
+
+	fakeClient.PrependReactor("patch", "nodes", func(action k8stesting.Action) (handled bool, ret apiruntime.Object, err error) {
+		patchAction := action.(k8stesting.PatchAction)
+		if patchAction.GetName() == nodeName {
+			if patchAttempts == 0 {
+				patchAttempts++
+
+				// Simulate successful patch on backend but client timed out / got conflict
+				// We actually apply the lock so the next Get sees it
+				obj, _ := fakeClient.Tracker().Get(corev1.SchemeGroupVersion.WithResource("nodes"), "", nodeName)
+				node := obj.(*corev1.Node)
+				node.Annotations = map[string]string{
+					NodeLockKey: GenerateNodeLockKeyByPod(pod),
+				}
+				fakeClient.Tracker().Update(corev1.SchemeGroupVersion.WithResource("nodes"), node, "")
+
+				return true, nil, apierrors.NewConflict(corev1.Resource("nodes"), nodeName, nil)
+			}
+		}
+		return false, nil, nil
+	})
+
+	err := SetNodeLock(nodeName, "", pod)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if patchAttempts == 0 {
+		t.Fatalf("expected patch to be intercepted")
+	}
+}
+
+func TestReleaseNodeLock_RetryAborted(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeName := "retry-node-release"
+	podName := "retry-pod"
+	podNamespace := "retry-ns"
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+		},
+	}
+
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				NodeLockKey: GenerateNodeLockKeyByPod(pod),
+			},
+		},
+	}, metav1.CreateOptions{})
+
+	fakeClient := client.KubeClient.(*fake.Clientset)
+	patchAttempts := 0
+
+	fakeClient.PrependReactor("patch", "nodes", func(action k8stesting.Action) (handled bool, ret apiruntime.Object, err error) {
+		patchAction := action.(k8stesting.PatchAction)
+		if patchAction.GetName() == nodeName {
+			if patchAttempts == 0 {
+				patchAttempts++
+
+				// Simulate that during the retry interval, another pod acquired the lock
+				obj, _ := fakeClient.Tracker().Get(corev1.SchemeGroupVersion.WithResource("nodes"), "", nodeName)
+				node := obj.(*corev1.Node)
+				otherPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "other"},
+				}
+				node.Annotations = map[string]string{
+					NodeLockKey: GenerateNodeLockKeyByPod(otherPod),
+				}
+				fakeClient.Tracker().Update(corev1.SchemeGroupVersion.WithResource("nodes"), node, "")
+
+				return true, nil, apierrors.NewConflict(corev1.Resource("nodes"), nodeName, nil)
+			}
+		}
+		return false, nil, nil
+	})
+
+	err := ReleaseNodeLock(nodeName, "", pod, false)
+	if err != nil {
+		t.Fatalf("expected nil error (aborted gracefully), got %v", err)
+	}
+	if patchAttempts == 0 {
+		t.Fatalf("expected patch to be intercepted")
+	}
+
+	// Verify the lock is still held by 'other'
+	node, _ := fakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if !strings.Contains(node.Annotations[NodeLockKey], "other") {
+		t.Fatalf("expected lock to be held by other pod, got %v", node.Annotations[NodeLockKey])
 	}
 }


### PR DESCRIPTION
fix(util): re-evaluate lock state in optimistic locking retry loop

## What happened
The HAMi scheduler and device plugins rely on `pkg/util/nodelock` to implement a distributed node lock using Kubernetes node annotations (`hami.io/mutex.lock`).

Currently, `SetNodeLock` and `ReleaseNodeLock` correctly use an optimistic locking pattern via `retry.OnError`, but the condition checking occurs *outside* the retry function. Inside the `retry.OnError` block, the code blindly fetches the new `resourceVersion` and patches the node without evaluating whether the lock is still available (or still owned by the caller).

This leads to a race condition where concurrent scheduler instances blindly overwrite each other's locks upon a patch conflict.

## What you expected to happen
The `retry.OnError` loop should explicitly re-evaluate the lock state after fetching the node (inside the loop). If the node is already locked by another process (for `SetNodeLock`) or the lock is no longer owned by the current pod (for `ReleaseNodeLock`), the retry loop should abort rather than blindly applying the patch.

## How to reproduce it (as minimally and precisely as possible)
1. Run two instances of `SetNodeLock` concurrently for the same node.
2. The first instance patches the node successfully.
3. The second instance fails with a 409 Conflict.
4. The second instance's `retry.OnError` triggers, fetches the node, and unceremoniously overwrites the first instance's lock because it fails to check `node.Annotations[NodeLockKey]` inside the retry block.

## Environment
* HAMi version: master

--
In a perfect world, AI assistance would produce equal or higher quality
work than any human. That isn't the world we live in today, and in many cases
AI-generated code can contain subtle bugs or not adhere to project-specific
best practices. I say this despite being a fan of and using them successfully
myself (with heavy supervision)!

When using AI assistance, we expect contributors to understand the code
that is produced and be able to answer critical questions about it. It
isn't a maintainer's job to review a PR so broken that it requires
significant rework to be acceptable.

Please be respectful to maintainers and disclose AI assistance.

**AI Assistance Disclosure:** This PR was identified and written with the assistance of an AI agent. The AI was used to identify the concurrency race condition within the optimistic locking retry logic, write the fix, and draft this PR description. The solution was fully reviewed, vetted, and manually verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-lock acquisition when ownership changes during retries.
  * Prevented lock releases from removing another pod’s lock.
  * Treats safely aborted releases as successful no-ops.
  * Added handling for lock contention without unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->