### PR TITLE
refactor(scheduler): compute score before appending to shared NodeList

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -177,10 +177,10 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 			}
 
 			if ctrfit {
+				score.OverrideScore(snapshot, userNodePolicy)
 				fitNodesMutex.Lock()
 				res.NodeList = append(res.NodeList, &score)
 				fitNodesMutex.Unlock()
-				score.OverrideScore(snapshot, userNodePolicy)
 				klog.V(4).InfoS(common.NodeFitPod, "pod", klog.KObj(task), "node", nodeID, "score", score.Score)
 			}
 		}(nodeID, node)


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

This PR is a small readability and code-ordering improvement.

In `calcScoreWithOptions()`, `score.OverrideScore(snapshot, userNodePolicy)` was called after `&score` had already been appended to `res.NodeList`. During review, this ordering was initially suspected to expose a data race. However, as confirmed by @Eshiv-Pandey using the Go race detector, this is **not** a race—the existing `wg.Wait()` guarantees that `res.NodeList` is not accessed until all scoring goroutines, including `OverrideScore()`, have completed.

This change moves `score.OverrideScore(...)` before acquiring `fitNodesMutex` and publishing `&score` to `res.NodeList`. The behavior is unchanged, but the publication point now makes it explicit that a `NodeScore` is fully initialized before becoming visible through the shared slice, improving readability and making the ordering easier to reason about.

## Which issue(s) this PR fixes

N/A — no functional bug is being fixed. This is a cleanup following the discussion in #2316.

## Special notes for your reviewer

- No functional or behavioral changes.
- Verified locally with `go test ./pkg/scheduler/... -race -count=1`.
- This change only improves the ordering of operations to make the publication invariant more explicit.

## AI assistance disclosure

I consulted ChatGPT and Claude during the initial investigation of the scoring path, which led me to incorrectly suspect a data race. Following @Eshiv-Pandey's review, I verified that the synchronization was already correct, updated the change accordingly, and confirmed the behavior locally. The final implementation, commit message, and PR description were written and verified by me, and I take full responsibility for the contribution.

## Does this PR introduce a user-facing change?

```release-note
NONE
```