### PR TITLE
fix(util): make same-pod node lock acquisition idempotent

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2091,6 +2091,74 @@ func (m *bindLockMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) erro
 	return nil
 }
 
+// sharedLockMockDevice mirrors backends (e.g. nvidia, ascend, hygon, metax) that
+// all acquire the same node-lock annotation key "hami.io/mutex.lock" through the
+// shared pkg/util/nodelock helper.
+type sharedLockMockDevice struct {
+	registerMockDevice
+	vendor string
+}
+
+func (m *sharedLockMockDevice) CommonWord() string { return m.vendor }
+func (m *sharedLockMockDevice) LockNode(n *corev1.Node, p *corev1.Pod) error {
+	return nodelockutil.LockNode(n.Name, nodelockutil.NodeLockKey, p)
+}
+func (m *sharedLockMockDevice) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
+	return nodelockutil.ReleaseNodeLock(n.Name, nodelockutil.NodeLockKey, p, false)
+}
+
+// Test_Bind_MultiDeviceBackendsSharingNodeLock reproduces #2243: a pod requesting
+// two device types whose backends both lock the same node annotation must not
+// contend with itself during Bind.
+func Test_Bind_MultiDeviceBackendsSharingNodeLock(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-multi-device", Namespace: "default", UID: types.UID("uid-multi-device"),
+		},
+	}
+	mockA := &sharedLockMockDevice{vendor: "shared-lock-a"}
+	mockB := &sharedLockMockDevice{vendor: "shared-lock-b"}
+
+	oldRetry := config.NodeLockRetryTimeout
+	config.NodeLockRetryTimeout = 500 * time.Millisecond
+	oldDevicesMap := device.DevicesMap
+	device.DevicesMap = map[string]device.Devices{mockA.vendor: mockA, mockB.vendor: mockB}
+	t.Cleanup(func() {
+		config.NodeLockRetryTimeout = oldRetry
+		device.DevicesMap = oldDevicesMap
+	})
+
+	s := NewScheduler()
+	t.Cleanup(func() { close(s.stopCh) })
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	s.eventRecorder = record.NewBroadcaster().NewRecorder(scheme, corev1.EventSource{})
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	fakeClient := fake.NewSimpleClientset(pod, node)
+	s.kubeClient = fakeClient
+	client.KubeClient = fakeClient
+
+	// lockAllDevices must succeed when both backends lock the same node for the
+	// same pod, and the resulting annotation must reference the locking pod.
+	if err := s.lockAllDevices(node, pod); err != nil {
+		t.Fatalf("lockAllDevices failed for same-pod multi-backend lock: %v", err)
+	}
+	nodeAfter, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	lockValue, ok := nodeAfter.Annotations[nodelockutil.NodeLockKey]
+	require.True(t, ok, "node lock annotation must be set")
+	if !strings.HasSuffix(lockValue, nodelockutil.NodeLockSep+nodelockutil.GeneratePodNamespaceName(pod, nodelockutil.NodeLockSep)) {
+		t.Fatalf("node lock %q does not reference the locking pod", lockValue)
+	}
+
+	s.releaseAllDevices(node, pod)
+	nodeAfter, err = fakeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok = nodeAfter.Annotations[nodelockutil.NodeLockKey]
+	require.False(t, ok, "node lock annotation must be released after all backends finish")
+}
+
 var errContention = fmt.Errorf("contended: %w", nodelockutil.ErrNodeLockContention)
 
 func setupBindLockRetryTest(t *testing.T, retryTimeout time.Duration, pod *corev1.Pod, mock *bindLockMockDevice) (*Scheduler, extenderv1.ExtenderBindingArgs, func()) {

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -229,6 +229,14 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 		return err
 	}
 
+	// A lock already held by this same pod (e.g., a multi-device pod whose
+	// earlier backend locked the node through the shared annotation key) is an
+	// idempotent re-acquisition, not contention.
+	if ns != "" && previousPodName != "" && ns == pods.Namespace && previousPodName == pods.Name {
+		klog.InfoS("Node lock already held by this pod", "node", nodeName, "podName", pods.Name, "podNamespace", pods.Namespace)
+		return nil
+	}
+
 	var skipOwnerCheck = false
 	if time.Since(lockTime) > NodeLockTimeout {
 		klog.InfoS("Node lock expired", "node", nodeName, "lockTime", lockTime, "timeout", NodeLockTimeout)

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -63,6 +63,35 @@ func Test_LockNode(t *testing.T) {
 			args: args{
 				nodeName: func() string {
 					name := "worker-1"
+					client.KubeClient.CoreV1().Pods("hami-ns").Create(context.TODO(), &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "hami", Namespace: "hami-ns"},
+					}, metav1.CreateOptions{})
+					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: name,
+							Annotations: map[string]string{
+								NodeLockKey: GenerateNodeLockKeyByPod(&corev1.Pod{
+									ObjectMeta: metav1.ObjectMeta{Name: "hami", Namespace: "hami-ns"},
+								}),
+							},
+						},
+					}, metav1.CreateOptions{})
+					return name
+				},
+				pods: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other",
+						Namespace: "other-ns",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "node lock is idempotent for the same pod",
+			args: args{
+				nodeName: func() string {
+					name := "worker-1b"
 					client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: name,
@@ -82,7 +111,7 @@ func Test_LockNode(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "node lock is invalid",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Makes node lock acquisition idempotent for the same pod. lockAllDevices acquires a node lock for every registered device backend, and several backends (nvidia, ascend, hygon, metax, kunlun, etc.) share the same hami.io/mutex.lock annotation through pkg/util/nodelock. When a pod requests two of those device types, the second backend sees the lock created by the first backend, which is held by the *same pod*, but LockNode treats it as contention and fails the Bind.

**Which issue(s) this PR fixes**:

Fixes #2243

**Special notes for your reviewer**:

LockNode previously only released and re-acquired the lock when it was expired or dangling (owner pod no longer exists). A lock owned by the same pod fell through to the contention error, so a single Bind that locked the node through multiple backends would fail with 
ode ... has been locked within 5m0s: node lock contention.

The fix treats a lock already held by the same pod as an idempotent re-acquisition and returns success. Release behavior is unchanged: ReleaseNodeLock already skips locks not owned by the calling pod, so the first backend to finish does not remove the shared lock.

Validation:

- go test ./pkg/util/nodelock/... -count=1 -race
- go test ./pkg/scheduler -run Test_Bind_MultiDeviceBackendsSharingNodeLock -count=1 -v (Linux CI; the scheduler package depends on go-nvml which is Linux-only)

**Does this PR introduce a user-facing change?**:

No.

**AI assistance disclosure**:

This PR description was generated with the assistance of an AI coding tool. The author reviewed and verified all changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-lock handling so the same pod can safely reacquire its existing lock.
  * Prevented unnecessary lock conflicts when multiple device backends coordinate access to the same node.

* **Tests**
  * Added coverage for shared node locking across device backends.
  * Added validation that locks are correctly associated with pods and removed after release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
