### PR TITLE
test(vGPUmonitor): cover the container metrics collection path

### DIFF
--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -31,8 +31,22 @@ const stubDeviceMax = 16
 // count and the trailing slots read back invalid, so the check functions walk the
 // same 16 slots they do in production.
 type stubInfo struct {
-	priority int
-	uuids    []string
+	priority   int
+	uuids      []string
+	total      []uint64
+	limit      []uint64
+	ctxSize    []uint64
+	modSize    []uint64
+	bufSize    []uint64
+	smUtil     []uint64
+	lastKernel int64
+}
+
+func slot(v []uint64, i int) uint64 {
+	if i >= 0 && i < len(v) {
+		return v[i]
+	}
+	return 0
 }
 
 func (s *stubInfo) DeviceMax() int { return stubDeviceMax }
@@ -43,22 +57,22 @@ func (s *stubInfo) DeviceUUID(i int) string {
 	}
 	return ""
 }
-func (s *stubInfo) DeviceMemoryContextSize(int) uint64 { return 0 }
-func (s *stubInfo) DeviceMemoryModuleSize(int) uint64  { return 0 }
-func (s *stubInfo) DeviceMemoryBufferSize(int) uint64  { return 0 }
-func (s *stubInfo) DeviceMemoryOffset(int) uint64      { return 0 }
-func (s *stubInfo) DeviceMemoryTotal(int) uint64       { return 0 }
-func (s *stubInfo) DeviceSmUtil(int) uint64            { return 0 }
-func (s *stubInfo) SetDeviceSmLimit(uint64)            {}
-func (s *stubInfo) IsValidUUID(i int) bool             { return i < len(s.uuids) }
-func (s *stubInfo) DeviceMemoryLimit(int) uint64       { return 0 }
-func (s *stubInfo) SetDeviceMemoryLimit(uint64)        {}
-func (s *stubInfo) LastKernelTime() int64              { return 0 }
-func (s *stubInfo) GetPriority() int                   { return s.priority }
-func (s *stubInfo) GetRecentKernel() int32             { return 1 }
-func (s *stubInfo) SetRecentKernel(int32)              {}
-func (s *stubInfo) GetUtilizationSwitch() int32        { return 0 }
-func (s *stubInfo) SetUtilizationSwitch(int32)         {}
+func (s *stubInfo) DeviceMemoryContextSize(i int) uint64 { return slot(s.ctxSize, i) }
+func (s *stubInfo) DeviceMemoryModuleSize(i int) uint64  { return slot(s.modSize, i) }
+func (s *stubInfo) DeviceMemoryBufferSize(i int) uint64  { return slot(s.bufSize, i) }
+func (s *stubInfo) DeviceMemoryOffset(int) uint64        { return 0 }
+func (s *stubInfo) DeviceMemoryTotal(i int) uint64       { return slot(s.total, i) }
+func (s *stubInfo) DeviceSmUtil(i int) uint64            { return slot(s.smUtil, i) }
+func (s *stubInfo) SetDeviceSmLimit(uint64)              {}
+func (s *stubInfo) IsValidUUID(i int) bool               { return i < len(s.uuids) }
+func (s *stubInfo) DeviceMemoryLimit(i int) uint64       { return slot(s.limit, i) }
+func (s *stubInfo) SetDeviceMemoryLimit(uint64)          {}
+func (s *stubInfo) LastKernelTime() int64                { return s.lastKernel }
+func (s *stubInfo) GetPriority() int                     { return s.priority }
+func (s *stubInfo) GetRecentKernel() int32               { return 1 }
+func (s *stubInfo) SetRecentKernel(int32)                {}
+func (s *stubInfo) GetUtilizationSwitch() int32          { return 0 }
+func (s *stubInfo) SetUtilizationSwitch(int32)           {}
 
 func TestCheckFunctionsHighPriority(t *testing.T) {
 	sw := map[string]UtilizationPerDevice{"gpu-0": {0, 1}}

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+)
+
+const testUUID = "GPU-12345678-1234-1234-1234-123456789012" // 40 chars, valid UTF-8
+
+func collectContainer(t *testing.T, cu *nvidia.ContainerUsage, nowSec int64) ([]prometheus.Metric, error) {
+	t.Helper()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "trainer-0"}}
+	ctr := corev1.Container{Name: "worker"}
+	cc := ClusterManagerCollector{ClusterManager: &ClusterManager{}}
+	ch := make(chan prometheus.Metric, 64)
+	err := cc.collectContainerMetrics(ch, pod, ctr, cu, nowSec)
+	close(ch)
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	return got, err
+}
+
+func gaugeValue(t *testing.T, m prometheus.Metric) (float64, map[string]string) {
+	t.Helper()
+	var d dto.Metric
+	if err := m.Write(&d); err != nil {
+		t.Fatal(err)
+	}
+	labels := map[string]string{}
+	for _, p := range d.GetLabel() {
+		labels[p.GetName()] = p.GetValue()
+	}
+	return d.GetGauge().GetValue(), labels
+}
+
+func TestCollectContainerMetrics(t *testing.T) {
+	cu := &nvidia.ContainerUsage{Info: &stubInfo{
+		uuids:      []string{testUUID},
+		total:      []uint64{8000},
+		limit:      []uint64{10000},
+		ctxSize:    []uint64{1000},
+		modSize:    []uint64{500},
+		bufSize:    []uint64{300},
+		smUtil:     []uint64{42},
+		lastKernel: 100,
+	}}
+
+	metrics, err := collectContainer(t, cu, 160)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[*prometheus.Desc]float64{
+		ctrvGPUdesc:                8000,
+		ctrvGPUlimitdesc:           10000,
+		ctrDeviceMemorydesc:        8000,
+		ctrDeviceUtilizationdesc:   42,
+		ctrDeviceMemoryContextDesc: 1000,
+		ctrDeviceMemoryModuleDesc:  500,
+		ctrDeviceMemoryBufferDesc:  300,
+		ctrDeviceLastKernelDesc:    60, // nowSec - lastKernel = 160 - 100
+	}
+	if len(metrics) != len(want) {
+		t.Fatalf("got %d metrics, want %d", len(metrics), len(want))
+	}
+	for _, m := range metrics {
+		exp, ok := want[m.Desc()]
+		if !ok {
+			t.Errorf("unexpected metric: %s", m.Desc())
+			continue
+		}
+		v, labels := gaugeValue(t, m)
+		if v != exp {
+			t.Errorf("%s = %v, want %v", m.Desc(), v, exp)
+		}
+		if labels["namespace"] != "team-a" || labels["pod"] != "trainer-0" ||
+			labels["container"] != "worker" || labels["vdevice_index"] != "0" ||
+			labels["device_uuid"] != testUUID {
+			t.Errorf("%s has wrong labels: %v", m.Desc(), labels)
+		}
+	}
+}
+
+func TestCollectContainerMetricsNoKernelActivity(t *testing.T) {
+	cu := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{testUUID}}}
+	metrics, err := collectContainer(t, cu, 160)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metrics {
+		if m.Desc() == ctrDeviceLastKernelDesc {
+			t.Error("last-kernel metric should not be emitted when no kernel has run")
+		}
+	}
+	if len(metrics) != 7 {
+		t.Errorf("got %d metrics, want 7", len(metrics))
+	}
+}
+
+func TestCollectContainerMetricsBadInput(t *testing.T) {
+	if _, err := collectContainer(t, nil, 0); err == nil {
+		t.Error("nil ContainerUsage should return an error")
+	}
+	if _, err := collectContainer(t, &nvidia.ContainerUsage{}, 0); err == nil {
+		t.Error("nil ContainerUsage.Info should return an error")
+	}
+	short := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{"gpu-short"}}}
+	if _, err := collectContainer(t, short, 0); err == nil {
+		t.Error("a UUID shorter than 40 chars should return an error")
+	}
+}
+
+func TestCollectContainerMetricsSkipsInvalidUTF8UUID(t *testing.T) {
+	bad := "\xff" + strings.Repeat("a", 39) // 40 bytes, not valid UTF-8
+	cu := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{bad}}}
+	metrics, err := collectContainer(t, cu, 0)
+	if err != nil {
+		t.Fatalf("invalid UTF-8 UUID should be skipped, not error: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("got %d metrics for an invalid UUID, want 0", len(metrics))
+	}
+}

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -94,6 +94,7 @@ func TestCollectContainerMetrics(t *testing.T) {
 			t.Errorf("unexpected metric: %s", m.Desc())
 			continue
 		}
+		delete(want, m.Desc())
 		v, labels := gaugeValue(t, m)
 		if v != exp {
 			t.Errorf("%s = %v, want %v", m.Desc(), v, exp)
@@ -103,6 +104,9 @@ func TestCollectContainerMetrics(t *testing.T) {
 			labels["device_uuid"] != testUUID {
 			t.Errorf("%s has wrong labels: %v", m.Desc(), labels)
 		}
+	}
+	if len(want) != 0 {
+		t.Errorf("expected metrics not emitted: %v", want)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
`cmd/vGPUmonitor` had almost no coverage of its metrics collector (~6% of the
package). `collectContainerMetrics` — which emits the per-container GPU memory,
utilization, and last-kernel metrics — had none. This adds unit tests for it:

- a healthy device, asserting the value and the `namespace/pod/container/vdevice_index/device_uuid` labels of every emitted metric;
- the `hami_container_last_kernel_elapsed_seconds` metric only being emitted once a kernel has actually run (`LastKernelTime > 0`), and computed as `nowSec - lastKernel`;
- the error paths: nil `ContainerUsage`, nil `Info`, and a UUID shorter than 40 chars;
- an invalid-UTF-8 UUID being skipped (so a not-yet-initialised shared-memory slot doesn't take down the scrape).

Rather than add a second mock, it extends the existing `stubInfo` in
`feedback_test.go` with the memory/utilization fields the collector reads; the
existing feedback tests are unaffected (the new fields default to zero).

This raises `cmd/vGPUmonitor` coverage from ~6% to ~18%. No runtime code changes.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
`make verify` and the full unit suite pass locally. These run in CI now that
`cmd/vGPUmonitor` was added to the test command in #2250.

**AI assistance disclosure**:
I used AI assistance (Claude Code) to understand what tests is needed and then took assistance from codex while writing these tests. I reviewed and verified them, confirmed they exercise the intended paths, ran `make verify`
locally, and take responsibility for the change.

**Does this PR introduce a user-facing change?**:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for multi-device blocking and priority checks under contention and incomplete device data.
  * Added validation for container GPU metrics, including labels, metric values, kernel timing, inactive kernels, invalid input, and malformed device identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->