### PR TITLE
fix(device): use HasPrefix and TrimPrefix in DelQuota

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -228,10 +228,10 @@ func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
 	for idx, val := range quota.Spec.Hard {
 		value, ok := val.AsInt64()
 		if ok {
-			if len(idx.String()) <= len("limits.") {
+			if !strings.HasPrefix(idx.String(), "limits.") {
 				continue
 			}
-			dn := idx.String()[len("limits."):]
+			dn := strings.TrimPrefix(idx.String(), "limits.")
 			if !IsManagedQuota(dn) {
 				continue
 			}

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -252,3 +252,33 @@ func TestAddQuotaAndDelQuota(t *testing.T) {
 		t.Errorf("DelQuota: expected core limit 0, got %d", (*qm.Quotas[ns])[coreName].Limit)
 	}
 }
+
+func TestDelQuotaNonLimitsKey(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "testns"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+
+	rq := &corev1.ResourceQuota{}
+	rq.Namespace = ns
+	rq.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName):  *resource.NewQuantity(100, resource.DecimalSI),
+		corev1.ResourceName("limits." + coreName): *resource.NewQuantity(10, resource.DecimalSI),
+	}
+	qm.AddQuota(rq)
+
+	// Quota with non-limits keys (including 7-character prefix key).
+	unrelatedQuota := &corev1.ResourceQuota{}
+	unrelatedQuota.Namespace = ns
+	unrelatedQuota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("requests." + memName): *resource.NewQuantity(50, resource.DecimalSI),
+		corev1.ResourceName("0123456" + memName):   *resource.NewQuantity(50, resource.DecimalSI),
+	}
+
+	// DelQuota on non-limits keys should NOT reset active quota limits.
+	qm.DelQuota(unrelatedQuota)
+	if (*qm.Quotas[ns])[memName].Limit != 100 {
+		t.Errorf("DelQuota: expected memory limit 100 after deleting non-limits quota, got %d", (*qm.Quotas[ns])[memName].Limit)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes an issue in `QuotaManager.DelQuota` where resource quota keys were not validated for the "limits." prefix before slicing.

Previously, DelQuota only checked if the key length was greater than len("limits.") (7 characters) and sliced the first 7 characters. As a result, any non-limits. key longer than 7 characters whose suffix after 7 matched a managed resource (e.g., 0123456nvidia.com/gpumem) would pass IsManagedQuota and reset quotaInfo.Limit = 0, unexpectedly corrupting namespace quota limits.

This PR updates DelQuota to use strings.HasPrefix(idx.String(), "limits.") and strings.TrimPrefix(idx.String(), "limits.") to be the same as AddQuota, ensuring non-limits. keys are safely ignored.

**Which issue(s) this PR fixes**:
Fixes #2271

**Special notes for your reviewer**:
This would be me first time contributing to HAMI. If anything is out of order or I made some mistake do let me know. Thanks.

**Does this PR introduce a user-facing change?**:
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when removing device quota resources, preventing incorrectly formatted quota names from being processed.
  * Fixed an issue where removing quotas containing only unrelated resources could reset existing managed limits.
  * Existing managed memory limits now remain unchanged when unrelated quota resources are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->