### PR TITLE
fix(plugin): release node lock on getAllocateResponse failure

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -647,6 +647,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(devreq))
 			if err != nil {
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

getAllocateResponse failure path in the non-MIG Allocate loop was missing
a PodAllocationFailed call. Every other error exit in the same function
calls it, this was the only one that skipped it.

Node lock stays set on the node after the failure. Next GPU request on
that node either hangs or fails.

**Which issue(s) this PR fixes**:
Fixes #2214

**Special notes for your reviewer**:

Only affects the non-MIG path. getAllocateResponse isn't called in the
MIG branch.

**Does this PR introduce a user-facing change?**:

`NONE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed pod resource allocations by recording the failure state when an allocation response cannot be generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->