### PR TITLE
fix(quota): honor an explicit zero limit in ResourceQuota

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -27,6 +27,12 @@ import (
 type Quota struct {
 	Used  int64
 	Limit int64
+	// LimitSet distinguishes an explicitly configured limit (including an
+	// explicit 0, which blocks all usage) from an entry auto-created by usage
+	// tracking, which carries Limit 0 but means "no limit configured". FitQuota
+	// gates on this rather than Limit != 0 so that a ResourceQuota of "0" is
+	// honored as a hard block instead of being read as unlimited.
+	LimitSet bool
 }
 
 type DeviceQuota map[string]*Quota
@@ -75,13 +81,13 @@ func (q *QuotaManager) FitQuota(ns string, memreq int64, memoryFactor int32, cor
 		if memoryFactor > 1 {
 			limit = limit * int64(memoryFactor)
 		}
-		if limit != 0 && memQuota.Used+memreq > limit {
+		if memQuota.LimitSet && memQuota.Used+memreq > limit {
 			klog.V(4).InfoS("resourceMem quota not fitted", "limit", limit, "used", memQuota.Used, "alloc", memreq)
 			return false
 		}
 	}
 	coreQuota, ok := (*dq)[coreResourceName]
-	if ok && coreQuota.Limit != 0 && coreQuota.Used+coresreq > coreQuota.Limit {
+	if ok && coreQuota.LimitSet && coreQuota.Used+coresreq > coreQuota.Limit {
 		klog.V(4).InfoS("resourceCores quota not fitted", "limit", coreQuota.Limit, "used", coreQuota.Used, "alloc", coresreq)
 		return false
 	}
@@ -210,6 +216,7 @@ func (q *QuotaManager) AddQuota(quota *corev1.ResourceQuota) {
 				}
 			}
 			(*dp)[dn].Limit = value
+			(*dp)[dn].LimitSet = true
 			klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
 		}
 	}
@@ -239,6 +246,7 @@ func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
 			if dq, ok := q.Quotas[quota.Namespace]; ok {
 				if quotaInfo, ok := (*dq)[dn]; ok {
 					quotaInfo.Limit = 0
+					quotaInfo.LimitSet = false
 				}
 			}
 		}
@@ -261,8 +269,9 @@ func (q *QuotaManager) GetResourceQuota() map[string]*DeviceQuota {
 		curDQ := &DeviceQuota{}
 		for name, quota := range *dq {
 			(*curDQ)[name] = &Quota{
-				Used:  quota.Used,
-				Limit: quota.Limit,
+				Used:     quota.Used,
+				Limit:    quota.Limit,
+				LimitSet: quota.LimitSet,
 			}
 		}
 		quotasCopy[ns] = curDQ

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -126,8 +126,8 @@ func TestFitQuota(t *testing.T) {
 	coreName := "nvidia.com/gpucore"
 
 	qm.Quotas[ns] = &DeviceQuota{
-		memName:  &Quota{Used: 1000, Limit: 2000},
-		coreName: &Quota{Used: 200, Limit: 400},
+		memName:  &Quota{Used: 1000, Limit: 2000, LimitSet: true},
+		coreName: &Quota{Used: 200, Limit: 400, LimitSet: true},
 	}
 
 	// Should fit
@@ -157,6 +157,26 @@ func TestFitQuota(t *testing.T) {
 	// Should fit if device not present
 	if !qm.FitQuota(ns, 1000, 1, 100, "unknown-device") {
 		t.Error("FitQuota should return true if device not present")
+	}
+}
+
+func TestFitQuotaExplicitZeroBlocks(t *testing.T) {
+	initTest()
+	qm := &QuotaManager{Quotas: make(map[string]*DeviceQuota)}
+	ns := "team-zero"
+	memName := "nvidia.com/gpumem"
+
+	// An operator sets a ResourceQuota of "0" to block all GPU memory in the namespace.
+	rq := &corev1.ResourceQuota{}
+	rq.Namespace = ns
+	rq.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName): *resource.NewQuantity(0, resource.DecimalSI),
+	}
+	qm.AddQuota(rq)
+
+	// The explicit zero must block any positive request, not be read as "unlimited".
+	if qm.FitQuota(ns, 500, 1, 0, "NVIDIA") {
+		t.Error(`FitQuota admitted a 500 request under limits.nvidia.com/gpumem: "0"; an explicit zero quota must block`)
 	}
 }
 

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -269,8 +269,8 @@ func TestFitResourceQuota(t *testing.T) {
 	coreName := "nvidia.com/gpucores"
 
 	qm.Quotas[ns] = &device.DeviceQuota{
-		memName:  &device.Quota{Used: 1000, Limit: 2000},
-		coreName: &device.Quota{Used: 200, Limit: 400},
+		memName:  &device.Quota{Used: 1000, Limit: 2000, LimitSet: true},
+		coreName: &device.Quota{Used: 200, Limit: 400, LimitSet: true},
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`FitQuota` used `Limit != 0` to decide whether a quota was configured. As a
result, setting `limits.nvidia.com/gpumem: "0"` (or `gpucores: "0"`) in a
ResourceQuota — which an operator would use to block all GPU usage in a
namespace — was silently treated as "no limit", and every pod was admitted
instead of being denied.

This adds a `LimitSet` flag to `Quota` to distinguish an explicitly configured
limit (including an explicit `0`) from an entry auto-created by usage tracking.
`AddQuota` sets it, `DelQuota` clears it, and `FitQuota` now gates on `LimitSet`
instead of `Limit != 0`, so an explicit zero is honored as a hard block.
Usage-tracking entries keep `LimitSet` false and behave exactly as before.

**Which issue(s) this PR fixes**:
Fixes #2312

**Special notes for your reviewer**:
This revives the fix from #1904 by @iasthc, which was closed by the activity
policy without review rather than on merit — full credit to them for the
original approach. I've added a regression test (`TestFitQuotaExplicitZeroBlocks`)
that admits a request under a `"0"` quota on the pre-fix code and blocks it after,
and updated `TestFitQuota` so its manually-built quotas carry `LimitSet`.
`make verify` and the `pkg/device` unit tests pass locally.

**AI assistance disclosure**:
I used AI assistance (Claude Code) while confirming the root cause .
wrote  the regression test by myself . I reviewed and verified the change, ran `make verify` locally,
and take responsibility for it.

**Does this PR introduce a user-facing change?**:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota enforcement now correctly applies explicitly configured limits, including zero-valued memory, CPU core, and GPU memory limits.
  * Quota usage and copied quota data preserve whether a limit was intentionally configured.
  * Removing a quota now clears its configured-limit status, preventing stale restrictions from affecting future resource requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->