### PR TITLE
fix(vGPUmonitor): skip uninitialized short UUIDs instead of exit

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -499,8 +499,8 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 	for i := range c.Info.DeviceNum() {
 		uuid := c.Info.DeviceUUID(i)
 		if len(uuid) < 40 {
-			klog.Errorf("Invalid UUID length for device %d in Pod %s/%s, Container %s", i, pod.Namespace, pod.Name, ctr.Name)
-			return fmt.Errorf("invalid UUID length for device %d", i)
+			klog.Warningf("Device %d in Pod %s/%s, Container %s has invalid UUID length %d (shared memory not yet initialised); skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name, len(uuid))
+			continue
 		}
 		uuid = uuid[0:40] // Ensure UUID is truncated to 40 characters
 		if !utf8.ValidString(uuid) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**: In cmd/vGPUMonitor/metrics.go there is a function collectContainerMetrics during checking the correct uuid format there are two cases. One checks if the characters are less that 40 and the other check correct utf format. The utf format one throws warning and skips that device. While the other one if the chrtrs are less than 40 throws error and exits.

I think both of them should follow the same behaviour. 

**Which issue(s) this PR fixes**:
Fixes #2302 

**Special notes for your reviewer**: Would like to know if it was intentional or I am having an oversight

**Does this PR introduce a user-facing change?**: NA

<img width="1532" height="476" alt="image" src="https://github.com/user-attachments/assets/194f0d5f-8c38-4b48-9bf5-6bd377b96df0" />

disclosure: Antigravity was used to audit the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container metrics collection now continues when a device has an invalid UUID.
  * Invalid devices are skipped with a warning, allowing metrics for other devices to be collected normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->