### PR TITLE
Syntax Compilation Error in vGPUmonitor metrics / scheduler tests

### DIFF
--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -92,14 +92,18 @@ func start() error {
 	errCh := make(chan error, 2)
 
 	// Start the metrics service
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		if err := initMetrics(ctx, containerLister); err != nil {
 			errCh <- err
 		}
-	})
+	}()
 
 	// Start the monitoring and feedback service
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		for {
 			if err := watchAndFeedback(ctx, containerLister, lockChannel); err != nil {
 				// if err is temporary closed, wait for lock file to be removed
@@ -114,7 +118,7 @@ func start() error {
 			}
 			return
 		}
-	})
+	}()
 
 	// Capture system signals
 	signalCh := make(chan os.Signal, 1)

--- a/pkg/scheduler/register_race_test.go
+++ b/pkg/scheduler/register_race_test.go
@@ -103,22 +103,26 @@ func Test_register_NodeCacheConcurrency(t *testing.T) {
 	// CheckHealth reports needUpdate and register() reaches the s.nodes read/write.
 	// indexer.Update never errors for the default store and require/FailNow must not
 	// run outside the test goroutine, so the error is ignored.
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		printed := map[string]bool{}
 		sel := labels.Everything()
 		for v := 1; v <= rounds; v++ {
 			_ = indexer.Update(mkNode(v%2 == 0))
 			s.register(sel, printed)
 		}
-	})
+	}()
 
 	// delete loop(s): the real informer delete callback removes the node from s.nodes.
 	for range deleters {
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			for v := 1; v <= rounds; v++ {
 				s.onDelNode(mkNode(true))
 			}
-		})
+		}()
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Closes #2319 
### Location:
* **File**: [main.go](file:///c:/Users/Hp/HAMi/cmd/vGPUmonitor/main.go#L95) in `cmd/vGPUmonitor/` and [register_race_test.go](file:///c:/Users/Hp/HAMi/pkg/scheduler/register_race_test.go#L106) in `pkg/scheduler/`


### Code:
```go
var wg sync.WaitGroup
...
wg.Go(func() {
    ...
})
```

### Explanation:
The developer declares the synchronization variable `wg` as type `sync.WaitGroup` from the standard Go `sync` library, but invokes it using `wg.Go(func() { ... })`.

### Reason for Crash:
The standard library `sync.WaitGroup` in Go has no `Go()` method (which belongs to the `golang.org/x/sync/errgroup` package). This mismatch represents a **syntax compilation error** that prevents the `vGPUmonitor` command from building, and breaks the execution of test suites (`register_race_test.go`), halting deployment processes.

### Error Diagram:
```mermaid
graph TD
    A[Compile/Build command run] --> B[Check main.go / tests]
    B --> C[Compiler spots: wg.Go undefined]
    C --> D[Compilation Fails]
    D --> E[Cannot deploy vGPUmonitor / Run scheduler tests]
```

<!--
Add one of the following kinds:
/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility of concurrent monitoring and metrics service execution.
  * Updated concurrency handling in scheduler registration tests while preserving existing behavior and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->