### PR TITLE
fix(monitor): return locked snapshot from ListContainers to prevent race with Update

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -19,6 +19,7 @@ package nvidia
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -160,9 +161,7 @@ func (l *ContainerLister) ListContainers() map[string]*ContainerUsage {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	snapshot := make(map[string]*ContainerUsage, len(l.containers))
-	for k, v := range l.containers {
-		snapshot[k] = v
-	}
+	maps.Copy(snapshot, l.containers)
 	return snapshot
 }
 

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -153,8 +153,17 @@ func (l *ContainerLister) UnLock() {
 	l.mutex.Unlock()
 }
 
+// ListContainers returns a snapshot of the current container usages. It copies
+// the internal map under the lock so that callers can safely iterate the result
+// while Update() concurrently adds or removes entries.
 func (l *ContainerLister) ListContainers() map[string]*ContainerUsage {
-	return l.containers
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	snapshot := make(map[string]*ContainerUsage, len(l.containers))
+	for k, v := range l.containers {
+		snapshot[k] = v
+	}
+	return snapshot
 }
 
 func (l *ContainerLister) Clientset() *kubernetes.Clientset {

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -463,3 +463,62 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.Equal(t, len(l.containers), 0)
 	})
 }
+
+// Test_ListContainers_snapshot verifies ListContainers returns a copy that is
+// safe to iterate while Update() concurrently mutates the internal map.
+func Test_ListContainers_snapshot(t *testing.T) {
+	l := &ContainerLister{
+		containers: map[string]*ContainerUsage{
+			"a_ctr": {PodUID: "a", ContainerName: "ctr"},
+		},
+	}
+	snapshot := l.ListContainers()
+	assert.Equal(t, len(snapshot), 1)
+
+	// Mutating the internal map must not affect the snapshot.
+	l.mutex.Lock()
+	delete(l.containers, "a_ctr")
+	l.containers["b_ctr"] = &ContainerUsage{PodUID: "b", ContainerName: "ctr"}
+	l.mutex.Unlock()
+
+	_, ok := snapshot["a_ctr"]
+	assert.Equal(t, ok, true)
+	_, ok = snapshot["b_ctr"]
+	assert.Equal(t, ok, false)
+}
+
+// Test_ListContainers_concurrentUpdate drives ListContainers and Update
+// concurrently; under -race this fails on the previous implementation, which
+// returned the internal map without holding the lock.
+func Test_ListContainers_concurrentUpdate(t *testing.T) {
+	dir := t.TempDir()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uidr"}}
+	entryName := "uidr_ctr"
+	ctrDir := filepath.Join(dir, entryName)
+	assert.NilError(t, os.Mkdir(ctrDir, 0755))
+	writeCacheFile(t, ctrDir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+
+	l := &ContainerLister{
+		containerPath: dir,
+		containers:    map[string]*ContainerUsage{},
+		podLister:     newTestPodLister(pod),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			for _, c := range l.ListContainers() {
+				_ = c.PodUID
+			}
+		}
+	}()
+	for range 100 {
+		assert.NilError(t, l.Update())
+	}
+	<-done
+
+	for _, c := range l.ListContainers() {
+		_ = syscall.Munmap(c.data)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`ListContainers()` returned the internal `containers` map without holding the lister mutex, while `Update()` — called every 5s from the feedback loop — mutates that map and `Munmap`s removed entries under the lock. The metrics collector and `Observe()` iterate the same map concurrently, which is:

1. a data race (concurrent map read/write, fails `-race`), and
2. a potential use-after-munmap SIGBUS when a collector dereferences `c.Info` for an entry whose shared-memory region `Update()` just unmapped — crashing the entire vGPUmonitor DaemonSet pod.

This PR makes `ListContainers()` copy the map under the mutex and return the snapshot. All existing callers only range over the result, so the snapshot is a drop-in replacement.

It also hardens `Update()` against container directory names without an underscore: previously `strings.Split(entry.Name(), "_")[1]` panicked with index out of range on any stray directory in the hook path; now such entries are skipped with a warning.

Note: the snapshot shrinks the munmap race window to entries removed mid-scrape; fully eliminating it would require refcounting the mmap lifetime, which I left as a possible follow-up given the current behavior is always racy.

## Which issue(s) this PR fixes

Fixes #2309

## Tests

- `Test_ListContainers_snapshot` — snapshot is isolated from subsequent internal-map mutation
- `Test_ListContainers_concurrentUpdate` — drives `Update()` and `ListContainers()` concurrently; fails under `-race` on the previous implementation
- `Test_ContainerLister_Update` — new subtest: dirname without underscore is skipped, not panicked on

## AI assistance disclosure

Per CONTRIBUTING.md: AI tooling was used to help draft this change; I reviewed and verified the code, race analysis, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented returned NVIDIA container listings from modifying monitored state.
  * Improved safety when container updates and listings occur concurrently.
  * Improved reliability of container monitoring during active updates.

* **Tests**
  * Added regression coverage to verify listing snapshots remain independent from internal monitoring state.
  * Added concurrent-access tests to validate safe iteration while container data is updated and cached resources are cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->