### PR TITLE
Nil Pointer Dereference in Scheduler HTTP Endpoint Handlers  

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -32,18 +32,21 @@ import (
 
 const maxRequestSize = 1024 * 1024 // 1MB limit
 
-func checkBody(w http.ResponseWriter, r *http.Request) {
+func checkBody(w http.ResponseWriter, r *http.Request) bool {
 	if r.Body == nil {
 		http.Error(w, "Please send a request body", 400)
-		return
+		return false
 	}
+	return true
 }
 
 func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 	klog.Infoln("Initializing Predicate Route")
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infoln("Entering Predicate Route handler")
-		checkBody(w, r)
+		if !checkBody(w, r) {
+			return
+		}
 
 		var buf bytes.Buffer
 		// Limit the body size to prevent deep nesting/resource exhaustion attacks
@@ -98,6 +101,9 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 func Bind(s *scheduler.Scheduler) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		klog.V(5).Infoln("Entering Bind handler")
+		if !checkBody(w, r) {
+			return
+		}
 		var buf bytes.Buffer
 		// Limit the body size to prevent deep nesting/resource exhaustion attacks
 		limitedReader := io.LimitReader(r.Body, maxRequestSize)

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -134,7 +134,9 @@ func TestCheckBodyNil(t *testing.T) {
 	req.Body = nil
 	w := httptest.NewRecorder()
 
-	checkBody(w, req)
+	if checkBody(w, req) {
+		t.Error("Expected checkBody to return false for nil body")
+	}
 
 	if w.Code != 400 {
 		t.Errorf("Expected status 400 for nil body, got %d", w.Code)
@@ -210,5 +212,19 @@ func TestBind_DecodeError(t *testing.T) {
 	}
 	if result.Error == "" {
 		t.Error("expected a decode error to be reported in the bind result")
+	}
+}
+
+func TestBind_NilBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/bind", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := Bind(s)
+	handler(w, req, nil)
+
+	if w.Code != 400 {
+		t.Errorf("Expected status 400 for nil body, got %d", w.Code)
 	}
 }


### PR DESCRIPTION


### Location:
* **File**: [route.go](file:///c:/Users/Hp/HAMi/pkg/scheduler/routes/route.go#L46-L51) in `pkg/scheduler/routes/`


### Code:
```go
func checkBody(w http.ResponseWriter, r *http.Request) {
    if r.Body == nil {
        http.Error(w, "Please send a request body", 400)
        return // returns from checkBody, NOT from PredicateRoute
    }
}
```
```go
// PredicateRoute handler:
checkBody(w, r)
limitedReader := io.LimitReader(r.Body, maxRequestSize)
```

### Explanation:
`checkBody` checks if the HTTP request has a body. If it is `nil`, it writes an error response and returns. However, it returns from the helper `checkBody`, not from the calling route handler (`PredicateRoute`).

### Reason for Crash:
The route handler continues executing even if the body is `nil`. It calls `io.LimitReader(r.Body, ...)` which passes `nil` as the reader. When the JSON Decoder tries to read from the body, it dereferences the `nil` pointer inside `LimitReader` (`nil.Read()`), throwing a **runtime panic: nil pointer dereference**, crashing the request goroutine.

### Crash Flow:
```mermaid
sequenceDiagram
    participant C as HTTP Client
    participant H as Route Handler
    participant B as checkBody
    C->>H: POST /filter (Body = nil)
    H->>B: checkBody(w, r)
    B-->>C: Write HTTP 400 Error
    B-->>H: Return from checkBody
    Note over H: Execution continues!
    H->>H: io.LimitReader(nil, ...)
    H->>H: json.NewDecoder(nil).Decode()
    Note over H: panic: nil pointer dereference
```

---
Add one of the following kinds:
/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2315 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with missing bodies are now rejected with an HTTP 400 response.
  * Prevented further request processing when body validation fails.
* **Tests**
  * Added coverage to verify correct handling of requests without bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->