### PR TITLE
feat(metrics): record scheduling duration and attempt counters in scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
@@ -55,6 +57,24 @@ const (
 	defaultResync    = 1 * time.Hour
 	syncedPollPeriod = 100 * time.Millisecond
 )
+
+var (
+	schedulingDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "hami_scheduler_scheduling_duration_seconds",
+		Help:    "Duration of pod scheduling filter and score execution in seconds",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	schedulingAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hami_scheduler_scheduling_attempts_total",
+		Help: "Total number of pod scheduling attempts by result and reason",
+	}, []string{"result", "reason"})
+)
+
+func init() {
+	_ = prometheus.Register(schedulingDuration)
+	_ = prometheus.Register(schedulingAttempts)
+}
 
 type Scheduler struct {
 	*nodeManager
@@ -900,6 +920,11 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 }
 
 func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFilterResult, error) {
+	start := time.Now()
+	defer func() {
+		schedulingDuration.Observe(time.Since(start).Seconds())
+	}()
+
 	klog.InfoS("Starting schedule filter process", "pod", args.Pod.Name, "uuid", args.Pod.UID, "namespace", args.Pod.Namespace)
 	resourceReqs := device.Resourcereqs(args.Pod)
 	resourceReqTotal := 0
@@ -912,6 +937,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		klog.V(1).InfoS("Pod does not request any resources",
 			"pod", args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("does not request any resource"))
+		schedulingAttempts.WithLabelValues("failed", "no_resource_requested").Inc()
 		if args.Nodes != nil {
 			return &extenderv1.ExtenderFilterResult{
 				Nodes:       args.Nodes,
@@ -943,6 +969,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	nodeUsage, _, failedNodes, err := s.getNodesUsage(args.NodeNames, args.Pod)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		schedulingAttempts.WithLabelValues("failed", "get_nodes_usage_error").Inc()
 		return nil, err
 	}
 	if len(failedNodes) != 0 {
@@ -953,12 +980,14 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	if err != nil {
 		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		schedulingAttempts.WithLabelValues("failed", "calc_score_error").Inc()
 		return nil, err
 	}
 	if len((*nodeScores).NodeList) == 0 {
 		klog.V(4).InfoS("No available nodes meet the required scores",
 			"pod", args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
+		schedulingAttempts.WithLabelValues("failed", "no_available_node").Inc()
 		return &extenderv1.ExtenderFilterResult{
 			FailedNodes: failedNodes,
 		}, nil
@@ -987,6 +1016,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	err = util.PatchPodAnnotations(args.Pod, annotations)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		schedulingAttempts.WithLabelValues("failed", "patch_annotations_error").Inc()
 		if added {
 			s.quotaManager.RmUsage(args.Pod, m.Devices)
 		}
@@ -995,6 +1025,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	}
 	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, nodeScores.NodeList)
 	s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringSucceed, successMsg, nil)
+	schedulingAttempts.WithLabelValues("success", "scheduled").Inc()
 	res := extenderv1.ExtenderFilterResult{NodeNames: &[]string{m.NodeID}}
 	return &res, nil
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -2306,4 +2307,35 @@ func Test_Bind_PodGroupPodNonContentionErrorDoesNotRetry(t *testing.T) {
 	require.Contains(t, res.Error, "apiserver 500")
 	require.Equal(t, int32(1), mock.lockCalls.Load(),
 		"non-contention error must not trigger retry")
+}
+
+func TestSchedulingMetricsRecording(t *testing.T) {
+	s := &Scheduler{
+		quotaManager: device.NewQuotaManager(),
+		podManager:   device.NewPodManager(),
+	}
+
+	podNoRes := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-no-res",
+			Namespace: "default",
+		},
+	}
+
+	nodes := []string{"node-1"}
+	args := extenderv1.ExtenderArgs{
+		Pod:       podNoRes,
+		NodeNames: &nodes,
+	}
+
+	beforeCount := testutil.ToFloat64(schedulingAttempts.WithLabelValues("failed", "no_resource_requested"))
+
+	_, err := s.Filter(args)
+	require.NoError(t, err)
+
+	afterCount := testutil.ToFloat64(schedulingAttempts.WithLabelValues("failed", "no_resource_requested"))
+	require.Equal(t, beforeCount+1, afterCount, "expected schedulingAttempts counter to increment by 1")
+
+	histCount := testutil.CollectAndCount(schedulingDuration)
+	require.Greater(t, histCount, 0, "expected schedulingDuration metric to be collected")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, `pkg/scheduler/scheduler.go` does not record any Prometheus duration histograms or attempt counters during the Pod scheduling loop.
In this PR we added control plane telemetry to `pkg/scheduler`:
1. `hami_scheduler_scheduling_duration_seconds` (Histogram): Measures execution duration of `Filter()` and `Score()` scheduling decisions in seconds.
2. `hami_scheduler_scheduling_attempts_total` (Counter): Tracks total Pod scheduling attempts labeled by `result` (`"success"` / `"failed"`) and `reason`.

This brings HAMi's scheduler extender in line with standard Kubernetes `kube-scheduler` metrics conventions (`scheduler_scheduling_attempt_duration_seconds`).

**Which issue(s) this PR fixes**:
Fixes #2341 

**AI Assistance Disclosure**:
I used AI assistance to analyze codebase patterns and structure tests and format the PR description, but all changes were manually inspected, written, and verified.


**Special notes for your reviewer**:
Unit test `TestSchedulingMetricsRecording` added in `pkg/scheduler/scheduler_test.go` and verified 100% PASS.
<img width="473" height="60" alt="image" src="https://github.com/user-attachments/assets/c9792330-7df1-405f-ab2a-fa3f6aef60d2" />

**Does this PR introduce a user-facing change?**:
```release-note
Expose `hami_scheduler_scheduling_duration_seconds` histogram and `hami_scheduler_scheduling_attempts_total` counter in scheduler extender.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for scheduler performance, including filtering and scoring duration.
  * Added scheduling attempt counters covering successful scheduling and common failure conditions, such as insufficient resources, unavailable nodes, and scoring or annotation errors.
  * These metrics provide improved visibility into scheduling behavior and help identify performance bottlenecks or failure trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->