### PR TITLE
fix: release node lock on allocate response failure

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -647,6 +647,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 			response, err := plugin.getAllocateResponse(plugin.GetContainerDeviceStrArray(devreq))
 			if err != nil {
+				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
 			}
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1035,6 +1035,90 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 	require.Equal(t, "50", response.ContainerResponses[0].Envs["CUDA_DEVICE_SM_LIMIT"])
 }
 
+func TestAllocateReleasesNodeLockWhenNonMIGAllocateResponseFails(t *testing.T) {
+	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"cdi-annotations"})
+	deviceIDStrategy := v1.DeviceIDStrategyUUID
+
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							DeviceIDStrategy: &deviceIDStrategy,
+						},
+					},
+				},
+			},
+		},
+		cdiHandler: &cdi.InterfaceMock{
+			QualifiedNameFunc: func(string, string) string {
+				return "invalid-cdi-device-name"
+			},
+		},
+		deviceListStrategies: deviceListStrategies,
+		cdiAnnotationPrefix:  v1.DefaultCDIAnnotationPrefix,
+	}
+
+	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-annotated-a,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+	}
+
+	previousGetPendingPod := getPendingPod
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	defer func() { getPendingPod = previousGetPendingPod }()
+
+	eraseCalled := false
+	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
+	eraseNextDeviceTypeFromAnnotation = func(string, corev1.Pod) error {
+		eraseCalled = true
+		return nil
+	}
+	defer func() { eraseNextDeviceTypeFromAnnotation = previousEraseNextDeviceTypeFromAnnotation }()
+
+	failedCalled := false
+	previousPodAllocationFailed := podAllocationFailed
+	podAllocationFailed = func(nodeName string, failedPod *corev1.Pod, lockName string) {
+		failedCalled = true
+		require.Equal(t, pod, failedPod)
+		require.Equal(t, NodeLockNvidia, lockName)
+	}
+	defer func() { podAllocationFailed = previousPodAllocationFailed }()
+
+	successCalled := false
+	previousPodAllocationTrySuccess := podAllocationTrySuccess
+	podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {
+		successCalled = true
+	}
+	defer func() { podAllocationTrySuccess = previousPodAllocationTrySuccess }()
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{{
+			DevicesIds: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0"},
+		}},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get allocate response")
+	require.True(t, failedCalled)
+	require.False(t, eraseCalled)
+	require.False(t, successCalled)
+}
+
 func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) {
 	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"envvar"})
 	deviceIDStrategy := v1.DeviceIDStrategyUUID

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1038,6 +1038,8 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 func TestAllocateReleasesNodeLockWhenNonMIGAllocateResponseFails(t *testing.T) {
 	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"cdi-annotations"})
 	deviceIDStrategy := v1.DeviceIDStrategyUUID
+	expectedNodeName := "node-a"
+	t.Setenv(util.NodeNameEnvName, expectedNodeName)
 
 	plugin := &NvidiaDevicePlugin{
 		config: &nvidia.DeviceConfig{
@@ -1092,6 +1094,7 @@ func TestAllocateReleasesNodeLockWhenNonMIGAllocateResponseFails(t *testing.T) {
 	previousPodAllocationFailed := podAllocationFailed
 	podAllocationFailed = func(nodeName string, failedPod *corev1.Pod, lockName string) {
 		failedCalled = true
+		require.Equal(t, expectedNodeName, nodeName)
 		require.Equal(t, pod, failedPod)
 		require.Equal(t, NodeLockNvidia, lockName)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

This PR releases the NVIDIA node lock when `getAllocateResponse()` fails in the non-MIG allocation path.

Previously, this error path returned immediately without calling `PodAllocationFailed(nodename, current, NodeLockNvidia)`, leaving `hami.io/mutex.lock` held on the node. That could block or fail subsequent GPU allocation requests on the same node.

**Which issue(s) this PR fixes**:
Fixes #2214 

**Special notes for your reviewer**:
AI assistance disclosure: I consulted AI to understand the codebase and review the relevant allocation error paths. The production fix was authored manually by me. The regression test was co-authored with Codex and reviewed by me.

**Does this PR introduce a user-facing change?**:
Yes, but only as bug a fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of device allocation failures by recording pod allocation failures when generating a container response fails.
  * Ensured node locks are released correctly after non-MIG allocation errors.
* **Tests**
  * Added regression coverage for invalid device names, failure cleanup, callback behavior, and lock release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->