### PR TITLE
fix(scheduler): return early from PredicateRoute on nil body

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -32,18 +32,21 @@ import (
 
 const maxRequestSize = 1024 * 1024 // 1MB limit
 
-func checkBody(w http.ResponseWriter, r *http.Request) {
+func checkBody(w http.ResponseWriter, r *http.Request) bool {
 	if r.Body == nil {
 		http.Error(w, "Please send a request body", 400)
-		return
+		return false
 	}
+	return true
 }
 
 func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 	klog.Infoln("Initializing Predicate Route")
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infoln("Entering Predicate Route handler")
-		checkBody(w, r)
+		if !checkBody(w, r) {
+			return
+		}
 
 		var buf bytes.Buffer
 		// Limit the body size to prevent deep nesting/resource exhaustion attacks

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -134,10 +134,28 @@ func TestCheckBodyNil(t *testing.T) {
 	req.Body = nil
 	w := httptest.NewRecorder()
 
-	checkBody(w, req)
+	if checkBody(w, req) {
+		t.Error("expected checkBody to return false for nil body")
+	}
 
 	if w.Code != 400 {
 		t.Errorf("Expected status 400 for nil body, got %d", w.Code)
+	}
+}
+
+func TestPredicateRoute_NilBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/filter", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	handler := PredicateRoute(&scheduler.Scheduler{})
+	handler(w, req, nil)
+
+	if w.Code != 400 {
+		t.Errorf("expected status 400 for nil body, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Please send a request body") {
+		t.Errorf("expected nil-body error message, got %q", w.Body.String())
 	}
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

`checkBody` already responded with HTTP 400 when `r.Body == nil`, but `PredicateRoute` ignored that and continued into `io.LimitReader` / JSON decode, which nil-dereferences. Make `checkBody` return a bool and return from the handler on failure. Add a `PredicateRoute` regression test for nil body (existing `TestCheckBodyNil` only covered `checkBody` in isolation).


**Which issue(s) this PR fixes**:
Fixes #2296

**Special notes for your reviewer**:
 Verified with: `go test ./pkg/scheduler/routes/ -count=1 -short` and `PATH="$(go env GOPATH)/bin:$PATH" make verify`.


**Does this PR introduce a user-facing change?**:
No

AI Assistance Disclosure: Used Cursor to help locate the missing early return and draft the regression test. I reviewed the change against issue, ran the unit tests and `make verify` myself, and confirmed the nil-body path returns 400 without panicking before opening this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with missing bodies now receive a clear HTTP 400 response.
  * Prevented further request processing after detecting an absent body.

* **Tests**
  * Added coverage to verify correct handling and error messaging for requests without bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->