### PR TITLE
fix(device): use len(devices) for GenReason in kunlun and awsneuron

### DIFF
--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -371,7 +371,7 @@ func (neuron *AWSNeuronDevices) Fit(devices []*device.DeviceUsage, request devic
 		if len(alloc) == 0 {
 			reason[common.NumaNotFit]++
 			klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
-			return false, tmpDevs, common.GenReason(reason, len(reason))
+			return false, tmpDevs, common.GenReason(reason, len(devices))
 		}
 		for _, dev := range alloc {
 			for _, val := range devices {

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -860,6 +860,33 @@ func TestDevices_Fit(t *testing.T) {
 			wantDevIDs: []string{},
 			wantReason: "1/1 ExclusiveDeviceAllocateConflict",
 		},
+		{
+			name: "fit fail: NumaNotFit with multiple devices",
+			devices: []*device.DeviceUsage{
+				{
+					ID: "dev-0", Index: 0, Used: 0, Count: 2, Totalcore: 3,
+					Type: AWSNeuronDevice, Health: true,
+					CustomInfo: map[string]any{AWSNodeType: "trn"},
+				},
+				{
+					ID: "dev-1", Index: 1, Used: 0, Count: 2, Totalcore: 3,
+					Type: AWSNeuronDevice, Health: true,
+					CustomInfo: map[string]any{AWSNodeType: "trn"},
+				},
+			},
+			request: device.ContainerDeviceRequest{
+				Nums:             2,
+				Memreq:           0,
+				MemPercentagereq: 0,
+				Coresreq:         2,
+				Type:             AWSNeuronDevice,
+			},
+			annos:      map[string]string{},
+			wantFit:    false,
+			wantLen:    0,
+			wantDevIDs: []string{},
+			wantReason: "1/2 NumaNotFit",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -188,7 +188,7 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 	if len(alloc) == 0 {
 		reason[common.NumaNotFit]++
 		klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
-		return false, tmpDevs, common.GenReason(reason, len(reason))
+		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
 
 	for _, dev := range alloc {

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -52,6 +52,19 @@ func TestKunlunVDevices_Fit_Mutex(t *testing.T) {
 	assert.Equal(t, reason, "8/8 "+common.ExclusiveDeviceAllocateConflict)
 }
 
+func TestKunlunVDevices_Fit_NumaNotFit(t *testing.T) {
+	dev := &KunlunVDevices{}
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{Index: uint(i), Used: 0, Usedmem: 0, Totalmem: 1024}
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Memreq: 2048}
+
+	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, reason, "1/8 "+common.NumaNotFit)
+}
+
 func TestKunlunDevices_Fit_NumaNotFit(t *testing.T) {
 	dev := &KunlunDevices{}
 	devices := make([]*device.DeviceUsage, 8)

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kunlun
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -50,7 +49,20 @@ func TestKunlunVDevices_Fit_Mutex(t *testing.T) {
 	}}
 	fit, _, reason := dev.Fit(devices, req, mutexPod, nodeInfo, allocated)
 	assert.Equal(t, fit, false)
-	assert.Assert(t, strings.Contains(reason, common.ExclusiveDeviceAllocateConflict), reason)
+	assert.Equal(t, reason, "8/8 "+common.ExclusiveDeviceAllocateConflict)
+}
+
+func TestKunlunDevices_Fit_NumaNotFit(t *testing.T) {
+	dev := &KunlunDevices{}
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{Index: uint(i), Used: 1}
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: KunlunGPUDevice}
+
+	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Equal(t, reason, "1/8 "+common.NumaNotFit)
 }
 
 func Test_graphSelect(t *testing.T) {

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -255,7 +255,7 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			reason[common.NumaNotFit]++
 			klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums)
 		}
-		return false, tmpDevs, common.GenReason(reason, len(reason))
+		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
 	for _, dev := range alloc {
 		for _, val := range devices {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

Kunlun XPU, Kunlun VXPU, and one AWS Neuron Fit failure path called `common.GenReason(reason, len(reason))`, so the denominator was the number of reason keys (usually `1`) instead of candidate devices. That produced strings like `1/1 NumaNotFit` instead of `1/8 NumaNotFit`.
Other backends already use `len(devices)` after #2238; the AWS Neuron single-device fail path in the same file already did too. This PR updates the three remaining call sites and adds unit coverage.

**Which issue(s) this PR fixes**:
Fixes #2291

**Special notes for your reviewer**:

- Reason-string only; no allocation-policy change.
- Verified with `go test ./pkg/device/kunlun/ ./pkg/device/awsneuron/ -count=1 -short` and `make verify`.


**Does this PR introduce a user-facing change?**:
No

AI Assistance Disclosure: Used Cursor to help locate matching call sites and draft the initial test cases. I reviewed the change against the issue, ran the unit tests and `make verify` myself, and confirmed the reason-string behaviour before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected device allocation failure messages to report the total number of requested devices.
  * Improved NUMA-related allocation reasons for AWS Neuron and Kunlun devices.
  * Allocation conflicts now consistently report clear, accurate failure details.

* **Tests**
  * Added coverage for multi-device and NUMA-incompatible allocation failures.
  * Strengthened validation of allocation conflict reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->