### PR TITLE
fix(device-plugin): guard against malformed MIG output parsing

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -161,15 +161,22 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 			continue
 		}
 		klog.Infoln("inspecting", val)
-		num := strings.Split(val, "Device")[1]
-		num = strings.Split(num, ":")[0]
+		deviceParts := strings.SplitN(val, "Device", 2)
+		if len(deviceParts) < 2 {
+			continue
+		}
+		num := strings.SplitN(deviceParts[1], ":", 2)[0]
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
 			klog.Fatal("atoi failed num=", num)
 		}
 		if index == idx {
-			outputStr := strings.Split(val, ":")[2]
+			colonParts := strings.SplitN(val, ":", 3)
+			if len(colonParts) < 3 {
+				continue
+			}
+			outputStr := colonParts[2]
 			outputStr = strings.TrimSpace(outputStr)
 			outputStr = strings.TrimRight(outputStr, ")")
 			return outputStr

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -169,7 +169,7 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
-			klog.Fatal("atoi failed num=", num)
+			continue
 		}
 		if index == idx {
 			colonParts := strings.SplitN(val, ":", 3)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -940,3 +940,71 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 		t.Errorf("expected stale config to be removed, stat err: %v", err)
 	}
 }
+
+func TestGetMigUUIDFromSmiOutput(t *testing.T) {
+	// validOutput simulates a real nvidia-smi -L section for a GPU with UUID
+	// GPU-abc123 containing two MIG devices at Device 0 and Device 1.
+	validOutput := strings.Join([]string{
+		"GPU 0: NVIDIA A100 (UUID: GPU-abc123)",
+		"  MIG 1g.5gb Device 0: (UUID: MIG-dev0)",
+		"  MIG 1g.5gb Device 1: (UUID: MIG-dev1)",
+	}, "\n")
+
+	tests := []struct {
+		name   string
+		output string
+		uuid   string
+		idx    int
+		want   string
+	}{
+		{
+			name:   "valid output returns UUID for idx 0",
+			output: validOutput,
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "MIG-dev0",
+		},
+		{
+			name:   "valid output returns UUID for idx 1",
+			output: validOutput,
+			uuid:   "GPU-abc123",
+			idx:    1,
+			want:   "MIG-dev1",
+		},
+		{
+			name:   "missing Device token does not panic",
+			output: "GPU 0: NVIDIA A100 (UUID: GPU-abc123)\n  MIG 1g.5gb MALFORMED_NO_DEVICE_TOKEN",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name:   "insufficient colon fields does not panic",
+			output: "GPU 0: NVIDIA A100 (UUID: GPU-abc123)\n  MIG 1g.5gb Device 0: no-second-colon",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name: "mixed valid and malformed lines, only malformed is skipped",
+			output: strings.Join([]string{
+				"GPU 0: NVIDIA A100 (UUID: GPU-abc123)",
+				"  MIG 1g.5gb MALFORMED_LINE",
+				"  MIG 1g.5gb Device 1: (UUID: MIG-dev1)",
+			}, "\n"),
+			uuid: "GPU-abc123",
+			idx:  1,
+			want: "MIG-dev1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetMigUUIDFromSmiOutput(tc.output, tc.uuid, tc.idx)
+			if got != tc.want {
+				t.Errorf("GetMigUUIDFromSmiOutput() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -996,6 +996,17 @@ func TestGetMigUUIDFromSmiOutput(t *testing.T) {
 			idx:  1,
 			want: "MIG-dev1",
 		},
+		{
+			name: "non-numeric device number does not panic and skips line",
+			output: strings.Join([]string{
+				"GPU 0: NVIDIA A100 (UUID: GPU-abc123)",
+				"  MIG 1g.5gb Device abc: (UUID: MIG-invalid)",
+				"  MIG 1g.5gb Device 1: (UUID: MIG-dev1)",
+			}, "\n"),
+			uuid: "GPU-abc123",
+			idx:  1,
+			want: "MIG-dev1",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`GetMigUUIDFromSmiOutput()` (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go`) parsed `nvidia-smi` output by directly indexing into the slices returned by `strings.Split()`, for example:

```go
strings.Split(val, "Device")[1]
strings.Split(val, ":")[2]
```

If a parsed line did not contain the expected delimiters, these unchecked index operations could panic with an `index out of range` error.

This PR hardens the parser by replacing the unchecked indexing with bounded parsing using `strings.SplitN()` and validating the resulting slice lengths before accessing them. Malformed lines are skipped, while the parsing behavior for valid `nvidia-smi` output remains unchanged.

## Which issue(s) this PR fixes

Fixes #2359 

## Special notes for your reviewer

- No behavioral changes for valid `nvidia-smi` output.
- Uses `strings.SplitN()` with bounds checks to avoid unchecked slice indexing.
- Added regression tests covering:
  - Valid MIG output.
  - Missing `Device` token.
  - Insufficient `:`-separated fields.
  - Mixed valid and malformed input.
- Verified locally with:
  - `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -v`
  - `make verify`

## AI assistance disclosure

I consulted ChatGPT and Claude to identify and discuss the defensive parsing improvement. The implementation, tests, validation, commit message, and final code changes were completed and verified by me. I reviewed all generated suggestions, ran the relevant tests and `make verify` locally, and take full responsibility for the final contribution.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or malformed NVIDIA device information.
  * Prevented potential crashes when processing unexpected `nvidia-smi` output.
  * Continued extracting MIG UUIDs correctly from valid device entries.

* **Tests**
  * Added coverage for valid, incomplete, and malformed device information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->