### PR TITLE
docs: remove duplicated A100 model and fix full-width parentheses in …

### DIFF
--- a/docs/develop/dynamic-mig.md
+++ b/docs/develop/dynamic-mig.md
@@ -45,7 +45,7 @@ data:
             - name: 4g.24gb
               memory: 24576
               count: 1
-      - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB", "A100-SXM4-40GB" ]
+      - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB" ]
         allowedGeometries:
           - 
             - name: 1g.5gb
@@ -130,7 +130,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-          nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory （Optional,Integer)
+          nvidia.com/gpumem: 8000 # Each vGPU contains 8000M device memory (Optional, Integer)
 ```
 
 A task can decide only to use `mig` or `hami-core` by setting `annotations.nvidia.com/vgpu-mode` to corresponding value, as the example below shows:
@@ -150,7 +150,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-          nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory （Optional,Integer
+          nvidia.com/gpumem: 8000 # Each vGPU contains 8000M device memory (Optional, Integer)
 ```
 
 ## Procedures


### PR DESCRIPTION
## What this PR does

Fixes the example config in `docs/develop/dynamic-mig.md`:

- The `knownMigGeometries` example listed `"A100-SXM4-40GB"` twice in the
  same models array. The actual default config in
  `charts/hami/templates/scheduler/device-configmap.yaml` has no duplicate,
  so the doc now matches it.
- Two YAML comments used Chinese full-width parentheses (`（Optional,Integer)`),
  and the second one was never closed. Replaced with `(Optional, Integer)`.

Documentation-only change, no code affected.

## AI Assistance Disclosure

This PR was prepared with AI assistance (docs only). I have reviewed
every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected dynamic MIG configuration examples by removing a duplicate GPU model.
  * Fixed formatting and notation inconsistencies, including unit capitalization, parentheses, and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->