### PR TITLE
fix(awsneuron): guard nil CustomInfo maps

### DIFF
--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -261,6 +261,9 @@ func (dev *AWSNeuronDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 	n.Usedcores += ctr.Usedcores
 	n.Usedmem += ctr.Usedmem
 
+	if n.CustomInfo == nil {
+		n.CustomInfo = make(map[string]any)
+	}
 	num, ok := n.CustomInfo[AWSUsageInfo]
 	if !ok || num == nil {
 		n.CustomInfo[AWSUsageInfo] = 0
@@ -393,6 +396,9 @@ func (neuron *AWSNeuronDevices) Fit(devices []*device.DeviceUsage, request devic
 	}
 	for i, v := range slices.Backward(devices) {
 		dev := v
+		if dev.CustomInfo == nil {
+			dev.CustomInfo = make(map[string]any)
+		}
 		_, ok := dev.CustomInfo[AWSUsageInfo]
 		if !ok {
 			dev.CustomInfo[AWSUsageInfo] = int(dev.Usedcores)

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -402,6 +402,46 @@ func Test_GenerateResourceRequests(t *testing.T) {
 	}
 }
 
+func TestAddResourceUsageInitializesNilCustomInfo(t *testing.T) {
+	dev := &AWSNeuronDevices{}
+	usage := &device.DeviceUsage{}
+	container := &device.ContainerDevice{
+		CustomInfo: map[string]any{AWSUsageInfo: 1},
+	}
+
+	assert.NilError(t, dev.AddResourceUsage(&corev1.Pod{}, usage, container))
+	assert.Equal(t, usage.CustomInfo[AWSUsageInfo], 1)
+}
+
+func TestFitInitializesNilCustomInfo(t *testing.T) {
+	dev := InitAWSNeuronDevice(AWSNeuronConfig{})
+	usage := &device.DeviceUsage{
+		ID:        "dev-0",
+		Count:     2,
+		Totalcore: 3,
+		Usedcores: 1,
+		Type:      AWSNeuronDevice,
+	}
+	request := device.ContainerDeviceRequest{
+		Nums:     1,
+		Type:     AWSNeuronDevice,
+		Coresreq: 1,
+	}
+
+	fit, allocations, reason := dev.Fit(
+		[]*device.DeviceUsage{usage},
+		request,
+		&corev1.Pod{},
+		nil,
+		nil,
+	)
+
+	assert.Assert(t, fit)
+	assert.Equal(t, reason, "")
+	assert.Equal(t, usage.CustomInfo[AWSUsageInfo], 1)
+	assert.Equal(t, len(allocations[AWSNeuronDevice]), 1)
+}
+
 func Test_countMaskAvailable(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Initializes `DeviceUsage.CustomInfo` before the two AWS Neuron write paths that can receive a nil map:

- `AddResourceUsage` when recording `AWSUsageInfo`;
- the single-card `Fit` path when deriving usage from `Usedcores`.

Without these guards, either path can panic with `assignment to entry in nil map`. Focused regression tests cover both cases and verify that the existing usage values are preserved.

**Which issue(s) this PR fixes**:

Fixes #2294

**Special notes for your reviewer**:

This is a unit-level defensive hardening change. It does not alter the normal registration path, where `GetNodeDevices` already initializes `CustomInfo`. No AWS Neuron hardware was available; validation used race-enabled unit tests for the affected backend.

Validation:

- `go test -race ./pkg/device/awsneuron -count=1`
- `make verify`
- `git diff --check`

This PR was developed with Codex assistance. I reviewed the implementation, regression coverage, and validation results before submission.

**Does this PR introduce a user-facing change?**:

No. It prevents a defensive edge-case panic without changing normal allocation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS Neuron resource allocation when device metadata is initially empty.
  * Preserved AWS Neuron usage details during resource tracking and allocation.
  * Improved successful fitting and allocation behavior for single-device requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->