### PR TITLE
feat(helm): add opt-in PrometheusRule alerts for GPU metrics

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -196,6 +196,26 @@ This document provides detailed descriptions of all configurable values paramete
 | `devicePlugin.updateStrategy.type` | Update strategy type | `RollingUpdate` |
 | `devicePlugin.updateStrategy.rollingUpdate.maxUnavailable` | Maximum unavailable count | `1` |
 
+## Monitoring and Alerting Configuration
+
+HAMi exposes GPU metrics from the scheduler and the in-container monitor. When you
+run the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator),
+set `prometheus.enabled=true` and `prometheus.alerts.enabled=true` to install a
+`PrometheusRule` with a starter set of GPU alerts. The rule is only rendered when
+the `monitoring.coreos.com/v1` `PrometheusRule` CRD is present. All thresholds are
+percentages (0-100) to match HAMi's `*_ratio` metrics.
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `legacyMetrics` | Also expose the legacy (pre-`hami_`) metric names | `false` |
+| `prometheus.enabled` | Enable Prometheus integration (ServiceMonitor and alerts) | `false` |
+| `prometheus.alerts.enabled` | Install a `PrometheusRule` with HAMi GPU alerts | `false` |
+| `prometheus.alerts.labels` | Extra labels on the `PrometheusRule` so the Operator's `ruleSelector` picks it up | `{}` |
+| `prometheus.alerts.rules.gpuMemoryNearlyExhausted` | Scheduler-allocated GPU memory on a node is near capacity | `{enabled: true, threshold: 90, for: 10m, severity: warning}` |
+| `prometheus.alerts.rules.gpuCoresNearlyExhausted` | Scheduler-allocated GPU cores on a device are near capacity | `{enabled: true, threshold: 90, for: 10m, severity: warning}` |
+| `prometheus.alerts.rules.vgpuMemoryNearLimit` | A container is near its vGPU memory limit and may be OOM-killed | `{enabled: true, threshold: 95, for: 5m, severity: warning}` |
+| `prometheus.alerts.rules.schedulerMetricsAbsent` | Scheduler has stopped exposing device metrics (off by default; also fires on GPU-less clusters) | `{enabled: false, for: 15m, severity: critical}` |
+
 ## Device Configuration
 
 ### AWS Neuron

--- a/charts/hami/templates/prometheusrule.yaml
+++ b/charts/hami/templates/prometheusrule.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.alerts.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") }}
+# Prometheus alerting rules for HAMi GPU metrics.
+# Opt in with prometheus.enabled=true and prometheus.alerts.enabled=true.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "hami-vgpu.fullname" . }}-alerts
+  namespace: {{ include "hami-vgpu.namespace" . }}
+  labels:
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.alerts.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: hami-gpu.rules
+      rules:
+        {{- with .Values.prometheus.alerts.rules.gpuMemoryNearlyExhausted }}
+        {{- if .enabled }}
+        - alert: HAMiGPUMemoryNearlyExhausted
+          expr: hami_node_gpu_memory_allocated_ratio > {{ .threshold }}
+          for: {{ .for | quote }}
+          labels:
+            severity: {{ .severity | quote }}
+          annotations:
+            summary: 'GPU memory on node {{`{{ $labels.node }}`}} is nearly exhausted'
+            description: 'Node {{`{{ $labels.node }}`}} device {{`{{ $labels.device_index }}`}} ({{`{{ $labels.device_uuid }}`}}) has {{`{{ printf "%.1f" $value }}`}}% of GPU memory allocated by the scheduler (threshold {{ .threshold }}%).'
+        {{- end }}
+        {{- end }}
+        {{- with .Values.prometheus.alerts.rules.gpuCoresNearlyExhausted }}
+        {{- if .enabled }}
+        - alert: HAMiGPUCoresNearlyExhausted
+          expr: hami_gpu_core_allocated_ratio > {{ .threshold }}
+          for: {{ .for | quote }}
+          labels:
+            severity: {{ .severity | quote }}
+          annotations:
+            summary: 'GPU cores on node {{`{{ $labels.node }}`}} are nearly exhausted'
+            description: 'Node {{`{{ $labels.node }}`}} device {{`{{ $labels.device_index }}`}} ({{`{{ $labels.device_uuid }}`}}) has {{`{{ printf "%.1f" $value }}`}}% of GPU cores allocated by the scheduler (threshold {{ .threshold }}%).'
+        {{- end }}
+        {{- end }}
+        {{- with .Values.prometheus.alerts.rules.vgpuMemoryNearLimit }}
+        {{- if .enabled }}
+        - alert: HAMivGPUMemoryNearLimit
+          expr: 100 * hami_vgpu_memory_used_bytes / (hami_vgpu_memory_limit_bytes > 0) > {{ .threshold }}
+          for: {{ .for | quote }}
+          labels:
+            severity: {{ .severity | quote }}
+          annotations:
+            summary: 'Container {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is near its vGPU memory limit'
+            description: 'Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is using {{`{{ printf "%.1f" $value }}`}}% of its vGPU memory limit (threshold {{ .threshold }}%) and may be OOM-killed.'
+        {{- end }}
+        {{- end }}
+        {{- with .Values.prometheus.alerts.rules.schedulerMetricsAbsent }}
+        {{- if .enabled }}
+        - alert: HAMiSchedulerMetricsAbsent
+          expr: absent(hami_gpu_memory_limit_bytes)
+          for: {{ .for | quote }}
+          labels:
+            severity: {{ .severity | quote }}
+          annotations:
+            summary: 'HAMi scheduler is not exposing GPU metrics'
+            description: 'No hami_gpu_memory_limit_bytes samples have been scraped for {{ .for }}. The HAMi scheduler may be down or its metrics endpoint unreachable. (This also fires on clusters that have no GPUs.)'
+        {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/hami/templates/prometheusrule.yaml
+++ b/charts/hami/templates/prometheusrule.yaml
@@ -21,7 +21,7 @@ spec:
         {{- with .Values.prometheus.alerts.rules.gpuMemoryNearlyExhausted }}
         {{- if .enabled }}
         - alert: HAMiGPUMemoryNearlyExhausted
-          expr: hami_node_gpu_memory_allocated_ratio > {{ .threshold }}
+          expr: 100 * hami_node_gpu_memory_allocated_ratio > {{ .threshold }}
           for: {{ .for | quote }}
           labels:
             severity: {{ .severity | quote }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -542,6 +542,40 @@ legacyMetrics: false
 
 prometheus:
   enabled: false
+  # Install a PrometheusRule with a starter set of HAMi GPU alerts. This requires
+  # prometheus.enabled=true and the monitoring.coreos.com/v1 PrometheusRule CRD
+  # (Prometheus Operator). All thresholds are percentages (0-100) to match HAMi's
+  # *_ratio metrics.
+  alerts:
+    enabled: false
+    # Extra labels added to the PrometheusRule so your Prometheus Operator's
+    # ruleSelector picks it up (for example: release: kube-prometheus-stack).
+    labels: {}
+    rules:
+      # Scheduler-allocated GPU memory on a node is close to capacity.
+      gpuMemoryNearlyExhausted:
+        enabled: true
+        threshold: 90
+        for: 10m
+        severity: warning
+      # Scheduler-allocated GPU compute cores on a device are close to capacity.
+      gpuCoresNearlyExhausted:
+        enabled: true
+        threshold: 90
+        for: 10m
+        severity: warning
+      # A container is using nearly all of its vGPU memory limit and may hit an OOM.
+      vgpuMemoryNearLimit:
+        enabled: true
+        threshold: 95
+        for: 5m
+        severity: warning
+      # The scheduler has stopped exposing device metrics (possible outage). Off by
+      # default because absent() also fires on clusters that simply have no GPUs.
+      schedulerMetricsAbsent:
+        enabled: false
+        for: 15m
+        severity: critical
 
 # Device config overrides
 # If content is set under device-config.content, it will be used as the device-config.yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an opt-in `PrometheusRule` to the Helm chart so clusters running the
Prometheus Operator get a starter set of HAMi GPU alerts out of the box. Today the
chart exposes GPU metrics (and a ServiceMonitor) but ships no alerting, so every
operator has to hand-write the same rules against HAMi's metric names.

The rule is fully opt-in and non-breaking. It only renders when all three hold:

- `prometheus.enabled=true`
- `prometheus.alerts.enabled=true`
- the `monitoring.coreos.com/v1` `PrometheusRule` CRD is installed

Existing installs render nothing new.

The default rules cover the common operational risks:

| Alert | Fires when | Default |
| --- | --- | --- |
| `HAMiGPUMemoryNearlyExhausted` | node's scheduler-allocated GPU memory > 90% | on, warning, 10m |
| `HAMiGPUCoresNearlyExhausted` | device's scheduler-allocated GPU cores > 90% | on, warning, 10m |
| `HAMivGPUMemoryNearLimit` | a container is > 95% of its vGPU memory limit | on, warning, 5m |
| `HAMiSchedulerMetricsAbsent` | `hami_gpu_memory_limit_bytes` absent | off, critical, 15m |

Each rule is individually toggleable and carries its own `threshold`, `for`, and
`severity`. Extra labels can be attached to the `PrometheusRule` so the Operator's
`ruleSelector` picks it up. Thresholds are percentages (0-100) to match HAMi's
`*_ratio` metrics. `HAMiSchedulerMetricsAbsent` is off by default because `absent()`
also fires on clusters that simply have no GPUs.

All metric names and label sets used by the rules were verified against the
scheduler and vGPU-monitor metric definitions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Gating verified with `helm template`:

- defaults (all off) → 0 rules
- `prometheus.enabled=true` only → 0 rules
- alerts on but CRD absent → 0 rules
- alerts on + CRD present → 1 `PrometheusRule` with 3 default alerts

`helm lint` passes. New chart values are documented in `charts/hami/README.md`.
The chart version is intentionally not bumped, matching how other feature PRs to
the chart (e.g. #2290, #2091, #1887) leave the version to the release commit.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were
reviewed and verified by me.

**Does this PR introduce a user-facing change?**:

```release-note
Helm: add opt-in Prometheus alerting rules (`prometheus.alerts.enabled`) for GPU memory/core exhaustion and vGPU memory limits.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Prometheus monitoring and alerting for GPU memory, GPU core usage, vGPU memory limits, and missing scheduler metrics.
  * Added support for customizing alert thresholds, durations, severities, and labels.
  * Added documentation for enabling Prometheus integration and installing alert rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->