### PR TITLE
fix(scheduler): apply ResourceQuota updates without dropping the limit

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -188,21 +188,49 @@ func IsManagedQuota(quotaName string) bool {
 func (q *QuotaManager) AddQuota(quota *corev1.ResourceQuota) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
+	q.addQuotaLocked(quota)
+	q.logQuotasLocked()
+}
+
+func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	q.delQuotaLocked(quota)
+	q.logQuotasLocked()
+}
+
+// UpdateQuota swaps oldQuota's limits for newQuota's without releasing the lock
+// in between. Doing it as DelQuota followed by AddQuota would leave the limits
+// zeroed for the gap between the two, and FitQuota reads a zero limit as no
+// limit, so a check landing in that gap is waved through. The kube quota
+// controller rewrites status.used on every pod event, so updates arrive
+// constantly while pods are being scheduled.
+func (q *QuotaManager) UpdateQuota(oldQuota, newQuota *corev1.ResourceQuota) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	if oldQuota != nil {
+		q.delQuotaLocked(oldQuota)
+	}
+	if newQuota != nil {
+		q.addQuotaLocked(newQuota)
+	}
+	q.logQuotasLocked()
+}
+
+// addQuotaLocked requires q.mutex to be held.
+func (q *QuotaManager) addQuotaLocked(quota *corev1.ResourceQuota) {
 	for idx, val := range quota.Spec.Hard {
 		value, ok := val.AsInt64()
 		if ok {
-			if !strings.HasPrefix(idx.String(), "limits.") {
-				continue
-			}
-			dn := strings.TrimPrefix(idx.String(), "limits.")
-			if !IsManagedQuota(dn) {
+			dn, ok := managedQuotaName(idx)
+			if !ok {
 				continue
 			}
 			if q.Quotas[quota.Namespace] == nil {
 				q.Quotas[quota.Namespace] = &DeviceQuota{}
 			}
 			dp := q.Quotas[quota.Namespace]
-			_, ok := (*dp)[dn]
+			_, ok = (*dp)[dn]
 			if !ok {
 				(*dp)[dn] = &Quota{
 					Used:  0,
@@ -213,26 +241,15 @@ func (q *QuotaManager) AddQuota(quota *corev1.ResourceQuota) {
 			klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
 		}
 	}
-	if klog.V(4).Enabled() {
-		for _, val := range q.Quotas {
-			for idx, val1 := range *val {
-				klog.V(4).Infoln("after val=", idx, ":", val1)
-			}
-		}
-	}
 }
 
-func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
-	q.mutex.Lock()
-	defer q.mutex.Unlock()
+// delQuotaLocked requires q.mutex to be held.
+func (q *QuotaManager) delQuotaLocked(quota *corev1.ResourceQuota) {
 	for idx, val := range quota.Spec.Hard {
 		value, ok := val.AsInt64()
 		if ok {
-			if !strings.HasPrefix(idx.String(), "limits.") {
-				continue
-			}
-			dn := strings.TrimPrefix(idx.String(), "limits.")
-			if !IsManagedQuota(dn) {
+			dn, ok := managedQuotaName(idx)
+			if !ok {
 				continue
 			}
 			klog.V(4).InfoS("quota remove:", "idx=", idx, "val", value)
@@ -243,12 +260,29 @@ func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
 			}
 		}
 	}
+}
 
-	if klog.V(4).Enabled() {
-		for _, val := range q.Quotas {
-			for idx, val1 := range *val {
-				klog.V(4).Infoln("after val=", idx, ":", val1)
-			}
+// managedQuotaName maps a ResourceQuota key to the device resource it limits,
+// reporting false for keys this manager does not track.
+func managedQuotaName(idx corev1.ResourceName) (string, bool) {
+	if !strings.HasPrefix(idx.String(), "limits.") {
+		return "", false
+	}
+	dn := strings.TrimPrefix(idx.String(), "limits.")
+	if !IsManagedQuota(dn) {
+		return "", false
+	}
+	return dn, true
+}
+
+// logQuotasLocked requires q.mutex to be held.
+func (q *QuotaManager) logQuotasLocked() {
+	if !klog.V(4).Enabled() {
+		return
+	}
+	for _, val := range q.Quotas {
+		for idx, val1 := range *val {
+			klog.V(4).Infoln("after val=", idx, ":", val1)
 		}
 	}
 }

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -17,6 +17,7 @@ package device
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -280,5 +281,102 @@ func TestDelQuotaNonLimitsKey(t *testing.T) {
 	qm.DelQuota(unrelatedQuota)
 	if (*qm.Quotas[ns])[memName].Limit != 100 {
 		t.Errorf("DelQuota: expected memory limit 100 after deleting non-limits quota, got %d", (*qm.Quotas[ns])[memName].Limit)
+	}
+}
+
+// A ResourceQuota update must never leave the limits zeroed, even briefly.
+// FitQuota reads a zero limit as no limit, so a check landing mid-update would
+// be waved through. The kube quota controller rewrites status.used on every pod
+// event, so updates arrive exactly when pods are being scheduled.
+func TestUpdateQuotaKeepsLimitEnforced(t *testing.T) {
+	initTest()
+	ns := "update-window"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits.nvidia.com/gpumem"): *resource.NewQuantity(1000, resource.DecimalSI),
+			},
+		},
+	}
+	qm.AddQuota(quota)
+	// The namespace is already at its limit, so every answer below must be false.
+	(*qm.Quotas[ns])["nvidia.com/gpumem"].Used = 1000
+
+	var wrongAdmits int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				qm.UpdateQuota(quota, quota)
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for range 50000 {
+			if qm.FitQuota(ns, 1, 1, 0, "NVIDIA") {
+				atomic.AddInt64(&wrongAdmits, 1)
+			}
+		}
+		close(stop)
+	})
+
+	wg.Wait()
+	if wrongAdmits > 0 {
+		t.Errorf("quota went unenforced for %d checks while updates were in flight", wrongAdmits)
+	}
+}
+
+func TestUpdateQuota(t *testing.T) {
+	initTest()
+	ns := "update-apply"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	quotaWith := func(mem, core int64) *corev1.ResourceQuota {
+		hard := corev1.ResourceList{}
+		if mem > 0 {
+			hard["limits.nvidia.com/gpumem"] = *resource.NewQuantity(mem, resource.DecimalSI)
+		}
+		if core > 0 {
+			hard["limits.nvidia.com/gpucore"] = *resource.NewQuantity(core, resource.DecimalSI)
+		}
+		return &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+			Spec:       corev1.ResourceQuotaSpec{Hard: hard},
+		}
+	}
+
+	old := quotaWith(1000, 100)
+	qm.AddQuota(old)
+
+	// Raising the memory limit and dropping the core one entirely.
+	qm.UpdateQuota(old, quotaWith(2000, 0))
+
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 2000 {
+		t.Errorf("memory limit = %d, want 2000", got)
+	}
+	// A key the new quota no longer carries is released, not left at its old value.
+	if got := (*qm.Quotas[ns])["nvidia.com/gpucore"].Limit; got != 0 {
+		t.Errorf("core limit = %d, want 0 now that the new quota drops it", got)
+	}
+
+	// Usage already recorded survives an update.
+	(*qm.Quotas[ns])["nvidia.com/gpumem"].Used = 500
+	qm.UpdateQuota(quotaWith(2000, 0), quotaWith(3000, 0))
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Used; got != 500 {
+		t.Errorf("used = %d, want 500 preserved across the update", got)
+	}
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 3000 {
+		t.Errorf("memory limit = %d, want 3000", got)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -250,30 +250,46 @@ func (s *Scheduler) onAddQuota(obj any) {
 	s.quotaManager.AddQuota(quota)
 }
 
+// onUpdateQuota applies both halves of the change under a single lock. Doing
+// this as a delete followed by an add leaves the limits zeroed in between, and
+// FitQuota reads a zero limit as no limit, so quota goes unenforced for the gap.
 func (s *Scheduler) onUpdateQuota(oldObj, newObj any) {
-	s.onDelQuota(oldObj)
-	s.onAddQuota(newObj)
+	oldQuota, ok := asResourceQuota(oldObj)
+	if !ok {
+		return
+	}
+	newQuota, ok := asResourceQuota(newObj)
+	if !ok {
+		return
+	}
+	s.quotaManager.UpdateQuota(oldQuota, newQuota)
 }
 
 func (s *Scheduler) onDelQuota(obj any) {
-	var quota *corev1.ResourceQuota
-
-	switch t := obj.(type) {
-	case *corev1.ResourceQuota:
-		quota = t
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		quota, ok = t.Obj.(*corev1.ResourceQuota)
-		if !ok {
-			klog.Errorf("resource quota tombstone contained object of type %T", t.Obj)
-			return
-		}
-	default:
-		klog.Errorf("unknown resource quota delete object type %T", obj)
+	quota, ok := asResourceQuota(obj)
+	if !ok {
 		return
 	}
-
 	s.quotaManager.DelQuota(quota)
+}
+
+// asResourceQuota unwraps an informer object, including the tombstone a delete
+// carries when the watch missed the event.
+func asResourceQuota(obj any) (*corev1.ResourceQuota, bool) {
+	switch t := obj.(type) {
+	case *corev1.ResourceQuota:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		quota, ok := t.Obj.(*corev1.ResourceQuota)
+		if !ok {
+			klog.Errorf("resource quota tombstone contained object of type %T", t.Obj)
+			return nil, false
+		}
+		return quota, true
+	default:
+		klog.Errorf("unknown resource quota object type %T", obj)
+		return nil, false
+	}
 }
 
 func (s *Scheduler) Start() error {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Scheduler.onUpdateQuota` applied a ResourceQuota change by deleting the old one
and adding the new one:

```go
func (s *Scheduler) onUpdateQuota(oldObj, newObj any) {
	s.onDelQuota(oldObj)
	s.onAddQuota(newObj)
}
```

`DelQuota` zeroes each managed limit, releases the manager's write lock and
returns. `AddQuota` then takes the lock again to restore them. The lock is free
in between, and `FitQuota` treats a zero limit as no limit:

```go
if limit != 0 && memQuota.Used+memreq > limit {
```

So a quota check landing in that gap, from admission or from a backend's
`Fit()`, both on their own goroutines, skips the comparison and admits the pod.
The namespace is unenforced for the duration.

This is not a rare interleaving. The kube-controller-manager quota controller
rewrites `status.used` on essentially every pod create and delete in the
namespace, so `UpdateFunc` fires continuously in any active namespace, which is
exactly when pods are being scheduled. The informer's 1 hour resync fires it
again for every ResourceQuota even when nothing changed. `AddQuota` only reads
`Spec.Hard`, so those status-only updates zero and restore the limits for
nothing.

**The fix**

`QuotaManager.UpdateQuota(old, new)` does both halves under one acquisition of
the lock. The add and delete bodies move into `addQuotaLocked` / `delQuotaLocked`
so all three entry points share them, and the repeated `limits.` prefix and
`IsManagedQuota` check becomes `managedQuotaName`.

On the scheduler side `onUpdateQuota` calls it, and the informer-object
unwrapping that `onDelQuota` already did, tombstone included, moves into
`asResourceQuota` so both handlers use it. `onDelQuota` previously logged
"unknown resource quota delete object type" for an update too; it now says
"object" since it is shared.

**Tests**

`TestUpdateQuotaKeepsLimitEnforced` drives updates on one goroutine while a
second asks `FitQuota` 50000 times, with the namespace already at its limit so
every answer must be false. Against the old del-then-add it records **25001**
wrongly admitted checks; with this change, zero. `TestUpdateQuota` covers the
plain semantics: a raised limit is applied, a key the new quota drops is
released, and `Used` survives the update.

**Which issue(s) this PR fixes**:
Fixes #2385

**Special notes for your reviewer**:

`DelQuota` writing `Limit = 0` to mean "removed" is left as it is. #2312 is
changing what an explicit zero means, and if it lands then the sentinel and a
real zero limit want reconciling. That is a semantic decision for that issue,
not something to settle here, and this PR is correct either way, since the point
is that no reader ever observes the intermediate state.

Also left alone: `DelQuota` never removes the map entry, so a namespace that
once had a quota keeps its entry and its `Used` accounting for the process
lifetime. That is a slow leak rather than a correctness problem and I did not
want to fold it in. Noted in #2385.

Not validated on real hardware. The change is confined to the scheduler
extender's quota bookkeeping and is covered by unit tests, which CONTRIBUTING
allows for scheduler-scoped changes.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed namespace ResourceQuota going briefly unenforced every time the quota
object was updated, which in an active namespace meant on nearly every pod
create and delete.
```

---

AI assistance disclosure: this change was developed with Claude Code — spotting
the window, the fix, and the tests. Flagging the extent up front per
CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota updates to apply limit changes atomically, preventing temporary incorrect admission decisions.
  * Preserved existing resource usage when quota limits change.
  * Correctly removed resources that are no longer included in updated quotas.
  * Improved handling of quota add and delete events, including deleted-object notifications.

* **Tests**
  * Added coverage for concurrent quota updates and enforcement of limits during changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->