### PR TITLE
docs: fix header typo, capitalization, and table alignment in roadmap.md

### DIFF
--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -1,18 +1,18 @@
-# roadmap
-| Production | Manufacturer  | Type             | MemoryIsolation | CoreIsolation | MultiCard support |
+# Roadmap
+| Product    | Manufacturer  | Type             | MemoryIsolation | CoreIsolation | MultiCard support |
 |------------|---------------|------------------|-----------------|---------------|-------------------|
 | GPU        | NVIDIA        | All              | ✅              | ✅            | ✅                |
 | MLU        | Cambricon     | 370, 590         | ✅              | ✅            | ❌                |
 | GCU        | Enflame       | S60              | ✅              | ✅            | ❌                |
 | DCU        | Hygon         | Z100, Z100L      | ✅              | ✅            | ❌                |
 | NPU        | Ascend        | 310P, 910B, 910B3| ✅              | ✅            | ❌                |
-| GPU        | iluvatar      | All              | ✅              | ✅            | ❌                |
+| GPU        | Iluvatar      | All              | ✅              | ✅            | ❌                |
 | DPU        | Teco          | Checking         | In progress     | In progress   | ❌                |
 | GPU        | Moore Threads | MTT S4000        | ✅              | ✅            | ❌                |
 | GPU        | Birentech     | Biren166M        | ✅              | ✅            | ❌                |
 | GPU        | MetaX         | MXC500           | ✅              | ✅            | ❌                |
 | XPU        | Kunlunxin     | P800             | ✅              | ✅            | ❌                |
-| GPU        | Vastai        | VA16             | ✅              | ✅            | ❌              |      
+| GPU        | Vastai        | VA16             | ✅              | ✅            | ❌                |
 
 
 - [ ] Support video codec processing


### PR DESCRIPTION
## What this PR does

Cleans up the device support matrix in `docs/develop/roadmap.md`:

- Table header "Production" → "Product".
- "iluvatar" → "Iluvatar" to match the capitalization of other vendors.
- Fixed the misaligned Vastai row and removed trailing whitespace.
- Page title "# roadmap" → "# Roadmap".

Documentation-only change, no code affected.

## AI Assistance Disclosure

This PR was prepared with AI assistance (docs only). I have reviewed
every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization and formatting in the development roadmap.
  * Fixed a table header and manufacturer name.
  * Removed trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->