### PR TITLE
Permission / Ownership Crash on Lock File Directory Creation

### DIFF
--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -80,12 +80,12 @@ func start() error {
 	// and the vGPU monitor should attempt to create this directory by default to ensure its creation.
 	err = plugin.CreateMigApplyLockDir()
 	if err != nil {
-		return fmt.Errorf("failed to create MIG apply lock directory: %v", err)
+		return fmt.Errorf("failed to create MIG apply lock directory: %v. You can configure a writeable lock file path using the HAMI_MIG_LOCK_FILE environment variable", err)
 	}
 
 	lockChannel, err := plugin.WatchLockFile()
 	if err != nil {
-		return fmt.Errorf("failed to watch lock file: %v", err)
+		return fmt.Errorf("failed to watch lock file: %v. You can configure a writeable lock file path using the HAMI_MIG_LOCK_FILE environment variable", err)
 	}
 
 	var wg sync.WaitGroup

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
@@ -24,9 +24,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	MigApplyLockFile = "/tmp/hami/hami-mig-apply.lock"
+var (
+	MigApplyLockFile = getMigApplyLockFile()
 )
+
+func getMigApplyLockFile() string {
+	if val := os.Getenv("HAMI_MIG_LOCK_FILE"); val != "" {
+		return val
+	}
+	return "/tmp/hami/hami-mig-apply.lock"
+}
+
 
 // CreateMigApplyLockDir creates the lock directory for MIG apply operation
 func CreateMigApplyLockDir() error {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
@@ -157,6 +157,12 @@ func TestWatchLockFile(t *testing.T) {
 }
 
 func TestCreateAndRemoveMigApplyLock(t *testing.T) {
+	oldLockFile := MigApplyLockFile
+	tmpDir := t.TempDir()
+	MigApplyLockFile = filepath.Join(tmpDir, "hami-mig-apply.lock")
+	defer func() {
+		MigApplyLockFile = oldLockFile
+	}()
 
 	t.Run("CreateLock", func(t *testing.T) {
 		err := CreateMigApplyLockDir()

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -295,11 +295,11 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		if deviceSupportMig {
 			err = CreateMigApplyLockDir()
 			if err != nil {
-				klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
+				klog.Fatalf("CreateMIGLockSubDir failed: %v. You can configure a writeable lock file path using the HAMI_MIG_LOCK_FILE environment variable.", err)
 			}
 			err = RemoveMigApplyLock()
 			if err != nil {
-				klog.Fatalf("RemoveMigApplyLock failed: %v", err)
+				klog.Fatalf("RemoveMigApplyLock failed: %v. You can configure a writeable lock file path using the HAMI_MIG_LOCK_FILE environment variable.", err)
 			}
 
 			cmd := exec.Command("nvidia-mig-parted", "export")

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -283,7 +283,7 @@ func (nv *NvidiaDevicePlugin) DisableOtherNVMLOperation() {
 	// Create MIG apply lock file
 	if err := CreateMigApplyLock(); err != nil {
 		// If the lock file creation fails, it is highly likely that the mig apply will be failed, so the plugin should terminate.
-		klog.Fatalf("Failed to create MIG apply lock: %v", err)
+		klog.Fatalf("Failed to create MIG apply lock: %v. You can configure a writeable lock file path using the HAMI_MIG_LOCK_FILE environment variable.", err)
 		return
 	}
 


### PR DESCRIPTION

### Location:
* **File**: [server.go](file:///c:/Users/Hp/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go#L296-L303) in `pkg/device-plugin/nvidiadevice/nvinternal/plugin/` and [lock.go](file:///c:/Users/Hp/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
### Code:
```go
// lock.go
const (
    MigApplyLockFile = "/tmp/hami/hami-mig-apply.lock"
)
```
```go
// server.go
err = CreateMigApplyLockDir()
if err != nil {
    klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
}
```

### Explanation:
During startup, the plugin attempts to create the directory `/tmp/hami` and place a file-system lock at `/tmp/hami/hami-mig-apply.lock` to synchronize MIG configuration writes.

### Reason for Crash:
The path `/tmp/hami` is hardcoded. If a previous run of the container (or a different container on the host) created `/tmp/hami` with restrictive permissions (e.g. as root) and the current container runs as non-root (or has limited write permissions under SecurityContext/SELinux), the write/delete fails. Since the plugin reacts by calling `klog.Fatalf`, **the container crashes immediately on startup and enters a crash loop.**

### Crash Flow:
```mermaid
graph TD
    A[Start Plugin] --> B[Try to write lock at /tmp/hami/..]
    B --> C{Write Permission Denied?}
    C -->|Yes| D[CreateMigApplyLockDir errors]
    D --> E[klog.Fatalf called]
    E --> F[Container crashes on startup]
```

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the MIG operation lock-file location with the `HAMI_MIG_LOCK_FILE` environment variable.
  * Retains `/tmp/hami/hami-mig-apply.lock` as the default location when no custom path is provided.

* **Bug Fixes**
  * Improved lock-file error messages to display the configured path, making configuration issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->