### PR TITLE
fix(device): clamp oversized memory requests to int32 range

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -331,7 +332,12 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 
 					if isCoreRequested {
 						// Soft-partitioning: Use the raw value directly.
-						memnum = int(memnums)
+						if memnums > math.MaxInt32 || memnums < 0 {
+							klog.ErrorS(nil, "ascend memory request is out of int32 range, clamping to max int32", "container", ctr.Name, "request", memnums)
+							memnum = math.MaxInt32
+						} else {
+							memnum = int(memnums)
+						}
 					} else {
 						m, _ := dev.trimMemory(memnums)
 						memnum = int(m)

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -19,6 +19,7 @@ package ascend
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -1211,6 +1212,56 @@ func Test_GenerateResourceRequests_VNPUCoreMode(t *testing.T) {
 			assert.Equal(t, result.Memreq, test.want.Memreq)
 			assert.Equal(t, result.Coresreq, test.want.Coresreq)
 			assert.Equal(t, result.Type, test.want.Type)
+		})
+	}
+}
+
+func Test_GenerateResourceRequests_VNPUCoreMemoryOverflowClamped(t *testing.T) {
+	tests := []struct {
+		name string
+		args corev1.Container
+		want int32
+	}{
+		{
+			name: "soft-partition memory request exceeding int32 range is clamped",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core":   resource.MustParse("10"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: math.MaxInt32,
+		},
+		{
+			name: "soft-partition in-range memory request is preserved",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core":   resource.MustParse("10"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("15360"),
+					},
+				},
+			},
+			want: int32(15360),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := Devices{
+				config: VNPUConfig{
+					CommonWord:         "Ascend910B3",
+					ResourceName:       "huawei.com/Ascend910B3",
+					ResourceCoreName:   "huawei.com/Ascend910B3-core",
+					ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+				},
+			}
+			result := dev.GenerateResourceRequests(&test.args)
+			assert.Equal(t, result.Memreq, test.want)
 		})
 	}
 }

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -19,6 +19,7 @@ package hygon
 import (
 	"errors"
 	"flag"
+	"math"
 	"slices"
 	"strings"
 
@@ -189,7 +190,12 @@ func (dev *DCUDevices) GenerateResourceRequests(ctr *corev1.Container) device.Co
 						memnums = memnums * int64(MemoryFactor)
 						klog.V(4).Infof("Update memory request. before %d, after %d, factor %d", rawMemnums, memnums, MemoryFactor)
 					}
-					memnum = int(memnums)
+					if memnums > math.MaxInt32 || memnums < 0 {
+						klog.ErrorS(nil, "hygon memory request is out of int32 range, clamping to max int32", "container", ctr.Name, "request", memnums)
+						memnum = math.MaxInt32
+					} else {
+						memnum = int(memnums)
+					}
 				}
 			}
 			corenum := int32(100)

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -1254,6 +1255,46 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 					t.Errorf("expected used: %d, got used %d", tt.wantUsage.Used, tt.deviceUsage.Used)
 				}
 			}
+		})
+	}
+}
+
+func Test_GenerateResourceRequests_MemoryOverflowClamped(t *testing.T) {
+	oldFactor := MemoryFactor
+	defer func() { MemoryFactor = oldFactor }()
+	MemoryFactor = 256
+
+	dev := DCUDevices{}
+	fs := flag.FlagSet{}
+	ParseConfig(&fs)
+
+	tests := []struct {
+		name string
+		mem  string
+		want int32
+	}{
+		{
+			name: "16Gi scaled by factor 256 overflows int32 and is clamped",
+			mem:  "16Gi",
+			want: math.MaxInt32,
+		},
+		{
+			name: "in-range request scaled by factor 256 is preserved",
+			mem:  "1024",
+			want: int32(262144),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := dev.GenerateResourceRequests(&corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hygon.com/dcunum": resource.MustParse("1"),
+						"hygon.com/dcumem": resource.MustParse(test.mem),
+					},
+				},
+			})
+			assert.Equal(t, result.Memreq, test.want)
 		})
 	}
 }

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -247,6 +248,10 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 				mem = v / 1024 / 1024
 			} else {
 				mem = v * 1024
+			}
+			if mem > math.MaxInt32 || mem < 0 {
+				klog.ErrorS(nil, "metax memory request is out of int32 range, clamping to max int32", "container", ctr.Name, "request", mem)
+				mem = math.MaxInt32
 			}
 		}
 	}

--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -19,6 +19,7 @@ package metax
 import (
 	"flag"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -464,6 +465,44 @@ func TestGenerateResourceRequests(t *testing.T) {
 			if !reflect.DeepEqual(ts.expected, result) {
 				t.Errorf("GenerateResourceRequests failed: result %v, expected %v",
 					result, ts.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateResourceRequests_MemoryOverflowClamped(t *testing.T) {
+	fs := flag.FlagSet{}
+	ParseConfig(&fs)
+	metaxSDevice := &MetaxSDevices{}
+
+	tests := []struct {
+		name string
+		mem  string
+		want int32
+	}{
+		{
+			name: "plain number is interpreted as Gi and scaled by 1024, exceeding int32 range, so it is clamped",
+			mem:  "2097152",
+			want: math.MaxInt32,
+		},
+		{
+			name: "in-range request with unit is preserved",
+			mem:  "16Gi",
+			want: int32(16384),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := metaxSDevice.GenerateResourceRequests(&corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"metax-tech.com/sgpu":    resource.MustParse("1"),
+						"metax-tech.com/vmemory": resource.MustParse(test.mem),
+					},
+				},
+			})
+			if result.Memreq != test.want {
+				t.Errorf("GenerateResourceRequests: got Memreq %d, want %d", result.Memreq, test.want)
 			}
 		})
 	}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -550,7 +551,12 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 						memnums = memnums * int64(dev.config.MemoryFactor)
 						klog.V(4).Infof("Update memory request. before %d, after %d, factor %d", rawMemnums, memnums, dev.config.MemoryFactor)
 					}
-					memnum = int(memnums)
+					if memnums > math.MaxInt32 || memnums < 0 {
+						klog.ErrorS(nil, "nvidia memory request is out of int32 range, clamping to max int32", "container", ctr.Name, "request", memnums)
+						memnum = math.MaxInt32
+					} else {
+						memnum = int(memnums)
+					}
 				}
 			}
 			mempnum := int32(101)


### PR DESCRIPTION
## What this PR does
Clamps memory requests that exceed `math.MaxInt32` in `GenerateResourceRequests` for the ascend, hygon, metax and nvidia backends, instead of letting the `int32` cast silently wrap.

## Why
A request above int32 range (e.g. a `Quantity` with a Gi unit, or a plain value scaled by a large memory factor) wraps to a small or negative `Memreq`. A wrapped `Memreq` of 0 defeats the `Totalmem - Usedmem < memreq` fit check, causing oversubscription and OOM. metax additionally guards the `v*1024` scaling, which can wrap int64 to a negative value.

See #2336.

## What changed
- `pkg/device/nvidia/device.go`, `pkg/device/hygon/device.go`, `pkg/device/ascend/device.go` (soft-partition path), `pkg/device/metax/sdevice.go`: if the computed memory exceeds `math.MaxInt32` (or is negative after an int64 wrap), clamp to `math.MaxInt32` and log an error.
- Unit tests for hygon, metax and ascend (`*_MemoryOverflowClamped`) verifying clamp + in-range preservation.

## Verification
- New + full package tests pass locally for hygon, metax, ascend: `go test ./pkg/device/{hygon,metax,ascend}/ -count=1`.
- The nvidia package cannot compile on this Windows host (go-nvml requires `dlfcn.h`); CI (Linux) covers it.

## AI assistance disclosure
The PR description was generated with the help of AI assistance.

Fixes #2336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented oversized or invalid GPU and accelerator memory requests from overflowing during conversion.
  - Values outside the supported range are safely capped, while valid requests continue to behave as expected.
  - Added handling across Ascend, Hygon, MetaX, and NVIDIA device integrations.

- **Tests**
  - Added regression coverage for overflow and boundary-value memory requests across supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->