### PR TITLE
fix(cambricon): clamp oversized memory request before int32 conversion

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"slices"
 	"strings"
@@ -251,7 +252,12 @@ func (dev *CambriconDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 				memnums, ok := mem.AsInt64()
 				klog.Infoln("mluResourceMem", mem, memnums)
 				if ok {
-					memnum = int(memnums) * 256
+					if memnums > math.MaxInt32/256 || memnums < 0 {
+						klog.ErrorS(nil, "cambricon memory request is out of int32 range, clamping to max int32", "container", ctr.Name, "request", memnums)
+						memnum = math.MaxInt32
+					} else {
+						memnum = int(memnums * 256)
+					}
 				}
 			}
 			corenum := int32(100)

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -19,6 +19,7 @@ package cambricon
 import (
 	"context"
 	"flag"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -284,6 +285,44 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Type:             CambriconMLUDevice,
 				Memreq:           int32(0),
 				MemPercentagereq: int32(100),
+				Coresreq:         int32(2),
+			},
+		},
+		{
+			name: "vmemory expressed in Gi units no longer wraps to zero",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cambricon.com/mlu":              resource.MustParse("1"),
+						"cambricon.com/mlu.smlu.vmemory": resource.MustParse("16Gi"),
+						"cambricon.com/mlu.smlu.vcore":   resource.MustParse("2"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             CambriconMLUDevice,
+				Memreq:           int32(math.MaxInt32),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(2),
+			},
+		},
+		{
+			name: "oversized plain vmemory value clamps to max int32",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cambricon.com/mlu":              resource.MustParse("1"),
+						"cambricon.com/mlu.smlu.vmemory": resource.MustParse("10000000"),
+						"cambricon.com/mlu.smlu.vcore":   resource.MustParse("2"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             CambriconMLUDevice,
+				Memreq:           int32(math.MaxInt32),
+				MemPercentagereq: int32(0),
 				Coresreq:         int32(2),
 			},
 		},


### PR DESCRIPTION
## What this PR does
Clamps the cambricon memory request in `GenerateResourceRequests` to the int32 range instead of letting the `int32` cast silently wrap.

## Why
`memnums` is computed as a 64-bit int and then narrowed with `int32()`, which wraps to 0 for any request above `math.MaxInt32/256`. Requesting `cambricon.com/mlu.smlu.vmemory` in Gi units (e.g. 16Gi) therefore produced `Memreq=0`, so `Fit()` scheduled the pod with no memory accounting and could oversubscribe an already-full MLU. Same class of bug fixed for enflame (#2145/#2190) and addressed for the other backends in #2338.

See #2278.

## What changed
- `pkg/device/cambricon/device.go`: if the memory request exceeds `math.MaxInt32/256` (or is negative), clamp `memnum` to `math.MaxInt32` and log an error; otherwise apply the scaling.
- Unit test in `pkg/device/cambricon/device_test.go` verifying the clamp and in-range preservation.

## Verification
- New + existing cambricon package tests pass locally: `go test ./pkg/device/cambricon/ -count=1`.

## AI assistance disclosure
The PR description was generated with the help of AI assistance.

Fixes #2278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid or oversized Cambricon memory requests from overflowing.
  - Large and negative memory values are now safely capped at the supported maximum.
  - Valid memory requests continue to be converted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->