### PR TITLE
fix(monitor): skip dirs without underscore in Update instead of panicking

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -185,8 +185,13 @@ func (l *ContainerLister) Update() error {
 		if !entry.IsDir() {
 			continue
 		}
+		parts := strings.SplitN(entry.Name(), "_", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			klog.Warningf("Skipping dir with unexpected name format: %s", entry.Name())
+			continue
+		}
 		dirName := filepath.Join(l.containerPath, entry.Name())
-		podUID := strings.Split(entry.Name(), "_")[0]
+		podUID := parts[0]
 		if !podUIDs[podUID] {
 			dirInfo, err := os.Stat(dirName)
 			if err == nil && dirInfo.ModTime().Add(resyncInterval).After(time.Now()) {
@@ -209,11 +214,10 @@ func (l *ContainerLister) Update() error {
 			continue
 		}
 		if usage == nil {
-			// no cuInit in container
 			continue
 		}
 		usage.PodUID = podUID
-		usage.ContainerName = strings.Split(entry.Name(), "_")[1]
+		usage.ContainerName = parts[1]
 		l.containers[entry.Name()] = usage
 		klog.Infof("Adding ctr dirname %s in monitorpath", dirName)
 	}

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -432,4 +432,34 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.Equal(t, got.ContainerName, "mycontainer")
 		defer func() { _ = syscall.Munmap(got.data) }()
 	})
+
+	t.Run("dir without underscore in name is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "nodashes"}}
+		ctrDir := filepath.Join(dir, "nodashes")
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		writeCacheFile(t, ctrDir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		assert.Equal(t, len(l.containers), 0)
+	})
+
+	t.Run("dir with trailing underscore is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid"}}
+		ctrDir := filepath.Join(dir, "uid_")
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		writeCacheFile(t, ctrDir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{},
+			podLister:     newTestPodLister(pod),
+		}
+		assert.NilError(t, l.Update())
+		assert.Equal(t, len(l.containers), 0)
+	})
 }


### PR DESCRIPTION
## Summary

`Update()` in `pkg/monitor/nvidia/cudevshr.go` called `strings.Split(entry.Name(), "_")[1]` without checking that the split produced at least two parts. Any directory under the hook path whose name contains no underscore, a stray directory from another tool, a partial write, or operator error causes an index out of range panic that crashes vGPUmonitor and silences all GPU metrics on that node.

- `pkg/monitor/nvidia/cudevshr.go`: replaced both `strings.Split(...)[idx]` calls with a single `strings.SplitN(..., "_", 2)`; directories that don't match the expected `<podUID>_<containerName>` format are skipped with a warning log instead of panicking
- `pkg/monitor/nvidia/cudevshr_test.go`: added `"dir without underscore in name is skipped"` regression case to `Test_ContainerLister_Update`
- All existing `Test_ContainerLister_Update` subtests continue to pass

**Which issue(s) this PR fixes:**
Part of #2126 (LFX observability hardening - vGPU monitor stability)

**Special notes for your reviewer:**
The `strings.Split(...)[0]` on line 189 was safe (always produces at least one element), but the `[1]` on line 216 was not. The fix consolidates both into one `SplitN` call so the validation happens once before either index is used.

**Does this PR introduce a user-facing change?**
Yes vGPUmonitor no longer panics when a directory without an underscore appears in the hook path; GPU metrics continue to be reported normally.

**AI Disclosure:**
AI assistance was used for code inspection and draft formatting; all logic, test cases, and verification were manually checked and validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA container monitoring by ignoring malformed directory entries.
  * Prevented entries missing pod or container identifiers from creating container mappings.
  * Added validation for more consistent monitoring data parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->