### PR TITLE
feat: allow per-node memoryFactor override in device-plugin

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -370,6 +370,7 @@ devicePlugin:
             "preconfigureddevicememory": 0,
             "enablenumatopology": false,
             "migstrategy": "none",
+            "memoryfactor": 1,
             "filterdevices": {
               "uuid": [],
               "index": []

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -137,6 +137,9 @@ func readFromConfigFile(sConfig *nvidia.NvidiaConfig, path string) (string, erro
 			if err := mergo.Merge(&sConfig.NodeDefaultConfig, val.NodeDefaultConfig, mergo.WithOverride); err != nil {
 				return "", err
 			}
+			if val.NodeDefaultConfig.MemoryFactor != nil {
+				sConfig.MemoryFactor = *val.NodeDefaultConfig.MemoryFactor
+			}
 			if val.FilterDevice != nil && (len(val.FilterDevice.UUID) > 0 || len(val.FilterDevice.Index) > 0) {
 				nvidia.DevicePluginFilterDevice = val.FilterDevice
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -629,12 +629,12 @@ func Test_pathGeneration(t *testing.T) {
 }
 
 func Test_configOverride(t *testing.T) {
-	t.Setenv("NODE_NAME", "testnode")
 	logLevel1 := nvidia.Debugs
 	logLevel2 := nvidia.Infos
 	split1 := uint(2)
 	memScale1 := 1.5
 	coreScale1 := 1.2
+	memFactor1 := int32(2)
 
 	split2 := uint(3)
 	memScale2 := 0.8
@@ -655,6 +655,7 @@ func Test_configOverride(t *testing.T) {
 					DeviceMemoryScaling: &memScale1,
 					DeviceCoreScaling:   &coreScale1,
 					LogLevel:            &logLevel1,
+					MemoryFactor:        &memFactor1,
 				},
 				Name:                         "node-1",
 				OperatingMode:                "default",
@@ -684,6 +685,9 @@ func Test_configOverride(t *testing.T) {
 	}
 	path := t.TempDir()
 	os.WriteFile(path+"/config.json", bytes, 0644)
+
+	// Test 1: testnode (no MemoryFactor override, should fall back to global value 5)
+	t.Setenv("NODE_NAME", "testnode")
 	nvconfig := nvidia.NvidiaConfig{
 		NodeDefaultConfig: nvidia.NodeDefaultConfig{
 			DeviceSplitCount:    func() *uint { v := uint(1); return &v }(),
@@ -696,6 +700,7 @@ func Test_configOverride(t *testing.T) {
 		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
 		ResourceCoreName:             "nvidia.com/gpucores",
 		DefaultGPUNum:                int32(2),
+		MemoryFactor:                 int32(5), // global value
 	}
 	_, err = readFromConfigFile(&nvconfig, path+"/config.json")
 	if err != nil {
@@ -707,15 +712,56 @@ func Test_configOverride(t *testing.T) {
 			DeviceMemoryScaling: func() *float64 { v := 0.8; return &v }(),
 			DeviceCoreScaling:   func() *float64 { v := 1.4; return &v }(),
 			LogLevel:            func() *nvidia.LibCudaLogLevel { v := nvidia.Infos; return &v }(),
+			MemoryFactor:        nil,
 		},
 		ResourceCountName:            "nvidia.com/gpu",
 		ResourceMemoryName:           "nvidia.com/gpumem",
 		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
 		ResourceCoreName:             "nvidia.com/gpucores",
 		DefaultGPUNum:                int32(2),
+		MemoryFactor:                 int32(5), // remains global value
 	}
 	if !reflect.DeepEqual(nvconfig, expected) {
 		t.Errorf("Expected %v, got %v", expected, nvconfig)
+	}
+
+	// Test 2: node-1 (with MemoryFactor override, should override global value 5 to 2)
+	t.Setenv("NODE_NAME", "node-1")
+	nvconfig2 := nvidia.NvidiaConfig{
+		NodeDefaultConfig: nvidia.NodeDefaultConfig{
+			DeviceSplitCount:    func() *uint { v := uint(1); return &v }(),
+			DeviceMemoryScaling: func() *float64 { v := 1.0; return &v }(),
+			DeviceCoreScaling:   func() *float64 { v := 1.0; return &v }(),
+			LogLevel:            func() *nvidia.LibCudaLogLevel { v := nvidia.Error; return &v }(),
+		},
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		DefaultGPUNum:                int32(2),
+		MemoryFactor:                 int32(5), // global value
+	}
+	_, err = readFromConfigFile(&nvconfig2, path+"/config.json")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected2 := nvidia.NvidiaConfig{
+		NodeDefaultConfig: nvidia.NodeDefaultConfig{
+			DeviceSplitCount:    func() *uint { v := uint(2); return &v }(),
+			DeviceMemoryScaling: func() *float64 { v := 1.5; return &v }(),
+			DeviceCoreScaling:   func() *float64 { v := 1.2; return &v }(),
+			LogLevel:            func() *nvidia.LibCudaLogLevel { v := nvidia.Debugs; return &v }(),
+			MemoryFactor:        func() *int32 { v := int32(2); return &v }(),
+		},
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		DefaultGPUNum:                int32(2),
+		MemoryFactor:                 int32(2), // overridden value
+	}
+	if !reflect.DeepEqual(nvconfig2, expected2) {
+		t.Errorf("Expected %v, got %v", expected2, nvconfig2)
 	}
 }
 

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -132,7 +132,8 @@ type NodeDefaultConfig struct {
 	// EnableNUMATopology advertises the physical GPU's NUMA node on each vGPU
 	// replica so kubelet's TopologyManager can align CPU and GPU NUMA nodes.
 	// Defaults to false to preserve existing admission behavior.
-	EnableNUMATopology *bool `yaml:"enableNumaTopology" json:"enablenumatopology"`
+	EnableNUMATopology *bool  `yaml:"enableNumaTopology" json:"enablenumatopology"`
+	MemoryFactor       *int32 `yaml:"memoryFactor,omitempty" json:"memoryfactor,omitempty"`
 }
 
 type FilterDevice struct {


### PR DESCRIPTION
Fixes #2287

### What this PR does / why we need it:
Currently, `memoryFactor` is a global setting in `NvidiaConfig`. When using Volcano vGPU DP (or in general heterogeneous clusters), different nodes might need different chunk granularities to avoid gRPC size limits on nodes with large GPUs, without forcing small GPUs to use large chunk sizes. 

This PR allows configuring `memoryfactor` on a per-node basis via the `nodeconfig` configmap array, parsing it securely and falling back to the global default if omitted.

### Implementation details:
Added `MemoryFactor` as an optional pointer (`*int32` with `omitempty`) inside `NodeDefaultConfig` to preserve backwards compatibility. In `server.go`, the specific `memoryfactor` cleanly overrides the global `sConfig.MemoryFactor` during node config initialization.

### AI Assistance Notice:
> I consulted an AI assistant to explore the repository structure and reason about the scheduling flow, but the code changes and the solution design were authored and verified manually by myself.

### Testing:
- `make verify` and `go test ./...` passed locally.
- *Note on Hardware Validation:* This PR only affects how the config file is parsed into structs and doesn't change the underlying device isolation/allocation logic directly, so it was tested via unit tests without needing a bare-metal multi-GPU validation.

### Release note:
```release-note
Allow setting `memoryfactor` on a per-node basis using `nodeConfiguration.config` in helm values.
```

### Known Limits:
**Scheduler vs Device Plugin Consistency:** When using the default HAMi scheduler, the MutatingAdmissionWebhook operates at the cluster level before a node is assigned, so it will continue to use the global `memoryFactor`. The per-node `memoryFactor` is only applied locally by the DP. Users relying on the HAMi scheduler must ensure their global `memoryFactor` aligns with their workloads, while Volcano users (who bypass the HAMi webhook entirely) can fully benefit from this per-node chunking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable memory scaling for NVIDIA device nodes.
  * The memory factor defaults to 1 and can be customized per node.
  * Node-specific memory settings override the global configuration when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->