### PR TITLE
fix(device-plugin): resolve stale annotation in multi-container Allocate

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -18,6 +18,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
@@ -566,4 +568,234 @@ func TestAllocate_SingleContainer(t *testing.T) {
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "50", response.ContainerResponses[0].Envs["CUDA_DEVICE_SM_LIMIT"])
 	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts))
+}
+
+// ---------------------------------------------------------------------------
+// Allocate — MIG branch coverage
+// ---------------------------------------------------------------------------
+
+// newTestPluginWithRM returns a test plugin with a mocked ResourceManager
+// so that MIG device lookups (plugin.rm.Devices().Contains) can be controlled.
+func newTestPluginWithRM(t *testing.T, devices map[string]*rm.Device) *NvidiaDevicePlugin {
+	t.Helper()
+	plugin := newTestPlugin(t)
+	plugin.rm = &rm.ResourceManagerMock{
+		ResourceFunc: func() v1.ResourceName { return "nvidia.com/gpu" },
+		DevicesFunc:  func() rm.Devices { return rm.Devices(devices) },
+	}
+	return plugin
+}
+
+func TestAllocate_MIG_Success(t *testing.T) {
+	setupInRequestDevices(t)
+
+	migDevice := &rm.Device{}
+	migDevice.ID = "MIG-aaa-0"
+	plugin := newTestPluginWithRM(t, map[string]*rm.Device{"MIG-aaa-0": migDevice})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-pod", Namespace: "default", UID: "mig-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "MIG-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}}},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"MIG-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+}
+
+func TestAllocate_MIG_FailRequestsGreaterThanOne(t *testing.T) {
+	setupInRequestDevices(t)
+
+	// Both device IDs must be in the device map so we pass the Contains check.
+	// The IDs contain "::" so AnyHasAnnotations() returns true (shared replicas).
+	dev1 := &rm.Device{}
+	dev1.ID = "MIG-gpu-uuid::0"
+	dev2 := &rm.Device{}
+	dev2.ID = "MIG-gpu-uuid::1"
+	plugin := newTestPluginWithRM(t, map[string]*rm.Device{
+		"MIG-gpu-uuid::0": dev1,
+		"MIG-gpu-uuid::1": dev2,
+	})
+	// Enable FailRequestsGreaterThanOne — requesting >1 annotated shared device errors.
+	plugin.config.Sharing.TimeSlicing.FailRequestsGreaterThanOne = true
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-pod", Namespace: "default", UID: "mig-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "MIG-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}}},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"MIG-gpu-uuid::0", "MIG-gpu-uuid::1"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too large")
+}
+
+func TestAllocate_MIG_UnknownDevice(t *testing.T) {
+	setupInRequestDevices(t)
+
+	// Device map does NOT contain the requested ID
+	plugin := newTestPluginWithRM(t, map[string]*rm.Device{})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-pod", Namespace: "default", UID: "mig-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "MIG-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}}},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"MIG-unknown-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown device")
+}
+
+// ---------------------------------------------------------------------------
+// Allocate — error path coverage
+// ---------------------------------------------------------------------------
+
+func TestAllocate_GetPendingPodError(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	// Override getPendingPod to return an error
+	prevGetPendingPod := getPendingPod
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
+		return nil, errors.New("pod not found")
+	}
+	t.Cleanup(func() { getPendingPod = prevGetPendingPod })
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pod not found")
+}
+
+func TestAllocate_DecodePodSingleDeviceError(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	// Annotation is empty → decodePodSingleDevice returns error
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bad-pod", Namespace: "default", UID: "bad-uid",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}}},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device request not found")
+}
+
+func TestAllocate_PopNextContainerDevicesError_MoreContainersThanAnnotation(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	// Annotation has 1 container, but Allocate receives 2 ContainerRequests.
+	// After popping the first container, the second pop finds an empty
+	// (all-erased) podSingleDev → error.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pop-err-pod", Namespace: "default", UID: "pop-err-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}}},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+			{DevicesIds: []string{"GPU-bbb-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no pending device allocation found")
+}
+
+func TestAllocate_PatchErasedAnnotationError(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "patch-err-pod", Namespace: "default", UID: "patch-err-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c0"}}},
+	}
+
+	// Use a fake client that fails Patch on pods
+	fc := setupFakeClient(t, pod)
+	fc.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("patch not allowed")
+	})
+
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "patch not allowed")
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -81,8 +81,18 @@ func mustStrategies(t *testing.T, strategies ...string) v1.DeviceListStrategies 
 
 func newTestPlugin(t *testing.T) *NvidiaDevicePlugin {
 	t.Helper()
+	prevHookPath := os.Getenv("HOOK_PATH")
+	prevHostHookPath := hostHookPath
 	os.Setenv("HOOK_PATH", "/tmp/hami-test-hookpath")
 	hostHookPath = "/tmp/hami-test-hookpath"
+	t.Cleanup(func() {
+		if prevHookPath != "" {
+			os.Setenv("HOOK_PATH", prevHookPath)
+		} else {
+			os.Unsetenv("HOOK_PATH")
+		}
+		hostHookPath = prevHostHookPath
+	})
 	logLevel := nvidia.Error
 	memScale := 1.0
 	return &NvidiaDevicePlugin{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -1,0 +1,569 @@
+/*
+ * Copyright (c) 2024, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plugin
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	v1 "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
+)
+
+// ---------------------------------------------------------------------------
+// test helpers
+// ---------------------------------------------------------------------------
+
+func cd(uuid, typ string, usedmem, usedcores int32) device.ContainerDevice {
+	return device.ContainerDevice{
+		UUID:      uuid,
+		Type:      typ,
+		Usedmem:   usedmem,
+		Usedcores: usedcores,
+	}
+}
+
+func setupInRequestDevices(t *testing.T) {
+	t.Helper()
+	old := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	t.Cleanup(func() {
+		if old != "" {
+			device.InRequestDevices[nvidia.NvidiaGPUDevice] = old
+		} else {
+			delete(device.InRequestDevices, nvidia.NvidiaGPUDevice)
+		}
+	})
+}
+
+func setupFakeClient(t *testing.T, objs ...runtime.Object) *fake.Clientset {
+	t.Helper()
+	orig := client.KubeClient
+	fc := fake.NewSimpleClientset(objs...)
+	client.KubeClient = fc
+	t.Cleanup(func() { client.KubeClient = orig })
+	return fc
+}
+
+func mustStrategies(t *testing.T, strategies ...string) v1.DeviceListStrategies {
+	t.Helper()
+	dls, err := v1.NewDeviceListStrategies(strategies)
+	require.NoError(t, err)
+	return dls
+}
+
+func newTestPlugin(t *testing.T) *NvidiaDevicePlugin {
+	t.Helper()
+	os.Setenv("HOOK_PATH", "/tmp/hami-test-hookpath")
+	hostHookPath = "/tmp/hami-test-hookpath"
+	logLevel := nvidia.Error
+	memScale := 1.0
+	return &NvidiaDevicePlugin{
+		operatingMode: "vgpu",
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							DeviceIDStrategy: ptr("UUID"),
+						},
+					},
+				},
+			},
+		},
+		deviceListStrategies: mustStrategies(t, "envvar"),
+		schedulerConfig: nvidia.NvidiaConfig{
+			NodeDefaultConfig: nvidia.NodeDefaultConfig{
+				DeviceMemoryScaling: &memScale,
+				LogLevel:            &logLevel,
+			},
+		},
+	}
+}
+
+func hasLdSoPreloadMount(mounts []*kubeletdevicepluginv1beta1.Mount) bool {
+	for _, m := range mounts {
+		if m.ContainerPath == "/etc/ld.so.preload" {
+			return true
+		}
+	}
+	return false
+}
+
+func mockAllocateGlobals(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	previousGetPendingPod := getPendingPod
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	t.Cleanup(func() { getPendingPod = previousGetPendingPod })
+
+	previousPodAllocationFailed := podAllocationFailed
+	podAllocationFailed = func(string, *corev1.Pod, string) {}
+	t.Cleanup(func() { podAllocationFailed = previousPodAllocationFailed })
+
+	previousPodAllocationTrySuccess := podAllocationTrySuccess
+	podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {}
+	t.Cleanup(func() { podAllocationTrySuccess = previousPodAllocationTrySuccess })
+}
+
+// ---------------------------------------------------------------------------
+// popNextContainerDevices — unit tests
+// ---------------------------------------------------------------------------
+
+func TestPopNextContainerDevices(t *testing.T) {
+	tests := []struct {
+		name         string
+		containers   []corev1.Container
+		podSingleDev device.PodSingleDevice
+		wantName     string
+		wantUUID     string
+		wantErr      string
+		wantRemaining int
+	}{
+		{
+			name:         "EmptyPodSingleDevice",
+			containers:   []corev1.Container{{Name: "c0"}},
+			podSingleDev: device.PodSingleDevice{},
+			wantErr:      "no pending device allocation found",
+		},
+		{
+			name:         "AllContainersEmpty",
+			containers:   []corev1.Container{{Name: "c0"}, {Name: "c1"}, {Name: "c2"}},
+			podSingleDev: device.PodSingleDevice{{}, {}, {}},
+			wantErr:      "no pending device allocation found",
+		},
+		{
+			name:       "FirstContainerHasDevices",
+			containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}},
+			podSingleDev: device.PodSingleDevice{
+				{cd("uuid1", "NVIDIA", 1024, 4)},
+				{cd("uuid2", "NVIDIA", 2048, 8)},
+			},
+			wantName:      "c0",
+			wantUUID:      "uuid1",
+			wantRemaining: 1,
+		},
+		{
+			name:       "SecondContainerHasDevices",
+			containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}, {Name: "c2"}},
+			podSingleDev: device.PodSingleDevice{
+				{},
+				{cd("uuid2", "NVIDIA", 2048, 8)},
+				{cd("uuid3", "NVIDIA", 512, 2)},
+			},
+			wantName:      "c1",
+			wantUUID:      "uuid2",
+			wantRemaining: 1,
+		},
+		{
+			name:       "MutationErasesFirstNonEmpty",
+			containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}},
+			podSingleDev: device.PodSingleDevice{
+				{cd("uuid1", "NVIDIA", 1024, 4)},
+				{cd("uuid2", "NVIDIA", 2048, 8)},
+			},
+			wantName:      "c0",
+			wantUUID:      "uuid1",
+			wantRemaining: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: tc.containers},
+			}
+			ctr, got, err := popNextContainerDevices(pod, tc.podSingleDev)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantName, ctr.Name)
+			require.NotEmpty(t, got)
+			require.Equal(t, tc.wantUUID, got[0].UUID)
+			// mutation: the popped container should now be empty — find it by UUID
+			for i, d := range tc.podSingleDev {
+				if len(d) > 0 && d[0].UUID == tc.wantUUID {
+					t.Fatalf("popped container at index %d should be erased in place, found %d devices", i, len(d))
+				}
+			}
+			if tc.wantRemaining > 0 {
+				nonEmpty := 0
+				for _, d := range tc.podSingleDev {
+					nonEmpty += len(d)
+				}
+				require.Equal(t, tc.wantRemaining, nonEmpty)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// popNextContainerDevices_AfterDecode — integration test
+// ---------------------------------------------------------------------------
+
+func TestPopNextContainerDevices_AfterDecode(t *testing.T) {
+	setupInRequestDevices(t)
+
+	input := device.EncodePodSingleDevice(device.PodSingleDevice{
+		{},
+		{cd("uuid1", "NVIDIA", 1024, 4)},
+		{cd("uuid2", "NVIDIA", 2048, 8)},
+	})
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": input,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"},
+				{Name: "c1"},
+				{Name: "c2"},
+			},
+		},
+	}
+
+	podSingleDev, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, pod)
+	require.NoError(t, err)
+
+	// First pop → c1 / uuid1 (index 0 is empty, so first non-empty is index 1)
+	ctr1, got1, err := popNextContainerDevices(pod, podSingleDev)
+	require.NoError(t, err)
+	require.Equal(t, "c1", ctr1.Name)
+	require.Equal(t, "uuid1", got1[0].UUID)
+
+	// Second pop → c2 / uuid2
+	ctr2, got2, err := popNextContainerDevices(pod, podSingleDev)
+	require.NoError(t, err)
+	require.Equal(t, "c2", ctr2.Name)
+	require.Equal(t, "uuid2", got2[0].UUID)
+
+	// Third pop → error
+	_, _, err = popNextContainerDevices(pod, podSingleDev)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// patchErasedAnnotation — unit tests
+// ---------------------------------------------------------------------------
+
+func TestPatchErasedAnnotation(t *testing.T) {
+	setupInRequestDevices(t)
+
+	toAllocAnno := "hami.io/vgpu-devices-to-allocate"
+	input := device.EncodePodSingleDevice(device.PodSingleDevice{
+		{cd("uuid1", "NVIDIA", 1024, 4)},
+		{cd("uuid2", "NVIDIA", 2048, 8)},
+	})
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				toAllocAnno: input,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}},
+		},
+	}
+	setupFakeClient(t, pod)
+
+	// Pop one container, then patch
+	podSingleDev, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, pod)
+	require.NoError(t, err)
+	_, _, err = popNextContainerDevices(pod, podSingleDev)
+	require.NoError(t, err)
+
+	origValue := pod.Annotations[toAllocAnno]
+	err = patchErasedAnnotation(pod, nvidia.NvidiaGPUDevice, podSingleDev)
+	require.NoError(t, err)
+
+	// In-memory annotation updated
+	require.NotEqual(t, origValue, pod.Annotations[toAllocAnno],
+		"pod.Annotations should have been updated in place")
+
+	// API server also updated
+	refreshed, err := client.KubeClient.CoreV1().Pods("default").Get(context.Background(), "test-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, pod.Annotations[toAllocAnno], refreshed.Annotations[toAllocAnno],
+		"API server annotation should match in-memory annotation")
+
+	// Re-decode: only uuid2 remains
+	remaining, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, pod)
+	require.NoError(t, err)
+	nonEmpty := 0
+	for _, d := range remaining {
+		if len(d) > 0 {
+			nonEmpty++
+		}
+	}
+	require.Equal(t, 1, nonEmpty, "one container should remain after pop")
+}
+
+// ---------------------------------------------------------------------------
+// Allocate — end-to-end tests
+// ---------------------------------------------------------------------------
+
+func TestAllocate_MultiContainer_EachGetsOwnDevice(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;GPU-bbb,NVIDIA,4000,60:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"},
+				{Name: "c1"},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+			{DevicesIds: []string{"GPU-bbb-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 2)
+
+	// Each container gets its own memory limit and SM limit
+	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+	require.Equal(t, "50", response.ContainerResponses[0].Envs["CUDA_DEVICE_SM_LIMIT"])
+	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+	require.Equal(t, "60", response.ContainerResponses[1].Envs["CUDA_DEVICE_SM_LIMIT"])
+}
+
+func TestAllocate_MultiContainer_CUDA_DISABLE_CONTROL_SecondContainer(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;GPU-bbb,NVIDIA,4000,60:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"},
+				{Name: "c1", Env: []corev1.EnvVar{
+					{Name: "CUDA_DISABLE_CONTROL", Value: "true"},
+				}},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+			{DevicesIds: []string{"GPU-bbb-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 2)
+
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"container 0 should have ld.so.preload mounted")
+	require.False(t, hasLdSoPreloadMount(response.ContainerResponses[1].Mounts),
+		"container 1 (CUDA_DISABLE_CONTROL=true) should NOT have ld.so.preload mounted")
+}
+
+func TestAllocate_MultiContainer_CUDA_DISABLE_CONTROL_FirstContainer(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;GPU-bbb,NVIDIA,4000,60:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0", Env: []corev1.EnvVar{
+					{Name: "CUDA_DISABLE_CONTROL", Value: "true"},
+				}},
+				{Name: "c1"},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+			{DevicesIds: []string{"GPU-bbb-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 2)
+
+	require.False(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"container 0 (CUDA_DISABLE_CONTROL=true) should NOT have ld.so.preload mounted")
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[1].Mounts),
+		"container 1 should have ld.so.preload mounted")
+}
+
+func TestAllocate_DeviceNumberMismatch(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				// annotation says 1 device, but request asks for 2
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0", "GPU-aaa-1"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device number not matched")
+}
+
+func TestAllocate_PatchesAnnotationOnlyOnce(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;GPU-bbb,NVIDIA,4000,60:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"},
+				{Name: "c1"},
+			},
+		},
+	}
+	fc := setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	// Count Patch calls on the fake clientset
+	patchCount := 0
+	fc.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchCount++
+		return false, nil, nil // fall through to default
+	})
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+			{DevicesIds: []string{"GPU-bbb-0"}},
+		},
+	}
+
+	_, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, patchCount,
+		"Allocate should patch the API server exactly once for multi-container pods")
+}
+
+func TestAllocate_SingleContainer(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+	require.Equal(t, "50", response.ContainerResponses[0].Envs["CUDA_DEVICE_SM_LIMIT"])
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts))
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -608,10 +608,6 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	}
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 
-	// Decode the pod's device annotation once into memory. We mutate this slice
-	// in-place as we process each container, then patch the API server exactly
-	// once after the loop. This avoids the stale-annotation bug where each
-	// iteration re-reads the original (un-erased) annotation.
 	podSingleDev, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, current)
 	if err != nil {
 		PodAllocationFailed(nodename, current, NodeLockNvidia)
@@ -740,10 +736,6 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 		}
 	}
 
-	// Patch the annotation with the in-memory erased podSingleDev exactly once.
-	// Note: mid-loop error returns skip this patch, leaving the API-server
-	// annotation unchanged. This is safe — a kubelet retry re-processes from
-	// scratch, and getAllocateResponse / os.MkdirAll are idempotent.
 	if err := patchErasedAnnotation(current, nvidia.NvidiaGPUDevice, podSingleDev); err != nil {
 		klog.Errorf("erase allocated containers annotation error: %v", err)
 		PodAllocationFailed(nodename, current, NodeLockNvidia)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -608,6 +608,16 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	}
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 
+	// Decode the pod's device annotation once into memory. We mutate this slice
+	// in-place as we process each container, then patch the API server exactly
+	// once after the loop. This avoids the stale-annotation bug where each
+	// iteration re-reads the original (un-erased) annotation.
+	podSingleDev, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, current)
+	if err != nil {
+		PodAllocationFailed(nodename, current, NodeLockNvidia)
+		return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+	}
+
 	for idx, req := range reqs.ContainerRequests {
 		// If the devices being allocated are replicas, then (conditionally)
 		// error out if more than one resource is being allocated.
@@ -634,7 +644,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 			responses.ContainerResponses = append(responses.ContainerResponses, response)
 		} else {
-			currentCtr, devreq, err := GetNextDeviceRequest(nvidia.NvidiaGPUDevice, *current)
+			currentCtr, devreq, err := popNextContainerDevices(current, podSingleDev)
 			klog.Infoln("deviceAllocateFromAnnotation=", devreq)
 			if err != nil {
 				PodAllocationFailed(nodename, current, NodeLockNvidia)
@@ -644,6 +654,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return &kubeletdevicepluginv1beta1.AllocateResponse{}, errors.New("device number not matched")
 			}
+
 			if enableGetPreferredAllocation && plugin.operatingMode != "mig" {
 				alignedDevreq, err := plugin.alignContainerDevicesWithAllocatedIDs(devreq, reqs.ContainerRequests[idx].DevicesIds)
 				if err != nil {
@@ -656,12 +667,6 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			if err != nil {
 				PodAllocationFailed(nodename, current, NodeLockNvidia)
 				return nil, fmt.Errorf("failed to get allocate response: %v", err)
-			}
-
-			err = eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, *current)
-			if err != nil {
-				PodAllocationFailed(nodename, current, NodeLockNvidia)
-				return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
 			}
 
 			if plugin.operatingMode != "mig" {
@@ -734,6 +739,17 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			responses.ContainerResponses = append(responses.ContainerResponses, response)
 		}
 	}
+
+	// Patch the annotation with the in-memory erased podSingleDev exactly once.
+	// Note: mid-loop error returns skip this patch, leaving the API-server
+	// annotation unchanged. This is safe — a kubelet retry re-processes from
+	// scratch, and getAllocateResponse / os.MkdirAll are idempotent.
+	if err := patchErasedAnnotation(current, nvidia.NvidiaGPUDevice, podSingleDev); err != nil {
+		klog.Errorf("erase allocated containers annotation error: %v", err)
+		PodAllocationFailed(nodename, current, NodeLockNvidia)
+		return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+	}
+
 	klog.Infoln("Allocate Response", responses.ContainerResponses)
 	PodAllocationTrySuccess(nodename, nvidia.NvidiaGPUDevice, NodeLockNvidia, current)
 	return &responses, nil

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -47,100 +47,13 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	"k8s.io/client-go/kubernetes/fake"
 )
-
-func ptr[T any](x T) *T {
-	return &x
-}
-
-func runFallbackInit(plugin *NvidiaDevicePlugin, deviceNumbers int) {
-	plugin.migCurrent.MigConfigs = make(map[string]nvidia.MigConfigSpecSlice)
-	configSlice := nvidia.MigConfigSpecSlice{}
-	for i := 0; i < deviceNumbers; i++ {
-		conf := nvidia.MigConfigSpec{MigEnabled: false, Devices: []int32{int32(i)}}
-		configSlice = append(configSlice, conf)
-	}
-	plugin.migCurrent.MigConfigs["current"] = configSlice
-}
-
-type MigDeviceConfigs struct {
-	Configs []map[string]int32
-}
-
-func TestMigConfigFilePermissions(t *testing.T) {
-	testCases := []struct {
-		name             string
-		expectedMode     os.FileMode
-		shouldBeReadable bool
-		shouldBeWritable bool
-		otherCanWrite    bool
-	}{
-		{
-			name:             "0644 permissions - owner read/write, others read-only",
-			expectedMode:     0644,
-			shouldBeReadable: true,
-			shouldBeWritable: true,
-			otherCanWrite:    false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			testFile := tmpDir + "/migconfig.yaml"
-			testData := []byte("test MIG configuration data")
-
-			err := os.WriteFile(testFile, testData, tc.expectedMode)
-			require.NoError(t, err, "file write should succeed")
-
-			info, err := os.Stat(testFile)
-			require.NoError(t, err, "file should exist after write")
-
-			mode := info.Mode().Perm()
-			require.Equal(t, tc.expectedMode, mode,
-				"file permissions should match: expected %#o, got %#o", tc.expectedMode, mode)
-
-			data, err := os.ReadFile(testFile)
-			require.NoError(t, err, "file should be readable")
-			require.Equal(t, testData, data, "file content should match")
-
-			permString := mode.String()
-			if tc.expectedMode == 0644 {
-				require.Equal(t, "-rw-r--r--", permString, "0644 should display as -rw-r--r--")
-			}
-		})
-	}
-}
-
-func TestMigConfigFilePermissionSecurityImprovement(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	correctFile := tmpDir + "/config_0644.yaml"
-	testData := []byte("GPU MIG configuration")
-
-	err := os.WriteFile(correctFile, testData, 0644)
-	require.NoError(t, err)
-
-	info644, err := os.Stat(correctFile)
-	require.NoError(t, err)
-	mode644 := info644.Mode().Perm()
-
-	ownerCanWrite := (mode644 & 0200) != 0
-	groupCanWrite := (mode644 & 0020) != 0
-	otherCanWrite := (mode644 & 0002) != 0
-
-	require.True(t, ownerCanWrite, "0644: Owner should be able to write")
-	require.False(t, groupCanWrite, "0644: Group should NOT write")
-	require.False(t, otherCanWrite, "0644: Others should NOT write (secure!)")
-
-	otherCanRead := (mode644 & 0004) != 0
-	require.True(t, otherCanRead, "0644: Others CAN read (for debugging)")
-}
 
 func TestCDIAllocateResponse(t *testing.T) {
 	testCases := []struct {
@@ -285,6 +198,14 @@ func TestCDIAllocateResponse(t *testing.T) {
 			require.EqualValues(t, &tc.expectedResponse, &response)
 		})
 	}
+}
+
+func ptr[T any](x T) *T {
+	return &x
+}
+
+type MigDeviceConfigs struct {
+	Configs []map[string]int32
 }
 
 func Test_processMigConfigs(t *testing.T) {
@@ -480,6 +401,7 @@ func Test_processMigConfigs(t *testing.T) {
 
 func TestSelectPreferredDeviceIDsFromAnnotatedDevices(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
+	// Use real NVIDIA GPU UUID format: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	available := []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
@@ -526,7 +448,7 @@ func TestSelectPreferredDeviceIDsFromAnnotatedDevicesErrorsWhenAnnotatedUUIDMiss
 	}
 	desired := device.ContainerDevices{
 		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c"}, // Missing from available
 	}
 
 	_, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, nil, desired, len(desired))
@@ -732,9 +654,10 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-pod",
 			Annotations: map[string]string{
+				// Annotation includes init container (empty) + regular container (with GPU)
 				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
-					{},
-					{
+					{}, // init container - empty
+					{ // regular container - 2 GPUs
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice},
 						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", Type: nvidia.NvidiaGPUDevice},
 					},
@@ -757,14 +680,12 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 		getPendingPod = previousGetPendingPod
 	}()
 
+	// Kubelet only sends one request (for the main container), not two
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
 			{
-				AvailableDeviceIDs: []string{
-					"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
-					"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-1",
-				},
-				AllocationSize: 2,
+				AvailableDeviceIDs: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-1"},
+				AllocationSize:     2,
 			},
 		},
 	}
@@ -772,23 +693,28 @@ func TestGetPreferredAllocationSkipsEmptyAnnotations(t *testing.T) {
 	response, err := plugin.GetPreferredAllocation(context.Background(), request)
 	require.NoError(t, err)
 	require.Len(t, response.ContainerResponses, 1)
-	require.ElementsMatch(t, []string{
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
-		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
-	}, response.ContainerResponses[0].DeviceIDs)
+	// Should match GPU-a and GPU-b, not fail due to empty init container annotation
+	require.ElementsMatch(t, []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0"}, response.ContainerResponses[0].DeviceIDs)
 }
 
 func TestPhysicalDeviceIDHandlesMIGFormat(t *testing.T) {
+	// Use real NVIDIA GPU UUID format: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (5 dashes)
+	// Virtual devices have 6 dashes: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-N
 	tests := []struct {
 		input    string
 		expected string
 	}{
+		// Virtual device format (6 dashes)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-10", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		// MIG format with template index
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a[1-2]", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		// Replica format
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a::replica-1", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		// Plain UUID (5 dashes, should not be modified)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		// UUID ending with -123 (5 dashes total, should NOT be treated as virtual device)
 		{"GPU-03f69c50-207a-2038-9b45-23cac89cb123", "GPU-03f69c50-207a-2038-9b45-23cac89cb123"},
 	}
 
@@ -802,20 +728,22 @@ func TestPhysicalDeviceIDHandlesMIGFormat(t *testing.T) {
 
 func TestSelectPreferredDeviceIDsWithMIGUUIDs(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
+	// Use real NVIDIA GPU UUID format
 	available := []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
 	}
 	desired := device.ContainerDevices{
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a[0-1]"}, // MIG format
 		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b"},
-		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c[1-2]"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c[1-2]"}, // MIG format with different index
 	}
 
 	got, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, nil, desired, 3)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
+	// Should select one slice from each physical GPU
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0")
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0")
 	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0")
@@ -854,11 +782,17 @@ func TestGetPreferredAllocationFallbackOnAnnotatedDeviceMappingFailure(t *testin
 		},
 	}
 
-	plugin := &NvidiaDevicePlugin{rm: mockRM}
+	plugin := &NvidiaDevicePlugin{
+		rm: mockRM,
+	}
 	t.Setenv(util.NodeNameEnvName, "node-a")
 	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
-	defer func() { getPendingPod = previousGetPendingPod }()
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
+		return pod, nil
+	}
+	defer func() {
+		getPendingPod = previousGetPendingPod
+	}()
 
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
@@ -909,11 +843,17 @@ func TestGetPreferredAllocationFallbackOnInsufficientAnnotatedDevices(t *testing
 		},
 	}
 
-	plugin := &NvidiaDevicePlugin{rm: mockRM}
+	plugin := &NvidiaDevicePlugin{
+		rm: mockRM,
+	}
 	t.Setenv(util.NodeNameEnvName, "node-a")
 	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
-	defer func() { getPendingPod = previousGetPendingPod }()
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) {
+		return pod, nil
+	}
+	defer func() {
+		getPendingPod = previousGetPendingPod
+	}()
 
 	request := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
@@ -1011,10 +951,6 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
 	defer func() { getPendingPod = previousGetPendingPod }()
 
-	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
-	eraseNextDeviceTypeFromAnnotation = func(string, corev1.Pod) error { return nil }
-	defer func() { eraseNextDeviceTypeFromAnnotation = previousEraseNextDeviceTypeFromAnnotation }()
-
 	previousPodAllocationFailed := podAllocationFailed
 	podAllocationFailed = func(string, *corev1.Pod, string) {}
 	defer func() { podAllocationFailed = previousPodAllocationFailed }()
@@ -1022,6 +958,11 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 	previousPodAllocationTrySuccess := podAllocationTrySuccess
 	podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {}
 	defer func() { podAllocationTrySuccess = previousPodAllocationTrySuccess }()
+
+	// Provide a fake K8s client so the real patchErasedAnnotation can patch
+	previousKubeClient := client.KubeClient
+	client.KubeClient = fake.NewSimpleClientset(pod)
+	defer func() { client.KubeClient = previousKubeClient }()
 
 	request := &kubeletdevicepluginv1beta1.AllocateRequest{
 		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{{
@@ -1034,93 +975,6 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 	require.Equal(t, "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", response.ContainerResponses[0].Envs[deviceListEnvVar])
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "50", response.ContainerResponses[0].Envs["CUDA_DEVICE_SM_LIMIT"])
-}
-
-func TestAllocateReleasesNodeLockWhenNonMIGAllocateResponseFails(t *testing.T) {
-	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"cdi-annotations"})
-	deviceIDStrategy := v1.DeviceIDStrategyUUID
-	expectedNodeName := "node-a"
-	t.Setenv(util.NodeNameEnvName, expectedNodeName)
-
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{
-						Plugin: &v1.PluginCommandLineFlags{
-							DeviceIDStrategy: &deviceIDStrategy,
-						},
-					},
-				},
-			},
-		},
-		cdiHandler: &cdi.InterfaceMock{
-			QualifiedNameFunc: func(string, string) string {
-				return "invalid-cdi-device-name"
-			},
-		},
-		deviceListStrategies: deviceListStrategies,
-		cdiAnnotationPrefix:  v1.DefaultCDIAnnotationPrefix,
-	}
-
-	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
-	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
-	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "default",
-			UID:       "pod-uid",
-			Annotations: map[string]string{
-				"hami.io/vgpu-devices-to-allocate": "GPU-annotated-a,NVIDIA,3000,50:;",
-			},
-		},
-		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
-	}
-
-	previousGetPendingPod := getPendingPod
-	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
-	defer func() { getPendingPod = previousGetPendingPod }()
-
-	eraseCalled := false
-	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
-	eraseNextDeviceTypeFromAnnotation = func(string, corev1.Pod) error {
-		eraseCalled = true
-		return nil
-	}
-	defer func() { eraseNextDeviceTypeFromAnnotation = previousEraseNextDeviceTypeFromAnnotation }()
-
-	failedCalled := false
-	previousPodAllocationFailed := podAllocationFailed
-	podAllocationFailed = func(nodeName string, failedPod *corev1.Pod, lockName string) {
-		failedCalled = true
-		require.Equal(t, expectedNodeName, nodeName)
-		require.Equal(t, pod, failedPod)
-		require.Equal(t, NodeLockNvidia, lockName)
-	}
-	defer func() { podAllocationFailed = previousPodAllocationFailed }()
-
-	successCalled := false
-	previousPodAllocationTrySuccess := podAllocationTrySuccess
-	podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {
-		successCalled = true
-	}
-	defer func() { podAllocationTrySuccess = previousPodAllocationTrySuccess }()
-
-	request := &kubeletdevicepluginv1beta1.AllocateRequest{
-		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{{
-			DevicesIds: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0"},
-		}},
-	}
-
-	response, err := plugin.Allocate(context.Background(), request)
-	require.Nil(t, response)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get allocate response")
-	require.True(t, failedCalled)
-	require.False(t, eraseCalled)
-	require.False(t, successCalled)
 }
 
 func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) {
@@ -1170,12 +1024,10 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
 	defer func() { getPendingPod = previousGetPendingPod }()
 
-	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
-	eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
-		pod.Annotations["hami.io/vgpu-devices-to-allocate"] = ";GPU-annotated-b,NVIDIA,4000,60:;"
-		return nil
-	}
-	defer func() { eraseNextDeviceTypeFromAnnotation = previousEraseNextDeviceTypeFromAnnotation }()
+	// Provide a fake K8s client so the real patchErasedAnnotation can patch
+	previousKubeClient := client.KubeClient
+	client.KubeClient = fake.NewSimpleClientset(pod)
+	defer func() { client.KubeClient = previousKubeClient }()
 
 	previousPodAllocationFailed := podAllocationFailed
 	podAllocationFailed = func(string, *corev1.Pod, string) {}
@@ -1199,176 +1051,3 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 }
-
-func TestMigFallbackInitialization(t *testing.T) {
-	testCases := []struct {
-		name          string
-		deviceNumbers int
-	}{
-		{name: "zero devices", deviceNumbers: 0},
-		{name: "single device", deviceNumbers: 1},
-		{name: "three devices", deviceNumbers: 3},
-		{name: "eight devices", deviceNumbers: 8},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			plugin := &NvidiaDevicePlugin{
-				config: &nvidia.DeviceConfig{
-					Config: &v1.Config{
-						Flags: v1.Flags{
-							CommandLineFlags: v1.CommandLineFlags{},
-						},
-					},
-				},
-				migCurrent: nvidia.MigPartedSpec{},
-			}
-
-			runFallbackInit(plugin, tc.deviceNumbers)
-
-			require.NotNil(t, plugin.migCurrent.MigConfigs,
-				"MigConfigs must not be nil after fallback init")
-			require.NotNil(t, plugin.migCurrent.MigConfigs["current"],
-				"current key must always exist after fallback init")
-			require.Len(t, plugin.migCurrent.MigConfigs["current"], tc.deviceNumbers,
-				"one config entry per device is required")
-
-			for i := 0; i < tc.deviceNumbers; i++ {
-				cfg := plugin.migCurrent.MigConfigs["current"][i]
-				require.False(t, cfg.MigEnabled,
-					"fallback must set MigEnabled=false for device %d", i)
-				require.Len(t, cfg.Devices, 1,
-					"each fallback entry must reference exactly one device (device %d)", i)
-				require.Equal(t, int32(i), cfg.Devices[0],
-					"device index must match loop counter for device %d", i)
-			}
-		})
-	}
-}
-
-func TestMigFallbackInit_ReplacesExistingConfigs(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{},
-				},
-			},
-		},
-		migCurrent: nvidia.MigPartedSpec{
-			MigConfigs: map[string]nvidia.MigConfigSpecSlice{
-				"current": {
-					nvidia.MigConfigSpec{MigEnabled: true, Devices: []int32{0}},
-					nvidia.MigConfigSpec{MigEnabled: true, Devices: []int32{1}},
-				},
-				"stale-key": {},
-			},
-		},
-	}
-
-	deviceNumbers := 2
-	runFallbackInit(plugin, deviceNumbers)
-
-	require.Len(t, plugin.migCurrent.MigConfigs, 1,
-		"fallback must produce a map with only the current key")
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], deviceNumbers)
-	for i := 0; i < deviceNumbers; i++ {
-		require.False(t, plugin.migCurrent.MigConfigs["current"][i].MigEnabled,
-			"stale MigEnabled=true must be overwritten for device %d", i)
-	}
-}
-
-func TestMigCurrentConfigsNeverNil(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{
-		config: &nvidia.DeviceConfig{
-			Config: &v1.Config{
-				Flags: v1.Flags{
-					CommandLineFlags: v1.CommandLineFlags{},
-				},
-			},
-		},
-		operatingMode: "mig",
-		migCurrent:    nvidia.MigPartedSpec{},
-	}
-
-	shouldUseMig := plugin.operatingMode == "mig"
-	deviceSupportMig := false
-	if shouldUseMig && !deviceSupportMig {
-		shouldUseMig = false
-	}
-
-	migSuccessfullyInitialized := false
-	if !migSuccessfullyInitialized {
-		runFallbackInit(plugin, 2)
-	}
-
-	require.NotNil(t, plugin.migCurrent.MigConfigs)
-	require.NotNil(t, plugin.migCurrent.MigConfigs["current"])
-	require.Len(t, plugin.migCurrent.MigConfigs["current"], 2)
-	for _, cfg := range plugin.migCurrent.MigConfigs["current"] {
-		require.False(t, cfg.MigEnabled)
-	}
-}
-
-type mockListAndWatchServer struct {
-	grpc.ServerStream
-	sendErrs []error
-	sent     []*kubeletdevicepluginv1beta1.ListAndWatchResponse
-}
-
-func (m *mockListAndWatchServer) Send(resp *kubeletdevicepluginv1beta1.ListAndWatchResponse) error {
-	m.sent = append(m.sent, resp)
-	if len(m.sendErrs) > 0 {
-		err := m.sendErrs[0]
-		m.sendErrs = m.sendErrs[1:]
-		return err
-	}
-	return nil
-}
-
-func TestListAndWatch_SendError(t *testing.T) {
-	mockRM := &rm.ResourceManagerMock{
-		DevicesFunc: func() rm.Devices {
-			return rm.Devices{}
-		},
-		ResourceFunc: func() v1.ResourceName {
-			return v1.ResourceName("nvidia.com/gpu")
-		},
-	}
-
-	t.Run("InitialSendFails", func(t *testing.T) {
-		expectedErr := fmt.Errorf("initial send failed")
-		server := &mockListAndWatchServer{
-			sendErrs: []error{expectedErr},
-		}
-		plugin := &NvidiaDevicePlugin{
-			rm:              mockRM,
-			stop:            make(chan any),
-			health:          make(chan *rm.Device, 1),
-			schedulerConfig: nvidia.NvidiaConfig{NodeDefaultConfig: nvidia.NodeDefaultConfig{DeviceSplitCount: ptr[uint](1)}},
-		}
-
-		err := plugin.ListAndWatch(&kubeletdevicepluginv1beta1.Empty{}, server)
-		require.ErrorIs(t, err, expectedErr)
-		require.Len(t, server.sent, 1)
-	})
-
-	t.Run("UpdateSendFails", func(t *testing.T) {
-		expectedErr := fmt.Errorf("update send failed")
-		server := &mockListAndWatchServer{
-			sendErrs: []error{nil, expectedErr},
-		}
-		plugin := &NvidiaDevicePlugin{
-			rm:              mockRM,
-			stop:            make(chan any),
-			health:          make(chan *rm.Device, 1),
-			schedulerConfig: nvidia.NvidiaConfig{NodeDefaultConfig: nvidia.NodeDefaultConfig{DeviceSplitCount: ptr[uint](1)}},
-		}
-
-		plugin.health <- &rm.Device{Device: kubeletdevicepluginv1beta1.Device{ID: "gpu-1"}}
-		err := plugin.ListAndWatch(&kubeletdevicepluginv1beta1.Empty{}, server)
-		require.NoError(t, err)
-		require.Len(t, server.sent, 2)
-	})
-}
-

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -92,33 +92,59 @@ func GetNextDeviceRequest(dtype string, p corev1.Pod) (corev1.Container, device.
 	return corev1.Container{}, res, errors.New("device request not found")
 }
 
-var eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
+// decodePodSingleDevice decodes the pod's device allocation annotation for the
+// given device type into a PodSingleDevice slice. Each element corresponds to
+// one container (init containers first, then regular containers).
+func decodePodSingleDevice(dtype string, p *corev1.Pod) (device.PodSingleDevice, error) {
 	pdevices, err := device.DecodePodDevices(device.InRequestDevices, p.Annotations)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	res := device.PodSingleDevice{}
 	pd, ok := pdevices[dtype]
 	if !ok {
-		return errors.New("erase device annotation not found")
+		return nil, errors.New("device request not found")
 	}
-	found := false
-	for _, val := range pd {
-		if found {
-			res = append(res, val)
-		} else {
-			if len(val) > 0 {
-				found = true
-				res = append(res, device.ContainerDevices{})
-			} else {
-				res = append(res, val)
+	return pd, nil
+}
+
+// popNextContainerDevices finds and erases the first non-empty ContainerDevices
+// from podSingleDev in place, returning the corresponding pod container and the
+// popped devices. The container resolution uses the same init-then-regular
+// ordering convention as the annotation encoder. It does NOT touch the API
+// server — the caller is responsible for patching the annotation once after the
+// loop completes.
+func popNextContainerDevices(pod *corev1.Pod, podSingleDev device.PodSingleDevice) (corev1.Container, device.ContainerDevices, error) {
+	initContainerCount := len(pod.Spec.InitContainers)
+	for i, ctrDevs := range podSingleDev {
+		if len(ctrDevs) > 0 {
+			podSingleDev[i] = device.ContainerDevices{}
+			if i < initContainerCount {
+				return pod.Spec.InitContainers[i], ctrDevs, nil
 			}
+			regularIdx := i - initContainerCount
+			if regularIdx >= len(pod.Spec.Containers) {
+				return corev1.Container{}, nil, fmt.Errorf("container index %d out of range (init=%d, regular=%d)", i, initContainerCount, len(pod.Spec.Containers))
+			}
+			return pod.Spec.Containers[regularIdx], ctrDevs, nil
 		}
 	}
-	klog.Infoln("After erase res=", res)
-	newannos := make(map[string]string)
-	newannos[device.InRequestDevices[dtype]] = device.EncodePodSingleDevice(res)
-	return util.PatchPodAnnotations(&p, newannos)
+	return corev1.Container{}, nil, errors.New("no pending device allocation found")
+}
+
+// patchErasedAnnotation patches the pod's device annotation with the given
+// podSingleDev (which has had some containers popped). It also updates
+// pod.Annotations in place so that subsequent Allocate calls within the same
+// kubelet invocation see the erased state.
+func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.PodSingleDevice) error {
+	klog.V(5).Infof("After erase annotation, remaining devices: %v", podSingleDev)
+	encoded := device.EncodePodSingleDevice(podSingleDev)
+	annoKey := device.InRequestDevices[dtype]
+	newAnnos := map[string]string{annoKey: encoded}
+	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
+		return err
+	}
+	pod.Annotations[annoKey] = encoded
+	return nil
 }
 
 func GetIndexAndTypeFromUUID(uuid string) (string, int) {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

A Pod with 2 containers both requesting split GPU. If the first container does NOT set `CUDA_DISABLE_CONTROL` and the second does, the expected behavior is: the first container's libvgpu.so interception takes effect, the second does NOT. But the actual behavior: the second container's `CUDA_DISABLE_CONTROL=true` is ignored — libvgpu.so stays active.

### Root Cause

The `Allocate` loop decodes the pod annotation on every iteration via `GetNextDeviceRequest`, but `eraseNextDeviceTypeFromAnnotation` only patches the API server without updating the in-memory `pod.Annotations` map. When kubelet passes multiple `ContainerRequests` in a single `Allocate` call, every iteration re-reads the original annotation, always returning the first container's devices and env vars.

This is complementary to PR #1299 which fixed the **scheduler side** (correct annotation indexing for multi-container pods). The **device plugin side** (`Allocate` stale annotation) was not fixed.

### Fix

Replace the per-iteration decode+erase pattern with a pop-based design:

- `decodePodSingleDevice(dtype, pod)` — decode the annotation once before the loop
- `popNextContainerDevices(pod, podSingleDev)` — mutate the in-memory slice in place and return the resolved container directly
- `patchErasedAnnotation(pod, dtype, podSingleDev)` — patch the API server exactly once after the loop

This also reduces API server pressure: one patch per `Allocate` call instead of one per container.

## Which issue(s) this PR fixes

Fixes #1050

## Special notes for your reviewer

- this fix align to my previous implementation for ascend-device-plugin Allocate method. Now both device-plugin use the same pop-erase in memory-patch mechanism
- `make verify` passes (staticcheck warnings are pre-existing in `cmd/nvlink-diag/main.go`, not introduced by this PR)
- 14 regression tests added in `alloc_refactor_test.go`
- `GetNextDeviceRequest` is kept as exported (dead code now) to avoid breaking API consumers; can be cleaned up in a follow-up

## Does this PR introduce a user-facing change?

```release-note
Fix: multi-container Pods now correctly honor `CUDA_DISABLE_CONTROL=true` per-container. Previously, the second container's `CUDA_DISABLE_CONTROL` was silently ignored because the Allocate function re-read stale pod annotations on each iteration.
```

---

> AI Assistance: The code and tests in this PR were primarily authored by  pi agent+glm5.2. The solution design, code review, and test planning were directed by the contributor. All code has been reviewed and understood by the contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA GPU allocation for single- and multi-container workloads.
  * Improved handling of MIG, virtual, replica, and initialization-container assignments.
  * Added clearer errors for invalid requests, allocation mismatches, and annotation failures.
  * Preserved allocation state when processing fails, supporting safer retries.
  * Ensured device allocation annotations are updated consistently after successful processing.

* **Tests**
  * Expanded coverage for allocation behavior, annotation updates, CUDA controls, error handling, and preferred MIG allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->