### PR TITLE
fix(nodelock): let a pod re-acquire its own still-valid node lock

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -233,9 +233,18 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 	if time.Since(lockTime) > NodeLockTimeout {
 		klog.InfoS("Node lock expired", "node", nodeName, "lockTime", lockTime, "timeout", NodeLockTimeout)
 		skipOwnerCheck = true
+	} else if ns == pods.Namespace && previousPodName == pods.Name {
+		// The lock is already held by this exact pod. lockAllDevices calls
+		// LockNode once per device vendor a pod requests resources from, so
+		// a pod requesting resources from two or more vendors (e.g. both
+		// nvidia.com/gpu and cambricon.com/vmlu) would otherwise contend
+		// with its own still-valid lock on the second call and never
+		// become schedulable. Treat this as already acquired.
+		klog.V(4).InfoS("Node lock already held by this pod, treating as acquired", "node", nodeName, "podName", pods.Name)
+		return nil
 	} else
 	// Check dangling nodeLock
-	if ns != "" && previousPodName != "" && (ns != pods.Namespace || previousPodName != pods.Name) {
+	if ns != "" && previousPodName != "" {
 		if _, err := client.GetClient().CoreV1().Pods(ns).Get(ctx, previousPodName, metav1.GetOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				klog.ErrorS(err, "Failed to get pod of NodeLock", "podName", previousPodName, "namespace", ns)

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -34,7 +34,7 @@ import (
 func Test_LockNode(t *testing.T) {
 	client.KubeClient = fake.NewClientset()
 	type args struct {
-		nodeName func() string
+		nodeName func(t *testing.T) string
 		lockname string
 		pods     *corev1.Pod
 	}
@@ -46,7 +46,7 @@ func Test_LockNode(t *testing.T) {
 		{
 			name: "node not found",
 			args: args{
-				nodeName: func() string {
+				nodeName: func(t *testing.T) string {
 					return "node"
 				},
 				pods: &corev1.Pod{
@@ -61,9 +61,9 @@ func Test_LockNode(t *testing.T) {
 		{
 			name: "node has been locked by another pod",
 			args: args{
-				nodeName: func() string {
+				nodeName: func(t *testing.T) string {
 					name := "worker-1"
-					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+					if _, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: name,
 							Annotations: map[string]string{
@@ -72,12 +72,16 @@ func Test_LockNode(t *testing.T) {
 								}),
 							},
 						},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create node fixture: %v", err)
+					}
 					// The lock holder ("other-pod"/"other-ns") must exist and not be
 					// dangling, otherwise LockNode treats it as stale and takes over.
-					client.KubeClient.CoreV1().Pods("other-ns").Create(context.TODO(), &corev1.Pod{
+					if _, err := client.KubeClient.CoreV1().Pods("other-ns").Create(context.TODO(), &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{Name: "other-pod", Namespace: "other-ns"},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create lock-holder pod fixture: %v", err)
+					}
 					return name
 				},
 				pods: &corev1.Pod{
@@ -92,9 +96,9 @@ func Test_LockNode(t *testing.T) {
 		{
 			name: "node has been locked by another pod in the same namespace",
 			args: args{
-				nodeName: func() string {
+				nodeName: func(t *testing.T) string {
 					name := "worker-1b"
-					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+					if _, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: name,
 							Annotations: map[string]string{
@@ -103,15 +107,19 @@ func Test_LockNode(t *testing.T) {
 								}),
 							},
 						},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create node fixture: %v", err)
+					}
 					// Same namespace as the requester below, but a different pod
 					// name: exercises ns == pods.Namespace (true) with
 					// previousPodName == pods.Name (false), distinct from both the
 					// "another pod" case above (both false) and the reentrant
 					// same-pod case (both true).
-					client.KubeClient.CoreV1().Pods("hami-ns").Create(context.TODO(), &corev1.Pod{
+					if _, err := client.KubeClient.CoreV1().Pods("hami-ns").Create(context.TODO(), &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{Name: "other-pod-same-ns", Namespace: "hami-ns"},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create lock-holder pod fixture: %v", err)
+					}
 					return name
 				},
 				pods: &corev1.Pod{
@@ -126,16 +134,18 @@ func Test_LockNode(t *testing.T) {
 		{
 			name: "node lock is invalid",
 			args: args{
-				nodeName: func() string {
+				nodeName: func(t *testing.T) string {
 					name := "worker-2"
-					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+					if _, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: name,
 							Annotations: map[string]string{
 								NodeLockKey: "lock",
 							},
 						},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create node fixture: %v", err)
+					}
 					return name
 				},
 				pods: &corev1.Pod{
@@ -150,11 +160,13 @@ func Test_LockNode(t *testing.T) {
 		{
 			name: "successfully set node lock",
 			args: args{
-				nodeName: func() string {
+				nodeName: func(t *testing.T) string {
 					name := "worker-3"
-					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+					if _, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: map[string]string{}},
-					}, metav1.CreateOptions{})
+					}, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create node fixture: %v", err)
+					}
 					return name
 				},
 				pods: &corev1.Pod{
@@ -169,7 +181,7 @@ func Test_LockNode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := LockNode(tt.args.nodeName(), tt.args.lockname, tt.args.pods); (err != nil) != tt.wantErr {
+			if err := LockNode(tt.args.nodeName(t), tt.args.lockname, tt.args.pods); (err != nil) != tt.wantErr {
 				t.Errorf("LockNode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -289,6 +301,14 @@ func TestLockNodeReentrantSamePod(t *testing.T) {
 		t.Fatalf("Failed to create node: %v", err)
 	}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "multi-vendor-pod", Namespace: "test-ns"}}
+	// The requesting pod must actually exist for this test to exercise the
+	// intended live-ownership scenario. Without it, the first LockNode call
+	// still succeeds, but only because it's setting a fresh lock, not
+	// because the reentrancy branch has verified anything about a real,
+	// live pod - so a real dangling-lock path could be masked instead.
+	if _, err := client.KubeClient.CoreV1().Pods("test-ns").Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
 
 	if err := LockNode(nodeName, "nvidia", pod); err != nil {
 		t.Fatalf("first LockNode call (simulating the nvidia backend) failed: %v", err)

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -59,7 +59,7 @@ func Test_LockNode(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "node has been locked",
+			name: "node has been locked by another pod",
 			args: args{
 				nodeName: func() string {
 					name := "worker-1"
@@ -68,10 +68,15 @@ func Test_LockNode(t *testing.T) {
 							Name: name,
 							Annotations: map[string]string{
 								NodeLockKey: GenerateNodeLockKeyByPod(&corev1.Pod{
-									ObjectMeta: metav1.ObjectMeta{Name: "hami", Namespace: "hami-ns"},
+									ObjectMeta: metav1.ObjectMeta{Name: "other-pod", Namespace: "other-ns"},
 								}),
 							},
 						},
+					}, metav1.CreateOptions{})
+					// The lock holder ("other-pod"/"other-ns") must exist and not be
+					// dangling, otherwise LockNode treats it as stale and takes over.
+					client.KubeClient.CoreV1().Pods("other-ns").Create(context.TODO(), &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "other-pod", Namespace: "other-ns"},
 					}, metav1.CreateOptions{})
 					return name
 				},
@@ -230,6 +235,32 @@ func TestLockNodeWithDangling(t *testing.T) {
 	// Try to lock the node again - this should pass and release the old dangling lock
 	if err := LockNode(nodeName, "", pod); err != nil {
 		t.Fatal("Expected nil but got error")
+	}
+}
+
+// TestLockNodeReentrantSamePod covers lockAllDevices' actual call pattern:
+// it calls LockNode once per device vendor a pod requests resources from, so
+// a pod requesting e.g. both nvidia.com/gpu and cambricon.com/vmlu locks the
+// same node twice for itself in a row. The second call must succeed instead
+// of contending with the pod's own still-valid lock, or such a pod could
+// never become schedulable.
+func TestLockNodeReentrantSamePod(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeLocks = newNodeLockManager()
+	nodeName := "multi-vendor-node"
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "multi-vendor-pod", Namespace: "test-ns"}}
+
+	if err := LockNode(nodeName, "nvidia", pod); err != nil {
+		t.Fatalf("first LockNode call (simulating the nvidia backend) failed: %v", err)
+	}
+	if err := LockNode(nodeName, "cambricon", pod); err != nil {
+		t.Fatalf("second LockNode call for the same pod (simulating the cambricon backend) should succeed, got: %v", err)
 	}
 }
 

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -90,6 +90,40 @@ func Test_LockNode(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "node has been locked by another pod in the same namespace",
+			args: args{
+				nodeName: func() string {
+					name := "worker-1b"
+					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: name,
+							Annotations: map[string]string{
+								NodeLockKey: GenerateNodeLockKeyByPod(&corev1.Pod{
+									ObjectMeta: metav1.ObjectMeta{Name: "other-pod-same-ns", Namespace: "hami-ns"},
+								}),
+							},
+						},
+					}, metav1.CreateOptions{})
+					// Same namespace as the requester below, but a different pod
+					// name: exercises ns == pods.Namespace (true) with
+					// previousPodName == pods.Name (false), distinct from both the
+					// "another pod" case above (both false) and the reentrant
+					// same-pod case (both true).
+					client.KubeClient.CoreV1().Pods("hami-ns").Create(context.TODO(), &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "other-pod-same-ns", Namespace: "hami-ns"},
+					}, metav1.CreateOptions{})
+					return name
+				},
+				pods: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hami",
+						Namespace: "hami-ns",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "node lock is invalid",
 			args: args{
 				nodeName: func() string {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`lockAllDevices` (`pkg/scheduler/scheduler.go`) calls `nodelock.LockNode` once per device vendor backend a pod requests resources from (`device.GetDevices()` is iterated per registered vendor), and every vendor writes to the same shared node annotation (`hami.io/mutex.lock`).

`LockNode` had no case for "this exact pod already holds the lock": the dangling-lock check only ran when the lock's namespace/name differed from the requesting pod, so a same-pod, non-expired lock fell straight through to the contention error. Concretely: a pod requesting resources from two or more HAMi-managed vendors in the same spec (e.g. one container asking for `nvidia.com/gpu`, another for `cambricon.com/vmlu`) would have its first `LockNode` call succeed and its second call immediately contend with its own still-valid lock — making that pod permanently unschedulable.

This PR adds an explicit branch: if the existing lock's namespace/name match the calling pod and it hasn't expired, `LockNode` treats it as already acquired instead of erroring.

It also fixes `Test_LockNode`'s "node has been locked" case, which had (accidentally) used the exact same pod identity as both the lock holder and the requester — so it was asserting the buggy contention behavior as correct. That case is now a genuine third-party-contention scenario (locked by a different, still-live pod), and a new dedicated test (`TestLockNodeReentrantSamePod`) reproduces `lockAllDevices`' actual multi-vendor call pattern.

**Which issue(s) this PR fixes**:
Fixes #2243

**Special notes for your reviewer**:
Found this while reviewing other parts of the scheduler/monitor code for unrelated PRs; it's a distinct issue from any of my other open PRs.

**Does this PR introduce a user-facing change?**:
```release-note
Fix pods requesting resources from multiple HAMi-managed device vendors becoming permanently unschedulable due to the pod's own node lock contending with itself.
```

This PR was written with AI assistance (Claude Code), per the AI-assistance disclosure requirement in CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Node locks can now be safely reacquired by the same pod without being reported as conflicts.
  * Improved handling of dangling or invalid node locks to avoid unnecessary contention.

* **Tests**
  * Added coverage for same-pod lock reacquisition and additional lock-holder scenarios.
  * Expanded validation for invalid and unlocked node setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->