### PR TITLE
fix(device,plugin): stop MIG usage corruption and fd leak

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
@@ -61,12 +61,12 @@ func createMigApplyLock(file string) error {
 		klog.Infof("MIG apply lock file already exists: %s", MigApplyLockFile)
 		return nil
 	}
-	_, err := os.Create(file)
+	f, err := os.Create(file)
 	if err != nil {
 		klog.Errorf("Failed to create MIG apply lock file: %v", err)
 		return err
 	}
-	return nil
+	return f.Close()
 }
 
 // RemoveMigApplyLock removes the lock file for MIG apply operation

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -678,7 +678,6 @@ func (dev *NvidiaGPUDevices) migNeedsReset(n *device.DeviceUsage) bool {
 }
 
 func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
-	n.Used++
 	if n.Mode == MigMode {
 		if dev.migNeedsReset(n) {
 			found := false
@@ -728,6 +727,7 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 			}
 		}
 	}
+	n.Used++
 	n.Usedcores += ctr.Usedcores
 	n.Usedmem += ctr.Usedmem
 	return nil

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -681,6 +681,7 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 	n.Used++
 	if n.Mode == MigMode {
 		if dev.migNeedsReset(n) {
+			found := false
 		OuterLoop:
 			for tidx, templates := range n.MigTemplate {
 				for idx, template := range templates {
@@ -700,9 +701,13 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 						}
 						n.MigUsage.Index = int32(tidx)
 						n.MigUsage.UsageList[usageListIdx].InUse = true
+						found = true
 						break OuterLoop
 					}
 				}
+			}
+			if !found {
+				return errors.New("mig template allocate resource fail")
 			}
 		} else {
 			found := false
@@ -839,7 +844,14 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			klog.V(5).InfoS(common.CardComputeUnitsExhausted, "pod", klog.KObj(pod), "device", dev.ID, "device index", i)
 			continue
 		}
-		if !nv.CustomFilterRule(allocated, request, tmpDevs[k.Type], dev) {
+		// CustomFilterRule must see the resolved memory request: for
+		// percentage-based requests (MemPercentagereq set, Memreq == 0),
+		// the raw request.Memreq is still 0, which would make its MIG
+		// template/slot size checks trivially pass regardless of whether
+		// any slot is actually big enough.
+		resolvedReq := request
+		resolvedReq.Memreq = memreq
+		if !nv.CustomFilterRule(allocated, resolvedReq, tmpDevs[k.Type], dev) {
 			reason[common.CardNotFoundCustomFilterRule]++
 			klog.V(5).InfoS(common.CardNotFoundCustomFilterRule, "pod", klog.KObj(pod), "device", dev.ID, "device index", i)
 			continue

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -844,11 +844,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			klog.V(5).InfoS(common.CardComputeUnitsExhausted, "pod", klog.KObj(pod), "device", dev.ID, "device index", i)
 			continue
 		}
-		// CustomFilterRule must see the resolved memory request: for
-		// percentage-based requests (MemPercentagereq set, Memreq == 0),
-		// the raw request.Memreq is still 0, which would make its MIG
-		// template/slot size checks trivially pass regardless of whether
-		// any slot is actually big enough.
+		// CustomFilterRule must see the resolved memory request, not the raw (possibly zero) Memreq field.
 		resolvedReq := request
 		resolvedReq.Memreq = memreq
 		if !nv.CustomFilterRule(allocated, resolvedReq, tmpDevs[k.Type], dev) {

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2887,12 +2887,7 @@ func TestFit_MigPercentageRequestRejectsUndersizedTemplate(t *testing.T) {
 	}
 	nv := InitNvidiaDevice(config)
 
-	// The only MIG template offers 1024MiB slots, but the pod requests 50%
-	// of an 8192MiB card (= 4096MiB) via MemPercentagereq rather than an
-	// explicit Memreq. CustomFilterRule must be evaluated against the
-	// resolved 4096MiB figure, not the raw (still zero) Memreq field, or
-	// it would wrongly report a fit against any unused slot regardless of
-	// size.
+	// The only MIG template offers 1024MiB slots, but the pod requests 4096MiB (50% of 8192MiB) via MemPercentagereq.
 	devices := []*device.DeviceUsage{
 		{
 			ID: "dev-0", Index: 0, Used: 0, Count: 1,

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2691,6 +2691,7 @@ func TestAddResourceUsage_MigNonResetNoSlot(t *testing.T) {
 	err := dev.AddResourceUsage(&corev1.Pod{}, usage, ctr)
 	assert.Assert(t, err != nil)
 	assert.Assert(t, strings.Contains(err.Error(), "mig template allocate resource fail"))
+	assert.Equal(t, usage.Used, int32(0))
 }
 
 func TestAddResourceUsage_MigResetNoFit(t *testing.T) {
@@ -2709,6 +2710,7 @@ func TestAddResourceUsage_MigResetNoFit(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "mig template allocate resource fail"))
 	// No template fit: usage counters must not reflect a phantom allocation.
 	assert.Equal(t, usage.Usedmem, int32(0))
+	assert.Equal(t, usage.Used, int32(0))
 	assert.Assert(t, !strings.Contains(ctr.UUID, "["))
 }
 

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2693,6 +2693,25 @@ func TestAddResourceUsage_MigNonResetNoSlot(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "mig template allocate resource fail"))
 }
 
+func TestAddResourceUsage_MigResetNoFit(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{})
+	usage := &device.DeviceUsage{
+		Mode: MigMode,
+		MigTemplate: []device.Geometry{
+			{
+				{Name: "1g.5gb", Memory: 1024, Core: 14, Count: 1},
+			},
+		},
+	}
+	ctr := &device.ContainerDevice{UUID: "GPU-0", Usedmem: 4096}
+	err := dev.AddResourceUsage(&corev1.Pod{}, usage, ctr)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "mig template allocate resource fail"))
+	// No template fit: usage counters must not reflect a phantom allocation.
+	assert.Equal(t, usage.Usedmem, int32(0))
+	assert.Assert(t, !strings.Contains(ctr.UUID, "["))
+}
+
 func TestCustomFilterRule_MigEmptyUsageWithTemplate(t *testing.T) {
 	dev := InitNvidiaDevice(NvidiaConfig{})
 	devusage := &device.DeviceUsage{
@@ -2854,6 +2873,38 @@ func TestFit_MutexPolicy(t *testing.T) {
 	// mutex cannot satisfy 2 cards when only one device is idle.
 	two := device.ContainerDeviceRequest{Nums: 2, Memreq: 100, Coresreq: 10, Type: NvidiaGPUDevice}
 	fit, _, _ = nv.Fit(devices, two, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+}
+
+func TestFit_MigPercentageRequestRejectsUndersizedTemplate(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+	}
+	nv := InitNvidiaDevice(config)
+
+	// The only MIG template offers 1024MiB slots, but the pod requests 50%
+	// of an 8192MiB card (= 4096MiB) via MemPercentagereq rather than an
+	// explicit Memreq. CustomFilterRule must be evaluated against the
+	// resolved 4096MiB figure, not the raw (still zero) Memreq field, or
+	// it would wrongly report a fit against any unused slot regardless of
+	// size.
+	devices := []*device.DeviceUsage{
+		{
+			ID: "dev-0", Index: 0, Used: 0, Count: 1,
+			Totalmem: 8192, Totalcore: 100, Type: NvidiaGPUDevice, Health: true,
+			Mode: MigMode,
+			MigTemplate: []device.Geometry{
+				{
+					{Name: "1g.5gb", Memory: 1024, Core: 14, Count: 1},
+				},
+			},
+		},
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, MemPercentagereq: 50, Coresreq: 10, Type: NvidiaGPUDevice}
+	fit, _, _ := nv.Fit(devices, req, &corev1.Pod{}, &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, false)
 }
 

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Two independent bugs found while auditing MIG resource accounting in `pkg/device/nvidia/device.go` and `pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go`:

1. **Silent MIG usage-accounting corruption for percentage-based memory requests.**
   `CustomFilterRule` checked MIG template/slot sizes against the raw, unresolved `request.Memreq`. For percentage-based memory requests (`MemPercentagereq` set, `Memreq == 0`), that comparison is always trivially true, so the filter could admit a device even when no MIG slot is actually big enough for the real (percentage-resolved) request.
   `AddResourceUsage`'s "fresh template" branch had no guard for the case where no template fits — unlike its sibling ("reuse existing slot") branch, which already returns an error in that case. So if no template fit, the function silently fell through and still incremented `Usedmem`/`Usedcores`, corrupting the node's device usage accounting and leaving `ContainerDevice.UUID` without a valid MIG index suffix.

   Fix: resolve the actual memory request before calling `CustomFilterRule` (instead of passing the still-zero `Memreq`), and add the same `found`-guard to `AddResourceUsage`'s fresh-template branch that the sibling branch already has.

2. **File descriptor leak in `createMigApplyLock`.**
   `os.Create(file)` returns an open `*os.File` that was discarded without calling `.Close()`. This function runs on every `ApplyMigTemplate()` call (via `DisableOtherNVMLOperation`), so every MIG reconfiguration on a node leaked one fd.

   Fix: close the file handle after creating it.

Added regression tests:
- `TestAddResourceUsage_MigResetNoFit` — verifies `AddResourceUsage` now returns an error (and doesn't touch usage counters) when no MIG template fits during a fresh template selection.
- `TestFit_MigPercentageRequestRejectsUndersizedTemplate` — verifies `Fit()` now correctly rejects a MIG device whose only template is too small for a percentage-based memory request (this previously passed incorrectly).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Both fixes are minimal and mirror existing patterns already in the file (the `found`-guard mirrors the sibling branch in `AddResourceUsage`; the fd close follows normal `os.Create` usage elsewhere in the codebase).

**Does this PR introduce a user-facing change?**:
```release-note
Fix MIG device usage accounting corruption for percentage-based memory requests, and fix a file descriptor leak in the MIG apply lock file creation.
```

**AI Assistance Disclosure:** I used Geminy to help investigate the codebase for bugs, diagnose the root cause of both issues, and draft the fix and regression tests. I reviewed, understood, and verified all AI-generated changes (build, tests, lint) before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MIG resource allocation to report errors when no suitable template is available.
  * Prevented failed allocations from changing usage records or assigning invalid MIG identifiers.
  * Corrected memory filtering for percentage-based resource requests.
  * Improved lock handling so file-closing errors are reported correctly.

* **Tests**
  * Added coverage for failed MIG allocations, percentage-based memory requests, and quota configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->