### PR TITLE
fix(plugin): guard mig smi output parsing against malformed lines

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -645,7 +645,12 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				}
 				devreq = alignedDevreq
 			}
-			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(devreq))
+			containerDevices, err := plugin.GetContainerDeviceStrArray(devreq)
+			if err != nil {
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
+				return nil, fmt.Errorf("failed to resolve container devices: %w", err)
+			}
+			response, err := plugin.getAllocateResponse(containerDevices)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -188,7 +188,7 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 	return ""
 }
 
-func GetMigUUIDFromIndex(uuid string, idx int) string {
+func GetMigUUIDFromIndex(uuid string, idx int) (string, error) {
 	defer nvml.Shutdown()
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
 		klog.Errorln("nvml Init err: ", nvret)
@@ -212,15 +212,18 @@ func GetMigUUIDFromIndex(uuid string, idx int) string {
 			klog.Fatalf("nvidia-smi -L failed with %s\n", err)
 		}
 		outStr := stdout.String()
-		uuid := GetMigUUIDFromSmiOutput(outStr, originuuid, idx)
-		return uuid
+		migUUID := GetMigUUIDFromSmiOutput(outStr, originuuid, idx)
+		if migUUID == "" {
+			return "", fmt.Errorf("failed to resolve MIG UUID for device %s at index %d via nvidia-smi fallback", originuuid, idx)
+		}
+		return migUUID, nil
 	}
 	res, ret := migdev.GetUUID()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get mig uuid error ret=`, ret)
 		panic(0)
 	}
-	return res
+	return res, nil
 }
 
 func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
@@ -467,7 +470,7 @@ func deepCopyMigConfig(src nvidia.MigConfigSpec) nvidia.MigConfigSpec {
 	return dst
 }
 
-func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevices) []string {
+func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevices) ([]string, error) {
 	tmp := []string{}
 	needsreset := false
 	position := 0
@@ -510,16 +513,15 @@ func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevic
 					}
 				}
 			}
-			migUUID := GetMigUUIDFromIndex(val.UUID, position)
-			if migUUID == "" {
-				klog.Errorf("failed to resolve MIG UUID for %s at position %d, skipping", val.UUID, position)
-				continue
+			migUUID, err := GetMigUUIDFromIndex(val.UUID, position)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve MIG UUID for %s at position %d: %w", val.UUID, position, err)
 			}
 			tmp = append(tmp, migUUID)
 		}
 	}
 	klog.V(3).Infoln("mig current=", nv.migCurrent, ":", needsreset, "position=", position, "uuid lists", tmp)
-	return tmp
+	return tmp, nil
 }
 
 var podAllocationTrySuccess = func(nodeName string, devName string, lockName string, pod *corev1.Pod) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -169,15 +169,19 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
-			klog.Fatal("atoi failed num=", num)
+			klog.Errorf("failed to parse device index from smi output line %q: %v", val, err)
+			continue
 		}
 		if index == idx {
 			colonParts := strings.Split(val, ":")
-			if len(colonParts) < 3 {
+			if len(colonParts) < 3 || !strings.Contains(colonParts[1], "UUID") {
 				continue
 			}
 			outputStr := strings.TrimSpace(colonParts[2])
 			outputStr = strings.TrimRight(outputStr, ")")
+			if !strings.HasPrefix(outputStr, "MIG-") {
+				continue
+			}
 			return outputStr
 		}
 	}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -161,16 +161,22 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 			continue
 		}
 		klog.Infoln("inspecting", val)
-		num := strings.Split(val, "Device")[1]
-		num = strings.Split(num, ":")[0]
+		deviceParts := strings.Split(val, "Device")
+		if len(deviceParts) < 2 {
+			continue
+		}
+		num := strings.Split(deviceParts[1], ":")[0]
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
 			klog.Fatal("atoi failed num=", num)
 		}
 		if index == idx {
-			outputStr := strings.Split(val, ":")[2]
-			outputStr = strings.TrimSpace(outputStr)
+			colonParts := strings.Split(val, ":")
+			if len(colonParts) < 3 {
+				continue
+			}
+			outputStr := strings.TrimSpace(colonParts[2])
 			outputStr = strings.TrimRight(outputStr, ")")
 			return outputStr
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -510,7 +510,12 @@ func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevic
 					}
 				}
 			}
-			tmp = append(tmp, GetMigUUIDFromIndex(val.UUID, position))
+			migUUID := GetMigUUIDFromIndex(val.UUID, position)
+			if migUUID == "" {
+				klog.Errorf("failed to resolve MIG UUID for %s at position %d, skipping", val.UUID, position)
+				continue
+			}
+			tmp = append(tmp, migUUID)
 		}
 	}
 	klog.V(3).Infoln("mig current=", nv.migCurrent, ":", needsreset, "position=", position, "uuid lists", tmp)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -882,3 +882,27 @@ func TestGetMigUUIDFromSmiOutput_MalformedLineTooFewColons(t *testing.T) {
 		t.Errorf("expected empty string for malformed line, got %q", got)
 	}
 }
+
+func TestGetMigUUIDFromSmiOutput_NonNumericDeviceIndex(t *testing.T) {
+	uuid := "GPU-b8f3c1a2-0000-0000-0000-000000000000"
+	output := "GPU 0: NVIDIA A100-SXM4-40GB (UUID: " + uuid + ")\n" +
+		"  MIG 3g.20gb  Device x: (UUID: MIG-11111111-1111-1111-1111-111111111111)\n" +
+		"  MIG 3g.20gb  Device  0: (UUID: MIG-22222222-2222-2222-2222-222222222222)\n"
+
+	got := GetMigUUIDFromSmiOutput(output, uuid, 0)
+	want := "MIG-22222222-2222-2222-2222-222222222222"
+	if got != want {
+		t.Errorf("expected non-numeric device index line to be skipped and %q returned, got %q", want, got)
+	}
+}
+
+func TestGetMigUUIDFromSmiOutput_MatchingIndexWithoutUUIDField(t *testing.T) {
+	uuid := "GPU-b8f3c1a2-0000-0000-0000-000000000000"
+	output := "GPU 0: NVIDIA A100-SXM4-40GB (UUID: " + uuid + ")\n" +
+		"  MIG 3g.20gb  Device 0: status: not-a-uuid\n"
+
+	got := GetMigUUIDFromSmiOutput(output, uuid, 0)
+	if got != "" {
+		t.Errorf("expected empty string when the UUID field is missing, got %q", got)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -846,3 +846,39 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 		t.Errorf("expected stale config to be removed, stat err: %v", err)
 	}
 }
+
+func TestGetMigUUIDFromSmiOutput_HappyPath(t *testing.T) {
+	uuid := "GPU-b8f3c1a2-0000-0000-0000-000000000000"
+	output := "GPU 0: NVIDIA A100-SXM4-40GB (UUID: " + uuid + ")\n" +
+		"  MIG 3g.20gb     Device  0: (UUID: MIG-11111111-1111-1111-1111-111111111111)\n" +
+		"  MIG 3g.20gb     Device  1: (UUID: MIG-22222222-2222-2222-2222-222222222222)\n" +
+		"GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-c9f4d2b3-0000-0000-0000-000000000000)\n"
+
+	got := GetMigUUIDFromSmiOutput(output, uuid, 1)
+	want := "MIG-22222222-2222-2222-2222-222222222222"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetMigUUIDFromSmiOutput_MalformedLineWithoutDeviceKeyword(t *testing.T) {
+	uuid := "GPU-b8f3c1a2-0000-0000-0000-000000000000"
+	output := "GPU 0: NVIDIA A100-SXM4-40GB (UUID: " + uuid + ")\n" +
+		"  MIG-instance-not-yet-configured\n"
+
+	got := GetMigUUIDFromSmiOutput(output, uuid, 0)
+	if got != "" {
+		t.Errorf("expected empty string for malformed line, got %q", got)
+	}
+}
+
+func TestGetMigUUIDFromSmiOutput_MalformedLineTooFewColons(t *testing.T) {
+	uuid := "GPU-b8f3c1a2-0000-0000-0000-000000000000"
+	output := "GPU 0: NVIDIA A100-SXM4-40GB (UUID: " + uuid + ")\n" +
+		"  MIG 3g.20gb  Device 0: no-uuid-here\n"
+
+	got := GetMigUUIDFromSmiOutput(output, uuid, 0)
+	if got != "" {
+		t.Errorf("expected empty string for malformed line, got %q", got)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`GetMigUUIDFromSmiOutput` (nvidia-smi fallback for MIG UUID lookup) indexed into `strings.Split` results with no bounds checking, so any MIG-block line not matching the exact expected shape caused an `index out of range` panic instead of being skipped turning a recoverable NVML error into a device plugin crash. Same general pattern as the scheduler-side fix in #2088 (unguarded indexing while parsing a MIG index/UUID string) a different component and code path, not otherwise related.

This PR bounds-checks both splits and skips the malformed line instead of indexing blindly.

Not raised issue as it is a small fix.

**Special notes for your reviewer**:

- Reproduced the panic first (crafted `nvidia-smi -L` input missing the expected `"Device"` keyword), then fixed it. Regression tests added covering the happy path and both previously-panicking malformed cases.
- Not validated on physical MIG hardware, verified via unit tests reproducing the malformed-output panic and its fix, plus `go build`/`go vet`/`go test -race`. Diff: 10+/4- (fix) + 40+ (tests).

**Does this PR introduce a user-facing change?**:

```release-note
Fix a panic in the NVIDIA device plugin's nvidia-smi-based MIG UUID fallback lookup when the parsed output line doesn't match the expected format.
```

---

**AI assistance disclosure**: AI assistance was used to help trace the fallback path, reproduce the panic and suggest an initial fix. I manually investigated the issue, validated the root cause, refined and implemented the solution, verified the behavior, added the tests and reviewed all changes before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed GPU management output during MIG UUID lookup.
  - Invalid device indices, incomplete lines, and entries without valid MIG UUIDs are now safely skipped.
  - Valid device entries continue to be processed as expected, reducing errors in GPU device detection.

- **Tests**
  - Added coverage for successful MIG UUID lookup, malformed device lines, non-numeric indices, and incomplete output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->