### PR TITLE
fix(scheduler): notify on node annotation/label updates

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -200,6 +200,20 @@ func (s *Scheduler) onDelPod(obj any) {
 	}
 }
 
+// onUpdateNode notifies registration when node labels or annotations change.
+// Status-only updates are ignored so Node heartbeats do not wake register().
+func (s *Scheduler) onUpdateNode(oldObj, newObj any) {
+	oldNode, ok1 := oldObj.(*corev1.Node)
+	newNode, ok2 := newObj.(*corev1.Node)
+	if !ok1 || !ok2 {
+		return
+	}
+	if maps.Equal(oldNode.Labels, newNode.Labels) && maps.Equal(oldNode.Annotations, newNode.Annotations) {
+		return
+	}
+	s.doNodeNotify()
+}
+
 // onDelNode handles node delete events. It removes any in-memory per-node
 // lock bookkeeping to avoid unbounded growth when nodes are removed by
 // autoscalers or administratively.
@@ -294,6 +308,7 @@ func (s *Scheduler) Start() error {
 	}
 	nodeEventHandlerRegistration, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { s.doNodeNotify() },
+		UpdateFunc: s.onUpdateNode,
 		DeleteFunc: s.onDelNode,
 	})
 	if err != nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -987,6 +987,71 @@ func TestSchedulerOnDelNodeCleansLockDirectNode(t *testing.T) {
 	require.Equal(t, 0, nodelockutil.NodeLockCountForTest())
 }
 
+func TestSchedulerOnUpdateNode(t *testing.T) {
+	drainNotify := func(s *Scheduler) {
+		select {
+		case <-s.nodeNotify:
+		default:
+		}
+	}
+	expectNotify := func(t *testing.T, s *Scheduler) {
+		t.Helper()
+		select {
+		case <-s.nodeNotify:
+		case <-time.After(time.Second):
+			t.Fatal("expected node notification")
+		}
+	}
+	expectNoNotify := func(t *testing.T, s *Scheduler) {
+		t.Helper()
+		select {
+		case <-s.nodeNotify:
+			t.Fatal("unexpected node notification")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	t.Run("annotation change notifies", func(t *testing.T) {
+		s := NewScheduler()
+		drainNotify(s)
+		oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Annotations: map[string]string{"a": "1"}}}
+		newNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Annotations: map[string]string{"a": "2"}}}
+		s.onUpdateNode(oldNode, newNode)
+		expectNotify(t, s)
+	})
+
+	t.Run("label change notifies", func(t *testing.T) {
+		s := NewScheduler()
+		drainNotify(s)
+		oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{"l": "1"}}}
+		newNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{"l": "2"}}}
+		s.onUpdateNode(oldNode, newNode)
+		expectNotify(t, s)
+	})
+
+	t.Run("status-only change does not notify", func(t *testing.T) {
+		s := NewScheduler()
+		drainNotify(s)
+		oldNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1", Annotations: map[string]string{"a": "1"}},
+			Status:     corev1.NodeStatus{Phase: corev1.NodePending},
+		}
+		newNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1", Annotations: map[string]string{"a": "1"}},
+			Status:     corev1.NodeStatus{Phase: corev1.NodeRunning},
+		}
+		s.onUpdateNode(oldNode, newNode)
+		expectNoNotify(t, s)
+	})
+
+	t.Run("non-node objects do not notify", func(t *testing.T) {
+		s := NewScheduler()
+		drainNotify(s)
+		s.onUpdateNode(struct{}{}, struct{}{})
+		expectNoNotify(t, s)
+	})
+}
+
 func TestSchedulerOnDelNodeCleansLockFromTombstone(t *testing.T) {
 	nodelockutil.ResetNodeLocksForTest()
 	t.Cleanup(nodelockutil.ResetNodeLocksForTest)


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The node informer only had Add/Delete handlers. Annotation updates on existing nodes (device plugin handshake/inventory) did not call `doNodeNotify()`, so re-registration waited for the 15s ticker. Add `UpdateFunc` that notifies when labels or annotations change, and ignore status-only updates so Node heartbeats do not wake `register()`.

**Which issue(s) this PR fixes**:
Fixes #2303

**Special notes for your reviewer**:

- Verified with: `go test ./pkg/scheduler/ -count=1 -short -run 'TestSchedulerOnUpdateNode|TestSchedulerOnDelNode'` and `PATH="$(go env GOPATH)/bin:$PATH" make verify`.

**Does this PR introduce a user-facing change?**:
No

AI Assistance Disclosure: Used Cursor to help locate the missing UpdateFunc and draft the filter/tests. I reviewed the change against issue, ran the unit tests and `make verify` myself, and confirmed annotation/label updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler updates now respond to node label and annotation changes.
  * Status-only node updates and invalid objects no longer trigger unnecessary notifications.

* **Tests**
  * Added coverage for node update handling, including relevant changes and ignored updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->