### PR TITLE
 fix(metrics): include all metric descriptors in Describe

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -224,6 +224,8 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ctrDeviceMemoryContextDesc
 	ch <- ctrDeviceMemoryModuleDesc
 	ch <- ctrDeviceMemoryBufferDesc
+	ch <- ctrDeviceLastKernelDesc
+	ch <- ctrDeviceMigInfo
 
 	if cc.ClusterManager.LegacyMetrics {
 		ch <- legacyHostGPUdesc

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -211,9 +211,9 @@ func sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueT
 	}
 }
 
-// Describe is implemented with DescribeByCollect. That's possible because the
-// Collect method will always return the same two metrics with the same two
-// descriptors.
+// Describe sends the superset of every descriptor that Collect can emit,
+// including the ones Collect only emits conditionally, plus the legacy
+// descriptors when legacy metrics are enabled.
 func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- hostGPUdesc
 	ch <- ctrvGPUdesc

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// collectDescribe drains a collector's Describe method into a slice.
+func collectDescribe(cc ClusterManagerCollector) []*prometheus.Desc {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		cc.Describe(ch)
+		close(ch)
+	}()
+	var got []*prometheus.Desc
+	for d := range ch {
+		got = append(got, d)
+	}
+	return got
+}
+
+// TestDescribeCoversAllCollectedDescriptors guards the Prometheus Collector
+// contract: Describe must announce the superset of every descriptor Collect
+// can emit. ctrDeviceLastKernelDesc and ctrDeviceMigInfo are emitted only
+// conditionally in Collect, which is exactly why they were previously missing
+// here; this test fails on the pre-fix code (9 descriptors) and passes with
+// the full set.
+func TestDescribeCoversAllCollectedDescriptors(t *testing.T) {
+	cc := ClusterManagerCollector{ClusterManager: &ClusterManager{LegacyMetrics: false}}
+
+	want := map[*prometheus.Desc]bool{
+		hostGPUdesc:                false,
+		hostGPUUtilizationdesc:     false,
+		ctrvGPUdesc:                false,
+		ctrvGPUlimitdesc:           false,
+		ctrDeviceMemorydesc:        false,
+		ctrDeviceUtilizationdesc:   false,
+		ctrDeviceMemoryContextDesc: false,
+		ctrDeviceMemoryModuleDesc:  false,
+		ctrDeviceMemoryBufferDesc:  false,
+		ctrDeviceLastKernelDesc:    false,
+		ctrDeviceMigInfo:           false,
+	}
+
+	got := collectDescribe(cc)
+	if len(got) != len(want) {
+		t.Errorf("Describe() emitted %d descriptors, want %d", len(got), len(want))
+	}
+	for _, d := range got {
+		if _, ok := want[d]; !ok {
+			t.Errorf("Describe() emitted an unexpected descriptor: %v", d)
+			continue
+		}
+		want[d] = true
+	}
+	for d, seen := range want {
+		if !seen {
+			t.Errorf("Describe() did not announce descriptor: %v", d)
+		}
+	}
+}
+
+// TestDescribeIncludesLegacyDescriptors verifies the legacy branch still
+// announces its eight additional descriptors when legacy metrics are enabled.
+func TestDescribeIncludesLegacyDescriptors(t *testing.T) {
+	initLegacyDescriptors()
+	cc := ClusterManagerCollector{ClusterManager: &ClusterManager{LegacyMetrics: true}}
+
+	const wantCount = 11 + 8 // modern superset + legacy descriptors
+	if got := len(collectDescribe(cc)); got != wantCount {
+		t.Errorf("Describe() with legacy metrics emitted %d descriptors, want %d", got, wantCount)
+	}
+}


### PR DESCRIPTION
 What type of PR: /kind bug

 What this PR does / why: Describe() in cmd/vGPUmonitor/metrics.go omitted two descriptors that Collect() emits conditionally (hami_container_last_kernel_elapsed_seconds, hami_mig_device_info). This aligns Describe() with the Prometheus superset contract and the legacy branch, corrects a stale comment, and adds a regression test that fails on the old code and passes now.

 Which issue(s) this PR fixes: Fixes #2247 

Special notes for reviewer: No change to scrape output — client_golang already tolerates undescribed metrics — so this is contract hygiene, not a runtime fix. make verify and go test ./cmd/vGPUmonitor/ pass locally.

 AI assistance disclosure: I used AI assistance (Claude Code) to identify this Describe/Collect gap . 
Did implemented the fix and test my myself . I reviewed and understand the change, wrote the commit messages myself, ran make verify and the tests locally, and take responsibility for the PR and for addressing review feedback.

Does this PR introduce a user-facing change?: NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metric discovery so all available modern, optional, and legacy metrics are reported correctly.
  * Ensured metric collection remains consistent across standard and legacy configurations.

* **Tests**
  * Added coverage verifying that published metric descriptors match collected metrics in both modern and legacy modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->