### PR TITLE
docs: fix grammar and unbalanced parentheses in scheduler-policy.md

### DIFF
--- a/docs/develop/scheduler-policy.md
+++ b/docs/develop/scheduler-policy.md
@@ -2,29 +2,29 @@
 
 ## Summary
 
-Current in a cluster with many GPU nodes, nodes are not `binpack` or `spread` when making scheduling decisions, nor are GPU cards `binpack` or `spread` when using vGPU.
+Currently, in a cluster with many GPU nodes, nodes are not `binpack` or `spread` when making scheduling decisions, nor are GPU cards `binpack` or `spread` when using vGPU.
 
 ## Proposal
 
-We add a `node-scheduler-policy` and `gpu-scheduler-policy` to config, then scheduler to use this policy can impl node `binpack` or `spread` or GPU `binpack` or `spread`. and
-use can set Pod annotation to change this default policy, use `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` to overlay scheduler config.
+We add a `node-scheduler-policy` and `gpu-scheduler-policy` to the config, so the scheduler can implement node `binpack` or `spread` and GPU `binpack` or `spread`. Users can
+set Pod annotations to change this default policy, using `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` to override the scheduler config.
 
 ### User Stories
 
-This is a GPU cluster, having two node, the following story takes this cluster as a prerequisite.
+This is a GPU cluster with two nodes; the following stories take this cluster as a prerequisite.
 
 ![scheduler-policy-story.png](./imgs/scheduler-policy-story.png)
 
 #### Story 1
 
-node binpack, use one node’s GPU card whenever possible, egs:
+node binpack, use one node’s GPU card whenever possible, e.g.:
 - cluster resources:
-  - node1: GPU having 4 GPU device
-  - node2: GPU having 4 GPU device
+  - node1: GPU having 4 GPU devices
+  - node2: GPU having 4 GPU devices
 
 - request:
-  - pod1: User 1 GPU
-  - pod2: User 1 GPU
+  - pod1: Uses 1 GPU
+  - pod2: Uses 1 GPU
 
 - scheduler result:
   - pod1: scheduler to node1
@@ -32,15 +32,15 @@ node binpack, use one node’s GPU card whenever possible, egs:
 
 #### Story 2
 
-node spread, use GPU cards from different nodes as much as possible, egs:
+node spread, use GPU cards from different nodes as much as possible, e.g.:
 
 - cluster resources:
-    - node1: GPU having 4 GPU device
-    - node2: GPU having 4 GPU device
+    - node1: GPU having 4 GPU devices
+    - node2: GPU having 4 GPU devices
 
 - request:
-    - pod1: User 1 GPU
-    - pod2: User 1 GPU
+    - pod1: Uses 1 GPU
+    - pod2: Uses 1 GPU
 
 - scheduler result:
     - pod1: scheduler to node1
@@ -48,14 +48,14 @@ node spread, use GPU cards from different nodes as much as possible, egs:
 
 #### Story 3
 
-GPU binpack, use the same GPU card as much as possible, egs:
+GPU binpack, use the same GPU card as much as possible, e.g.:
 
 - cluster resources:
-    - node1: GPU having 4 GPU device, they are GPU1,GPU2,GPU3,GPU4
+    - node1: GPU having 4 GPU devices, they are GPU1,GPU2,GPU3,GPU4
 
 - request:
-    - pod1: User 1 GPU, gpucore is 20%, gpumem-percentage is 20% 
-    - pod2: User 1 GPU, gpucore is 20%, gpumem-percentage is 20%
+    - pod1: Uses 1 GPU, gpucore is 20%, gpumem-percentage is 20%
+    - pod2: Uses 1 GPU, gpucore is 20%, gpumem-percentage is 20%
 
 - scheduler result:
     - pod1: scheduler to node1, select GPU1 this device
@@ -63,14 +63,14 @@ GPU binpack, use the same GPU card as much as possible, egs:
 
 #### Story 4
 
-GPU spread, use different GPU cards when possible, egs:
+GPU spread, use different GPU cards when possible, e.g.:
 
 - cluster resources:
-    - node1: GPU having 4 GPU device, they are GPU1,GPU2,GPU3,GPU4
+    - node1: GPU having 4 GPU devices, they are GPU1,GPU2,GPU3,GPU4
 
 - request:
-    - pod1: User 1 GPU, gpucore is 20%, gpumem-percentage is 20%
-    - pod2: User 1 GPU, gpucore is 20%, gpumem-percentage is 20%
+    - pod1: Uses 1 GPU, gpucore is 20%, gpumem-percentage is 20%
+    - pod2: Uses 1 GPU, gpucore is 20%, gpumem-percentage is 20%
 
 - scheduler result:
     - pod1: scheduler to node1, select GPU1 this device
@@ -84,10 +84,10 @@ GPU spread, use different GPU cards when possible, egs:
 
 #### Binpack
 
-Binpack mainly considers node resource usage. The more full the usage, the higher the score.
+Binpack mainly considers node resource usage. The fuller the usage, the higher the score.
 
 ```
-score: ((request + used) / allocatable) * 10 
+score: ((request + used) / allocatable) * 10
 ```
 
 1. Binpack scoring information for Node 1 is as follows
@@ -109,7 +109,7 @@ So, in `Binpack` policy we can select `Node1`.
 Spread mainly considers node resource usage. The less it is used, the lower the score. Spread selects the node with the lowest score.
 
 ```
-score: ((request + used) / allocatable) * 10 
+score: ((request + used) / allocatable) * 10
 ```
 
 1. Spread scoring information for Node 1 is as follows
@@ -132,17 +132,17 @@ So, in `Spread` policy we can select `Node2`.
 
 Binpack mainly focuses on the computing power and video memory usage of each card. The more it is used, the higher the score.
 ```
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. Binpack scoring information for GPU 1 is as follows
 ```
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((20+10)/100 + (1000+2000)/8000) * 10 = 6.75
 ```
 
 2. Binpack scoring information for GPU 2 is as follows
 ```
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((20+70)/100 + (1000+6000)/8000) * 10 = 17.75
 ```
 
 So, in `Binpack` policy we can select `GPU2`.
@@ -151,17 +151,17 @@ So, in `Binpack` policy we can select `GPU2`.
 
 Spread mainly focuses on the computing power and video memory usage of each card. The less it is used, the lower the score. Spread selects the GPU with the lowest score.
 ```
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. Spread scoring information for GPU 1 is as follows
 ```
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((20+10)/100 + (1000+2000)/8000) * 10 = 6.75
 ```
 
 2. Spread scoring information for GPU 2 is as follows
 ```
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((20+70)/100 + (1000+6000)/8000) * 10 = 17.75
 ```
 
 So, in `Spread` policy we can select `GPU1`.


### PR DESCRIPTION
## What this PR does

Fixes several small issues in `docs/develop/scheduler-policy.md`:

- The GPU binpack/spread score formulas and worked examples had an extra
  closing parenthesis, e.g. `... / allocatable.mem)) * 10`.
- Grammar fixes: "Current in a cluster" → "Currently, in a cluster",
  "use can set" → "users can set", "User 1 GPU" → "Uses 1 GPU",
  "egs:" → "e.g.:", singular/plural fixes.
- Removed trailing whitespace in code blocks.

Documentation-only change, no code affected.

## AI Assistance Disclosure

This PR was prepared with AI assistance (docs only). I have reviewed
every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified scheduler policies for node and GPU bin-packing and spreading.
  * Documented configuration options and Pod annotation overrides.
  * Corrected scoring formulas, examples, and terminology for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->