### PR TITLE
fix(leaderelection): require underscore separator in isHolderOf

### DIFF
--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -166,7 +166,7 @@ func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
+	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname+"_")
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -460,6 +460,24 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 			g.Expect(result).Should(g.BeFalse())
 		})
 	})
+
+	ginkgo.Context("When holder identity is a longer hostname sharing our prefix", func() {
+		ginkgo.It("isHolderOf should return false to prevent false positive", func() {
+			// lm.hostname = "dev"; holder identity belongs to "dev-server", not "dev"
+			holderIdentity := generateHolderIdentity("dev-server")
+			lease := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity: &holderIdentity,
+				},
+			}
+			result := lm.isHolderOf(lease)
+			g.Expect(result).Should(g.BeFalse())
+		})
+	})
 })
 
 var _ = ginkgo.Describe("DummyLeaderManager", func() {


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

`isHolderOf` in `pkg/util/leaderelection/leaderelection.go` checks whether the lease holder identity belongs to this instance using:

```go
return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
```

The Kubernetes lease holder identity format is `hostname_<uuid>`. Because the check does not require the `_` separator, a replica with hostname `dev` will incorrectly return `true` for a lease held by `dev-server_<uuid>`.

## Which issue(s) this PR fixes

Fixes #2154

## Special notes for your reviewer

The change is a one-character addition: `m.hostname` → `m.hostname+"_"`.

A regression test is added in the existing Ginkgo suite that directly exercises the false-positive case:

- hostname `dev` vs holder identity `dev-server_<uuid>` → must return `false`

This is scheduler-only. No device-allocation or in-container isolation path changed.

## Does this PR introduce a user-facing change?

No.

---

**AI assistance disclosure:**

AI assistance was used to identify the issue, implement the fix, and draft this PR description. The change and test were reviewed and verified manually. I take responsibility for this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader identity validation to prevent similarly prefixed hostnames from being incorrectly treated as the local leader.
  * Added coverage for hostname-prefix edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->