### PR TITLE
chore(metrics): remove leftover client_golang tutorial scaffolding

### DIFF
--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -142,10 +142,7 @@ func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) e
 
 	reg.MustRegister(versionmetrics.NewBuildInfoCollector())
 
-	// Construct cluster managers. In real code, we would assign them to
-	// variables to then do something with them.
 	NewClusterManager("vGPU", reg, containerLister, legacyMetrics)
-	//NewClusterManager("ca", reg)
 
 	// Uncomment to add the standard process and Go metrics to the custom registry.
 	//reg.MustRegister(

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -551,11 +551,9 @@ func sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType pr
 	return nil
 }
 
-// NewClusterManager first creates a Prometheus-ignorant ClusterManager
-// instance. Then, it creates a ClusterManagerCollector for the just created
-// ClusterManager. Finally, it registers the ClusterManagerCollector with a
-// wrapping Registerer that adds the zone as a label. In this way, the metrics
-// collected by different ClusterManagerCollectors do not collide.
+// NewClusterManager creates a ClusterManager for the given zone, backs its pod
+// lookups with a shared informer, and registers its collector with reg through
+// a wrapping Registerer that adds the zone as a label.
 func NewClusterManager(zone string, reg prometheus.Registerer, containerLister *nvidia.ContainerLister, legacyMetrics bool) *ClusterManager {
 	if legacyMetrics {
 		initLegacyDescriptors()

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -38,42 +38,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// ClusterManager is an example for a system that might have been built without
-// Prometheus in mind. It models a central manager of jobs running in a
-// cluster. Thus, we implement a custom Collector called
-// ClusterManagerCollector, which collects information from a ClusterManager
-// using its provided methods and turns them into Prometheus Metrics for
-// collection.
-//
-// An additional challenge is that multiple instances of the ClusterManager are
-// run within the same binary, each in charge of a different zone. We need to
-// make use of wrapping Registerers to be able to register each
-// ClusterManagerCollector instance with Prometheus.
+// ClusterManager holds the state the vGPUMonitor's Prometheus collector reads
+// from: the pod and container listers used to gather per-container GPU usage,
+// and the zone label each ClusterManagerCollector is registered under via a
+// wrapping Registerer.
 type ClusterManager struct {
-	Zone string
-	// Contains many more fields not listed in this example.
+	Zone            string
 	PodLister       listerscorev1.PodLister
 	containerLister *nvidia.ContainerLister
 	LegacyMetrics   bool
-}
-
-// ReallyExpensiveAssessmentOfTheSystemState is a mock for the data gathering a
-// real cluster manager would have to do. Since it may actually be really
-// expensive, it must only be called once per collection. This implementation,
-// obviously, only returns some made-up data.
-func (c *ClusterManager) ReallyExpensiveAssessmentOfTheSystemState() (
-	oomCountByHost map[string]int, ramUsageByHost map[string]float64,
-) {
-	// Just example fake data.
-	oomCountByHost = map[string]int{
-		"foo.example.org": 42,
-		"bar.example.org": 2001,
-	}
-	ramUsageByHost = map[string]float64{
-		"foo.example.org": 6.023e23,
-		"bar.example.org": 3.14,
-	}
-	return
 }
 
 // ClusterManagerCollector implements the Collector interface.
@@ -237,52 +210,9 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-//func parseidstr(podusage string) (string, string, error) {
-//	tmp := strings.Split(podusage, "_")
-//	if len(tmp) > 1 {
-//		return tmp[0], tmp[1], nil
-//	} else {
-//		return "", "", errors.New("parse error")
-//	}
-//}
-//
-//func gettotalusage(usage podusage, vidx int) (deviceMemory, error) {
-//	added := deviceMemory{
-//		bufferSize:  0,
-//		contextSize: 0,
-//		moduleSize:  0,
-//		offset:      0,
-//		total:       0,
-//	}
-//	for _, val := range usage.sr.procs {
-//		added.bufferSize += val.used[vidx].bufferSize
-//		added.contextSize += val.used[vidx].contextSize
-//		added.moduleSize += val.used[vidx].moduleSize
-//		added.offset += val.used[vidx].offset
-//		added.total += val.used[vidx].total
-//	}
-//	return added, nil
-//}
-//
-//func getTotalUtilization(usage podusage, vidx int) deviceUtilization {
-//	added := deviceUtilization{
-//		decUtil: 0,
-//		encUtil: 0,
-//		smUtil:  0,
-//	}
-//	for _, val := range usage.sr.procs {
-//		added.decUtil += val.deviceUtil[vidx].decUtil
-//		added.encUtil += val.deviceUtil[vidx].encUtil
-//		added.smUtil += val.deviceUtil[vidx].smUtil
-//	}
-//	return added
-//}
-
-// Collect first triggers the ReallyExpensiveAssessmentOfTheSystemState. Then it
-// creates constant metrics for each host on the fly based on the returned data.
-//
-// Note that Collect could be called concurrently, so we depend on
-// ReallyExpensiveAssessmentOfTheSystemState to be concurrency-safe.
+// Collect gathers GPU, pod, and container metrics on each scrape and sends them
+// to the provided channel. It may be called concurrently, so the collection
+// helpers it calls must be concurrency-safe.
 func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	klog.Info("Starting to collect metrics for vGPUMonitor")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes dead scaffolding left over from the client_golang tutorial in `cmd/vGPUmonitor/metrics.go`: the unused `ReallyExpensiveAssessmentOfTheSystemState` mock function (returned fabricated data, no callers), a block of commented-out functions (`parseidstr`, `gettotalusage`, `getTotalUtilization`), and two stale doc comments referencing them. No functional change — the `Zone` field and all metric output are untouched.

**Which issue(s) this PR fixes**:
Addresses the dead-code item of #2249 (per-scrape descriptor hoisting will follow as a separate PR).

**Special notes for your reviewer**:
No behavior change. `make verify` and `go build ./cmd/vGPUmonitor/` pass locally.

**AI assistance disclosure**:
I used AI assistance (Claude Code) to identify the dead code . I reviewed and verified the change (confirmed zero callers), wrote the commit message myself, ran `make verify` locally, and take responsibility for it.

**Does this PR introduce a user-facing change?**:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated monitoring documentation to accurately describe GPU, pod, and container metric collection.
  * Clarified concurrency requirements and the current monitoring behavior.
  * Removed outdated examples and obsolete guidance to make the documentation easier to follow.
  * Improved descriptions of cluster monitoring and metric collection for clearer reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->