### PR TITLE
fix(scheduler): enforce ResourceQuota for every device backend

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -416,6 +416,7 @@ func (dev *Devices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  dev.config.ResourceName,
 		ResourceMemoryName: dev.config.ResourceMemoryName,
 		ResourceCoreName:   dev.config.ResourceCoreName,
+		MemoryFactor:       dev.config.MemoryFactor,
 	}
 }
 

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -429,5 +429,6 @@ func (dev *CambriconDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  MLUResourceCount,
 		ResourceMemoryName: MLUResourceMemory,
 		ResourceCoreName:   MLUResourceCores,
+		MemoryFactor:       MemoryFactor,
 	}
 }

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -54,6 +54,9 @@ const (
 	DsmluProfile          = "CAMBRICON_DSMLU_PROFILE"
 	DsmluResourceAssigned = "CAMBRICON_DSMLU_ASSIGNED"
 	retry                 = 5
+	// MemoryFactor converts the vmemory unit used in the pod spec into the MiB
+	// HAMi accounts internally. One cambricon.com/mlu.smlu.vmemory is 256 MiB.
+	MemoryFactor = 256
 )
 
 var (
@@ -198,7 +201,7 @@ func (dev *CambriconDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo
 			Index:        uint(i),
 			ID:           n.Name + "-cambricon-mlu-" + fmt.Sprint(i),
 			Count:        100,
-			Devmem:       int32(memoryTotal * 256 * 100 / cards),
+			Devmem:       int32(memoryTotal * MemoryFactor * 100 / cards),
 			Devcore:      100,
 			Type:         CambriconMLUDevice,
 			Numa:         0,
@@ -251,7 +254,7 @@ func (dev *CambriconDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 				memnums, ok := mem.AsInt64()
 				klog.Infoln("mluResourceMem", mem, memnums)
 				if ok {
-					memnum = int(memnums) * 256
+					memnum = int(memnums) * MemoryFactor
 				}
 			}
 			corenum := int32(100)

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -160,6 +160,12 @@ type ResourceNames struct {
 	ResourceCountName  string
 	ResourceMemoryName string
 	ResourceCoreName   string
+	// MemoryFactor is the scale GenerateResourceRequests applies to the memory
+	// value read off the container spec. Recorded usage is in scaled units
+	// while a ResourceQuota limit is written in unscaled ones, so a quota check
+	// has to bring the limit up by the same factor. Backends that do not scale
+	// leave this zero.
+	MemoryFactor int32
 }
 
 type ContainerDevice struct {

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -352,5 +352,6 @@ func (dev *DCUDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  HygonResourceCount,
 		ResourceMemoryName: HygonResourceMemory,
 		ResourceCoreName:   HygonResourceCores,
+		MemoryFactor:       MemoryFactor,
 	}
 }

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -368,5 +368,6 @@ func (dev *IluvatarDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  dev.config.ResourceCountName,
 		ResourceMemoryName: dev.config.ResourceMemoryName,
 		ResourceCoreName:   dev.config.ResourceCoreName,
+		MemoryFactor:       MemoryFactor,
 	}
 }

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -33,6 +33,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// MemoryFactor converts the vmemory unit used in the pod spec into the MiB
+// HAMi accounts internally. One iluvatar vmemory unit is 256 MiB.
+const MemoryFactor = 256
+
 var (
 	enableIluvatar bool
 )
@@ -213,7 +217,7 @@ func (dev *IluvatarDevices) GenerateResourceRequests(ctr *corev1.Container) devi
 			if ok {
 				memnums, ok := mem.AsInt64()
 				if ok {
-					memnum = int(memnums) * 256
+					memnum = int(memnums) * MemoryFactor
 				}
 			}
 			corenum := int32(0)

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -41,6 +41,10 @@ const (
 	MetaxSGPUDevice     = "Metax-SGPU"
 
 	MetaxNodeLock = "hami.io/mutex.lock"
+
+	// MemoryFactor converts the vmemory unit used in the pod spec into the MiB
+	// HAMi accounts internally. A bare vmemory value is read as Gi.
+	MemoryFactor = 1024
 )
 
 const (
@@ -246,7 +250,7 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 			if hasUnit {
 				mem = v / 1024 / 1024
 			} else {
-				mem = v * 1024
+				mem = v * MemoryFactor
 			}
 		}
 	}

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -480,6 +480,7 @@ func (dev *MetaxSDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  MetaxResourceNameVCount,
 		ResourceMemoryName: MetaxResourceNameVMemory,
 		ResourceCoreName:   MetaxResourceNameVCore,
+		MemoryFactor:       MemoryFactor,
 	}
 }
 

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -51,6 +51,9 @@ const (
 	MthreadsPredicateTime    = "mthreads.com/predicate-time"
 	coresPerMthreadsGPU      = 16
 	memoryPerMthreadsGPU     = 96
+	// MemoryFactor converts the vmemory unit used in the pod spec into the MiB
+	// HAMi accounts internally. One mthreads vmemory unit is 512 MiB.
+	MemoryFactor = 512
 )
 
 var (
@@ -137,7 +140,7 @@ func (dev *MthreadsDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo,
 			Index:        uint(i),
 			ID:           n.Name + "-mthreads-" + fmt.Sprint(i),
 			Count:        100,
-			Devmem:       int32(memoryTotal * 512 * coresPerMthreadsGPU / cores),
+			Devmem:       int32(memoryTotal * MemoryFactor * coresPerMthreadsGPU / cores),
 			Devcore:      coresPerMthreadsGPU,
 			Type:         MthreadsGPUDevice,
 			Numa:         0,
@@ -221,7 +224,7 @@ func (dev *MthreadsDevices) GenerateResourceRequests(ctr *corev1.Container) devi
 			if ok {
 				memnums, ok := mem.AsInt64()
 				if ok {
-					memnum = int(memnums) * 512
+					memnum = int(memnums) * MemoryFactor
 					klog.InfoS("Memory allocation calculated",
 						"container", ctr.Name,
 						"requestedMem", memnums,

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -403,5 +403,6 @@ func (dev *MthreadsDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  MthreadsResourceCount,
 		ResourceMemoryName: MthreadsResourceMemory,
 		ResourceCoreName:   MthreadsResourceCores,
+		MemoryFactor:       MemoryFactor,
 	}
 }

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -893,6 +893,7 @@ func (dev *NvidiaGPUDevices) GetResourceNames() device.ResourceNames {
 		ResourceCountName:  dev.config.ResourceCountName,
 		ResourceMemoryName: dev.config.ResourceMemoryName,
 		ResourceCoreName:   dev.config.ResourceCoreName,
+		MemoryFactor:       dev.config.MemoryFactor,
 	}
 }
 

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
-	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
 
@@ -130,46 +129,31 @@ func isPrivilegedContainer(ctr *corev1.Container) bool {
 
 func fitResourceQuota(pod *corev1.Pod) bool {
 	for deviceName, dev := range device.GetDevices() {
-		// Only supports NVIDIA
-		if deviceName != nvidia.NvidiaGPUDevice {
+		resourceNames := dev.GetResourceNames()
+		if len(resourceNames.ResourceMemoryName) == 0 && len(resourceNames.ResourceCoreName) == 0 {
+			// Nothing this backend exposes can carry a quota.
 			continue
 		}
-		memoryFactor := nvidia.MemoryFactor
-		resourceNames := dev.GetResourceNames()
-		resourceName := corev1.ResourceName(resourceNames.ResourceCountName)
-		memResourceName := corev1.ResourceName(resourceNames.ResourceMemoryName)
-		coreResourceName := corev1.ResourceName(resourceNames.ResourceCoreName)
-		var memoryReq int64 = 0
-		var coresReq int64 = 0
-		getRequest := func(ctr *corev1.Container, resName corev1.ResourceName) (int64, bool) {
-			v, ok := ctr.Resources.Limits[resName]
-			if !ok {
-				v, ok = ctr.Resources.Requests[resName]
+
+		// Ask the backend what the pod is requesting rather than reading the
+		// container spec here. It applies its own memory factor, defaults and
+		// template rounding, which is what the scheduler later records as used,
+		// so this keeps admission and the scheduler on the same numbers.
+		var memoryReq, coresReq int64
+		for i := range pod.Spec.Containers {
+			req := dev.GenerateResourceRequests(&pod.Spec.Containers[i])
+			if req.Nums == 0 {
+				continue
 			}
-			if ok {
-				if n, ok := v.AsInt64(); ok {
-					return n, true
-				}
-			}
-			return 0, false
+			memoryReq += int64(req.Memreq) * int64(req.Nums)
+			coresReq += int64(req.Coresreq) * int64(req.Nums)
 		}
-		for _, ctr := range pod.Spec.Containers {
-			req, ok := getRequest(&ctr, resourceName)
-			if ok {
-				if memReq, ok := getRequest(&ctr, memResourceName); ok {
-					memoryReq += memReq * req
-				}
-				if coreReq, ok := getRequest(&ctr, coreResourceName); ok {
-					coresReq += coreReq * req
-				}
-			}
+		if memoryReq == 0 && coresReq == 0 {
+			continue
 		}
-		if memoryFactor > 1 {
-			oriMemReq := memoryReq
-			memoryReq = memoryReq * int64(memoryFactor)
-			klog.V(5).Infof("Adjusting memory request for quota check: oriMemReq %d, memoryReq %d, factor %d", oriMemReq, memoryReq, memoryFactor)
-		}
-		if !device.GetLocalCache().FitQuota(pod.Namespace, memoryReq, memoryFactor, coresReq, deviceName) {
+
+		klog.V(5).Infof("Checking quota for device %s: memory %d, cores %d, factor %d", deviceName, memoryReq, coresReq, resourceNames.MemoryFactor)
+		if !device.GetLocalCache().FitQuota(pod.Namespace, memoryReq, resourceNames.MemoryFactor, coresReq, deviceName) {
 			klog.Infof(template+" - Denying admission", pod.Namespace, pod.Name, pod.UID)
 			return false
 		}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"flag"
 	"strings"
 	"testing"
 
@@ -31,6 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/ascend"
+	"github.com/Project-HAMi/HAMi/pkg/device/cambricon"
+	"github.com/Project-HAMi/HAMi/pkg/device/hygon"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
@@ -422,6 +426,261 @@ func TestFitResourceQuota(t *testing.T) {
 				t.Errorf("Expected %v, but got %v", tc.fit, result)
 			}
 		})
+	}
+}
+
+// mluPod builds a pod requesting one MLU with the given vmemory and vcore.
+func mluPod(ns string, vmemory, vcore string) *corev1.Pod {
+	limits := corev1.ResourceList{
+		"cambricon.com/mlu":              resource.MustParse("1"),
+		"cambricon.com/mlu.smlu.vmemory": resource.MustParse(vmemory),
+	}
+	if vcore != "" {
+		limits["cambricon.com/mlu.smlu.vcore"] = resource.MustParse(vcore)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlu-pod", Namespace: ns},
+		Spec: corev1.PodSpec{
+			SchedulerName: "hami-scheduler",
+			Containers: []corev1.Container{{
+				Name:      "container1",
+				Resources: corev1.ResourceRequirements{Limits: limits},
+			}},
+		},
+	}
+}
+
+// Quota used to be checked for NVIDIA only, so a namespace limit on any other
+// vendor's memory or cores was silently ignored.
+func TestFitResourceQuotaNonNvidia(t *testing.T) {
+	config.SchedulerName = "hami-scheduler"
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "nvidia.com/gpu",
+			ResourceMemoryName:           "nvidia.com/gpumem",
+			ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+			ResourceCoreName:             "nvidia.com/gpucores",
+			DefaultGPUNum:                1,
+			MemoryFactor:                 1,
+		},
+		CambriconConfig: cambricon.CambriconConfig{
+			ResourceCountName:  "cambricon.com/mlu",
+			ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+			ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+		},
+		HygonConfig: hygon.HygonConfig{
+			ResourceCountName:  "hygon.com/dcunum",
+			ResourceMemoryName: "hygon.com/dcumem",
+			ResourceCoreName:   "hygon.com/dcucores",
+			// Hygon scales the requested memory by this before recording it.
+			MemoryFactor: 2,
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("failed to initialize devices: %v", err)
+	}
+
+	qm := device.NewQuotaManager()
+
+	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
+	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
+	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+	}
+	qm.Quotas["mlu-core"] = &device.DeviceQuota{
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+	}
+	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+	}
+	t.Cleanup(func() {
+		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
+			delete(qm.Quotas, ns)
+		}
+	})
+
+	dcuPod := func(ns, dcumem string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "dcu-pod", Namespace: ns},
+			Spec: corev1.PodSpec{
+				SchedulerName: "hami-scheduler",
+				Containers: []corev1.Container{{
+					Name: "container1",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("1"),
+							"hygon.com/dcumem": resource.MustParse(dcumem),
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name string
+		pod  *corev1.Pod
+		fit  bool
+	}{
+		{
+			name: "mlu memory within quota",
+			pod:  mluPod("mlu-mem", "50", ""),
+			fit:  true,
+		},
+		{
+			name: "mlu memory over quota",
+			pod:  mluPod("mlu-mem", "200", ""),
+			fit:  false,
+		},
+		{
+			name: "mlu cores over quota",
+			pod:  mluPod("mlu-core", "1", "60"),
+			fit:  false,
+		},
+		{
+			name: "mlu in a namespace with no quota",
+			pod:  mluPod("unquotaed", "10000", ""),
+			fit:  true,
+		},
+		{
+			name: "dcu memory within quota once the factor is applied",
+			pod:  dcuPod("dcu-mem", "800"),
+			fit:  true,
+		},
+		{
+			name: "dcu memory over quota",
+			pod:  dcuPod("dcu-mem", "1200"),
+			fit:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fitResourceQuota(tc.pod); got != tc.fit {
+				t.Errorf("fitResourceQuota() = %v, want %v", got, tc.fit)
+			}
+		})
+	}
+}
+
+// A pod asking for two MLUs consumes twice the per-device memory.
+func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
+	config.SchedulerName = "hami-scheduler"
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "nvidia.com/gpu",
+			ResourceMemoryName:           "nvidia.com/gpumem",
+			ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+			ResourceCoreName:             "nvidia.com/gpucores",
+			DefaultGPUNum:                1,
+			MemoryFactor:                 1,
+		},
+		CambriconConfig: cambricon.CambriconConfig{
+			ResourceCountName:  "cambricon.com/mlu",
+			ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+			ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("failed to initialize devices: %v", err)
+	}
+
+	qm := device.NewQuotaManager()
+	// 60 units is 15360 MiB of headroom.
+	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+	}
+	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
+
+	pod := mluPod("mlu-multi", "40", "")
+	pod.Spec.Containers[0].Resources.Limits["cambricon.com/mlu"] = resource.MustParse("2")
+
+	// 2 x 40 units is 80, past the 60 unit limit, even though one device fits.
+	if fitResourceQuota(pod) {
+		t.Error("fitResourceQuota() = true, want false: two devices should each count against the quota")
+	}
+}
+
+// Ascend applies a configurable factor to the memory it records, so the limit
+// has to be raised by the same factor or pods that are within quota get denied.
+func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
+	config.SchedulerName = "hami-scheduler"
+
+	fs := flag.NewFlagSet("ascend-quota-test", flag.ContinueOnError)
+	ascend.ParseConfig(fs)
+	if err := fs.Parse([]string{"--enable-ascend=true"}); err != nil {
+		t.Fatalf("failed to enable the ascend backend: %v", err)
+	}
+	t.Cleanup(func() {
+		restore := flag.NewFlagSet("ascend-quota-restore", flag.ContinueOnError)
+		ascend.ParseConfig(restore)
+		_ = restore.Parse([]string{"--enable-ascend=false"})
+	})
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "nvidia.com/gpu",
+			ResourceMemoryName:           "nvidia.com/gpumem",
+			ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+			ResourceCoreName:             "nvidia.com/gpucores",
+			DefaultGPUNum:                1,
+			MemoryFactor:                 1,
+		},
+		VNPUs: ascend.VNPUs{
+			Configs: []ascend.VNPUConfig{{
+				CommonWord:         "Ascend910B",
+				ResourceName:       "huawei.com/Ascend910B",
+				ResourceMemoryName: "huawei.com/Ascend910B-memory",
+				ResourceCoreName:   "huawei.com/Ascend910B-core",
+				MemoryCapacity:     65536,
+				MemoryAllocatable:  65536,
+				MemoryFactor:       4,
+			}},
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("failed to initialize devices: %v", err)
+	}
+	if _, ok := device.GetDevices()["Ascend910B"]; !ok {
+		t.Fatal("the ascend backend was not registered, the test would pass vacuously")
+	}
+
+	qm := device.NewQuotaManager()
+	qm.Quotas["ascend"] = &device.DeviceQuota{
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+	}
+	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
+
+	// Requesting -core keeps the raw scaled value instead of rounding to a
+	// template, which makes the arithmetic here easy to follow.
+	ascendPod := func(mem string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "ascend-pod", Namespace: "ascend"},
+			Spec: corev1.PodSpec{
+				SchedulerName: "hami-scheduler",
+				Containers: []corev1.Container{{
+					Name: "container1",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"huawei.com/Ascend910B":        resource.MustParse("1"),
+							"huawei.com/Ascend910B-memory": resource.MustParse(mem),
+							"huawei.com/Ascend910B-core":   resource.MustParse("1"),
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	// 4096 x factor 4 is 16384, against a limit of 8192 x 4 = 32768.
+	if !fitResourceQuota(ascendPod("4096")) {
+		t.Error("fitResourceQuota() = false, want true: the limit must be scaled by the same factor as the request")
+	}
+	// 8192 x 4 is 32768 used against 32768 available, and 8193 pushes it over.
+	if fitResourceQuota(ascendPod("8193")) {
+		t.Error("fitResourceQuota() = true, want false: the request exceeds the scaled limit")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`fitResourceQuota` in the admission webhook only ever looked at NVIDIA:

```go
// Only supports NVIDIA
if deviceName != nvidia.NvidiaGPUDevice {
    continue
}
```

So a namespace `ResourceQuota` on `cambricon.com/mlu.smlu.vmemory`,
`huawei.com/Ascend910B-memory`, `hygon.com/dcumem` or any other vendor resource
was accepted by the apiserver and then ignored. Pods were admitted no matter how
much of that quota the namespace had already used. `QuotaManager` itself is
device agnostic and works fine when called directly, so the gap is entirely in
the wiring.

Two commits:

1. `refactor(device): name the vmemory scaling constants` — no behaviour change,
   pulled out so the second diff is readable.
2. `fix(scheduler): enforce ResourceQuota for every device backend` — the fix.

**The unit problem, and why the loop could not just be widened**

This is where the earlier attempt in #2218 came unstuck, and @mesutoezdil's
review there is what shaped this patch. Several backends scale the memory value
from the pod spec before recording it as used:

| backend | scale |
|---|---|
| nvidia, ascend, hygon | configured `memoryFactor` |
| cambricon, iluvatar | 256 |
| mthreads | 512 |
| metax sgpu | 1024 |

Recorded usage is in scaled units. A `ResourceQuota` limit is written in
unscaled ones. Compare them directly and a pod asking for 50 units of MLU
vmemory against a 100 unit limit is measured as 12800 against 100 and denied,
even though it is well inside quota. Hardcoding `memoryFactor = 1` for
non-NVIDIA backends, which is what #2218 did, produces exactly that.

So each backend now reports its own scale through a new
`ResourceNames.MemoryFactor`, and `FitQuota` raises the limit by it — the same
thing it already did for NVIDIA. Backends that do not scale leave it zero.

The webhook also stops re-reading the container spec by hand and asks the
backend instead:

```go
req := dev.GenerateResourceRequests(&pod.Spec.Containers[i])
memoryReq += int64(req.Memreq) * int64(req.Nums)
coresReq  += int64(req.Coresreq) * int64(req.Nums)
```

That is the same call the scheduler makes on the Fit path, so admission and the
scheduler now work from identical numbers, including per-backend defaults and
Ascend's template rounding. It also drops about 25 lines of duplicated
limits/requests parsing.

**Tests**

`TestFitResourceQuotaNonNvidia`, `TestFitResourceQuotaCountsEveryDevice` and
`TestFitResourceQuotaAscendMemoryFactor` in `pkg/scheduler/webhook_test.go`.
They cover deny and allow for MLU memory, MLU cores, DCU memory with
`memoryFactor: 2`, Ascend with `memoryFactor: 4`, multi-device requests, and a
namespace with no quota. All five deny cases fail on master and pass with this
change.

`TestFitResourceQuotaAscendMemoryFactor` asserts the backend actually registered
before running, because the existing `TestFitResourceQuota/request_ascend` case
passes vacuously today — Ascend is behind `--enable-ascend` and was never in
`DevicesMap` for that test.

**Which issue(s) this PR fixes**:
Fixes #2157

**Special notes for your reviewer**:

Two behaviour changes worth a second look:

- NVIDIA memory quota now counts `defaultMemory` when a pod asks for
  `nvidia.com/gpu` without `nvidia.com/gpumem`. The old code only counted memory
  the pod named explicitly, which under-counted against what the scheduler
  actually records. Default config has `defaultMemory: 0`, so most deployments
  see no difference.
- Backends that default cores when none are requested (cambricon defaults to
  100) now have those cores counted. Same reasoning: that is what ends up in
  `Usedcores`.

Deliberately left out, happy to add if you would rather see them here:

- `FitQuota` on the scheduler `Fit()` path is still NVIDIA only. This PR fixes
  admission. Doing `Fit()` properly means touching every backend's allocation
  loop and I did not want to bury the webhook fix in that. Tracked separately in
  #2363, which also covers the admission-to-scheduling race @mesutoezdil raised
  below.
- Metax reads a bare `vmemory` value as Gi but a suffixed one as bytes. The 1024
  factor is right for the bare form, which is what a `ResourceQuota` uses. A
  quota written as `16Gi` would still be wrong, but that is `AddQuota`'s
  handling of suffixed quantities and predates this change.
- Init containers are not counted, same as before. That overlaps #1667.

Not validated on real hardware. The change is confined to the scheduler
extender's admission path and is covered by unit tests, which CONTRIBUTING
allows for scheduler-scoped changes.

**Does this PR introduce a user-facing change?**:

```release-note
ResourceQuota limits on non-NVIDIA accelerator memory and core resources are now
enforced at admission instead of being silently ignored.
```

---

AI assistance disclosure: this change was developed with Claude Code — codebase
exploration, working through the per-backend unit scaling, the tests, and this
description. Flagging the extent up front per CONTRIBUTING.
