### PR TITLE
test(device-plugin): add unit tests for imex and cdi packages

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/imex_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/imex_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdi
+
+import (
+	"testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/imex"
+)
+
+func TestImexChannelCDILib(t *testing.T) {
+	channels := imex.Channels{
+		{
+			ID:       "0",
+			Path:     "/dev/nvidia-caps-imex-channels/channel0",
+			HostPath: "/dev/nvidia-caps-imex-channels/channel0",
+		},
+	}
+
+	handler := &cdiHandler{
+		vendor:       "nvidia.com",
+		imexChannels: channels,
+	}
+
+	gen := handler.newImexChannelSpecGenerator()
+	if gen == nil {
+		t.Fatalf("expected non-nil SpecGenerator")
+	}
+
+	spec, err := gen.GetSpec()
+	if err != nil {
+		t.Fatalf("expected no error from GetSpec, got %v", err)
+	}
+
+	if spec == nil {
+		t.Fatalf("expected non-nil spec")
+	}
+
+	rawSpec := spec.Raw()
+	if rawSpec == nil {
+		t.Fatalf("expected non-nil raw spec")
+	}
+
+	if rawSpec.Kind != "nvidia.com/imex-channel" {
+		t.Errorf("expected Kind 'nvidia.com/imex-channel', got %s", rawSpec.Kind)
+	}
+	if len(rawSpec.Devices) != 1 {
+		t.Fatalf("expected 1 device spec, got %d", len(rawSpec.Devices))
+	}
+	if rawSpec.Devices[0].Name != "0" {
+		t.Errorf("expected device name '0', got %s", rawSpec.Devices[0].Name)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdi
+
+import (
+	"testing"
+)
+
+func TestNullHandler(t *testing.T) {
+	h := NewNullHandler()
+
+	if devices := h.AdditionalDevices(); devices != nil {
+		t.Fatalf("expected nil additional devices, got %v", devices)
+	}
+
+	if err := h.CreateSpecFile(); err != nil {
+		t.Fatalf("expected nil error from CreateSpecFile, got %v", err)
+	}
+
+	if name := h.QualifiedName("gpu", "0"); name != "" {
+		t.Fatalf("expected empty qualified name, got %s", name)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/options_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/options_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdi
+
+import (
+	"testing"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/imex"
+)
+
+func TestOptions(t *testing.T) {
+	c := &cdiHandler{}
+
+	strategies := spec.DeviceListStrategies{"cdi": true}
+	WithDeviceListStrategies(strategies)(c)
+	if !c.deviceListStrategies.Includes("cdi") {
+		t.Errorf("WithDeviceListStrategies failed, got %v", c.deviceListStrategies)
+	}
+
+	WithDriverRoot("/driver-root")(c)
+	if c.driverRoot != "/driver-root" {
+		t.Errorf("WithDriverRoot failed, got %s", c.driverRoot)
+	}
+
+	WithDevRoot("/dev-root")(c)
+	if c.devRoot != "/dev-root" {
+		t.Errorf("WithDevRoot failed, got %s", c.devRoot)
+	}
+
+	WithTargetDriverRoot("/target-driver-root")(c)
+	if c.targetDriverRoot != "/target-driver-root" {
+		t.Errorf("WithTargetDriverRoot failed, got %s", c.targetDriverRoot)
+	}
+
+	WithTargetDevRoot("/target-dev-root")(c)
+	if c.targetDevRoot != "/target-dev-root" {
+		t.Errorf("WithTargetDevRoot failed, got %s", c.targetDevRoot)
+	}
+
+	WithNvidiaCTKPath("/usr/bin/nvidia-ctk")(c)
+	if c.nvidiaCTKPath != "/usr/bin/nvidia-ctk" {
+		t.Errorf("WithNvidiaCTKPath failed, got %s", c.nvidiaCTKPath)
+	}
+
+	WithDeviceIDStrategy("uuid")(c)
+	if c.deviceIDStrategy != "uuid" {
+		t.Errorf("WithDeviceIDStrategy failed, got %s", c.deviceIDStrategy)
+	}
+
+	WithVendor("nvidia.com")(c)
+	if c.vendor != "nvidia.com" {
+		t.Errorf("WithVendor failed, got %s", c.vendor)
+	}
+
+	WithGdrcopyEnabled(true)(c)
+	if !c.gdrcopyEnabled {
+		t.Errorf("WithGdrcopyEnabled failed")
+	}
+
+	WithGdsEnabled(true)(c)
+	if !c.gdsEnabled {
+		t.Errorf("WithGdsEnabled failed")
+	}
+
+	WithMofedEnabled(true)(c)
+	if !c.mofedEnabled {
+		t.Errorf("WithMofedEnabled failed")
+	}
+
+	ch := imex.Channels{&imex.Channel{ID: "0", Path: "/dev/channel0"}}
+	WithImexChannels(ch)(c)
+	if len(c.imexChannels) != 1 || c.imexChannels[0].ID != "0" {
+		t.Errorf("WithImexChannels failed, got %v", c.imexChannels)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/imex/imex_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/imex/imex_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+)
+
+func TestGetChannels(t *testing.T) {
+	t.Run("empty channels list", func(t *testing.T) {
+		cfg := &spec.Config{
+			Imex: spec.Imex{
+				ChannelIDs: []int{},
+				Required:   false,
+			},
+		}
+		channels, err := GetChannels(cfg, "/tmp")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(channels) != 0 {
+			t.Fatalf("expected 0 channels, got %d", len(channels))
+		}
+	})
+
+	t.Run("missing channel not required", func(t *testing.T) {
+		cfg := &spec.Config{
+			Imex: spec.Imex{
+				ChannelIDs: []int{999},
+				Required:   false,
+			},
+		}
+		channels, err := GetChannels(cfg, "/nonexistent-dev-root")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(channels) != 0 {
+			t.Fatalf("expected 0 channels, got %d", len(channels))
+		}
+	})
+
+	t.Run("missing channel required", func(t *testing.T) {
+		cfg := &spec.Config{
+			Imex: spec.Imex{
+				ChannelIDs: []int{999},
+				Required:   true,
+			},
+		}
+		channels, err := GetChannels(cfg, "/nonexistent-dev-root")
+		if err == nil {
+			t.Fatalf("expected error for missing required channel, got nil")
+		}
+		if channels != nil {
+			t.Fatalf("expected nil channels, got %v", channels)
+		}
+		if !strings.Contains(err.Error(), "requested IMEX channel channel999 does not exist") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("channel path is a regular file instead of char device", func(t *testing.T) {
+		tempDir := t.TempDir()
+		devDir := filepath.Join(tempDir, "dev/nvidia-caps-imex-channels")
+		if err := os.MkdirAll(devDir, 0755); err != nil {
+			t.Fatalf("failed to create temp dev dir: %v", err)
+		}
+
+		filePath := filepath.Join(devDir, "channel1")
+		if err := os.WriteFile(filePath, []byte("dummy"), 0644); err != nil {
+			t.Fatalf("failed to write dummy file: %v", err)
+		}
+
+		cfg := &spec.Config{
+			Imex: spec.Imex{
+				ChannelIDs: []int{1},
+				Required:   true,
+			},
+		}
+
+		channels, err := GetChannels(cfg, tempDir)
+		if err == nil {
+			t.Fatalf("expected error for non-character device file, got nil")
+		}
+		if channels != nil {
+			t.Fatalf("expected nil channels, got %v", channels)
+		}
+		if !strings.Contains(err.Error(), "is not a character device") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR adds comprehensive unit test coverage for the `imex` (`pkg/device-plugin/nvidiadevice/nvinternal/imex`) and `cdi` (`pkg/device-plugin/nvidiadevice/nvinternal/cdi`) packages in the NVIDIA device plugin internal implementation. Previously, both packages had zero unit test coverage (`coverage: 0.0% of statements`).

Specifically, this PR introduces:
- `pkg/device-plugin/nvidiadevice/nvinternal/imex/imex_test.go`: Tests `GetChannels()` for empty channel lists, non-required channel skips, required channel error handling, and character device file mode verification (83.3% statement coverage).
- `pkg/device-plugin/nvidiadevice/nvinternal/cdi/null_test.go`: Tests `NewNullHandler()` no-op CDI handler logic (`AdditionalDevices`, `CreateSpecFile`, `QualifiedName`).
- `pkg/device-plugin/nvidiadevice/nvinternal/cdi/options_test.go`: Tests option configuration setters (`WithDeviceListStrategies`, `WithDriverRoot`, `WithDevRoot`, `WithTargetDriverRoot`, `WithTargetDevRoot`, `WithNvidiaCTKPath`, `WithDeviceIDStrategy`, `WithVendor`, `WithGdrcopyEnabled`, `WithGdsEnabled`, `WithMofedEnabled`, `WithImexChannels`).
- `pkg/device-plugin/nvidiadevice/nvinternal/cdi/imex_test.go`: Tests IMEX channel CDI spec generation (`newImexChannelSpecGenerator()` and `GetSpec()`).

**Which issue(s) this PR fixes**:
Fixes #2354 

**Special notes for your reviewer**:
- All added files have Apache 2.0 license headers and pass `./hack/verify-license.sh`.
- Tests pass via `go test -v -cover ./pkg/device-plugin/nvidiadevice/nvinternal/imex/... ./pkg/device-plugin/nvidiadevice/nvinternal/cdi/...`.
- AI assistance disclosure: I used an AI tool for codebase navigation, unit test generation, and review support.

**Does this PR introduce a user-facing change?**:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for IMEX channel CDI specification generation.
  * Added validation for null CDI handler behavior and configuration options.
  * Added tests for IMEX channel discovery, including missing channels and invalid device paths.
  * Improved verification of successful and error-handling scenarios across CDI and IMEX functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->