### PR TITLE
test: run vGPUmonitor unit tests

### DIFF
--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -44,7 +44,7 @@ mkdir -p ./_output/coverage/
 mergeF="./_output/coverage/merge.out"
 rm -f ${mergeF}
 cov_file="./_output/coverage/coverage_pkg.txt"
-go test $(go list ./pkg/...) -short --race -count=1 -covermode=atomic -coverprofile=${cov_file}
+go test $(go list ./pkg/... ./cmd/vGPUmonitor) -short --race -count=1 -covermode=atomic -coverprofile=${cov_file}
 cat $cov_file | grep -v mode: | grep -v pkg/version | grep -v fake | grep -v main.go >>${mergeF}
 #merge them
 echo "mode: atomic" >coverage.out

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -44,7 +44,7 @@ mkdir -p ./_output/coverage/
 mergeF="./_output/coverage/merge.out"
 rm -f ${mergeF}
 cov_file="./_output/coverage/coverage_pkg.txt"
-go test $(go list ./pkg/... ./cmd/vGPUmonitor) -short --race -count=1 -covermode=atomic -coverprofile=${cov_file}
+go test $(go list ./pkg/... ./cmd/...) -short --race -count=1 -covermode=atomic -coverprofile=${cov_file}
 cat $cov_file | grep -v mode: | grep -v pkg/version | grep -v fake | grep -v main.go >>${mergeF}
 #merge them
 echo "mode: atomic" >coverage.out


### PR DESCRIPTION
/kind cleanup
**What this PR does / why we need it**:
`make test` only includes packages under `pkg`, so the existing `vGPUmonitor` tests are skipped. This adds `cmd/vGPUmonitor` to the same race-enabled test command.
**Which issue(s) this PR fixes**:
None.
**Special notes for your reviewer**:
No runtime code changes. The focused test, full unit suite, lint, license check, and import check pass.
**Does this PR introduce a user-facing change?**:
NONE.
AI disclosure: I used an AI tool for codebase navigation and validation. I reviewed the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage checks to include both package and command-line code.
  * Retained short test execution, race detection, single-run behavior, and atomic coverage reporting.
  * Coverage results now provide broader validation across the project’s core packages and executable components without changing the existing test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->