### PR TITLE
fix: skip faulty devices instead of panicking during registration

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -133,6 +133,7 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 			}
 		default:
 			klog.Error("nvml get memory error ret=", ret)
+			// continue skips to the next device in the outer loop, not just the switch
 			continue
 		}
 		Model, ret := ndev.GetName()
@@ -185,6 +186,11 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 		})
 		klog.V(3).Infof("Registered device id=%v, memory=%vMB, type=%v, numa=%v, health=%v", idx, registeredmem, Model, numa, health)
 	}
+
+	if len(res) == 0 && len(devs) > 0 {
+		klog.Warningf("All %d GPU devices failed NVML queries and were skipped. Returning an empty device list.", len(devs))
+	}
+
 	return &res
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -106,12 +106,12 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 		ndev, ret := nvml.DeviceGetHandleByUUID(UUID)
 		if ret != nvml.SUCCESS {
 			klog.Errorln("nvml new device by index error uuid=", UUID, "err=", ret)
-			panic(0)
+			continue
 		}
 		idx, ret := ndev.GetIndex()
 		if ret != nvml.SUCCESS {
 			klog.Errorln("nvml get index error ret=", ret)
-			panic(0)
+			continue
 		}
 		memoryTotal := 0
 		memory, ret := ndev.GetMemoryInfo()
@@ -133,12 +133,12 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 			}
 		default:
 			klog.Error("nvml get memory error ret=", ret)
-			panic(0)
+			continue
 		}
 		Model, ret := ndev.GetName()
 		if ret != nvml.SUCCESS {
 			klog.Error("nvml get name error ret=", ret)
-			panic(0)
+			continue
 		}
 
 		registeredmem := int32(memoryTotal / 1024 / 1024)


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it: This PR fixes a critical reliability issue where the HAMi device plugin crashes via panic(0) if a single GPU fails NVML queries during the buildDeviceMap registration loop (e.g. if the driver or hardware is in a bad state).

Instead of panicking and crashing the entire plugin, the loop now logs the error via klog.Errorln and safely uses continue to skip the faulty device, allowing the plugin to successfully register the remaining healthy GPUs on the node.

Which issue(s) this PR fixes: Fixes #2233 

Special notes for your reviewer:

This replaces all panic(0) calls with continue in the registration loop.
I have added DCO sign-off (Signed-off-by) to the commit.
Does this PR introduce a user-facing change?:

**Note** :This PR was created with the assistance of an AI coding agent.


release-note

Fix: the device plugin will no longer crash entirely if a single GPU is faulty or fails NVML queries during initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of NVIDIA device plugin during device discovery; query failures no longer cause crashes and are gracefully handled by skipping affected devices.
  * Enhanced error reporting with warnings emitted when device discovery results in an empty device list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->