### PR TITLE
feat(scheduler): graceful shutdown on SIGTERM to drain in-flight requests

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -156,8 +157,12 @@ func start() error {
 
 	// start monitor metrics
 	serveErrCh := make(chan error, 2)
-	// start monitor metrics
-	go initMetrics(ctx, config.MetricsBindAddress, sher, legacyMetrics, serveErrCh)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		initMetrics(ctx, config.MetricsBindAddress, sher, legacyMetrics, serveErrCh)
+	}()
 
 	// start http server
 	router := httprouter.New()
@@ -227,6 +232,9 @@ func start() error {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		klog.ErrorS(err, "HTTP server shutdown did not complete cleanly")
 	}
+	// Wait for the metrics server to finish draining before exiting.
+	cancel()
+	wg.Wait()
 	if serveErr != nil {
 		return serveErr
 	}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -147,12 +147,17 @@ func start() error {
 	}
 	defer sher.Stop()
 
-	// ctx is canceled on SIGINT/SIGTERM to trigger graceful shutdown.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	// ctx is canceled on SIGINT/SIGTERM or on a fatal server error to
+	// trigger graceful shutdown of both servers.
+	signalCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	ctx, cancel := context.WithCancel(signalCtx)
+	defer cancel()
 
 	// start monitor metrics
-	go initMetrics(ctx, config.MetricsBindAddress, sher, legacyMetrics)
+	serveErrCh := make(chan error, 2)
+	// start monitor metrics
+	go initMetrics(ctx, config.MetricsBindAddress, sher, legacyMetrics, serveErrCh)
 
 	// start http server
 	router := httprouter.New()
@@ -175,7 +180,6 @@ func start() error {
 		ReadTimeout:       60 * time.Second,
 	}
 
-	serveErrCh := make(chan error, 1)
 	if len(tlsCertFile) == 0 || len(tlsKeyFile) == 0 {
 		go func() {
 			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -205,20 +209,26 @@ func start() error {
 		}()
 	}
 
+	var serveErr error
 	select {
-	case err := <-serveErrCh:
-		return err
+	case serveErr = <-serveErrCh:
+		klog.ErrorS(serveErr, "server failed, shutting down")
+		// Cancel ctx so the other server drains via its own ctx.Done path.
+		cancel()
 	case <-ctx.Done():
+		klog.Info("Received termination signal, draining in-flight requests")
 	}
 
-	klog.Info("Received termination signal, draining in-flight requests")
 	// Drain within the kubelet's default 30s termination grace period so
 	// in-flight /bind requests finish and release their node locks instead
 	// of leaving them held for the full node-lock timeout.
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
-	defer cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	defer shutdownCancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		klog.ErrorS(err, "HTTP server shutdown did not complete cleanly")
+	}
+	if serveErr != nil {
+		return serveErr
 	}
 	klog.Info("Scheduler shut down gracefully")
 	return nil

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -19,10 +19,13 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -42,6 +45,12 @@ import (
 )
 
 //var version string
+
+// gracefulShutdownTimeout bounds how long the servers wait for in-flight
+// requests to drain after SIGTERM. It must stay below the pod's
+// terminationGracePeriodSeconds (default 30s) so draining finishes before
+// the kubelet sends SIGKILL.
+const gracefulShutdownTimeout = 25 * time.Second
 
 var (
 	sher            *scheduler.Scheduler
@@ -138,8 +147,12 @@ func start() error {
 	}
 	defer sher.Stop()
 
+	// ctx is canceled on SIGINT/SIGTERM to trigger graceful shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	// start monitor metrics
-	go initMetrics(config.MetricsBindAddress, sher, legacyMetrics)
+	go initMetrics(ctx, config.MetricsBindAddress, sher, legacyMetrics)
 
 	// start http server
 	router := httprouter.New()
@@ -155,47 +168,59 @@ func start() error {
 		klog.Infof("Profiling enabled, visit %s/debug/pprof/ to view profiles", config.HTTPBind)
 	}
 
+	server := &http.Server{
+		Addr:              config.HTTPBind,
+		Handler:           router,
+		ReadHeaderTimeout: 15 * time.Second,
+		ReadTimeout:       60 * time.Second,
+	}
+
+	serveErrCh := make(chan error, 1)
 	if len(tlsCertFile) == 0 || len(tlsKeyFile) == 0 {
-		server := &http.Server{
-			Addr:              config.HTTPBind,
-			Handler:           router,
-			ReadHeaderTimeout: 15 * time.Second,
-			ReadTimeout:       60 * time.Second,
-		}
-		if err := server.ListenAndServe(); err != nil {
-			return fmt.Errorf("listen and Serve error, %v", err)
-		}
+		go func() {
+			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				serveErrCh <- fmt.Errorf("listen and Serve error, %v", err)
+			}
+		}()
 	} else {
 		certWatcher, err := certwatcher.New(tlsCertFile, tlsKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to create cert watcher: %w", err)
 		}
 
-		tlsCfg := &tls.Config{
+		server.TLSConfig = &tls.Config{
 			GetCertificate: certWatcher.GetCertificate,
 		}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 		go func() {
-			if err := certWatcher.Start(ctx); err != nil && err != context.Canceled {
+			if err := certWatcher.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
 				klog.ErrorS(err, "cert watcher error")
 			}
 		}()
 
-		addr := config.HTTPBind
-		handler := router
-		server := &http.Server{
-			Addr:              addr,
-			Handler:           handler,
-			TLSConfig:         tlsCfg,
-			ReadHeaderTimeout: 15 * time.Second,
-			ReadTimeout:       60 * time.Second,
-		}
-		klog.InfoS("Starting HTTPS server", "address", addr)
-		if err := server.ListenAndServeTLS("", ""); err != nil {
-			return fmt.Errorf("HTTPS server error: %w", err)
-		}
+		klog.InfoS("Starting HTTPS server", "address", config.HTTPBind)
+		go func() {
+			if err := server.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				serveErrCh <- fmt.Errorf("HTTPS server error: %w", err)
+			}
+		}()
 	}
+
+	select {
+	case err := <-serveErrCh:
+		return err
+	case <-ctx.Done():
+	}
+
+	klog.Info("Received termination signal, draining in-flight requests")
+	// Drain within the kubelet's default 30s termination grace period so
+	// in-flight /bind requests finish and release their node locks instead
+	// of leaving them held for the full node-lock timeout.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		klog.ErrorS(err, "HTTP server shutdown did not complete cleanly")
+	}
+	klog.Info("Scheduler shut down gracefully")
 	return nil
 }
 

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -422,7 +424,7 @@ func NewClusterManager(zone string, reg prometheus.Registerer, metricsProvider s
 	return c
 }
 
-func initMetrics(bindAddress string, metricsProvider schedulerMetricsProvider, legacyMetrics bool) {
+func initMetrics(ctx context.Context, bindAddress string, metricsProvider schedulerMetricsProvider, legacyMetrics bool) {
 	klog.Info("Initializing metrics for scheduler")
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(versionmetrics.NewBuildInfoCollector())
@@ -437,5 +439,17 @@ func initMetrics(bindAddress string, metricsProvider schedulerMetricsProvider, l
 		ReadHeaderTimeout: 15 * time.Second,
 		ReadTimeout:       60 * time.Second,
 	}
-	log.Fatal(server.ListenAndServe())
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
+	}()
+
+	// Graceful shutdown on context cancellation.
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		klog.ErrorS(err, "metrics server shutdown did not complete cleanly")
+	}
 }

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"strings"
@@ -424,7 +423,10 @@ func NewClusterManager(zone string, reg prometheus.Registerer, metricsProvider s
 	return c
 }
 
-func initMetrics(ctx context.Context, bindAddress string, metricsProvider schedulerMetricsProvider, legacyMetrics bool) {
+// initMetrics serves Prometheus metrics until ctx is canceled, then drains the
+// server. A serve failure is reported on serveErrCh so main can shut down the
+// extender server too instead of exiting abruptly.
+func initMetrics(ctx context.Context, bindAddress string, metricsProvider schedulerMetricsProvider, legacyMetrics bool, serveErrCh chan<- error) {
 	klog.Info("Initializing metrics for scheduler")
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(versionmetrics.NewBuildInfoCollector())
@@ -441,7 +443,7 @@ func initMetrics(ctx context.Context, bindAddress string, metricsProvider schedu
 	}
 	go func() {
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal(err)
+			serveErrCh <- fmt.Errorf("metrics server error: %w", err)
 		}
 	}()
 


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

The scheduler extender exited immediately on SIGTERM: neither the extender HTTP(S) server nor the metrics server handled signals or called `Shutdown`, so a rolling upgrade or node drain killed the process mid-request. A `/bind` killed after `LockNode` succeeds but before the allocation completes leaves the node-lock annotation held, blocking GPU scheduling on that node for up to the node-lock timeout (default 5m). Recent stale-lock fixes (#2293, #2255) address symptoms; ungraceful scheduler death during bind is one way those stale locks get produced.

This PR:

- wires a `signal.NotifyContext(SIGINT, SIGTERM)` through `start()`;
- runs the extender server (TLS and non-TLS) in a goroutine and, on signal, drains it with `http.Server.Shutdown` bounded by a 25s timeout — below the default 30s `terminationGracePeriodSeconds`, so in-flight filter/bind requests finish and release their locks before the kubelet sends SIGKILL;
- applies the same shutdown-aware pattern to the metrics server (replacing `log.Fatal(server.ListenAndServe())`), mirroring what vGPUmonitor already does in `cmd/vGPUmonitor/main.go`;
- dedupes the TLS/non-TLS branches to share a single `http.Server`. Server startup errors still terminate the process as before, via an error channel.

No flag changes, no behavior change other than the drain on termination.

## Which issue(s) this PR fixes

Fixes #2330

## Tests

Verified `go build`/`go vet` pass for the scheduler binary. The change is confined to `main.go` process-lifecycle wiring plus the `initMetrics` signature; existing route/handler tests are unaffected.

Manual verification: sent SIGTERM to a running scheduler — it logs `Received termination signal, draining in-flight requests`, completes in-flight requests, and exits 0 within the drain window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler shutdown handling for stop and termination signals.
  * Active HTTP and HTTPS requests can complete before services exit.
  * Metrics endpoints now shut down gracefully and avoid treating expected closures as errors.
  * Improved reporting of unexpected serving failures.
  * TLS certificate monitoring now stops cleanly with the scheduler.
  * Added a bounded shutdown period to prevent services from hanging indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->