### PR TITLE
fix(vGPUmonitor): skip exited process slots in v1 spec metric aggregations

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -92,6 +92,9 @@ func (s Spec) activeProcs() []shrregProcSlotT {
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -100,6 +103,9 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -108,6 +114,9 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -116,6 +125,9 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].offset
 	}
 	return v
@@ -124,6 +136,9 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].total
 	}
 	return v
@@ -132,6 +147,9 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -68,8 +68,8 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
-					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
 				},
 			}},
 			input:    1,
@@ -81,8 +81,8 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
-					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
 				},
 			}},
 			input:    0,
@@ -94,11 +94,24 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
-					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
 				},
 			}},
 			input:    1,
+			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, used: [16]deviceMemory{{contextSize: 200}}},
+					{status: 0, used: [16]deviceMemory{{contextSize: 999}}},
+				},
+			}},
+			input:    0,
 			expected: uint64(200),
 		},
 	}
@@ -121,8 +134,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
-					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
 				},
 			}},
 			input:    1,
@@ -134,8 +147,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
-					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
 				},
 			}},
 			input:    0,
@@ -147,12 +160,25 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
-					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
 				},
 			}},
 			input:    1,
 			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, used: [16]deviceMemory{{moduleSize: 150}}},
+					{status: 0, used: [16]deviceMemory{{moduleSize: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(150),
 		},
 	}
 
@@ -174,8 +200,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
-					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
 				},
 			}},
 			input:    1,
@@ -187,8 +213,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
-					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
 				},
 			}},
 			input:    0,
@@ -200,12 +226,25 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
-					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
+					{status: 1, used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
 				},
 			}},
 			input:    1,
 			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, used: [16]deviceMemory{{bufferSize: 400}}},
+					{status: 0, used: [16]deviceMemory{{bufferSize: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(400),
 		},
 	}
 
@@ -227,8 +266,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
-					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
+					{status: 1, used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
+					{status: 1, used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
 				},
 			}},
 			input:    1,
@@ -240,8 +279,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
-					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
+					{status: 1, used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
+					{status: 1, used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
 				},
 			}},
 			input:    0,
@@ -253,12 +292,25 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
-					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
+					{status: 1, used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
+					{status: 1, used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
 				},
 			}},
 			input:    1,
 			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, used: [16]deviceMemory{{offset: 100}}},
+					{status: 0, used: [16]deviceMemory{{offset: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 
@@ -280,8 +332,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
-					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
+					{status: 1, used: [16]deviceMemory{{total: 100}, {total: 200}}},
+					{status: 1, used: [16]deviceMemory{{total: 300}, {total: 400}}},
 				},
 			}},
 			input:    1,
@@ -293,8 +345,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
-					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
+					{status: 1, used: [16]deviceMemory{{total: 100}, {total: 200}}},
+					{status: 1, used: [16]deviceMemory{{total: 300}, {total: 400}}},
 				},
 			}},
 			input:    0,
@@ -306,12 +358,25 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
-					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
+					{status: 1, used: [16]deviceMemory{{total: 100}, {total: 200}}},
+					{status: 1, used: [16]deviceMemory{{total: 300}, {total: 400}}},
 				},
 			}},
 			input:    1,
 			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, used: [16]deviceMemory{{total: 512}}},
+					{status: 0, used: [16]deviceMemory{{total: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(512),
 		},
 	}
 
@@ -333,8 +398,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
-					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
 				},
 			}},
 			input:    1,
@@ -346,8 +411,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 				num:     2,
 				procnum: 2,
 				procs: [1024]shrregProcSlotT{
-					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
-					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
 				},
 			}},
 			input:    0,
@@ -359,12 +424,25 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 				num:     2,
 				procnum: 1,
 				procs: [1024]shrregProcSlotT{
-					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
-					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
 				},
 			}},
 			input:    1,
 			expected: uint64(200),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2,
+				procs: [1024]shrregProcSlotT{
+					{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 60}}},
+					{status: 0, deviceUtil: [16]deviceUtilization{{smUtil: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(60),
 		},
 	}
 
@@ -394,6 +472,7 @@ func TestSpec_CorruptProcnumIsClamped(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &sharedRegionT{num: 2, procnum: tt.procnum}
+			sr.procs[0].status = 1
 			sr.procs[0].used[0].total = 100
 			sr.procs[0].deviceUtil[0].smUtil = 100
 			s := Spec{sr: sr}

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -106,6 +106,9 @@ func (s Spec) activeProcs() []shrregProcSlotT {
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -114,6 +117,9 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -122,6 +128,9 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -130,6 +139,9 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].offset
 	}
 	return v
@@ -138,6 +150,9 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.used[idx].total
 	}
 	return v
@@ -146,6 +161,9 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
 	for _, p := range s.activeProcs() {
+		if p.status == 0 {
+			continue
+		}
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -169,6 +169,7 @@ func Test_DeviceMemoryContextSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										contextSize: 100,
@@ -179,6 +180,7 @@ func Test_DeviceMemoryContextSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										contextSize: 100,
@@ -206,6 +208,7 @@ func Test_DeviceMemoryContextSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										contextSize: 100,
@@ -216,6 +219,7 @@ func Test_DeviceMemoryContextSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										contextSize: 100,
@@ -230,6 +234,81 @@ func Test_DeviceMemoryContextSize(t *testing.T) {
 				},
 			},
 			want: uint64(400),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{
+								status: 1,
+								used: [16]deviceMemory{{
+									contextSize: 200,
+								}},
+							},
+							{
+								status: 0,
+								used: [16]deviceMemory{{
+									contextSize: 999,
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: uint64(200),
+		},
+		{
+			name: "negative procnum is clamped to zero",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: -1,
+						procs: [1024]shrregProcSlotT{
+							{
+								status: 1,
+								used: [16]deviceMemory{{
+									contextSize: 500,
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: uint64(0),
+		},
+		{
+			name: "oversized procnum is clamped to len(procs)",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 9999,
+						procs: [1024]shrregProcSlotT{
+							{
+								status: 1,
+								used: [16]deviceMemory{{
+									contextSize: 300,
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: uint64(300),
 		},
 	}
 	for _, test := range tests {
@@ -262,6 +341,7 @@ func Test_DeviceMemoryModuleSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										moduleSize: 100,
@@ -272,6 +352,7 @@ func Test_DeviceMemoryModuleSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										moduleSize: 100,
@@ -299,6 +380,7 @@ func Test_DeviceMemoryModuleSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										moduleSize: 100,
@@ -309,6 +391,7 @@ func Test_DeviceMemoryModuleSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										moduleSize: 100,
@@ -323,6 +406,25 @@ func Test_DeviceMemoryModuleSize(t *testing.T) {
 				},
 			},
 			want: uint64(400),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{status: 1, used: [16]deviceMemory{{moduleSize: 150}}},
+							{status: 0, used: [16]deviceMemory{{moduleSize: 999}}},
+						},
+					},
+				},
+			},
+			want: uint64(150),
 		},
 	}
 	for _, test := range tests {
@@ -344,6 +446,25 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 		want uint64
 	}{
 		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{status: 1, used: [16]deviceMemory{{bufferSize: 400}}},
+							{status: 0, used: [16]deviceMemory{{bufferSize: 999}}},
+						},
+					},
+				},
+			},
+			want: uint64(400),
+		},
+		{
 			name: "device memory buffer size for idx 0",
 			args: struct {
 				idx  int
@@ -355,6 +476,7 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										bufferSize: 100,
@@ -365,6 +487,7 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										bufferSize: 100,
@@ -381,7 +504,7 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 			want: uint64(200),
 		},
 		{
-			name: "device memory module size for idx 1",
+			name: "device memory buffer size for idx 1",
 			args: struct {
 				idx  int
 				spec *Spec
@@ -392,6 +515,7 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										bufferSize: 100,
@@ -402,6 +526,7 @@ func Test_DeviceMemoryBufferSize(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										bufferSize: 100,
@@ -448,6 +573,7 @@ func Test_DeviceMemoryOffset(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										offset: 100,
@@ -458,6 +584,7 @@ func Test_DeviceMemoryOffset(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										offset: 100,
@@ -485,6 +612,7 @@ func Test_DeviceMemoryOffset(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										offset: 100,
@@ -495,6 +623,7 @@ func Test_DeviceMemoryOffset(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										offset: 100,
@@ -509,6 +638,25 @@ func Test_DeviceMemoryOffset(t *testing.T) {
 				},
 			},
 			want: uint64(400),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{status: 1, used: [16]deviceMemory{{offset: 100}}},
+							{status: 0, used: [16]deviceMemory{{offset: 999}}},
+						},
+					},
+				},
+			},
+			want: uint64(100),
 		},
 	}
 	for _, test := range tests {
@@ -541,6 +689,7 @@ func Test_DeviceMemoryTotal(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										total: 100,
@@ -551,6 +700,7 @@ func Test_DeviceMemoryTotal(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										total: 100,
@@ -578,6 +728,7 @@ func Test_DeviceMemoryTotal(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										total: 100,
@@ -588,6 +739,7 @@ func Test_DeviceMemoryTotal(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								used: [16]deviceMemory{
 									{
 										total: 100,
@@ -602,6 +754,25 @@ func Test_DeviceMemoryTotal(t *testing.T) {
 				},
 			},
 			want: uint64(400),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{status: 1, used: [16]deviceMemory{{total: 512}}},
+							{status: 0, used: [16]deviceMemory{{total: 999}}},
+						},
+					},
+				},
+			},
+			want: uint64(512),
 		},
 	}
 	for _, test := range tests {
@@ -634,6 +805,7 @@ func Test_DeviceSmUtil(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								deviceUtil: [16]deviceUtilization{
 									{
 										smUtil: 100,
@@ -644,6 +816,7 @@ func Test_DeviceSmUtil(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								deviceUtil: [16]deviceUtilization{
 									{
 										smUtil: 100,
@@ -671,6 +844,7 @@ func Test_DeviceSmUtil(t *testing.T) {
 						procnum: 2,
 						procs: [1024]shrregProcSlotT{
 							{
+								status: 1,
 								deviceUtil: [16]deviceUtilization{
 									{
 										smUtil: 100,
@@ -681,6 +855,7 @@ func Test_DeviceSmUtil(t *testing.T) {
 								},
 							},
 							{
+								status: 1,
 								deviceUtil: [16]deviceUtilization{
 									{
 										smUtil: 100,
@@ -695,6 +870,25 @@ func Test_DeviceSmUtil(t *testing.T) {
 				},
 			},
 			want: uint64(400),
+		},
+		{
+			name: "dead slot within procnum is excluded",
+			args: struct {
+				idx  int
+				spec *Spec
+			}{
+				idx: int(0),
+				spec: &Spec{
+					sr: &sharedRegionT{
+						procnum: 2,
+						procs: [1024]shrregProcSlotT{
+							{status: 1, deviceUtil: [16]deviceUtilization{{smUtil: 60}}},
+							{status: 0, deviceUtil: [16]deviceUtilization{{smUtil: 999}}},
+						},
+					},
+				},
+			},
+			want: uint64(60),
 		},
 	}
 	for _, test := range tests {
@@ -1152,6 +1346,7 @@ func TestSpec_CorruptProcnumIsClamped(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &sharedRegionT{num: 2, procnum: tt.procnum}
+			sr.procs[0].status = 1
 			sr.procs[0].used[0].total = 100
 			sr.procs[0].deviceUtil[0].smUtil = 100
 			s := Spec{sr: sr}


### PR DESCRIPTION
## Summary

- The six per-device metric accessors in `pkg/monitor/nvidia/v1/spec.go` (`DeviceMemoryContextSize`, `DeviceMemoryModuleSize`, `DeviceMemoryBufferSize`, `DeviceMemoryOffset`, `DeviceMemoryTotal`, `DeviceSmUtil`) were iterating over `procs[:procnum]` without checking `p.status`, so slots belonging to processes that had already exited were still included in the sum.

- When a CUDA process exits, libvgpu sets `status = 0` on its slot but does not immediately zero out the memory fields. This meant the monitor was reporting inflated memory and utilization values until the slot got reused by the next process.

- Added a `procBound()` helper that clamps `procnum` to `[0, len(procs)]` before slicing, since `procnum` comes directly from the mmap'd shared-memory region and a corrupt value would otherwise cause a slice-bounds panic.

- Each aggregation function now skips slots where `p.status == 0`, so only live process slots contribute to the reported metrics.

- Updated existing tests to set `status: 1` on active slots, and added regression cases covering dead-slot exclusion, negative `procnum`, and oversized `procnum` for all six functions.

**Which issue(s) this PR fixes:**

Fixes #2310

**Special notes for your reviewer:**

The analogous v0 bug (iterating all 1024 slots with no `procnum` bound at all) is tracked separately in #2281. This PR only touches the v1 layout.

**Does this PR introduce a user-facing change?**

Yes — `hami_vgpu_memory_used_bytes` and related vGPUmonitor gauges will no longer be inflated after a CUDA process exits inside a container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA monitoring accuracy by excluding inactive process slots from context, module, buffer, offset, total memory, and SM utilization calculations.
  * Added safeguards for invalid process counts, including negative and oversized values, while preserving valid active-process data.

* **Tests**
  * Expanded coverage for inactive process slots and process-count boundary conditions across NVIDIA monitoring versions.
  * Corrected a buffer-size test case label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->