### PR TITLE
fix(device-plugin): close file handle in createMigApplyLock

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
@@ -61,11 +61,12 @@ func createMigApplyLock(file string) error {
 		klog.Infof("MIG apply lock file already exists: %s", MigApplyLockFile)
 		return nil
 	}
-	_, err := os.Create(file)
+	f, err := os.Create(file)
 	if err != nil {
 		klog.Errorf("Failed to create MIG apply lock file: %v", err)
 		return err
 	}
+	defer f.Close()
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`os.Create()` returns an open `*os.File` that must be closed by the caller. `createMigApplyLock()` (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go`) created the MIG apply lock file but discarded the returned file handle without closing it:

```go
_, err := os.Create(file)
```

As a result, every successful invocation leaked a file descriptor. `createMigApplyLock()` is part of the MIG apply workflow (`ApplyMigTemplate` → `DisableOtherNVMLOperation` → `CreateMigApplyLock`), so repeated MIG reconfigurations can accumulate leaked file descriptors over the lifetime of the device-plugin process.

This PR stores the returned file handle and closes it immediately after the lock file is created. There are no behavioral changes.

## Which issue(s) this PR fixes

Fixes #2348

## Special notes for your reviewer

- No behavioral changes.
- `createMigApplyLock()` still creates the lock file and returns the same errors under the same conditions.
- This change only ensures the file descriptor returned by `os.Create()` is properly released.
- Verified locally with:
  - `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -v`
  - `make verify`

## AI assistance disclosure

I consulted ChatGPT and Claude to identify and understand the file descriptor leak. The implementation, validation, commit message, and final code changes were completed and verified by me. I reviewed all generated suggestions, ran the relevant tests and `make verify` locally, and take full responsibility for the final contribution.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource handling when creating device configuration locks.
  * Preserved existing lock-file behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->