### PR TITLE
fix(mthreads): correct invalid memory slice value in error message

### DIFF
--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -117,7 +117,7 @@ func (dev *MthreadsDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod
 			memnum, _ := mem.AsInt64()
 			found := slices.Contains(legalMemoryslices, memnum)
 			if !found {
-				return true, errors.New("sGPU memory request value is invalid, valid values are [1, 2, 4, 8, 16, 32, 64, 96]")
+				return true, errors.New("sGPU memory request value is invalid, valid values are [2, 4, 8, 16, 32, 64, 96]")
 			}
 		}
 	}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it:**

The `MutateAdmission` function in pkg/device/mthreads/device.go returns an error message that lists 1 as a valid memory slice value, but legalMemoryslices is []int64{2, 4, 8, 16, 32, 64, 96} ... it does NOT include 1.

This means a user who sets mthreads.com/sgpu-memory: 1 gets an error saying 1 is valid, but it's not actually accepted. This creates a confusing loop where the user retries with 1 and gets the same error.

This PR just removes 1 from the error message to match legalMemoryslices.

**Which issue(s) this PR fixes:**

None filed.

**Special notes for your reviewer:**

The legalMemoryslices variable is the source of truth for valid memory slice values. The error message should match it exactly.

**AI assistance disclosure:** I did not use any AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated valid sGPU memory request values. Requests must now use 2, 4, 8, 16, 32, 64, or 96 units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->