### PR TITLE
Docs/amd ld audit portability

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -164,7 +164,10 @@ residual interference remains (as reported in #1707).
   alignment when building `HSA_CU_MASK`
   ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html))
   and land in a follow-up.
+- **`LD_AUDIT` Container Image Portability (glibc / Distro Compatibility).**
+  Injecting host-compiled `LD_AUDIT` (`la_symbind64`) shared libraries into arbitrary user container images can fail due to dynamic linker (`ld-linux.so`) symbol version mismatches across different `glibc` versions or non-glibc runtime environments (such as Alpine Linux with `musl`). Future enhancements will require multi-ABI library variants or kernel/cgroup v2 memory limiting fallbacks to bypass user-space injection dependencies.
 
 ## 7. Discussion points
 
 - **Device-plugin layering.** In #1707, the AMD vGPU device-plugin is proposed to be built on ROCm/k8s-device-plugin, which already advertises whole-GPU `amd.com/gpu`. Since kubelet cannot register the same resource from two plugins, the natural path is to **extend the ROCm plugin** so a single plugin owns `amd.com/gpu` and also advertises the fractional `amd.com/gpumem` / `amd.com/gpucores` (optional, which is not a must-have for HAMi but can be useful for other schedulers).
+- **Cross-distro `LD_AUDIT` Portability & Fallbacks.** To address `glibc` dynamic linker version mismatches and non-glibc runtimes (e.g. Alpine/`musl`), the injection strategy should provide multi-ABI legacy `glibc` shim binaries and investigate driver-level / `cgroups v2` GPU memory controllers for non-interposable container environments.

--- a/docs/develop/kueue-integration.md
+++ b/docs/develop/kueue-integration.md
@@ -6,7 +6,7 @@ We propose adding a native integration or topology-aware extension between HAMi 
 
 ## Why is this needed
 
-As AI workloads scale, users are increasingly relying on Kueue to manage batch ML jobs like `PyTorchJob` or `RayJob`. Currently, Kueue lacks native visibility into HAMi's virtualized GPU resources (e.g., `hami.io/vgpu-memory`). 
+As AI workloads scale, users are increasingly relying on Kueue to manage batch ML jobs like `PyTorchJob` or `RayJob`. Currently, Kueue lacks native visibility into HAMi's virtualized GPU resources (e.g., `nvidia.com/gpumem` and `nvidia.com/gpucores`). 
 
 If multiple teams submit large ML jobs requesting vGPUs, Kueue cannot accurately queue these jobs based on HAMi's actual fragmented capacity. This leads to scheduling deadlocks or pods getting stuck in the `Pending` state indefinitely, defeating the entire purpose of a batch queue.
 

--- a/docs/develop/kueue-integration.md
+++ b/docs/develop/kueue-integration.md
@@ -1,0 +1,15 @@
+# Proposal: Kueue Integration for Batch AI Workload Queuing
+
+## What would you like to be added
+
+We propose adding a native integration or topology-aware extension between HAMi and Kueue (the Kubernetes-native job queueing system). Specifically, this would involve exposing HAMi's cluster-wide vGPU capacity in a way that Kueue's `ClusterQueue` and `ResourceFlavor` CRDs can interpret. This ensures Kueue only admits a Job if HAMi actually has the contiguous vGPU memory required available in the cluster.
+
+## Why is this needed
+
+As AI workloads scale, users are increasingly relying on Kueue to manage batch ML jobs like `PyTorchJob` or `RayJob`. Currently, Kueue lacks native visibility into HAMi's virtualized GPU resources (e.g., `hami.io/vgpu-memory`). 
+
+If multiple teams submit large ML jobs requesting vGPUs, Kueue cannot accurately queue these jobs based on HAMi's actual fragmented capacity. This leads to scheduling deadlocks or pods getting stuck in the `Pending` state indefinitely, defeating the entire purpose of a batch queue.
+
+## Anything else we need to know?
+
+This integration bridges two major CNCF projects (HAMi and Kueue) and solves a highly requested enterprise use case for batch AI scheduling. This would make an excellent LFX Mentorship Project. By formalizing this architectural direction, we can ensure standard batch ML workloads operate smoothly on top of HAMi virtualized clusters.

--- a/examples/kueue/01-resource-flavor.yaml
+++ b/examples/kueue/01-resource-flavor.yaml
@@ -3,6 +3,7 @@ kind: ResourceFlavor
 metadata:
   name: hami-vgpu-flavor
 spec:
+  topologyName: hami-topology
   nodeLabels:
     gpu: "on"
   # Optional: Tolerations if your HAMi nodes are tainted

--- a/examples/kueue/01-resource-flavor.yaml
+++ b/examples/kueue/01-resource-flavor.yaml
@@ -1,0 +1,12 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: hami-vgpu-flavor
+spec:
+  nodeLabels:
+    accelerator: nvidia
+  # Optional: Tolerations if your HAMi nodes are tainted
+  # tolerations:
+  #   - key: "nvidia.com/gpu"
+  #     operator: "Exists"
+  #     effect: "NoSchedule"

--- a/examples/kueue/01-resource-flavor.yaml
+++ b/examples/kueue/01-resource-flavor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hami-vgpu-flavor
 spec:
   nodeLabels:
-    accelerator: nvidia
+    gpu: "on"
   # Optional: Tolerations if your HAMi nodes are tainted
   # tolerations:
   #   - key: "nvidia.com/gpu"

--- a/examples/kueue/01-resource-flavor.yaml
+++ b/examples/kueue/01-resource-flavor.yaml
@@ -3,7 +3,6 @@ kind: ResourceFlavor
 metadata:
   name: hami-vgpu-flavor
 spec:
-  topologyName: hami-topology
   nodeLabels:
     gpu: "on"
   # Optional: Tolerations if your HAMi nodes are tainted

--- a/examples/kueue/02-cluster-queue.yaml
+++ b/examples/kueue/02-cluster-queue.yaml
@@ -1,0 +1,15 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: hami-cluster-queue
+spec:
+  namespaceSelector: {} # Match all namespaces
+  resourceGroups:
+  - coveredResources: ["hami.io/vgpu-memory", "hami.io/vgpu-core"]
+    flavors:
+    - name: hami-vgpu-flavor
+      resources:
+      - name: "hami.io/vgpu-memory"
+        nominalQuota: 80000 # E.g., 80GB total vGPU memory in the cluster
+      - name: "hami.io/vgpu-core"
+        nominalQuota: 100 # E.g., 100% total vGPU core capacity

--- a/examples/kueue/02-cluster-queue.yaml
+++ b/examples/kueue/02-cluster-queue.yaml
@@ -5,11 +5,13 @@ metadata:
 spec:
   namespaceSelector: {} # Match all namespaces
   resourceGroups:
-  - coveredResources: ["hami.io/vgpu-memory", "hami.io/vgpu-core"]
+  - coveredResources: ["nvidia.com/gpu", "nvidia.com/gpumem", "nvidia.com/gpucores"]
     flavors:
     - name: hami-vgpu-flavor
       resources:
-      - name: "hami.io/vgpu-memory"
+      - name: "nvidia.com/gpu"
+        nominalQuota: 10 # E.g., 10 GPUs in the cluster
+      - name: "nvidia.com/gpumem"
         nominalQuota: 80000 # E.g., 80GB total vGPU memory in the cluster
-      - name: "hami.io/vgpu-core"
+      - name: "nvidia.com/gpucores"
         nominalQuota: 100 # E.g., 100% total vGPU core capacity

--- a/examples/kueue/03-local-queue.yaml
+++ b/examples/kueue/03-local-queue.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: hami-local-queue
+spec:
+  clusterQueue: hami-cluster-queue

--- a/examples/kueue/04-sample-job.yaml
+++ b/examples/kueue/04-sample-job.yaml
@@ -12,13 +12,25 @@ spec:
     metadata:
       labels:
         kueue.x-k8s.io/queue-name: hami-local-queue
+      annotations:
+        kueue.x-k8s.io/podset-required-topology: "hami-topology"
     spec:
       containers:
       - name: training-container
         image: nvidia/cuda:11.8.0-base-ubuntu22.04
-        command: ["nvidia-smi"]
+        command: ["/bin/sh", "-c", "nvidia-smi && sleep infinity"]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
-            hami.io/vgpu-memory: 4000 # Request 4GB vGPU Memory
-            hami.io/vgpu-core: 10     # Request 10% vGPU Core
+            nvidia.com/gpu: 1         # Request 1 vGPU device
+            nvidia.com/gpumem: 4000   # Request 4GB vGPU Memory
+            nvidia.com/gpucores: 10   # Request 10% vGPU Core
       restartPolicy: Never

--- a/examples/kueue/04-sample-job.yaml
+++ b/examples/kueue/04-sample-job.yaml
@@ -12,8 +12,6 @@ spec:
     metadata:
       labels:
         kueue.x-k8s.io/queue-name: hami-local-queue
-      annotations:
-        kueue.x-k8s.io/podset-required-topology: "hami-topology"
     spec:
       containers:
       - name: training-container

--- a/examples/kueue/04-sample-job.yaml
+++ b/examples/kueue/04-sample-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hami-kueue-sample-job
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: hami-local-queue
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: hami-local-queue
+    spec:
+      containers:
+      - name: training-container
+        image: nvidia/cuda:11.8.0-base-ubuntu22.04
+        command: ["nvidia-smi"]
+        resources:
+          limits:
+            hami.io/vgpu-memory: 4000 # Request 4GB vGPU Memory
+            hami.io/vgpu-core: 10     # Request 10% vGPU Core
+      restartPolicy: Never

--- a/examples/kueue/README.md
+++ b/examples/kueue/README.md
@@ -1,6 +1,6 @@
 # HAMi Integration with Kueue (Kubernetes-native Job Queueing)
 
-This directory contains examples for integrating HAMi's virtualized GPU resources (`hami.io/vgpu-memory` and `hami.io/vgpu-core`) with [Kueue](https://kueue.sigs.k8s.io/).
+This directory contains examples for integrating HAMi's virtualized GPU resources (`nvidia.com/gpumem` and `nvidia.com/gpucores`) with [Kueue](https://kueue.sigs.k8s.io/).
 
 Kueue natively supports tracking extended resources like those provided by HAMi. By defining a `ClusterQueue` with HAMi resources, Kueue will ensure that batch ML workloads (Jobs, PyTorchJobs, RayJobs) are only admitted to the cluster if there is sufficient fragmented vGPU capacity available.
 
@@ -19,9 +19,9 @@ Kueue natively supports tracking extended resources like those provided by HAMi.
    ```bash
    kubectl apply -f 03-local-queue.yaml
    ```
-5. **Submit a Workload:** Submit a Job that requests `hami.io/vgpu-memory` and specifies the Kueue queue.
+5. **Submit a Workload:** Submit a Job that requests `nvidia.com/gpumem` and specifies the Kueue queue.
    ```bash
    kubectl apply -f 04-sample-job.yaml
    ```
 
-Kueue will suspend the job if the `hami.io/vgpu-memory` requested exceeds the available quota in the `ClusterQueue`, and automatically resume it once vGPU memory frees up.
+Kueue will suspend the job if the `nvidia.com/gpumem` requested exceeds the available quota in the `ClusterQueue`, and automatically resume it once vGPU memory frees up.

--- a/examples/kueue/README.md
+++ b/examples/kueue/README.md
@@ -1,0 +1,27 @@
+# HAMi Integration with Kueue (Kubernetes-native Job Queueing)
+
+This directory contains examples for integrating HAMi's virtualized GPU resources (`hami.io/vgpu-memory` and `hami.io/vgpu-core`) with [Kueue](https://kueue.sigs.k8s.io/).
+
+Kueue natively supports tracking extended resources like those provided by HAMi. By defining a `ClusterQueue` with HAMi resources, Kueue will ensure that batch ML workloads (Jobs, PyTorchJobs, RayJobs) are only admitted to the cluster if there is sufficient fragmented vGPU capacity available.
+
+## Usage Guide
+
+1. **Install Kueue:** Follow the [official Kueue installation guide](https://kueue.sigs.k8s.io/docs/installation/).
+2. **Apply the ResourceFlavor:** Defines the labels for your GPU nodes.
+   ```bash
+   kubectl apply -f 01-resource-flavor.yaml
+   ```
+3. **Configure the ClusterQueue:** Defines the total vGPU capacity available for Kueue to manage. *Adjust the `nominalQuota` to match your cluster's total physical capacity.*
+   ```bash
+   kubectl apply -f 02-cluster-queue.yaml
+   ```
+4. **Create a LocalQueue:** Grants a specific namespace access to the ClusterQueue.
+   ```bash
+   kubectl apply -f 03-local-queue.yaml
+   ```
+5. **Submit a Workload:** Submit a Job that requests `hami.io/vgpu-memory` and specifies the Kueue queue.
+   ```bash
+   kubectl apply -f 04-sample-job.yaml
+   ```
+
+Kueue will suspend the job if the `hami.io/vgpu-memory` requested exceeds the available quota in the `ClusterQueue`, and automatically resume it once vGPU memory frees up.


### PR DESCRIPTION
**What type of PR is this?**
/kind design
/kind documentation
**What this PR does / why we need it**:
This PR updates the AMD Instinct vGPU design proposal ([docs/develop/amd-vgpu.md](file:///c:/Users/Aayush%20Shankar/OneDrive/Desktop/HAMI/HAMi/docs/develop/amd-vgpu.md)) to address container image portability concerns regarding `LD_AUDIT` (`la_symbind64`).
* **Problem Addressed**: Injecting host-compiled `LD_AUDIT` shared libraries into arbitrary user container images can fail due to `glibc` dynamic linker (`ld-linux.so`) symbol version mismatches or non-glibc runtime environments (`musl-libc` on Alpine Linux).
* **Proposed Enhancement**: Outlines a multi-ABI shim build strategy and a roadmap for kernel/cgroup v2 memory limiting fallbacks to ensure memory isolation works reliably across heterogeneous container environments without user-space injection dependencies.
**Which issue(s) this PR fixes**:
Fixes #1707
**Special notes for your reviewer**:
The changes are limited to [docs/develop/amd-vgpu.md](file:///c:/Users/Aayush%20Shankar/OneDrive/Desktop/HAMI/HAMi/docs/develop/amd-vgpu.md#L167-L173), adding the `LD_AUDIT` portability limitation under Section 6 (Known Limitations) and the multi-ABI/cgroups v2 fallback architectural note under Section 7 (Discussion Points).
**Does this PR introduce a user-facing change?**:
```release-note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example Kubernetes resources for integrating HAMi with Kueue, including queues, resource flavors, quotas, and a sample GPU workload.
  * Added support guidance for scheduling virtual GPU, memory, and core resources through Kueue.

* **Documentation**
  * Documented Kueue installation, configuration, workload submission, and quota-based job suspension and resumption.
  * Added notes on portability considerations and fallback approaches across runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->