### PR TITLE
fix(vGPUmonitor): bound v0 spec metric sums to active proc slots

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -81,9 +81,17 @@ func (s Spec) DeviceNum() int {
 	return int(s.sr.num)
 }
 
+// activeProcs returns the process slots currently in use. procnum is read from
+// the shared-memory region and may be corrupt (negative or larger than the
+// backing array); clamp it to a valid range so slicing can never panic.
+func (s Spec) activeProcs() []shrregProcSlotT {
+	n := min(max(int(s.sr.procnum), 0), len(s.sr.procs))
+	return s.sr.procs[:n]
+}
+
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -91,7 +99,7 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -99,7 +107,7 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -107,7 +115,7 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].offset
 	}
 	return v
@@ -115,7 +123,7 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].total
 	}
 	return v
@@ -123,7 +131,7 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -83,7 +83,7 @@ func (s Spec) DeviceNum() int {
 
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -91,7 +91,7 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -99,7 +99,7 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -107,7 +107,7 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.used[idx].offset
 	}
 	return v
@@ -115,7 +115,7 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.used[idx].total
 	}
 	return v
@@ -123,7 +123,7 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -378,6 +378,36 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 	}
 }
 
+func TestSpec_CorruptProcnumIsClamped(t *testing.T) {
+	tests := []struct {
+		name     string
+		procnum  int32
+		expected uint64
+	}{
+		// Negative procnum clamps to 0 active slots, so nothing is summed.
+		{name: "negative procnum", procnum: -5, expected: 0},
+		// procnum larger than the backing array clamps to its length; only the
+		// single populated slot contributes.
+		{name: "procnum over backing array", procnum: 2000, expected: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sr := &sharedRegionT{num: 2, procnum: tt.procnum}
+			sr.procs[0].used[0].total = 100
+			sr.procs[0].deviceUtil[0].smUtil = 100
+			s := Spec{sr: sr}
+			// A corrupt procnum must never panic the slice bound.
+			if got := s.DeviceMemoryTotal(0); got != tt.expected {
+				t.Errorf("DeviceMemoryTotal(0) = %d, want %d", got, tt.expected)
+			}
+			if got := s.DeviceSmUtil(0); got != tt.expected {
+				t.Errorf("DeviceSmUtil(0) = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestDeviceMemoryLimit(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -65,7 +65,8 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 		{
 			name: "device memory context size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
 					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
@@ -77,7 +78,8 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 		{
 			name: "device memory context size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
 					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
@@ -85,6 +87,19 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
+					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 
@@ -103,7 +118,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 		{
 			name: "device memory module size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
 					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
@@ -115,7 +131,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 		{
 			name: "device memory module size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
 					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
@@ -123,6 +140,19 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
+					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 
@@ -141,7 +171,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 		{
 			name: "device memory buffer size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
 					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
@@ -153,7 +184,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 		{
 			name: "device memory buffer size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
 					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
@@ -161,6 +193,19 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
+					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 
@@ -179,7 +224,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 		{
 			name: "device memory offset for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
 					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
@@ -191,7 +237,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 		{
 			name: "device memory offset for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
 					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
@@ -199,6 +246,19 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
+					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 
@@ -217,7 +277,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 		{
 			name: "device memory total for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
 					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
@@ -229,7 +290,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 		{
 			name: "device memory total for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
 					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
@@ -237,6 +299,19 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
+					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 
@@ -255,7 +330,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 		{
 			name: "device sm util for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
 					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
@@ -267,7 +343,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 		{
 			name: "device sm util for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
 					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
@@ -275,6 +352,19 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale proc slot beyond procnum is ignored",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
+					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
+				},
+			}},
+			input:    1,
+			expected: uint64(200),
 		},
 	}
 

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -88,9 +88,17 @@ func (s Spec) DeviceNum() int {
 	return int(s.sr.num)
 }
 
+// activeProcs returns the process slots currently in use. procnum is read from
+// the shared-memory region and may be corrupt (negative or larger than the
+// backing array); clamp it to a valid range so slicing can never panic.
+func (s Spec) activeProcs() []shrregProcSlotT {
+	n := min(max(int(s.sr.procnum), 0), len(s.sr.procs))
+	return s.sr.procs[:n]
+}
+
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -98,7 +106,7 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -106,7 +114,7 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -114,7 +122,7 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].offset
 	}
 	return v
@@ -122,7 +130,7 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.used[idx].total
 	}
 	return v
@@ -130,7 +138,7 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs[:int(s.sr.procnum)] {
+	for _, p := range s.activeProcs() {
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -1083,3 +1083,29 @@ func Test_SetUtilizationSwitch(t *testing.T) {
 		})
 	}
 }
+
+func TestSpec_CorruptProcnumIsClamped(t *testing.T) {
+	tests := []struct {
+		name     string
+		procnum  int32
+		expected uint64
+	}{
+		// Negative procnum clamps to 0 active slots, so nothing is summed.
+		{name: "negative procnum", procnum: -5, expected: 0},
+		// procnum larger than the backing array clamps to its length; only the
+		// single populated slot contributes.
+		{name: "procnum over backing array", procnum: 2000, expected: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sr := &sharedRegionT{num: 2, procnum: tt.procnum}
+			sr.procs[0].used[0].total = 100
+			sr.procs[0].deviceUtil[0].smUtil = 100
+			s := Spec{sr: sr}
+			// A corrupt procnum must never panic the slice bound.
+			assert.Equal(t, tt.expected, s.DeviceMemoryTotal(0))
+			assert.Equal(t, tt.expected, s.DeviceSmUtil(0))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `pkg/monitor/nvidia/v0/spec.go`, the six per-device metric accessors (`DeviceMemoryContextSize`, `DeviceMemoryModuleSize`, `DeviceMemoryBufferSize`, `DeviceMemoryOffset`, `DeviceMemoryTotal` and `DeviceSmUtil`) iterate over the entire fixed-size `procs [1024]shrregProcSlotT` array instead of only the live slots bounded by `procnum`:

```go
for _, p := range s.sr.procs {          // iterates all 1024 slots
	v += p.used[idx].contextSize
}
```

`procnum` is the count of active process slots written by `libvgpu.so`. Slots at index `>= procnum` are not cleared and can retain stale, non-zero values from processes that have exited. Summing over all 1024 slots folds that stale data into the reported per-device memory and SM-utilization totals, inflating the corresponding vGPUmonitor gauges (and in the worst case pushing a value far above the real device usage/limit once a slot beyond `procnum` holds leftover data).

The v0 layout is reachable: `pkg/monitor/nvidia/cudevshr.go` selects it when the shared-region file size is `1197897`.

The v1 layout already bounded these loops to `s.sr.procs[:int(s.sr.procnum)]` (fixed in `acc8d91`, #1345) but the fix was never backported to v0. This PR backports it to v0.

**Changes**

- Bound all six v0 accessor loops to the active proc slots, mirroring v1.
- Route both v0 and v1 through a shared-shape `activeProcs()` helper that clamps `procnum` into `[0, len(procs)]` before slicing. `procnum` comes straight from the mmap'd shared-memory region, so a corrupt value (negative or larger than the backing array) would otherwise panic with `slice bounds out of range`. This also hardens the pre-existing v1 code, which had the same exposure.
- Update the existing spec tests to set `procnum` (they previously relied on all-zero trailing slots, so they would sum `procs[:0]` = 0 once the bound is applied).
- Add a stale-slot regression case per accessor asserting that a non-zero slot beyond `procnum` is excluded from the sum, plus a clamp regression test (negative and oversized `procnum`) for both v0 and v1.

**Which issue(s) this PR fixes**:
Fixes #2281

**Special notes for your reviewer**:

Verified red→green:
- With the loops still unbounded, the stale-slot cases return `600` instead of `200`; after the fix all pass.
- With `activeProcs()` slicing `procnum` directly (no clamp), the clamp test panics `slice bounds out of range [:-5]`; with the clamp it passes.

`go test ./pkg/monitor/nvidia/... -race` and `gofmt`/`go vet` are clean.

The clamp addresses review feedback on this PR (thanks @mesutoezdil) — folding it in here since it hardens the exact lines this PR touches, and applying it to v1 too keeps both layouts consistent.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.

**Does this PR introduce a user-facing change?**:

```release-note
Fix vGPUmonitor over-reporting device memory and SM utilization for the v0 shared-region layout, caused by counting stale process slots.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA monitoring reliability when process-count data is invalid or corrupted.
  * Device memory and SM utilization totals now ignore inactive process slots.
  * Prevented monitoring errors and crashes caused by negative or oversized process counts.

* **Tests**
  * Added coverage for invalid process counts and excluded process slots across NVIDIA monitoring versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->