### PR TITLE
fix(vGPUmonitor): bound v0 spec aggregation loops by procnum

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -81,9 +81,22 @@ func (s Spec) DeviceNum() int {
 	return int(s.sr.num)
 }
 
+// activeProcCount returns procnum clamped to [0, len(procs)], guarding
+// against a corrupted shared-memory region reporting a bogus value.
+func (s Spec) activeProcCount() int {
+	n := int(s.sr.procnum)
+	if n < 0 {
+		return 0
+	}
+	if n > len(s.sr.procs) {
+		return len(s.sr.procs)
+	}
+	return n
+}
+
 func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.used[idx].contextSize
 	}
 	return v
@@ -91,7 +104,7 @@ func (s Spec) DeviceMemoryContextSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.used[idx].moduleSize
 	}
 	return v
@@ -99,7 +112,7 @@ func (s Spec) DeviceMemoryModuleSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.used[idx].bufferSize
 	}
 	return v
@@ -107,7 +120,7 @@ func (s Spec) DeviceMemoryBufferSize(idx int) uint64 {
 
 func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.used[idx].offset
 	}
 	return v
@@ -115,7 +128,7 @@ func (s Spec) DeviceMemoryOffset(idx int) uint64 {
 
 func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.used[idx].total
 	}
 	return v
@@ -123,7 +136,7 @@ func (s Spec) DeviceMemoryTotal(idx int) uint64 {
 
 func (s Spec) DeviceSmUtil(idx int) uint64 {
 	v := uint64(0)
-	for _, p := range s.sr.procs {
+	for _, p := range s.sr.procs[:s.activeProcCount()] {
 		v += p.deviceUtil[idx].smUtil
 	}
 	return v

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -60,12 +60,37 @@ func TestSpec_DeviceNum(t *testing.T) {
 	}
 }
 
+func TestSpec_ActiveProcCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		procnum  int32
+		expected int
+	}{
+		{"zero", 0, 0},
+		{"normal in-bounds", 2, 2},
+		{"exact capacity", 1024, 1024},
+		{"negative clamps to 0", -1, 0},
+		{"large negative clamps to 0", -999, 0},
+		{"procnum > 1024 clamps to 1024", 1025, 1024},
+		{"large overflow clamps to 1024", 9999, 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Spec{sr: &sharedRegionT{procnum: tt.procnum}}
+			if got := s.activeProcCount(); got != tt.expected {
+				t.Errorf("activeProcCount() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 	tests := []specTest{
 		{
 			name: "device memory context size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
 					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
@@ -77,7 +102,8 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 		{
 			name: "device memory context size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{contextSize: 100}, {contextSize: 200}}},
 					{used: [16]deviceMemory{{contextSize: 300}, {contextSize: 400}}},
@@ -85,6 +111,20 @@ func TestSpec_DeviceMemoryContextSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{contextSize: 100}}},
+					// slot 1 is stale — procnum=1 must exclude it
+					{used: [16]deviceMemory{{contextSize: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 
@@ -103,7 +143,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 		{
 			name: "device memory module size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
 					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
@@ -115,7 +156,8 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 		{
 			name: "device memory module size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{moduleSize: 100}, {moduleSize: 200}}},
 					{used: [16]deviceMemory{{moduleSize: 300}, {moduleSize: 400}}},
@@ -123,6 +165,19 @@ func TestSpec_DeviceMemoryModuleSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{moduleSize: 100}}},
+					{used: [16]deviceMemory{{moduleSize: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 
@@ -141,7 +196,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 		{
 			name: "device memory buffer size for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
 					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
@@ -153,7 +209,8 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 		{
 			name: "device memory buffer size for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{bufferSize: 100}, {bufferSize: 200}}},
 					{used: [16]deviceMemory{{bufferSize: 300}, {bufferSize: 400}}},
@@ -161,6 +218,19 @@ func TestSpec_DeviceMemoryBufferSize(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{bufferSize: 100}}},
+					{used: [16]deviceMemory{{bufferSize: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 
@@ -179,7 +249,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 		{
 			name: "device memory offset for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
 					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
@@ -191,7 +262,8 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 		{
 			name: "device memory offset for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{offset: 100}, {offset: 200}}},
 					{used: [16]deviceMemory{{offset: 300}, {offset: 400}}},
@@ -199,6 +271,19 @@ func TestSpec_DeviceMemoryOffset(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{offset: 100}}},
+					{used: [16]deviceMemory{{offset: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 
@@ -217,7 +302,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 		{
 			name: "device memory total for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
 					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
@@ -229,7 +315,8 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 		{
 			name: "device memory total for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{used: [16]deviceMemory{{total: 100}, {total: 200}}},
 					{used: [16]deviceMemory{{total: 300}, {total: 400}}},
@@ -237,6 +324,42 @@ func TestSpec_DeviceMemoryTotal(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{total: 100}}},
+					{used: [16]deviceMemory{{total: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
+		},
+		{
+			name: "negative procnum clamps to 0, returns 0",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: -1,
+				procs: [1024]shrregProcSlotT{
+					{used: [16]deviceMemory{{total: 100}}},
+					{used: [16]deviceMemory{{total: 200}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(0),
+		},
+		{
+			name: "procnum > 1024 clamps to 1024, does not panic",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 2000,
+				procs:   [1024]shrregProcSlotT{},
+			}},
+			input:    0,
+			expected: uint64(0),
 		},
 	}
 
@@ -255,7 +378,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 		{
 			name: "device sm util for index 1",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
 					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
@@ -267,7 +391,8 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 		{
 			name: "device sm util for index 0",
 			spec: &Spec{sr: &sharedRegionT{
-				num: 2,
+				num:     2,
+				procnum: 2,
 				procs: [1024]shrregProcSlotT{
 					{deviceUtil: [16]deviceUtilization{{smUtil: 100}, {smUtil: 200}}},
 					{deviceUtil: [16]deviceUtilization{{smUtil: 300}, {smUtil: 400}}},
@@ -275,6 +400,19 @@ func TestSpec_DeviceSmUtil(t *testing.T) {
 			}},
 			input:    0,
 			expected: uint64(400),
+		},
+		{
+			name: "stale slots beyond procnum are excluded",
+			spec: &Spec{sr: &sharedRegionT{
+				num:     2,
+				procnum: 1,
+				procs: [1024]shrregProcSlotT{
+					{deviceUtil: [16]deviceUtilization{{smUtil: 100}}},
+					{deviceUtil: [16]deviceUtilization{{smUtil: 999}}},
+				},
+			}},
+			input:    0,
+			expected: uint64(100),
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The six metric-aggregation methods in `pkg/monitor/nvidia/v0/spec.go` (`DeviceMemoryContextSize`, 
`DeviceMemoryModuleSize`, `DeviceMemoryBufferSize`, `DeviceMemoryOffset`, `DeviceMemoryTotal`, 
`DeviceSmUtil`) iterated over the full 1024-slot `procs` array instead of stopping at `procnum`. 
Any slot beyond the active process count may retain stale, non-zeroed data from a previous CUDA 
process, causing `DeviceMemoryTotal()` and the five related methods to inflate reported usage. 
Inflated usage can trigger false throttling of live GPU workloads via the feedback loop in 
`feedback.go`.

This PR adds an `activeProcCount()` helper that clamps `procnum` to `[0, len(procs)]` before 
slicing. This is needed because `procnum` is read directly from raw mmap'd shared memory 
(written by `libvgpu.so` inside the container) with no field-level validation upstream — the 
existing file-size check only guarantees the buffer is the right total size, not that individual 
field values are sane. A naive fix using `procs[:int(procnum)]` would trade the stale-data bug 
for a new panic (slice bounds out of range) if `procnum` were ever corrupted to a negative value 
or a value greater than 1024. The clamp makes out-of-range values degrade safely instead.

**Which issue(s) this PR fixes**:
Fixes #2327

Note:
- The `v1` implementation (`pkg/monitor/nvidia/v1/spec.go`) already bounds these loops by 
  `procnum`, but has the same unguarded-value issue — a corrupted `procnum` there would panic 
  too. That's tracked separately under #2310 (which covers a different, pre-existing v1 defect: 
  a missing `p.status` guard). This PR intentionally does not touch `v1/spec.go` to keep scope 
  minimal; flagging it here for whoever picks up #2310.
- Existing tests in `spec_test.go` had `procnum` implicitly left at its zero value, meaning they 
  weren't actually exercising the bounded-iteration path before this fix — they'd have passed 
  regardless of correctness. I added explicit `procnum` values to all affected existing cases, 
  plus:
  - A new `TestSpec_ActiveProcCount` table covering 7 boundary values (zero, normal, exact 
    capacity, negative, large negative, over-capacity, large over-capacity)
  - 6 "stale slots beyond procnum are excluded" regression cases (one per aggregation method)
  - 2 end-to-end clamp cases in `TestSpec_DeviceMemoryTotal` proving negative/overflow `procnum` 
    values don't panic
- `go vet` and `golangci-lint` both pass clean on the changed package; full `v0` test suite 
  (26 tests) passes with `-race`.
- AI-assisted: this fix was identified by claude code - code review and then the coding part was done by claude but the methodolgy to solve it was not done by it, for that, I used gemini a bit to get better solution to it and a bit of chatgpt as well so i can get best solution

**Does this PR introduce a user-facing change?**:
```
Fix vGPUmonitor v0 spec: correctly bound process-slot aggregation by active process count 
instead of scanning all 1024 fixed slots, preventing inflated GPU memory/utilization metrics 
and false throttling caused by stale data in unused slots.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA monitoring accuracy by limiting process-based memory and utilization calculations to valid active processes.
  * Prevented stale process data from affecting reported metrics.
  * Added safeguards for negative or oversized process counts to avoid invalid calculations and runtime errors.

* **Tests**
  * Expanded coverage for zero, negative, bounded, and oversized process counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->