### PR TITLE
ci: move release workflow write permissions to job level

### DIFF
--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -21,15 +21,17 @@ on:
       tagoverride:
         required: false
         type: string
-# id-token is needed for keyless cosign signing
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    # id-token is needed for keyless cosign signing
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -21,15 +21,17 @@ on:
       tagoverride:
         required: false
         type: string
-# id-token is needed for keyless cosign signing
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    # id-token is needed for keyless cosign signing
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/call-release-notes.yaml
+++ b/.github/workflows/call-release-notes.yaml
@@ -8,13 +8,15 @@ on:
         required: true
         type: string
 
-# updates the github release page
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   generate-release-notes:
     runs-on: ubuntu-latest
+    # updates the github release page
+    permissions:
+      contents: write
     steps:
     - name: Download Artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
/kind cleanup
Scorecard flags any top-level write permission in a workflow (TokenPermissionsID). The three call-release workflows declared contents/packages/id-token writes at the top level; this scopes them to the single job that needs them and keeps the top level read-only. Behavior is unchanged since each workflow has exactly one job.

Resolves code scanning alerts:
- https://github.com/Project-HAMi/HAMi/security/code-scanning/1165
- https://github.com/Project-HAMi/HAMi/security/code-scanning/1166
- https://github.com/Project-HAMi/HAMi/security/code-scanning/1167

Same pattern as #2192. The alerts will close on the next scheduled Scorecard run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
