### PR TITLE
fix(scheduler): keep per-type device allocations aligned to container index

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -90,6 +90,25 @@ func fitInDevices(node *NodeUsage, requests device.ContainerDeviceRequests, pod 
 	return true, ""
 }
 
+// padDeviceAllocations ensures that for every device type discovered so far,
+// devices has exactly one entry per container, indexed by container order.
+// fitInDevices appends the current container's allocation to each requested
+// type, so when earlier containers did not request a type, its entry lands at
+// the wrong index; those entries are shifted right by the missing leading empty
+// slots. Types not requested by the current container only need a trailing
+// empty slot.
+func padDeviceAllocations(devices device.PodDevices, ctrid int, requestedTypes map[string]bool) {
+	for idx := range devices {
+		for len(devices[idx]) <= ctrid {
+			if requestedTypes[idx] {
+				devices[idx] = append(device.PodSingleDevice{device.ContainerDevices{}}, devices[idx]...)
+			} else {
+				devices[idx] = append(devices[idx], device.ContainerDevices{})
+			}
+		}
+	}
+}
+
 func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string) (*policy.NodeScoreList, error) {
 	return s.calcScoreWithOptions(nodes, resourceReqs, task, failedNodes, true, false)
 }
@@ -135,7 +154,6 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 			// Assume the node is a fit by default. This handles pods with no device
 			// requests, which should be schedulable on any node.
 			ctrfit := true
-			deviceType := ""
 			//This loop is for different container request
 			for ctrid, n := range resourceReqs {
 				sums := 0
@@ -143,23 +161,21 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 					sums += int(k.Nums)
 				}
 
-				// container need no device and we have got certain deviceType
-				if sums == 0 && deviceType != "" {
-					score.Devices[deviceType] = append(score.Devices[deviceType], device.ContainerDevices{})
+				// container need no device, fill missing empty allocation for all device types
+				if sums == 0 {
+					for idx := range score.Devices {
+						score.Devices[idx] = append(score.Devices[idx], device.ContainerDevices{})
+					}
 					continue
+				}
+				requestedTypes := make(map[string]bool, len(n))
+				for _, k := range n {
+					requestedTypes[k.Type] = true
 				}
 				klog.V(5).InfoS("fitInDevices", "pod", klog.KObj(task), "node", nodeID)
 				fit, reason := fitInDevices(node, n, task, nodeInfo, &score.Devices)
-				// found certain deviceType, fill missing empty allocation for containers before this
-				for idx := range score.Devices {
-					deviceType = idx
-					for len(score.Devices[idx]) <= ctrid {
-						emptyContainerDevices := device.ContainerDevices{}
-						emptyPodSingleDevice := device.PodSingleDevice{}
-						emptyPodSingleDevice = append(emptyPodSingleDevice, emptyContainerDevices)
-						score.Devices[idx] = append(emptyPodSingleDevice, score.Devices[idx]...)
-					}
-				}
+				// fill missing empty allocation for containers before this
+				padDeviceAllocations(score.Devices, ctrid, requestedTypes)
 				ctrfit = fit
 				if !fit {
 					klog.V(4).InfoS(common.NodeUnfitPod, "pod", klog.KObj(task), "node", nodeID, "reason", reason)

--- a/pkg/scheduler/score_align_test.go
+++ b/pkg/scheduler/score_align_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// Test_calcScore_MultiTypeContainerAlignment guards against container-index
+// misalignment of per-type device allocations for pods whose containers request
+// different device types (or no device at all). score.Devices must have exactly
+// one entry per container, indexed by container order, for every type that is
+// discovered, otherwise PatchAnnotations hands a device to the wrong container.
+func Test_calcScore_MultiTypeContainerAlignment(t *testing.T) {
+	oldDevicesMap := device.DevicesMap
+	defer func() { device.DevicesMap = oldDevicesMap }()
+	device.DevicesMap = map[string]device.Devices{
+		"mockA": &fitMockDevice{typeName: "mockA", uuid: "uuid-a"},
+		"mockB": &fitMockDevice{typeName: "mockB", uuid: "uuid-b"},
+	}
+
+	node := func() *map[string]*NodeUsage {
+		return &map[string]*NodeUsage{
+			"node1": {
+				Node:     &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				NodeInfo: &device.NodeInfo{},
+				Devices: policy.DeviceUsageList{
+					Policy: util.GPUSchedulerPolicySpread.String(),
+					DeviceLists: []*policy.DeviceListsScore{
+						{
+							Device: &device.DeviceUsage{
+								ID: "uuid-a", Index: 0, Type: "mockA",
+								Count: 4, Used: 0, Totalcore: 100, Usedcores: 0,
+								Totalmem: 8192, Usedmem: 0, Health: true,
+							},
+						},
+						{
+							Device: &device.DeviceUsage{
+								ID: "uuid-b", Index: 0, Type: "mockB",
+								Count: 4, Used: 0, Totalcore: 100, Usedcores: 0,
+								Totalmem: 8192, Usedmem: 0, Health: true,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		resourceReqs device.PodDeviceRequests
+		wantA        device.PodSingleDevice
+		wantB        device.PodSingleDevice
+	}{
+		{
+			name: "container0 requests mockA and container1 requests mockB",
+			resourceReqs: device.PodDeviceRequests{
+				{"mockA": {Nums: 1, Type: "mockA", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+				{"mockB": {Nums: 1, Type: "mockB", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+			},
+			wantA: device.PodSingleDevice{
+				{{Idx: 0, UUID: "uuid-a", Type: "mockA"}},
+				{},
+			},
+			wantB: device.PodSingleDevice{
+				{},
+				{{Idx: 0, UUID: "uuid-b", Type: "mockB"}},
+			},
+		},
+		{
+			name: "container1 requests mockB after a no-device container0",
+			resourceReqs: device.PodDeviceRequests{
+				{},
+				{"mockB": {Nums: 1, Type: "mockB", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+			},
+			wantA: nil,
+			wantB: device.PodSingleDevice{
+				{},
+				{{Idx: 0, UUID: "uuid-b", Type: "mockB"}},
+			},
+		},
+		{
+			name: "container0 requests mockA and container2 requests mockB with a no-device container1 in between",
+			resourceReqs: device.PodDeviceRequests{
+				{"mockA": {Nums: 1, Type: "mockA", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+				{},
+				{"mockB": {Nums: 1, Type: "mockB", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+			},
+			wantA: device.PodSingleDevice{
+				{{Idx: 0, UUID: "uuid-a", Type: "mockA"}},
+				{},
+				{},
+			},
+			wantB: device.PodSingleDevice{
+				{},
+				{},
+				{{Idx: 0, UUID: "uuid-b", Type: "mockB"}},
+			},
+		},
+	}
+
+	s := NewScheduler()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			task := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}, {Name: "c2"}},
+				},
+			}
+			got, err := s.calcScore(node(), test.resourceReqs, task, map[string]string{})
+			assert.NilError(t, err)
+			assert.Assert(t, got != nil)
+			assert.Equal(t, len(got.NodeList), 1)
+
+			devs := got.NodeList[0].Devices
+			assert.DeepEqual(t, devs["mockA"], test.wantA)
+			assert.DeepEqual(t, devs["mockB"], test.wantB)
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does
Fixes container-index misalignment of per-type device allocations in `calcScoreWithOptions` (`pkg/scheduler/score.go`).

## Why
For a pod whose containers request **different** device types (e.g. c0=NVIDIA, c1=kunlun), the fill loop prepended an empty slot to every already-discovered type, shifting previously-aligned allocations right by one container. `PatchAnnotations` → `EncodePodSingleDevice` → device-plugin `DecodePodDevices` restore devices by container index, so the wrong container receives the device. The fill loop also recorded `deviceType` from an arbitrary map key, so a no-device container padded only one randomly-chosen type.

See #2335.

## What changed
- New helper `padDeviceAllocations`:
  - types requested by the current container: prepend the missing leading empty slots (fixes late-discovery of a type after no-device containers),
  - other discovered types: append a single trailing empty slot,
  - a container with no device requests: append an empty slot to **all** discovered types.
- Regression tests (`Test_calcScore_MultiTypeContainerAlignment`) covering c0=mockA/c1=mockB, a type first discovered after a no-device container, and a no-device container between two different types.

## Verification
- The alignment algorithm was validated against the real `device` types for 10 scenarios (A–G + 3 regression cases), all pass.
- Full scheduler package cannot compile locally (Windows host; go-nvml requires `dlfcn.h`), so CI (Linux) runs the scheduler unit tests.

## AI assistance disclosure
The PR description was generated with the help of AI assistance.

Fixes #2335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling accuracy when containers request different device types or no devices.
  * Preserved consistent device-allocation positions across all containers, preventing mismatched allocation data.

* **Tests**
  * Added coverage for multi-device-type and device-free container scheduling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->