### PR TITLE
fix(scheduler): handle ResourceQuota tombstones

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -256,11 +256,23 @@ func (s *Scheduler) onUpdateQuota(oldObj, newObj any) {
 }
 
 func (s *Scheduler) onDelQuota(obj any) {
-	quota, ok := obj.(*corev1.ResourceQuota)
-	if !ok {
-		klog.Errorf("unknown del object type")
+	var quota *corev1.ResourceQuota
+
+	switch t := obj.(type) {
+	case *corev1.ResourceQuota:
+		quota = t
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		quota, ok = t.Obj.(*corev1.ResourceQuota)
+		if !ok {
+			klog.Errorf("resource quota tombstone contained object of type %T", t.Obj)
+			return
+		}
+	default:
+		klog.Errorf("unknown resource quota delete object type %T", obj)
 		return
 	}
+
 	s.quotaManager.DelQuota(quota)
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -900,7 +900,37 @@ func TestSchedulerOnDelQuotaClearsLimitFromTombstone(t *testing.T) {
 }
 
 func TestSchedulerOnDelQuotaIgnoresInvalidObjects(t *testing.T) {
+	const namespace = "invalid-quota-delete-test"
+
 	s := NewScheduler()
+
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	require.True(t, ok, "NVIDIA device should be registered")
+
+	resourceName := nvidiaDevice.GetResourceNames().ResourceMemoryName
+	require.NotEmpty(t, resourceName)
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gpu-quota",
+			Namespace: namespace,
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits." + resourceName): *resource.NewQuantity(1024, resource.BinarySI),
+			},
+		},
+	}
+
+	s.onAddQuota(quota)
+	t.Cleanup(func() {
+		s.onDelQuota(quota)
+	})
+
+	quotas := s.quotaManager.GetResourceQuota()
+	namespaceQuota, ok := quotas[namespace]
+	require.True(t, ok)
+	expectedLimit := (*namespaceQuota)[resourceName].Limit
 
 	tests := []struct {
 		name string
@@ -924,6 +954,11 @@ func TestSchedulerOnDelQuotaIgnoresInvalidObjects(t *testing.T) {
 			require.NotPanics(t, func() {
 				s.onDelQuota(test.obj)
 			})
+
+			currentQuotas := s.quotaManager.GetResourceQuota()
+			currentNamespaceQuota, ok := currentQuotas[namespace]
+			require.True(t, ok)
+			require.Equal(t, expectedLimit, (*currentNamespaceQuota)[resourceName].Limit)
 		})
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -855,6 +855,50 @@ func Test_Filter(t *testing.T) {
 	}
 }
 
+func TestSchedulerOnDelQuotaClearsLimitFromTombstone(t *testing.T) {
+	const namespace = "quota-tombstone-test"
+
+	s := NewScheduler()
+
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	require.True(t, ok, "NVIDIA device should be registered")
+
+	resourceName := nvidiaDevice.GetResourceNames().ResourceMemoryName
+	require.NotEmpty(t, resourceName, "NVIDIA memory resource name should not be empty")
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gpu-quota",
+			Namespace: namespace,
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits." + resourceName): *resource.NewQuantity(1024, resource.BinarySI),
+			},
+		},
+	}
+
+	s.onAddQuota(quota)
+	t.Cleanup(func() {
+		s.onDelQuota(quota)
+	})
+
+	quotas := s.quotaManager.GetResourceQuota()
+	namespaceQuota, ok := quotas[namespace]
+	require.True(t, ok)
+	require.Equal(t, int64(1024), (*namespaceQuota)[resourceName].Limit)
+
+	s.onDelQuota(cache.DeletedFinalStateUnknown{
+		Key: namespace + "/" + quota.Name,
+		Obj: quota,
+	})
+
+	quotas = s.quotaManager.GetResourceQuota()
+	namespaceQuota, ok = quotas[namespace]
+	require.True(t, ok)
+	require.Equal(t, int64(0), (*namespaceQuota)[resourceName].Limit)
+}
+
 func TestSchedulerOnDelNodeCleansLockDirectNode(t *testing.T) {
 	nodelockutil.ResetNodeLocksForTest()
 	t.Cleanup(nodelockutil.ResetNodeLocksForTest)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -899,6 +899,35 @@ func TestSchedulerOnDelQuotaClearsLimitFromTombstone(t *testing.T) {
 	require.Equal(t, int64(0), (*namespaceQuota)[resourceName].Limit)
 }
 
+func TestSchedulerOnDelQuotaIgnoresInvalidObjects(t *testing.T) {
+	s := NewScheduler()
+
+	tests := []struct {
+		name string
+		obj  any
+	}{
+		{
+			name: "tombstone containing non-quota object",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test/invalid",
+				Obj: struct{}{},
+			},
+		},
+		{
+			name: "unknown delete object",
+			obj:  struct{}{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				s.onDelQuota(test.obj)
+			})
+		})
+	}
+}
+
 func TestSchedulerOnDelNodeCleansLockDirectNode(t *testing.T) {
 	nodelockutil.ResetNodeLocksForTest()
 	t.Cleanup(nodelockutil.ResetNodeLocksForTest)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
The ResourceQuota informer may deliver a `cache.DeletedFinalStateUnknown` when a deletion is missed while its watch is disconnected.

`onDelQuota` previously accepted only a direct `*corev1.ResourceQuota`, so it ignored tombstone deletion events and left the deleted quota's device limits in HAMi's scheduler cache.

This change unwraps ResourceQuota tombstones while preserving normal deletion handling. Tombstones containing an unexpected object type are logged and ignored safely.

A regression test verifies that processing a ResourceQuota tombstone clears the cached device limit.

**Which issue(s) this PR fixes**:
Fixes #2257 

**Special notes for your reviewer**:
This change is scoped to the scheduler extender and does not require accelerator hardware.
Validation performed:
- `go test ./pkg/scheduler -run TestSchedulerOnDelQuotaClearsLimitFromTombstone -count=1 -v`
- `go test -short ./pkg/scheduler -count=1`
- `go test -race ./pkg/scheduler -run TestSchedulerOnDelQuotaClearsLimitFromTombstone -count=1`
- `make verify`
- `make test`

All checks passed on macOS arm64 with Go 1.26.5. with flying colors


**Does this PR introduce a user-facing change?**:
Yes. ResourceQuota deletions delivered through informer tombstones now clear cached device limits instead of continuing to enforce stale limits.

AI assistance disclosure:
AI assistance was used to investigate the bug and formatting the PR. I reviewed the changes, reproduced the failure before the fix, and verified the implementation and test results myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when resource quotas are deleted, including Kubernetes deletion tombstones.
  * Invalid or unsupported deletion events are safely ignored without causing errors or crashes.
  * Tracked resource limits are correctly cleared after quota deletion.

* **Tests**
  * Added coverage for quota deletion through tombstones and invalid deletion objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->