### PR TITLE
fix(metrics): replace dangerous MustNewConstMetric with safe helper in scheduler

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -198,113 +198,49 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 					if migs.InUse {
 						inuse = 1
 					}
-					ch <- prometheus.MustNewConstMetric(
-						nodeGPUMigInstance,
-						prometheus.GaugeValue,
-						float64(inuse),
-						nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), migs.Name+"-"+fmt.Sprint(idx),
-					)
+					if err := sendMetric(ch, nodeGPUMigInstance, prometheus.GaugeValue, float64(inuse), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), migs.Name+"-"+fmt.Sprint(idx)); err != nil {
+						klog.V(4).Infof("Failed to send nodeGPUMigInstance metric: %v", err)
+					}
 					if legacy {
-						ch <- prometheus.MustNewConstMetric(
-							legacyMigInstance,
-							prometheus.GaugeValue,
-							float64(inuse),
-							nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), migs.Name+"-"+fmt.Sprint(idx),
-						)
+						sendLegacyMetric(ch, legacyMigInstance, prometheus.GaugeValue, float64(inuse), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), migs.Name+"-"+fmt.Sprint(idx))
 					}
 				}
 			}
 
-			ch <- prometheus.MustNewConstMetric(
-				nodevGPUMemoryLimitDesc,
-				prometheus.GaugeValue,
-				float64(devs.Device.Totalmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				nodevGPUCoreLimitDesc,
-				prometheus.GaugeValue,
-				coreLimit,
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				nodevGPUMemoryAllocatedDesc,
-				prometheus.GaugeValue,
-				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				nodevGPUSharedNumDesc,
-				prometheus.GaugeValue,
-				float64(devs.Device.Used),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				nodeGPUCoreAllocatedDesc,
-				prometheus.GaugeValue,
-				coreAllocated,
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				nodeGPUOverview,
-				prometheus.GaugeValue,
-				float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-				nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
-			)
+			if err := sendMetric(ch, nodevGPUMemoryLimitDesc, prometheus.GaugeValue, float64(devs.Device.Totalmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodevGPUMemoryLimitDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, nodevGPUCoreLimitDesc, prometheus.GaugeValue, coreLimit, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodevGPUCoreLimitDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, nodevGPUMemoryAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodevGPUMemoryAllocatedDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, nodevGPUSharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodevGPUSharedNumDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, nodeGPUCoreAllocatedDesc, prometheus.GaugeValue, coreAllocated, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodeGPUCoreAllocatedDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, nodeGPUOverview, prometheus.GaugeValue, float64(devs.Device.Usedmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type); err != nil {
+				klog.V(4).Infof("Failed to send nodeGPUOverview metric: %v", err)
+			}
 
 			if devs.Device.Totalmem > 0 {
-				ch <- prometheus.MustNewConstMetric(
-					nodeGPUMemoryPercentage,
-					prometheus.GaugeValue,
-					float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
-				)
+				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index)); err != nil {
+					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
+				}
 			}
 
 			if legacy {
-				ch <- prometheus.MustNewConstMetric(
-					legacyMemoryLimitDesc,
-					prometheus.GaugeValue,
-					float64(devs.Device.Totalmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					legacyCoreLimitDesc,
-					prometheus.GaugeValue,
-					float64(devs.Device.Totalcore),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					legacyMemoryAllocatedDesc,
-					prometheus.GaugeValue,
-					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					legacySharedNumDesc,
-					prometheus.GaugeValue,
-					float64(devs.Device.Used),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					legacyCoreAllocatedDesc,
-					prometheus.GaugeValue,
-					float64(devs.Device.Usedcores),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
-				)
-				ch <- prometheus.MustNewConstMetric(
-					legacyOverview,
-					prometheus.GaugeValue,
-					float64(devs.Device.Usedmem)*float64(1024)*float64(1024),
-					nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type,
-				)
+				sendLegacyMetric(ch, legacyMemoryLimitDesc, prometheus.GaugeValue, float64(devs.Device.Totalmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				sendLegacyMetric(ch, legacyCoreLimitDesc, prometheus.GaugeValue, float64(devs.Device.Totalcore), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				sendLegacyMetric(ch, legacyMemoryAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type)
+				sendLegacyMetric(ch, legacySharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				sendLegacyMetric(ch, legacyCoreAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedcores), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				sendLegacyMetric(ch, legacyOverview, prometheus.GaugeValue, float64(devs.Device.Usedmem)*float64(1024)*float64(1024), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type)
 				if devs.Device.Totalmem > 0 {
-					ch <- prometheus.MustNewConstMetric(
-						legacyMemoryPercentage,
-						prometheus.GaugeValue,
-						float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem),
-						nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index),
-					)
+					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index))
 				}
 			}
 		}
@@ -327,19 +263,11 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	)
 	for ns, val := range cc.metricsProvider.GetQuotaManager().GetResourceQuota() {
 		for quotaname, q := range *val {
-			ch <- prometheus.MustNewConstMetric(
-				quotaUsedDesc,
-				prometheus.GaugeValue,
-				float64(q.Used),
-				ns, quotaname, fmt.Sprint(q.Limit),
-			)
+			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
+				klog.V(4).Infof("Failed to send quotaUsedDesc metric: %v", err)
+			}
 			if legacy {
-				ch <- prometheus.MustNewConstMetric(
-					legacyQuotaUsed,
-					prometheus.GaugeValue,
-					float64(q.Used),
-					ns, quotaname, fmt.Sprint(q.Limit),
-				)
+				sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))
 			}
 		}
 	}
@@ -361,27 +289,15 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 							val.Namespace, val.Name, ctridx, val.NodeID)
 						continue
 					}
-					ch <- prometheus.MustNewConstMetric(
-						ctrvGPUdeviceAllocatedMemoryDesc,
-						prometheus.GaugeValue,
-						float64(ctrdevval.Usedmem)*float64(1024)*float64(1024),
-						val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
-					ch <- prometheus.MustNewConstMetric(
-						ctrvGPUdeviceAllocatedCoreDesc,
-						prometheus.GaugeValue,
-						float64(ctrdevval.Usedcores),
-						val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
+					if err := sendMetric(ch, ctrvGPUdeviceAllocatedMemoryDesc, prometheus.GaugeValue, float64(ctrdevval.Usedmem)*float64(1024)*float64(1024), val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID); err != nil {
+						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedMemoryDesc metric: %v", err)
+					}
+					if err := sendMetric(ch, ctrvGPUdeviceAllocatedCoreDesc, prometheus.GaugeValue, float64(ctrdevval.Usedcores), val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID); err != nil {
+						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedCoreDesc metric: %v", err)
+					}
 					if legacy {
-						ch <- prometheus.MustNewConstMetric(
-							legacyAllocatedMemory,
-							prometheus.GaugeValue,
-							float64(ctrdevval.Usedmem)*float64(1024)*float64(1024),
-							val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
-						ch <- prometheus.MustNewConstMetric(
-							legacyAllocatedCore,
-							prometheus.GaugeValue,
-							float64(ctrdevval.Usedcores),
-							val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
+						sendLegacyMetric(ch, legacyAllocatedMemory, prometheus.GaugeValue, float64(ctrdevval.Usedmem)*float64(1024)*float64(1024), val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
+						sendLegacyMetric(ch, legacyAllocatedCore, prometheus.GaugeValue, float64(ctrdevval.Usedcores), val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID)
 					}
 					var totaldev int32
 					found := false
@@ -438,4 +354,22 @@ func initMetrics(bindAddress string, metricsProvider schedulerMetricsProvider, l
 		ReadTimeout:       60 * time.Second,
 	}
 	log.Fatal(server.ListenAndServe())
+}
+
+func sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) {
+	if desc == nil {
+		return
+	}
+	if err := sendMetric(ch, desc, valueType, value, labels...); err != nil {
+		klog.V(4).Infof("Failed to send legacy metric: %v", err)
+	}
+}
+
+func sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) error {
+	metric, err := prometheus.NewConstMetric(desc, valueType, value, labels...)
+	if err != nil {
+		return fmt.Errorf("failed to create metric: %w", err)
+	}
+	ch <- metric
+	return nil
 }

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -20,17 +20,40 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	schedulerpkg "github.com/Project-HAMi/HAMi/pkg/scheduler"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
 )
 
-// fakeMetricsProvider satisfies the schedulerMetricsProvider interface
-// with empty data for testing.
 type fakeMetricsProvider struct{}
 
 func (f *fakeMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage {
-	m := make(map[string]*schedulerpkg.NodeUsage)
+	m := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-abc-123",
+							Index:     0,
+							Used:      2,
+							Count:     4,
+							Usedmem:   4096,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Usedcores: 50,
+							Type:      "NVIDIA",
+							Mode:      "hami-core",
+						},
+					},
+				},
+			},
+		},
+	}
 	return &m
 }
 
@@ -41,6 +64,26 @@ func (f *fakeMetricsProvider) GetQuotaManager() *device.QuotaManager {
 
 func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
 	pm := device.NewPodManager()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       k8stypes.UID("uid-123"),
+		},
+	}
+	podDevices := device.PodDevices{
+		"NVIDIA": device.PodSingleDevice{
+			device.ContainerDevices{
+				{
+					UUID:      "GPU-abc-123",
+					Type:      "NVIDIA",
+					Usedmem:   2048,
+					Usedcores: 25,
+				},
+			},
+		},
+	}
+	pm.AddPod(pod, "node-1", podDevices)
 	return pm
 }
 

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The HAMi Authors.
+Copyright 2024 The HAMi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,104 +17,73 @@ limitations under the License.
 package main
 
 import (
-	"strings"
 	"testing"
 
-	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	schedulerpkg "github.com/Project-HAMi/HAMi/pkg/scheduler"
-	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
 )
 
-type fakeSchedulerMetricsProvider struct {
-	nodeUsage    map[string]*schedulerpkg.NodeUsage
-	quotaManager *device.QuotaManager
-	podManager   *device.PodManager
+// fakeMetricsProvider satisfies the schedulerMetricsProvider interface
+// with empty data for testing.
+type fakeMetricsProvider struct{}
+
+func (f *fakeMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage {
+	m := make(map[string]*schedulerpkg.NodeUsage)
+	return &m
 }
 
-func (f *fakeSchedulerMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage {
-	return &f.nodeUsage
+func (f *fakeMetricsProvider) GetQuotaManager() *device.QuotaManager {
+	qm := device.NewQuotaManager()
+	return qm
 }
 
-func (f *fakeSchedulerMetricsProvider) GetQuotaManager() *device.QuotaManager {
-	return f.quotaManager
+func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
+	pm := device.NewPodManager()
+	return pm
 }
 
-func (f *fakeSchedulerMetricsProvider) GetPodManager() *device.PodManager {
-	return f.podManager
-}
+func TestSchedulerDescribeCollectSync(t *testing.T) {
+	// A pedantic registry is strict and validates that all metrics collected
+	// have been described in Describe(), and checks for duplicate descriptors.
+	reg := prometheus.NewPedanticRegistry()
 
-func TestClusterManagerCollectorSkipsMemoryRatioWithNonPositiveTotalMemory(t *testing.T) {
-	nodeUsage := map[string]*schedulerpkg.NodeUsage{
-		"node-1": {
-			Devices: policy.DeviceUsageList{
-				DeviceLists: []*policy.DeviceListsScore{
-					{
-						Device: &device.DeviceUsage{
-							ID:        "zero-memory",
-							Index:     0,
-							Totalmem:  0,
-							Totalcore: 2,
-							Type:      "AWSNeuron",
-						},
-					},
-					{
-						Device: &device.DeviceUsage{
-							ID:        "negative-memory",
-							Index:     1,
-							Totalmem:  -1,
-							Totalcore: 2,
-							Type:      "test-device",
-						},
-					},
-					{
-						Device: &device.DeviceUsage{
-							ID:        "normal-memory",
-							Index:     2,
-							Usedmem:   1,
-							Totalmem:  4,
-							Totalcore: 2,
-							Type:      "NVIDIA",
-						},
-					},
-				},
-			},
-		},
+	c := &ClusterManager{
+		Zone:          "test-zone",
+		LegacyMetrics: false,
+	}
+	cc := ClusterManagerCollector{
+		ClusterManager:  c,
+		metricsProvider: &fakeMetricsProvider{},
 	}
 
-	collector := ClusterManagerCollector{
-		ClusterManager: &ClusterManager{
-			LegacyMetrics: true,
-		},
-		metricsProvider: &fakeSchedulerMetricsProvider{
-			nodeUsage:    nodeUsage,
-			quotaManager: device.NewQuotaManager(),
-			podManager:   device.NewPodManager(),
-		},
+	// Registering the collector calls Describe() and validates descriptors.
+	if err := reg.Register(cc); err != nil {
+		t.Fatalf("Failed to register ClusterManagerCollector (non-legacy): %v", err)
 	}
 
-	want := `
-# HELP hami_gpu_core_limit_ratio Device core limit for a certain GPU
-# TYPE hami_gpu_core_limit_ratio gauge
-hami_gpu_core_limit_ratio{device_index="0",device_type="AWSNeuron",device_uuid="zero-memory",node="node-1"} 2
-hami_gpu_core_limit_ratio{device_index="1",device_type="test-device",device_uuid="negative-memory",node="node-1"} 2
-hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 2
-# HELP hami_node_gpu_memory_allocated_ratio GPU Memory Allocated Percentage on a certain GPU
-# TYPE hami_node_gpu_memory_allocated_ratio gauge
-hami_node_gpu_memory_allocated_ratio{device_index="2",device_uuid="normal-memory",node="node-1"} 0.25
-# HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU
-# TYPE nodeGPUMemoryPercentage gauge
-nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"} 0.25
-`
+	// Invoke Gather to trigger Collect. Even without data,
+	// this ensures the Collect execution path does not panic.
+	if _, err := reg.Gather(); err != nil {
+		t.Errorf("Gather failed (non-legacy): %v", err)
+	}
 
-	if err := promtestutil.CollectAndCompare(
-		collector,
-		strings.NewReader(want),
-		"hami_gpu_core_limit_ratio",
-		"hami_node_gpu_memory_allocated_ratio",
-		"nodeGPUMemoryPercentage",
-	); err != nil {
-		t.Fatalf("unexpected collecting result:\n%s", err)
+	// Test the legacy metrics configuration.
+	regLegacy := prometheus.NewPedanticRegistry()
+	cLegacy := &ClusterManager{
+		Zone:          "test-zone-legacy",
+		LegacyMetrics: true,
+	}
+	ccLegacy := ClusterManagerCollector{
+		ClusterManager:  cLegacy,
+		metricsProvider: &fakeMetricsProvider{},
+	}
+
+	if err := regLegacy.Register(ccLegacy); err != nil {
+		t.Fatalf("Failed to register ClusterManagerCollector (legacy): %v", err)
+	}
+	if _, err := regLegacy.Gather(); err != nil {
+		t.Errorf("Gather failed (legacy): %v", err)
 	}
 }

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -29,10 +31,33 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
 )
 
-type fakeMetricsProvider struct{}
+type fakeMetricsProvider struct {
+	nodeUsage    map[string]*schedulerpkg.NodeUsage
+	quotaManager *device.QuotaManager
+	podManager   *device.PodManager
+}
 
 func (f *fakeMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.NodeUsage {
-	m := map[string]*schedulerpkg.NodeUsage{
+	return &f.nodeUsage
+}
+
+func (f *fakeMetricsProvider) GetQuotaManager() *device.QuotaManager {
+	return f.quotaManager
+}
+
+func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
+	return f.podManager
+}
+
+func TestSchedulerDescribeCollectSync(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	c := &ClusterManager{
+		Zone:          "test-zone",
+		LegacyMetrics: false,
+	}
+
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
 		"node-1": {
 			Devices: policy.DeviceUsageList{
 				DeviceLists: []*policy.DeviceListsScore{
@@ -54,15 +79,8 @@ func (f *fakeMetricsProvider) InspectAllNodesUsage() *map[string]*schedulerpkg.N
 			},
 		},
 	}
-	return &m
-}
 
-func (f *fakeMetricsProvider) GetQuotaManager() *device.QuotaManager {
 	qm := device.NewQuotaManager()
-	return qm
-}
-
-func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
 	pm := device.NewPodManager()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,19 +102,14 @@ func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
 		},
 	}
 	pm.AddPod(pod, "node-1", podDevices)
-	return pm
-}
 
-func TestSchedulerDescribeCollectSync(t *testing.T) {
-	reg := prometheus.NewPedanticRegistry()
-
-	c := &ClusterManager{
-		Zone:          "test-zone",
-		LegacyMetrics: false,
-	}
 	cc := ClusterManagerCollector{
-		ClusterManager:  c,
-		metricsProvider: &fakeMetricsProvider{},
+		ClusterManager: c,
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: qm,
+			podManager:   pm,
+		},
 	}
 
 	if err := reg.Register(cc); err != nil {
@@ -113,8 +126,12 @@ func TestSchedulerDescribeCollectSync(t *testing.T) {
 		LegacyMetrics: true,
 	}
 	ccLegacy := ClusterManagerCollector{
-		ClusterManager:  cLegacy,
-		metricsProvider: &fakeMetricsProvider{},
+		ClusterManager: cLegacy,
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: qm,
+			podManager:   pm,
+		},
 	}
 
 	if err := regLegacy.Register(ccLegacy); err != nil {
@@ -122,5 +139,79 @@ func TestSchedulerDescribeCollectSync(t *testing.T) {
 	}
 	if _, err := regLegacy.Gather(); err != nil {
 		t.Errorf("Gather failed (legacy): %v", err)
+	}
+}
+
+func TestClusterManagerCollectorSkipsMemoryRatioWithNonPositiveTotalMemory(t *testing.T) {
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "zero-memory",
+							Index:     0,
+							Totalmem:  0,
+							Totalcore: 2,
+							Type:      "AWSNeuron",
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "negative-memory",
+							Index:     1,
+							Totalmem:  -1,
+							Totalcore: 2,
+							Type:      "test-device",
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "normal-memory",
+							Index:     2,
+							Usedmem:   1,
+							Totalmem:  4,
+							Totalcore: 2,
+							Type:      "NVIDIA",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{
+			LegacyMetrics: true,
+		},
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: device.NewQuotaManager(),
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_gpu_core_limit_ratio Device core limit for a certain GPU
+# TYPE hami_gpu_core_limit_ratio gauge
+hami_gpu_core_limit_ratio{device_index="0",device_type="AWSNeuron",device_uuid="zero-memory",node="node-1"} 2
+hami_gpu_core_limit_ratio{device_index="1",device_type="test-device",device_uuid="negative-memory",node="node-1"} 2
+hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 2
+# HELP hami_node_gpu_memory_allocated_ratio GPU Memory Allocated Percentage on a certain GPU
+# TYPE hami_node_gpu_memory_allocated_ratio gauge
+hami_node_gpu_memory_allocated_ratio{device_index="2",device_uuid="normal-memory",node="node-1"} 0.25
+# HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU
+# TYPE nodeGPUMemoryPercentage gauge
+nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"} 0.25
+`
+
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_gpu_core_limit_ratio",
+		"hami_node_gpu_memory_allocated_ratio",
+		"nodeGPUMemoryPercentage",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -45,8 +45,6 @@ func (f *fakeMetricsProvider) GetPodManager() *device.PodManager {
 }
 
 func TestSchedulerDescribeCollectSync(t *testing.T) {
-	// A pedantic registry is strict and validates that all metrics collected
-	// have been described in Describe(), and checks for duplicate descriptors.
 	reg := prometheus.NewPedanticRegistry()
 
 	c := &ClusterManager{
@@ -58,18 +56,14 @@ func TestSchedulerDescribeCollectSync(t *testing.T) {
 		metricsProvider: &fakeMetricsProvider{},
 	}
 
-	// Registering the collector calls Describe() and validates descriptors.
 	if err := reg.Register(cc); err != nil {
 		t.Fatalf("Failed to register ClusterManagerCollector (non-legacy): %v", err)
 	}
 
-	// Invoke Gather to trigger Collect. Even without data,
-	// this ensures the Collect execution path does not panic.
 	if _, err := reg.Gather(); err != nil {
 		t.Errorf("Gather failed (non-legacy): %v", err)
 	}
 
-	// Test the legacy metrics configuration.
 	regLegacy := prometheus.NewPedanticRegistry()
 	cLegacy := &ClusterManager{
 		Zone:          "test-zone-legacy",


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it:** 

I saw that `cmd/scheduler/metrics.go` was still using `prometheus.MustNewConstMetric()` over 20 times. This is dangerous because if there is a small error with the metrics, it will crash the whole scheduler.

I noticed that the HAMi team already fixed this exact same issue for the `vGPUmonitor` component in PR #2170 by using a safe `sendMetric` function. But that fix was never applied to the scheduler component. The scheduler was still broken in the same way.

So, I did the same fix for the scheduler to finish the job:

I added the safe `sendMetric()` and `sendLegacyMetric()` functions to `cmd/scheduler/metrics.go`.
I replaced all the dangerous `MustNewConstMetric` calls with these safe functions. Now, if an error happens, it just logs a warning instead of crashing the scheduler.
I also updated the test file (cmd/scheduler/metrics_test.go) to properly test this safe code without any crashes.

**AI Assistance Disclosure**: I used an AI coding assistant to help me write the refactoring code and the tests, but I have manually reviewed, tested, and understood all the logic myself.

I made sure this is only a clean refactor. I was very careful to keep all the recent upstream features safely intact, and the test file is updated properly to use the new mock interface.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler metrics collection so individual metric errors no longer cause collection to panic.
  * Added error logging when metric creation fails while preserving GPU, MIG, quota, container, and legacy metric reporting.
  * Improved resilience when collecting metrics with invalid or unexpected values.

* **Tests**
  * Added validation that scheduler metrics register and gather successfully across current and legacy configurations.
  * Confirmed metric descriptions and collected metrics remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->