### PR TITLE
docs: add AI assistance disclosure to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,13 @@ Fixes #
 
 **Special notes for your reviewer**:
 
+**Was AI assistance used in this PR?**:
+
+<!--
+Required by the AI Assistance Notice in CONTRIBUTING.md. Disclose any use of AI
+assistance and the extent of it, e.g. docs only vs. code generation. This also
+applies to AI-generated replies to review comments. Trivial tab-completion limited
+to single keywords or short phrases does not need to be disclosed.
+-->
+
 **Does this PR introduce a user-facing change?**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,13 +19,18 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Was AI assistance used in this PR?**:
+**AI assistance disclosure**:
+
+Disclose any AI assistance used in this PR and the extent of it, for example docs only
+or code generation. Write `None` if you did not use any. See the
+[AI Assistance Notice](https://github.com/Project-HAMi/HAMi/blob/master/CONTRIBUTING.md#ai-assistance-notice)
+in CONTRIBUTING.md.
+
+- [ ] I have read the [Contribution Gates](https://github.com/Project-HAMi/HAMi/blob/master/CONTRIBUTING.md#contribution-gates) and understand that review replies must be written by me, not by an AI.
 
 <!--
-Required by the AI Assistance Notice in CONTRIBUTING.md. Disclose any use of AI
-assistance and the extent of it, e.g. docs only vs. code generation. This also
-applies to AI-generated replies to review comments. Trivial tab-completion limited
-to single keywords or short phrases does not need to be disclosed.
+This also applies to AI-generated replies to review comments. Trivial tab-completion
+limited to single keywords or short phrases does not need to be disclosed.
 -->
 
 **Does this PR introduce a user-facing change?**:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

CONTRIBUTING.md requires that any use of AI assistance be disclosed in the pull request, along with the extent of it. The PR template does not ask for this, so the requirement is easy to miss — in #2046 the disclosure was added only after a reviewer asked for it.

This adds a "Was AI assistance used in this PR?" field pointing at the AI Assistance Notice, including the exception that notice already makes for trivial tab-completion.

**Which issue(s) this PR fixes**:

None — raised by @mesutoezdil during review of #2046.

**Special notes for your reviewer**:

@mesutoezdil suggested this in #2046 and asked @spencercjh to open it; opening here since it hasn't landed yet — happy to close if one is already in flight.

The wording follows the existing AI Assistance Notice in CONTRIBUTING.md rather than introducing any new policy.

**Was AI assistance used in this PR?**:

Yes — Claude Code, to locate the CONTRIBUTING.md requirement and draft the template wording. I reviewed the result and take responsibility for its accuracy.

**Does this PR introduce a user-facing change?**:

NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with an AI assistance disclosure section.
  * Added guidance for reporting AI usage and AI-generated review-comment replies.
  * Added a Contribution Gates acknowledgment checkbox and an exception for trivial tab completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->