### PR TITLE
fix(device): guard nil maps in mthreads MutateAdmission

### DIFF
--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -97,9 +97,15 @@ func (dev *MthreadsDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod
 		if count.Value() <= 0 {
 			return false, fmt.Errorf("%s must be greater than 0", MthreadsResourceCount)
 		}
+		if ctr.Resources.Limits == nil {
+			ctr.Resources.Limits = corev1.ResourceList{}
+		}
 		if count.Value() > 1 {
 			ctr.Resources.Limits[corev1.ResourceName(MthreadsResourceCores)] = *resource.NewQuantity(count.Value()*int64(coresPerMthreadsGPU), resource.DecimalSI)
 			ctr.Resources.Limits[corev1.ResourceName(MthreadsResourceMemory)] = *resource.NewQuantity(count.Value()*int64(memoryPerMthreadsGPU), resource.DecimalSI)
+			if p.Annotations == nil {
+				p.Annotations = make(map[string]string)
+			}
 			p.Annotations["mthreads.com/request-gpu-num"] = fmt.Sprint(count.Value())
 			return ok, nil
 		}

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -103,6 +103,27 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "count one requested without limits",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"mthreads.com/vgpu": *resource.NewQuantity(1, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "don't set to count limit",
 			args: struct {
 				ctr *corev1.Container

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -65,6 +65,44 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "count over one without pod annotations",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"mthreads.com/vgpu": *resource.NewQuantity(2, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: true,
+		},
+		{
+			name: "count over one requested without limits",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"mthreads.com/vgpu": *resource.NewQuantity(2, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "don't set to count limit",
 			args: struct {
 				ctr *corev1.Container


### PR DESCRIPTION
## What this PR does

`MthreadsDevices.MutateAdmission` writes to `ctr.Resources.Limits` and
`p.Annotations` without checking they are non-nil. Writing to a nil map panics
in Go and crashes the mutating-webhook goroutine. Two ordinary inputs trigger
it:

- a pod that requests more than one `mthreads.com/vgpu` but carries no
  annotations (`p.Annotations == nil`) panics on the `request-gpu-num` write;
- a container that specifies the vgpu count under `requests` only, with no
  `limits` block (`ctr.Resources.Limits == nil`), panics on the cores/memory
  write.

Because the webhook runs `MutateAdmission` for every registered device on every
pod, this takes down admission for affected mthreads pods.

This initializes `ctr.Resources.Limits` and `p.Annotations` before writing,
matching the nil guard already used in the metax backend
(`pkg/device/metax/sdevice.go`).

## Fixes

Fixes #2253

## Testing

Added two cases to `Test_MutateAdmission` covering both inputs. Each produces
`panic: assignment to entry in nil map` before this change and passes after.
Verified red→green; full package passes under `-race`; gofmt clean.

## AI assistance disclosure

This change was developed with AI assistance (per CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission handling when resource limits or pod annotations are not initially configured.
  * vGPU requests with multiple devices are now admitted successfully in additional request and limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Note:** a requests-only extended-resource pod is eventually rejected by API validation, but mutating admission runs before validation, so the nil-`Limits` panic is still reachable.