### PR TITLE
fix: remove panic in calculateGPUPairScore

### DIFF
--- a/pkg/device/nvidia/calculate_score.go
+++ b/pkg/device/nvidia/calculate_score.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
 )
 
 // Device represents a GPU device as reported by NVML, including all of its
@@ -212,7 +213,8 @@ func calculateGPUPairScore(gpu0 *Device, gpu1 *Device) int {
 
 	if len(gpu0.Links[gpu1.Index]) != len(gpu1.Links[gpu0.Index]) {
 		err := fmt.Errorf("internal error in bestEffort GPU allocator: all P2PLinks between 2 GPUs should be bidirectional")
-		panic(err)
+		klog.ErrorS(err, "P2PLinks mismatch", "gpu0", gpu0.UUID, "gpu1", gpu1.UUID)
+		return 0
 	}
 
 	score := 0

--- a/pkg/device/nvidia/calculate_score.go
+++ b/pkg/device/nvidia/calculate_score.go
@@ -202,6 +202,8 @@ func calculateGPUScore(devices []*Device) ListDeviceScore {
 	return ds
 }
 
+// calculateGPUPairScore calculates a heuristic score representing the P2P connection
+// strength between two GPUs. A higher score implies better/faster communication links.
 func calculateGPUPairScore(gpu0 *Device, gpu1 *Device) int {
 	if gpu0 == nil || gpu1 == nil {
 		return 0

--- a/pkg/device/nvidia/calculate_score_test.go
+++ b/pkg/device/nvidia/calculate_score_test.go
@@ -106,6 +106,38 @@ func Test_calculateGPUScore(t *testing.T) {
 					UUID:  "gpu3",
 					Score: map[string]int{"gpu0": 200, "gpu1": 100, "gpu2": 200},
 				},
+		},
+		{
+			name: "asymmetric links",
+			args: []*Device{
+				{
+					Index: 0,
+					nvlibDevice: nvlibDevice{
+						UUID: "gpu0",
+					},
+					Links: map[int][]P2PLink{
+						1: {{Type: SingleNVLINKLink}},
+					},
+				},
+				{
+					Index: 1,
+					nvlibDevice: nvlibDevice{
+						UUID: "gpu1",
+					},
+					Links: map[int][]P2PLink{
+						0: {{Type: SingleNVLINKLink}, {Type: SingleNVLINKLink}}, // Asymmetric: 2 links here vs 1 above
+					},
+				},
+			},
+			want: ListDeviceScore{
+				{
+					UUID:  "gpu0",
+					Score: map[string]int{"gpu1": 0},
+				},
+				{
+					UUID:  "gpu1",
+					Score: map[string]int{"gpu0": 0},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
What does this PR do?
Fixes a critical reliability issue where the HAMi scheduler pod crashes via panic() if it encounters asymmetrical P2P links between two GPUs (which can happen due to hardware topology issues or driver glitches).

Instead of panicking and crashing the entire scheduler, calculateGPUPairScore now logs the error via klog.ErrorS with the affected GPU UUIDs and gracefully returns a score of 0. This allows the best-effort GPU allocator to continue operating safely with the remaining devices.

Which issue(s) this PR fixes:
Fixes #2228 

Testing
✅ Verified go build ./... passes.
✅ Ensured that asymmetrical link conditions result in an error log rather than a process crash.
✅ Added DCO sign-off.
PR Acceptance Criteria
 Commits are signed with Signed-off-by (DCO).
 Code is properly formatted.
 Resolves a crash vulnerability in the scheduler.
 
 This PR was created with the assistance of an AI coding agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asymmetric GPU peer-to-peer link data.
  * Invalid GPU link configurations now generate an error and safely return a zero score instead of terminating unexpectedly.
  * GPU scoring remains stable when peer-to-peer connectivity information is inconsistent.
  * Added safeguards for mismatched NVLink counts in GPU scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->