### PR TITLE
fix(scheduler): return deep copy in nodeManager.GetNode to prevent concurrent map read/write

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -117,9 +117,6 @@ func (m *nodeManager) GetNode(nodeID string) (*device.NodeInfo, error) {
 	if !ok {
 		return &device.NodeInfo{}, fmt.Errorf("node %v not found", nodeID)
 	}
-	// Return a deep copy to prevent concurrent map read/write races between
-	// scoring goroutines (readers) and addNode/rmNodeDevices (writers).
-	// ListNodes() already follows this same pattern for the same reason.
 	nodeInfoCopy := &device.NodeInfo{
 		ID:      n.ID,
 		Devices: make(map[string][]device.DeviceInfo, len(n.Devices)),

--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -113,10 +113,24 @@ func (m *nodeManager) rmNode(nodeID string) {
 func (m *nodeManager) GetNode(nodeID string) (*device.NodeInfo, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	if n, ok := m.nodes[nodeID]; ok {
-		return n, nil
+	n, ok := m.nodes[nodeID]
+	if !ok {
+		return &device.NodeInfo{}, fmt.Errorf("node %v not found", nodeID)
 	}
-	return &device.NodeInfo{}, fmt.Errorf("node %v not found", nodeID)
+	// Return a deep copy to prevent concurrent map read/write races between
+	// scoring goroutines (readers) and addNode/rmNodeDevices (writers).
+	// ListNodes() already follows this same pattern for the same reason.
+	nodeInfoCopy := &device.NodeInfo{
+		ID:      n.ID,
+		Devices: make(map[string][]device.DeviceInfo, len(n.Devices)),
+	}
+	if n.Node != nil {
+		nodeInfoCopy.Node = n.Node.DeepCopy()
+	}
+	for k, v := range n.Devices {
+		nodeInfoCopy.Devices[k] = device.DeepCopyDeviceInfos(v)
+	}
+	return nodeInfoCopy, nil
 }
 
 func (m *nodeManager) ListNodes() (map[string]*device.NodeInfo, error) {

--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -496,6 +496,17 @@ func TestGetNode_DeepCopy(t *testing.T) {
 		t.Errorf("GetNode returned a live pointer instead of a deep copy: internal Devmem was mutated to %d", internalMem)
 	}
 
+	// Mutate the returned copy's Node field.
+	got.Node.Name = "mutated-name"
+
+	m.mutex.RLock()
+	internalNodeName := m.nodes["node-copy"].Node.Name
+	m.mutex.RUnlock()
+
+	if internalNodeName == "mutated-name" {
+		t.Errorf("GetNode returned a live Node pointer instead of a deep copy: internal Node.Name was mutated to %s", internalNodeName)
+	}
+
 	// Verify error path for missing node.
 	_, err = m.GetNode("nonexistent-node")
 	if err == nil {

--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -458,3 +458,47 @@ func Test_rmNodeDevices(t *testing.T) {
 		})
 	}
 }
+
+// TestGetNode_DeepCopy verifies that GetNode returns an independent deep copy
+// of the internal NodeInfo so that concurrent writes via addNode/rmNodeDevices
+// cannot race with scoring goroutines that read the returned value.
+func TestGetNode_DeepCopy(t *testing.T) {
+	m := newNodeManager()
+	m.addNode("node-copy", &device.NodeInfo{
+		ID:   "node-copy",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-copy"}},
+		Devices: map[string][]device.DeviceInfo{
+			"NVIDIA": {{
+				ID:           "GPU-0",
+				Count:        int32(1),
+				Devcore:      int32(100),
+				Devmem:       int32(8000),
+				DeviceVendor: "NVIDIA",
+			}},
+		},
+	})
+
+	got, err := m.GetNode("node-copy")
+	if err != nil {
+		t.Fatalf("GetNode returned unexpected error: %v", err)
+	}
+
+	// Mutate the returned copy's Devices slice.
+	got.Devices["NVIDIA"][0].Devmem = int32(9999)
+
+	// The internal entry must be unaffected — if GetNode handed out the live
+	// pointer, this read would see 9999 too.
+	m.mutex.RLock()
+	internalMem := m.nodes["node-copy"].Devices["NVIDIA"][0].Devmem
+	m.mutex.RUnlock()
+
+	if internalMem == int32(9999) {
+		t.Errorf("GetNode returned a live pointer instead of a deep copy: internal Devmem was mutated to %d", internalMem)
+	}
+
+	// Verify error path for missing node.
+	_, err = m.GetNode("nonexistent-node")
+	if err == nil {
+		t.Error("expected error for nonexistent node, got nil")
+	}
+}

--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -459,9 +459,6 @@ func Test_rmNodeDevices(t *testing.T) {
 	}
 }
 
-// TestGetNode_DeepCopy verifies that GetNode returns an independent deep copy
-// of the internal NodeInfo so that concurrent writes via addNode/rmNodeDevices
-// cannot race with scoring goroutines that read the returned value.
 func TestGetNode_DeepCopy(t *testing.T) {
 	m := newNodeManager()
 	m.addNode("node-copy", &device.NodeInfo{
@@ -483,11 +480,8 @@ func TestGetNode_DeepCopy(t *testing.T) {
 		t.Fatalf("GetNode returned unexpected error: %v", err)
 	}
 
-	// Mutate the returned copy's Devices slice.
 	got.Devices["NVIDIA"][0].Devmem = int32(9999)
 
-	// The internal entry must be unaffected — if GetNode handed out the live
-	// pointer, this read would see 9999 too.
 	m.mutex.RLock()
 	internalMem := m.nodes["node-copy"].Devices["NVIDIA"][0].Devmem
 	m.mutex.RUnlock()
@@ -496,7 +490,6 @@ func TestGetNode_DeepCopy(t *testing.T) {
 		t.Errorf("GetNode returned a live pointer instead of a deep copy: internal Devmem was mutated to %d", internalMem)
 	}
 
-	// Mutate the returned copy's Node field.
 	got.Node.Name = "mutated-name"
 
 	m.mutex.RLock()
@@ -507,7 +500,6 @@ func TestGetNode_DeepCopy(t *testing.T) {
 		t.Errorf("GetNode returned a live Node pointer instead of a deep copy: internal Node.Name was mutated to %s", internalNodeName)
 	}
 
-	// Verify error path for missing node.
 	_, err = m.GetNode("nonexistent-node")
 	if err == nil {
 		t.Error("expected error for nonexistent node, got nil")


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`nodeManager.GetNode()` in `pkg/scheduler/nodes.go` returned a live pointer to the internal `NodeInfo` stored in the `nodes` map. In contrast, `ListNodes()` already returns deep copies to avoid exposing shared mutable state.

`GetNode()` is used from `calcScoreWithOptions()` (`pkg/scheduler/score.go`), where the returned `NodeInfo.Devices` map is accessed after the `nodeManager` read lock has been released. Meanwhile, `addNode()` and `rmNodeDevices()` (invoked from `register()`) update the same underlying `Devices` map while holding the write lock.

Returning the live object allows readers to continue accessing shared mutable state outside the lock, making concurrent map access possible.

This PR makes `GetNode()` return a deep copy of `NodeInfo`, matching the existing behavior of `ListNodes()`. Callers now receive an isolated snapshot instead of the live internal object, preventing concurrent access to the shared map.

## Which issue(s) this PR fixes

Fixes #2332

## Special notes for your reviewer

- Makes `GetNode()` consistent with `ListNodes()`.
- No behavioral or API changes; only the returned object's ownership changes.
- Verified locally with `go test ./pkg/scheduler/... -race -count=1`.

## AI assistance disclosure

I consulted ChatGPT and Claude to analyze the scheduler code paths and compare `GetNode()` with `ListNodes()`. The implementation, debugging, validation, commit message, and final code changes were completed and verified by me. I reviewed all generated suggestions, confirmed the fix locally, and take full responsibility for the final contribution.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node data isolation to prevent changes made by consumers from affecting scheduler state.
  * Preserved existing error handling when requested nodes are unavailable.

* **Tests**
  * Added coverage validating independent node data copies and missing-node behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->