### PR TITLE
feat(helm): allow passing device-config content directly via values.yaml

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
 data:
   device-config.yaml: |-
-  {{- if .Files.Glob "files/device-config.yaml" }}
+  {{- if and (index .Values "device-config") (index .Values "device-config" "content") }}
+  {{- (index .Values "device-config" "content") | nindent 4 }}
+  {{- else if .Files.Glob "files/device-config.yaml" }}
   {{- .Files.Get "files/device-config.yaml" | nindent 4}}
   {{- else }}
     nvidia:

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -541,3 +541,20 @@ legacyMetrics: false
 
 prometheus:
   enabled: false
+
+# Device config overrides
+# If content is set under device-config.content, it will be used as the device-config.yaml
+# payload in the hami-scheduler-device ConfigMap instead of files/device-config.yaml or the default config.
+# Example:
+# device-config:
+#   content: |
+#     nvidia:
+#       knownMigGeometries:
+#         - models: [ "RTX 6000 Ada" ]
+#           allowedGeometries:
+#             - - name: "1g.6gb"
+#                 core: 25
+#                 memory: 6144
+#                 count: 4
+device-config:
+  content: ""


### PR DESCRIPTION
Allows users to pass raw device configuration YAML content via the new key `device-config.content` in `values.yaml`. This eliminates the need to download and maintain a local copy of the Helm chart with physical files in `files/device-config.yaml` when adding or overriding custom GPU geometries or other device configs.

- Add `device-config.content` setting and comments to `charts/hami/values.yaml`
- Update `charts/hami/templates/scheduler/device-configmap.yaml` precedence logic
- Bump chart version to 2.9.1 in `Chart.yaml`

**What type of PR is this?**
feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/Project-HAMi/HAMi/issues/2276

Antigravity helped with the PR to develop and validate helm chart. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing inline device configuration through Helm values.
  * Inline configuration takes precedence over bundled configuration files and generated defaults.
  * Added support for configuring NVIDIA MIG geometries, including model matching, allowed geometries, core allocation, memory, and replica count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->