### PR TITLE
fix(scheduler): prevent nil body panic bug in Predicate and Bind handlers

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -102,6 +102,9 @@ func Bind(s *scheduler.Scheduler) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		klog.V(5).Infoln("Entering Bind handler")
 		var buf bytes.Buffer
+		if !checkBody(w, r) {
+			return
+		}
 		// Limit the body size to prevent deep nesting/resource exhaustion attacks
 		limitedReader := io.LimitReader(r.Body, maxRequestSize)
 		body := io.TeeReader(limitedReader, &buf)

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -143,6 +143,20 @@ func TestCheckBodyNil(t *testing.T) {
 	}
 }
 
+func TestCheckBody_ValidBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/test", strings.NewReader("some-body"))
+	w := httptest.NewRecorder()
+
+	valid := checkBody(w, req)
+
+	if !valid {
+		t.Error("Expected checkBody to return true for valid body, got false")
+	}
+	if w.Code != 200 {
+		t.Errorf("Expected status 200 (default) for valid body, got %d", w.Code)
+	}
+}
+
 func TestPredicateRoute_NilBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/predicate", nil)
 	req.Body = nil
@@ -154,6 +168,22 @@ func TestPredicateRoute_NilBody(t *testing.T) {
 
 	if w.Code != 400 {
 		t.Errorf("expected 400 for nil body, got %d", w.Code)
+	}
+}
+
+func TestBind_NilBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/bind", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := Bind(s)
+
+	// This should not panic
+	handler(w, req, nil)
+
+	if w.Code != 400 {
+		t.Errorf("Expected status 400 for nil body in Bind, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
What this PR does :
While reviewing the recent fix for issue #2296, I noticed that the `PredicateRoute` handler can still crash, and the `Bind` handler was completely missed in the previous fix.

**Problem:**
Right now, if a request has an empty (`nil`) body, the `checkBody` function sends back a `400 Bad Request` error: but  **it doesn't actually stop the rest of the code from running.** 

Because the code doesn't stop, it keeps going, tries to read the empty body, and then the whole scheduler crashes (panics). also, the `Bind` handler completely forgets to use the `checkBody` function, so it crashes the exact same way.

**Solution :**
To make the scheduler fully safe from crashing, this PR:
1)Changes `checkBody` so it returns `true` if the body is good, and `false` if it is empty.
2) Updates `PredicateRoute` to actually stop running (`return`) if `checkBody` says the body is empty.
3) Adds the missing `checkBody` check to the `Bind` handler.
4) Adds unit tests for both routes to prove that an empty body returns a 400 error and doesn't crash the program.

**AI Assistance Disclosure:**

I took help of AI to help me understand the problem and probable steps. However I have manually reviewed, tested, and fully understand all the changes introduced in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with a missing body now stop processing immediately and return a clear `400` error instead of continuing with invalid input.
  * Route handling is more robust for empty request bodies, preventing unexpected failures.
* **Tests**
  * Expanded coverage for missing-body and valid-body scenarios to verify the updated request handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->