### PR TITLE
fix(device): don't panic on asymmetric GPU P2P link data in calculateGPUPairScore

### DIFF
--- a/charts/hami/templates/device-plugin/monitorrole.yaml
+++ b/charts/hami/templates/device-plugin/monitorrole.yaml
@@ -24,6 +24,14 @@ rules:
       - update
       - list
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - create
+      - update
 {{- end -}}
     
     

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -212,10 +212,16 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 
 	var data []byte
 	if os.Getenv("ENABLE_TOPOLOGY_SCORE") == "true" {
-		gpuScore, err := nvidia.CalculateGPUScore(device.GetDevicesUUIDList(*devices))
+		gpuScore, hasAsymmetry, err := nvidia.CalculateGPUScore(device.GetDevicesUUIDList(*devices))
 		if err != nil {
 			klog.ErrorS(err, "calculate gpu topo score error")
 			return false, err
+		}
+		if hasAsymmetry {
+			util.EmitNodeWarningEvent(node, "AsymmetricGPUP2PLink",
+				"One or more GPU pairs on this node have asymmetric P2P link data; "+
+					"affected pairs scored 0 (possible NVLink hardware or driver issue)",
+				time.Hour)
 		}
 		data, err = json.Marshal(gpuScore)
 		if err != nil {

--- a/pkg/device/nvidia/calculate_score.go
+++ b/pkg/device/nvidia/calculate_score.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
 )
 
 // Device represents a GPU device as reported by NVML, including all of its
@@ -170,49 +171,60 @@ type DeviceScore struct {
 	Score map[string]int `json:"score"`
 }
 
-func CalculateGPUScore(available []string) (ListDeviceScore, error) {
+// CalculateGPUScore returns topology scores for the requested GPUs.
+// The bool return is true if any GPU pair had asymmetric P2P link data, indicating a
+// possible NVLink hardware or driver issue on this node.
+func CalculateGPUScore(available []string) (ListDeviceScore, bool, error) {
 	linkedDevices, err := NewDevices()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	requiredDevices, err := linkedDevices.Filter(available)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	score := calculateGPUScore(requiredDevices)
-	return score, nil
+	score, anyAsymmetric := calculateGPUScore(requiredDevices)
+	return score, anyAsymmetric, nil
 }
 
-func calculateGPUScore(devices []*Device) ListDeviceScore {
+func calculateGPUScore(devices []*Device) (ListDeviceScore, bool) {
 	ds := make(ListDeviceScore, len(devices))
+	anyAsymmetric := false
 	for indexI, gpuI := range devices {
 		score := make(map[string]int)
 		for indexJ, gpuJ := range devices {
 			if indexI == indexJ {
 				continue
 			}
-			score[gpuJ.UUID] = calculateGPUPairScore(gpuI, gpuJ)
+			s, asymmetric := calculateGPUPairScore(gpuI, gpuJ)
+			score[gpuJ.UUID] = s
+			anyAsymmetric = anyAsymmetric || asymmetric
 		}
 		ds[indexI] = DeviceScore{
 			Score: score,
 			UUID:  gpuI.UUID,
 		}
 	}
-	return ds
+	return ds, anyAsymmetric
 }
 
-func calculateGPUPairScore(gpu0 *Device, gpu1 *Device) int {
+func calculateGPUPairScore(gpu0 *Device, gpu1 *Device) (int, bool) {
 	if gpu0 == nil || gpu1 == nil {
-		return 0
+		return 0, false
 	}
 
 	if gpu0 == gpu1 {
-		return 0
+		return 0, false
 	}
 
 	if len(gpu0.Links[gpu1.Index]) != len(gpu1.Links[gpu0.Index]) {
-		err := fmt.Errorf("internal error in bestEffort GPU allocator: all P2PLinks between 2 GPUs should be bidirectional")
-		panic(err)
+		klog.Warningf("asymmetric P2P link data for GPU pair (index=%d uuid=%s) <-> (index=%d uuid=%s): "+
+			"%d link(s) from GPU %d to GPU %d, %d link(s) from GPU %d to GPU %d; "+
+			"scoring pair as 0 (possible NVLink hardware or driver issue)",
+			gpu0.Index, gpu0.UUID, gpu1.Index, gpu1.UUID,
+			len(gpu0.Links[gpu1.Index]), gpu0.Index, gpu1.Index,
+			len(gpu1.Links[gpu0.Index]), gpu1.Index, gpu0.Index)
+		return 0, true
 	}
 
 	score := 0
@@ -270,5 +282,5 @@ func calculateGPUPairScore(gpu0 *Device, gpu1 *Device) int {
 		}
 	}
 
-	return score
+	return score, false
 }

--- a/pkg/device/nvidia/calculate_score_test.go
+++ b/pkg/device/nvidia/calculate_score_test.go
@@ -17,13 +17,55 @@ limitations under the License.
 package nvidia
 
 import (
+	"fmt"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
 
+// Test_calculateGPUPairScore_asymmetric covers the one-sided NVLink case identified in
+// the bug investigation: dev0 has both a PCIe topology entry and an NVLink entry toward
+// dev1, but dev1 only has a PCIe topology entry toward dev0. This reflects a real hardware
+// or driver state where NVLink state is enabled on only one side.
+func Test_calculateGPUPairScore_asymmetric(t *testing.T) {
+	dev0 := &Device{
+		Index:       0,
+		nvlibDevice: nvlibDevice{UUID: "gpu0"},
+		Links: map[int][]P2PLink{
+			1: {
+				{Type: P2PLinkSameCPU},  // PCIe topology entry
+				{Type: FourNVLINKLinks}, // NVLink entry — only present on this side
+			},
+		},
+	}
+	dev1 := &Device{
+		Index:       1,
+		nvlibDevice: nvlibDevice{UUID: "gpu1"},
+		Links: map[int][]P2PLink{
+			0: {
+				{Type: P2PLinkSameCPU}, // PCIe topology entry only — NVLink absent
+			},
+		},
+	}
+
+	var score int
+	var asymmetric bool
+	assert.NilError(t, func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("unexpected panic: %v", r)
+			}
+		}()
+		score, asymmetric = calculateGPUPairScore(dev0, dev1)
+		return nil
+	}())
+
+	assert.Equal(t, score, 0, "asymmetric pair must score 0")
+	assert.Equal(t, asymmetric, true, "asymmetric flag must be set")
+}
+
 func Test_CalculateGPUScore(t *testing.T) {
-	score, err := CalculateGPUScore([]string{"GPU-ebe7c3f7-303d-558d-435e-99a160631fe4"})
+	score, _, err := CalculateGPUScore([]string{"GPU-ebe7c3f7-303d-558d-435e-99a160631fe4"})
 	t.Log(score)
 	t.Log(err)
 }
@@ -118,7 +160,8 @@ func Test_calculateGPUScore(t *testing.T) {
 					if i == j {
 						continue
 					}
-					score[gpuJ.UUID] = calculateGPUPairScore(gpuI, gpuJ)
+					s, _ := calculateGPUPairScore(gpuI, gpuJ)
+					score[gpuJ.UUID] = s
 				}
 				scoreList[i] = DeviceScore{
 					UUID:  gpuI.UUID,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
@@ -279,6 +280,77 @@ func IsPodTerminating(pod *corev1.Pod) bool {
 
 func AllContainersCreated(pod *corev1.Pod) bool {
 	return len(pod.Status.ContainerStatuses) >= len(pod.Spec.Containers)
+}
+
+// EmitNodeWarningEvent emits a Warning event on the given Node with deduplication.
+func EmitNodeWarningEvent(node *corev1.Node, reason, message string, dedupWindow time.Duration) {
+	c := client.GetClient()
+	if c == nil {
+		klog.Warningf("cannot emit node event for %s: Kubernetes client not initialized", node.Name)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fieldSel := fmt.Sprintf(
+		"involvedObject.kind=Node,involvedObject.name=%s,involvedObject.uid=%s,reason=%s",
+		node.Name, string(node.UID), reason,
+	)
+	existing, err := c.CoreV1().Events(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		FieldSelector: fieldSel,
+	})
+	if err != nil {
+		klog.Warningf("failed to list events for node %s: %v; will attempt create", node.Name, err)
+	}
+
+	now := metav1.Now()
+
+	if err == nil && len(existing.Items) > 0 {
+		// Client-side filter: the field selector is a server-side optimization; re-check
+		// here so the function is correct even against fake clients or non-compliant servers.
+		var latest *corev1.Event
+		for i := range existing.Items {
+			ev := &existing.Items[i]
+			if ev.InvolvedObject.UID != node.UID || ev.Reason != reason {
+				continue
+			}
+			if latest == nil || ev.LastTimestamp.After(latest.LastTimestamp.Time) {
+				latest = ev
+			}
+		}
+		if latest != nil && now.Sub(latest.LastTimestamp.Time) <= dedupWindow {
+			latest.Count++
+			latest.LastTimestamp = now
+			latest.Message = message
+			if _, err := c.CoreV1().Events(corev1.NamespaceDefault).Update(ctx, latest, metav1.UpdateOptions{}); err != nil {
+				klog.Warningf("failed to update node event for %s: %v", node.Name, err)
+			}
+			return
+		}
+	}
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: node.Name + "-",
+			Namespace:    corev1.NamespaceDefault,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Node",
+			Name:       node.Name,
+			UID:        node.UID,
+		},
+		Reason:         reason,
+		Message:        message,
+		Type:           corev1.EventTypeWarning,
+		Count:          1,
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+		Source:         corev1.EventSource{Component: "hami-device-plugin"},
+	}
+	if _, err := c.CoreV1().Events(corev1.NamespaceDefault).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		klog.Warningf("failed to create node event for %s: %v", node.Name, err)
+	}
 }
 
 func IsPodGroupMember(pod *corev1.Pod) bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,10 +19,12 @@ package util
 import (
 	"context"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
@@ -777,4 +779,98 @@ func TestSchedulerPolicyName_String(t *testing.T) {
 			assert.Equal(t, tt.want, tt.policy.String())
 		})
 	}
+}
+
+func TestEmitNodeWarningEvent(t *testing.T) {
+	const (
+		nodeName = "test-node"
+		nodeUID  = types.UID("test-uid-1234")
+		reason   = "AsymmetricGPUP2PLink"
+		msg1     = "first message"
+		msg2     = "updated message"
+	)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			UID:  nodeUID,
+		},
+	}
+	dedupWindow := time.Hour
+
+	t.Run("no existing event creates new event", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset()
+
+		EmitNodeWarningEvent(node, reason, msg1, dedupWindow)
+
+		events, err := client.KubeClient.CoreV1().Events(corev1.NamespaceDefault).List(
+			context.TODO(), metav1.ListOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(events.Items))
+		assert.Equal(t, reason, events.Items[0].Reason)
+		assert.Equal(t, msg1, events.Items[0].Message)
+		assert.Equal(t, int32(1), events.Items[0].Count)
+		assert.Equal(t, corev1.EventTypeWarning, events.Items[0].Type)
+	})
+
+	t.Run("existing event within dedupWindow updates count and message", func(t *testing.T) {
+		past := metav1.NewTime(time.Now().Add(-30 * time.Minute)) // within 1h window
+		existing := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName + "-existing",
+				Namespace: corev1.NamespaceDefault,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node",
+				Name: nodeName,
+				UID:  nodeUID,
+			},
+			Reason:         reason,
+			Message:        msg1,
+			Type:           corev1.EventTypeWarning,
+			Count:          3,
+			FirstTimestamp: past,
+			LastTimestamp:  past,
+		}
+		client.KubeClient = fake.NewClientset(existing)
+
+		EmitNodeWarningEvent(node, reason, msg2, dedupWindow)
+
+		events, err := client.KubeClient.CoreV1().Events(corev1.NamespaceDefault).List(
+			context.TODO(), metav1.ListOptions{})
+		assert.NilError(t, err)
+		// Must still be exactly one event — no new object created.
+		assert.Equal(t, 1, len(events.Items))
+		assert.Equal(t, int32(4), events.Items[0].Count)
+		assert.Equal(t, msg2, events.Items[0].Message)
+	})
+
+	t.Run("existing event outside dedupWindow creates new event", func(t *testing.T) {
+		old := metav1.NewTime(time.Now().Add(-2 * time.Hour)) // outside 1h window
+		existing := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName + "-old",
+				Namespace: corev1.NamespaceDefault,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node",
+				Name: nodeName,
+				UID:  nodeUID,
+			},
+			Reason:         reason,
+			Message:        msg1,
+			Type:           corev1.EventTypeWarning,
+			Count:          1,
+			FirstTimestamp: old,
+			LastTimestamp:  old,
+		}
+		client.KubeClient = fake.NewClientset(existing)
+
+		EmitNodeWarningEvent(node, reason, msg2, dedupWindow)
+
+		events, err := client.KubeClient.CoreV1().Events(corev1.NamespaceDefault).List(
+			context.TODO(), metav1.ListOptions{})
+		assert.NilError(t, err)
+		// Old event still present plus one new event.
+		assert.Equal(t, 2, len(events.Items))
+	})
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`calculateGPUPairScore` panicked when NVML reported asymmetric P2P/NVLink data
between a GPU pair, crashing the process that called it.

Correction to the original issue title/report: this function is only called
from the `nvidia-device-plugin` DaemonSet's background registration loop
(`pkg/device-plugin/.../register.go`), gated behind `ENABLE_TOPOLOGY_SCORE=true`
(set when `gpuSchedulerPolicy: topology-aware`). It is never called from the
central HAMi scheduler (`cmd/scheduler`). The actual blast radius is the
device-plugin pod on the affected node entering CrashLoopBackOff — not a
cluster-wide scheduling outage.

Asymmetric NVLink/P2P data between two GPUs is a legitimate, persistent
hardware/driver state (e.g. one-sided NVLink lane/port failure, or a driver
re-init that completes asymmetrically across two GPUs), not a software bug in
this codebase — NVML is accurately reporting a real asymmetric topology. Since
this state is persistent, crashing and retrying never resolves it: the
device-plugin would panic on every registration cycle indefinitely
(CrashLoopBackOff), permanently losing that node's GPU reporting until someone
notices and patches the code or replaces the hardware.

This PR:
- Replaces the `panic()` in `calculateGPUPairScore` with a `klog.Warning` log
  (GPU indices/UUIDs and link counts) and a returned score of `0` for the
  affected pair, instead of aborting the whole scoring pass.
- Leaves all other GPU pairs on the same node scored normally — we don't
  discard valid topology data for the rest of the node over one degraded pair.
- Emits a `Warning` Event (`AsymmetricGPUP2PLink`) on the Node object when any
  pair on that node is asymmetric, so operators can discover the degraded
  hardware via `kubectl describe node` or standard Event-based monitoring,
  instead of the plugin failing silently or crash-looping forever.
- Deduplicates Event emission by querying the API server directly (list
  existing events for the node+reason, update `Count`/`LastTimestamp` if one
  exists within a 1h window, otherwise create) rather than using client-go's
  `record.EventRecorder`. A recorder's dedup state is in-memory and would be
  wiped on every process restart — and this exact failure mode causes
  repeated restarts, so an in-memory recorder would re-emit on every
  crash-restart cycle. Querying the API server directly makes dedup durable
  across restarts.

**Testing**:
- New unit test `Test_calculateGPUPairScore_asymmetric` reproduces the
  one-sided NVLink case and asserts no panic, score `0`, `asymmetric == true`.
- New unit test suite `TestEmitNodeWarningEvent` (fake clientset) covers: no
  existing event → Create, existing event within dedup window → Update (Count
  incremented, message updated, no duplicate object), existing event outside
  the window → Create.
- Full existing test suites for `pkg/device/nvidia`, `pkg/util`, and
  `pkg/device-plugin` pass. Two pre-existing, unrelated failures
  (`pkg/util/client` — requires in-cluster/kubeconfig env; `rm.TestNvmlMigDevice_GetPaths`
  — requires MIG hardware) were confirmed present identically on `master` via
  a `git stash` before/after comparison, and are unaffected by this change.
- `golangci-lint run` and `go vet` are clean on all changed packages.

**Which issue(s) this PR fixes**:

Fixes #2228

**Special notes for your reviewer**:

- `calculateGPUPairScore`, `calculateGPUScore`, and `CalculateGPUScore` all
  gained an additional `bool` return value (`asymmetric` / `anyAsymmetric`) to
  propagate the mismatch signal up to the Event-emission call site. Confirmed
  via full-repo grep that `calculate_score.go:194` is the only production call
  site for `calculateGPUPairScore`, and `register.go` is the only caller of
  `CalculateGPUScore`, so this signature change has no other blast radius.
- Confirmed the downstream allocator (`computeWorstSingleCard`,
  `computeBestCombination` in `device.go`) reads scores from a plain
  `map[string]int` with no symmetry assumption — a `0` score for one direction
  of a pair is handled the same as a missing entry, so this fix is safe against
  existing allocation logic without further changes there.
- Happy to move the Event emission behind a feature flag or drop it entirely
  if maintainers prefer a smaller-scoped fix (i.e. just the panic → 0-score
  change without Event/dedup logic) — let me know and I'll split it out.

**Does this PR introduce a user-facing change?**:

```
Fixed a bug where the nvidia-device-plugin would panic and crash-loop when
NVML reported asymmetric P2P/NVLink data between a GPU pair (e.g. due to a
one-sided hardware/driver link failure) while topology-aware scheduling was
enabled. The affected GPU pair is now scored as having no usable P2P link
instead of crashing the plugin, and a Warning Event is emitted on the Node
object so operators can detect the underlying hardware issue.
```
**AI assistance disclosure:**
This PR was developed with AI assistance (Claude Code) used for investigation,
analysis, and initial implementation, under my direct supervision and review.
I reviewed the full diff, ran and verified all tests/lint locally, and can
explain the reasoning behind every design decision.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when asymmetric GPU interconnects are detected.
  * GPUs with asymmetric peer-to-peer links now receive a score of zero instead of causing failures.
* **New Features**
  * Added Kubernetes Node warning events for detected asymmetric GPU connectivity.
  * Repeated warnings are consolidated and updated for one hour to reduce duplicate notifications.
* **Tests**
  * Added coverage for asymmetric topology handling and warning-event deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->