### PR TITLE
fix(scheduler): return early when predicate body is nil

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -32,18 +32,21 @@ import (
 
 const maxRequestSize = 1024 * 1024 // 1MB limit
 
-func checkBody(w http.ResponseWriter, r *http.Request) {
+func checkBody(w http.ResponseWriter, r *http.Request) bool {
 	if r.Body == nil {
 		http.Error(w, "Please send a request body", 400)
-		return
+		return false
 	}
+	return true
 }
 
 func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 	klog.Infoln("Initializing Predicate Route")
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infoln("Entering Predicate Route handler")
-		checkBody(w, r)
+		if !checkBody(w, r) {
+			return
+		}
 
 		var buf bytes.Buffer
 		// Limit the body size to prevent deep nesting/resource exhaustion attacks

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -134,10 +134,26 @@ func TestCheckBodyNil(t *testing.T) {
 	req.Body = nil
 	w := httptest.NewRecorder()
 
-	checkBody(w, req)
+	if checkBody(w, req) {
+		t.Error("expected checkBody to reject a nil body")
+	}
 
 	if w.Code != 400 {
 		t.Errorf("Expected status 400 for nil body, got %d", w.Code)
+	}
+}
+
+func TestPredicateRoute_NilBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/predicate", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := PredicateRoute(s)
+	handler(w, req, nil)
+
+	if w.Code != 400 {
+		t.Errorf("expected 400 for nil body, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Return immediately from `PredicateRoute` when the request body is nil.
- Make `checkBody` report whether the body is valid.
- Add a regression test for the nil-body handler path.

## Testing

- `go test ./pkg/scheduler/routes -run '^TestPredicateRoute_NilBody$' -count=1`
- `go test ./pkg/scheduler/routes -short -race -count=1`
- `go test ./pkg/scheduler/... -short -race -count=1`

Fixes #2296

## AI assistance

I used Codex to inspect the code, implement the fix, and run the local tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with missing bodies now receive a clear HTTP 400 response.
  * Processing stops immediately after rejecting requests without a body.

* **Tests**
  * Added coverage to verify correct handling of requests with nil bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->