### PR TITLE
CPU Spin Lock and Log Flooding on NVML Event Error

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -148,7 +148,7 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 			for _, d := range devices {
 				unhealthy <- d
 			}
-			continue
+			return fmt.Errorf("error waiting for event: %v", ret)
 		}
 
 		if e.EventType != nvml.EventTypeXidCriticalError {


### PR DESCRIPTION
Closes #2321 

### Location:
* **File**: [health.go](file:///c:/Users/Hp/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go#L146-L152) in `pkg/device-plugin/nvidiadevice/nvinternal/rm/`
* **Lines**: 146-152 (`checkHealth`)

### Code:
```go
e, ret := eventSet.Wait(5000)
...
if ret != nvml.SUCCESS {
    klog.Infof("Error waiting for event: %v; Marking all devices as unhealthy", ret)
    for _, d := range devices {
        unhealthy <- d
    }
    continue
}
```

### Explanation:
`checkHealth` uses NVML events to watch for hardware errors (XIDs). It listens for event notifications by calling `eventSet.Wait(5000)` inside a loop.

### Reason for Crash:
If `eventSet.Wait()` fails with a persistent error (for instance, if the NVML context becomes corrupted or the GPU driver encounters a critical error), it returns a non-SUCCESS code immediately without blocking. The loop captures this, writes a log, sends all devices to the `unhealthy` channel, and executes a `continue`. Because the error is persistent, the loop immediately checks again, creating a **tight CPU spin lock consuming 100% of a CPU core and flooding logs/channels, locking up or crashing the device plugin.**

### Spin Lock Loop:
```mermaid
graph TD
    A[eventSet.Wait fails immediately] --> B[Log error]
    B --> C[Send unhealthy notification]
    C --> D[continue loop]
    D --> A
    Note over A,D: Loops with zero sleep delay:<br/>100% CPU usage & log spam!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NVML event-wait failures are now reported immediately when they are not timeout-related.
  * Devices are still marked unhealthy, while the underlying error is preserved for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->