### PR TITLE
fix(monitor): clamp SetDeviceSmLimit and SetDeviceMemoryLimit to maxDevices

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -138,10 +138,9 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	n := min(s.sr.num, maxDevices)
+	for idx := range n {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -158,10 +157,9 @@ func (s Spec) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	n := min(s.sr.num, maxDevices)
+	for idx := range n {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -469,6 +469,15 @@ func TestSpec_SetDeviceSmLimit(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("num larger than maxDevices does not panic", func(t *testing.T) {
+		s := &Spec{sr: &sharedRegionT{num: 9999}}
+		s.SetDeviceSmLimit(500)
+		want := [16]uint64{500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500}
+		if s.sr.smLimit != want {
+			t.Errorf("SetDeviceSmLimit with oversized num: got %v, want %v", s.sr.smLimit, want)
+		}
+	})
 }
 
 func TestSpec_IsValidUUID(t *testing.T) {
@@ -649,10 +658,8 @@ func TestSpec_SetDeviceMemoryLimit(t *testing.T) {
 					},
 				},
 			},
-			input: 500,
-			expected: []uint64{
-				500, 500, 500,
-			},
+			input:    500,
+			expected: []uint64{500, 500, 500},
 		},
 	}
 
@@ -665,6 +672,15 @@ func TestSpec_SetDeviceMemoryLimit(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("num larger than maxDevices does not panic", func(t *testing.T) {
+		s := &Spec{sr: &sharedRegionT{num: 9999}}
+		s.SetDeviceMemoryLimit(750)
+		want := [16]uint64{750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750}
+		if s.sr.limit != want {
+			t.Errorf("SetDeviceMemoryLimit with oversized num: got %v, want %v", s.sr.limit, want)
+		}
+	})
 }
 
 func TestSpec_LastKernelTime(t *testing.T) {

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -152,10 +152,9 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	n := min(s.sr.num, maxDevices)
+	for idx := range n {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -172,10 +171,9 @@ func (s Spec) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	n := min(s.sr.num, maxDevices)
+	for idx := range n {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -740,6 +740,13 @@ func Test_SetDeviceSmLimit(t *testing.T) {
 			assert.DeepEqual(t, result, test.want)
 		})
 	}
+
+	t.Run("num larger than maxDevices does not panic", func(t *testing.T) {
+		s := &Spec{sr: &sharedRegionT{num: 9999, smLimit: [16]uint64{}}}
+		s.SetDeviceSmLimit(500)
+		want := [16]uint64{500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500}
+		assert.DeepEqual(t, s.sr.smLimit, want)
+	})
 }
 
 func Test_IsValidUUID(t *testing.T) {
@@ -970,6 +977,13 @@ func Test_SetDeviceMemoryLimit(t *testing.T) {
 			assert.DeepEqual(t, result, test.want)
 		})
 	}
+
+	t.Run("num larger than maxDevices does not panic", func(t *testing.T) {
+		s := &Spec{sr: &sharedRegionT{num: 9999}}
+		s.SetDeviceMemoryLimit(750)
+		want := [16]uint64{750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750}
+		assert.DeepEqual(t, s.sr.limit, want)
+	})
 }
 
 func Test_LastKernelTime(t *testing.T) {


### PR DESCRIPTION
## Summary

`SetDeviceSmLimit` and `SetDeviceMemoryLimit` in both `pkg/monitor/nvidia/v0/spec.go` and `pkg/monitor/nvidia/v1/spec.go` iterated up to `sr.num` without clamping to the backing array size. `sr.limit` and `sr.smLimit` are both `[16]uint64`, matching `maxDevices = 16`. If `sr.num` comes in larger than 16 - due to shared-memory corruption or a version mismatch between libvgpu and the monitor, the write panics with an index out of bounds, bringing down the vGPU monitor and silencing all GPU metrics on that node.

The fix caps the loop to `min(sr.num, maxDevices)` in all four setters across v0 and v1, matching the same guard already applied to `sr.procnum` in `activeProcs()` (introduced in #2282).

**Files changed:**
- `pkg/monitor/nvidia/v0/spec.go`: `SetDeviceSmLimit`, `SetDeviceMemoryLimit`
- `pkg/monitor/nvidia/v1/spec.go`: `SetDeviceSmLimit`, `SetDeviceMemoryLimit`
- `pkg/monitor/nvidia/v0/spec_test.go`: added `"num larger than maxDevices does not panic"` regression case to both setter tests
- `pkg/monitor/nvidia/v1/spec_test.go`: same

**Which issue(s) this PR fixes:**
Part of #2126 (LFX observability hardening - vGPU monitor stability)

**Special notes for your reviewer:**
`sr.num` is written by libvgpu at shared-memory initialisation and is read directly from the mmap'd region. It should always be ≤ 16, but the same assumption was made about `sr.procnum` before #2282. This applies the identical guard to the remaining unclamped loops for consistency and to prevent the monitor from going down on corrupt input.

**Does this PR introduce a user-facing change?**
Yes - the vGPU monitor no longer panics if `sr.num` exceeds `maxDevices`, so all GPU metrics stay available instead of going dark.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Prevented errors when configuring shared-memory or memory limits for oversized device configurations.
* Ensured all supported device slots receive the appropriate limits across NVIDIA monitoring versions.

## Tests

* Added regression coverage confirming oversized device counts are handled safely without crashes.

**AI Disclosure:**  
AI assistance was used for code inspection and draft formatting. Changes and tests were manually validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->