### PR TITLE
test(device): add coverage for PodManager update, delete, and ListPodsUID paths

### DIFF
--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -313,7 +313,7 @@ func TestAddPod_UpdateExistingDevices(t *testing.T) {
 	added := podManager.AddPod(pod, "node1", PodDevices{"device1": {{}}})
 	assert.True(t, added, "AddPod should report true for a new pod")
 
-	updatedAgain := podManager.AddPod(pod, "node1", PodDevices{"device1": {{{UUID: "GPU-1"}}}})
+	updatedAgain := podManager.AddPod(pod, "node2", PodDevices{"device1": {{{UUID: "GPU-1"}}}})
 	assert.False(t, updatedAgain, "AddPod should report false when the pod already exists")
 
 	pi, ok := podManager.GetPod(pod)

--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -299,6 +299,100 @@ func TestAddPod(t *testing.T) {
 	}
 }
 
+func TestAddPod_UpdateExistingDevices(t *testing.T) {
+	podManager := NewPodManager()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			UID:       k8stypes.UID("uid1"),
+		},
+	}
+
+	added := podManager.AddPod(pod, "node1", PodDevices{"device1": {{}}})
+	assert.True(t, added, "AddPod should report true for a new pod")
+
+	updatedAgain := podManager.AddPod(pod, "node1", PodDevices{"device1": {{{UUID: "GPU-1"}}}})
+	assert.False(t, updatedAgain, "AddPod should report false when the pod already exists")
+
+	pi, ok := podManager.GetPod(pod)
+	assert.True(t, ok)
+	assert.Equal(t, "node1", pi.NodeID, "NodeID should be unchanged on update")
+	assert.Equal(t, PodDevices{"device1": {{{UUID: "GPU-1"}}}}, pi.Devices, "Devices should be replaced with the new value")
+}
+
+func TestDelPod(t *testing.T) {
+	podManager := NewPodManager()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			UID:       k8stypes.UID("uid1"),
+		},
+	}
+	podManager.AddPod(pod, "node1", PodDevices{"device1": {{}}})
+
+	_, ok := podManager.GetPod(pod)
+	assert.True(t, ok, "pod should be present before deletion")
+
+	podManager.DelPod(pod)
+	_, ok = podManager.GetPod(pod)
+	assert.False(t, ok, "pod should be absent after deletion")
+
+	assert.NotPanics(t, func() {
+		podManager.DelPod(pod)
+	})
+
+	unknownPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "ghost-pod",
+			UID:       k8stypes.UID("uid-ghost"),
+		},
+	}
+	assert.NotPanics(t, func() {
+		podManager.DelPod(unknownPod)
+	})
+}
+
+func TestListPodsUID(t *testing.T) {
+	podManager := NewPodManager()
+
+	uids, err := podManager.ListPodsUID()
+	assert.NoError(t, err)
+	assert.Empty(t, uids, "expected no pods when the manager is empty")
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			UID:       k8stypes.UID("uid1"),
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod2",
+			UID:       k8stypes.UID("uid2"),
+		},
+	}
+	podManager.AddPod(pod1, "node1", PodDevices{"device1": {{}}})
+	podManager.AddPod(pod2, "node2", PodDevices{"device2": {{}}})
+
+	uids, err = podManager.ListPodsUID()
+	assert.NoError(t, err)
+	assert.Len(t, uids, 2, "expected one entry per tracked pod")
+
+	gotUIDs := make(map[k8stypes.UID]bool, len(uids))
+	for _, p := range uids {
+		gotUIDs[p.UID] = true
+	}
+	assert.True(t, gotUIDs[pod1.UID], "expected pod1's UID to be present")
+	assert.True(t, gotUIDs[pod2.UID], "expected pod2's UID to be present")
+}
+
 func TestUpdatePod(t *testing.T) {
 	podManager := NewPodManager()
 


### PR DESCRIPTION
****What this PR does / why we need it**:**

Adds focused unit tests for previously uncovered `PodManager` paths:

- Tests `AddPod` behavior when updating an existing pod
- Tests `DelPod` removal behavior and handling of unknown pods
- Tests `ListPodsUID` with empty and populated managers

These tests improve coverage without changing runtime behavior.

**Which issue(s) this PR fixes**:

Fixes #2357

**Special notes for reviewer**:

Tests were added only; no production code changes were made.

Tests were verified in a WSL2 (Ubuntu) environment by running:

```bash
go test ./pkg/device/...
```

All tests passed successfully.

**Does this PR introduce a user-facing change?**:

No. This is a test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for updating existing pod devices while preserving node associations.
  * Added coverage for safely deleting pods, including repeated and unknown deletions.
  * Added coverage for listing tracked pod identifiers in empty and populated states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->