### PR TITLE
fix(hygon,metax): guard int32 narrowing in GenerateResourceRequests

### DIFF
--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -19,6 +19,7 @@ package hygon
 import (
 	"errors"
 	"flag"
+	"math"
 	"slices"
 	"strings"
 
@@ -175,6 +176,10 @@ func (dev *DCUDevices) GenerateResourceRequests(ctr *corev1.Container) device.Co
 	}
 	if ok {
 		if n, ok := v.AsInt64(); ok {
+			if n <= 0 || n > math.MaxInt32 {
+				klog.ErrorS(nil, "dcu device count request is out of range", "container", ctr.Name, "request", n)
+				return device.ContainerDeviceRequest{}
+			}
 			klog.Info("Found dcu devices")
 			memnum := 0
 			mem, ok := ctr.Resources.Limits[dcuResourceMem]
@@ -184,9 +189,17 @@ func (dev *DCUDevices) GenerateResourceRequests(ctr *corev1.Container) device.Co
 			if ok {
 				memnums, ok := mem.AsInt64()
 				if ok {
+					if memnums < 0 || memnums > math.MaxInt32 {
+						klog.ErrorS(nil, "dcu device memory request is out of range", "container", ctr.Name, "request", mem.String())
+						return device.ContainerDeviceRequest{}
+					}
 					if MemoryFactor > 1 {
 						rawMemnums := memnums
 						memnums = memnums * int64(MemoryFactor)
+						if memnums > math.MaxInt32 {
+							klog.ErrorS(nil, "dcu device memory request overflows int32 after applying memory factor", "container", ctr.Name, "raw", rawMemnums, "scaled", memnums, "factor", MemoryFactor)
+							return device.ContainerDeviceRequest{}
+						}
 						klog.V(4).Infof("Update memory request. before %d, after %d, factor %d", rawMemnums, memnums, MemoryFactor)
 					}
 					memnum = int(memnums)
@@ -200,6 +213,10 @@ func (dev *DCUDevices) GenerateResourceRequests(ctr *corev1.Container) device.Co
 			if ok {
 				corenums, ok := core.AsInt64()
 				if ok {
+					if corenums < 0 || corenums > math.MaxInt32 {
+						klog.ErrorS(nil, "dcu device core request is out of range", "container", ctr.Name, "request", core.String())
+						return device.ContainerDeviceRequest{}
+					}
 					corenum = int32(corenums)
 				}
 			}

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -616,6 +616,47 @@ func Test_GenerateResourceRequests(t *testing.T) {
 	}
 }
 
+func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
+	tests := []struct {
+		name string
+		args *corev1.Container
+		want device.ContainerDeviceRequest
+	}{
+		{
+			name: "oversized dcu count exceeds int32 range",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hygon.com/dcunum": resource.MustParse("2200000000"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "negative dcu cores",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hygon.com/dcunum":   resource.MustParse("1"),
+						"hygon.com/dcucores": resource.MustParse("-1"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := DCUDevices{}
+			fs := flag.FlagSet{}
+			ParseConfig(&fs)
+			result := dev.GenerateResourceRequests(test.args)
+			assert.DeepEqual(t, result, test.want)
+		})
+	}
+}
+
 // Test_GenerateResourceRequests_MemoryFactorOverflow covers the case where the
 // raw memory request fits in int32 but overflows once MemoryFactor is applied.
 func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -592,6 +592,18 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Coresreq:         int32(1),
 			},
 		},
+		{
+			name: "oversized dcu memory request exceeds int32 range",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hygon.com/dcunum": resource.MustParse("1"),
+						"hygon.com/dcumem": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -602,6 +614,30 @@ func Test_GenerateResourceRequests(t *testing.T) {
 			assert.DeepEqual(t, result, test.want)
 		})
 	}
+}
+
+// Test_GenerateResourceRequests_MemoryFactorOverflow covers the case where the
+// raw memory request fits in int32 but overflows once MemoryFactor is applied.
+func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
+	origFactor := MemoryFactor
+	MemoryFactor = 1024
+	defer func() { MemoryFactor = origFactor }()
+
+	dev := DCUDevices{}
+	fs := flag.FlagSet{}
+	ParseConfig(&fs)
+
+	// 3000000 fits in int32, but 3000000 * 1024 exceeds math.MaxInt32.
+	ctr := &corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"hygon.com/dcunum": resource.MustParse("1"),
+				"hygon.com/dcumem": resource.MustParse("3000000"),
+			},
+		},
+	}
+	result := dev.GenerateResourceRequests(ctr)
+	assert.DeepEqual(t, result, device.ContainerDeviceRequest{})
 }
 
 func TestDevices_LockNode(t *testing.T) {

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -259,9 +259,6 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 			if hasUnit {
 				mem = v / 1024 / 1024
 			} else {
-				// Guard the multiplication itself: v * MemoryFactor can overflow
-				// int64 and wrap to a small value that slips past the range check
-				// below, so reject before multiplying.
 				if v < 0 || v > int64(math.MaxInt32)/int64(MemoryFactor) {
 					klog.ErrorS(nil, "metax sgpu device memory request is out of range", "container", ctr.Name, "request", memQuantity.String())
 					return device.ContainerDeviceRequest{}

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -229,11 +230,19 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 			ctr.Name, MetaxResourceNameVCount)
 		return device.ContainerDeviceRequest{}
 	}
+	if count <= 0 || count > math.MaxInt32 {
+		klog.ErrorS(nil, "metax sgpu device count request is out of range", "container", ctr.Name, "request", count)
+		return device.ContainerDeviceRequest{}
+	}
 
 	core := int64(100)
 	coreQuantity, ok := ctr.Resources.Limits[corev1.ResourceName(MetaxResourceNameVCore)]
 	if ok {
 		if v, ok := coreQuantity.AsInt64(); ok {
+			if v < 0 || v > math.MaxInt32 {
+				klog.ErrorS(nil, "metax sgpu device core request is out of range", "container", ctr.Name, "request", coreQuantity.String())
+				return device.ContainerDeviceRequest{}
+			}
 			core = v
 		}
 	}
@@ -250,7 +259,11 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 			if hasUnit {
 				mem = v / 1024 / 1024
 			} else {
-				mem = v * MemoryFactor
+				mem = v * int64(MemoryFactor)
+			}
+			if mem < 0 || mem > math.MaxInt32 {
+				klog.ErrorS(nil, "metax sgpu device memory request is out of range", "container", ctr.Name, "request", memQuantity.String())
+				return device.ContainerDeviceRequest{}
 			}
 		}
 	}

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -259,6 +259,13 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 			if hasUnit {
 				mem = v / 1024 / 1024
 			} else {
+				// Guard the multiplication itself: v * MemoryFactor can overflow
+				// int64 and wrap to a small value that slips past the range check
+				// below, so reject before multiplying.
+				if v < 0 || v > int64(math.MaxInt32)/int64(MemoryFactor) {
+					klog.ErrorS(nil, "metax sgpu device memory request is out of range", "container", ctr.Name, "request", memQuantity.String())
+					return device.ContainerDeviceRequest{}
+				}
 				mem = v * int64(MemoryFactor)
 			}
 			if mem < 0 || mem > math.MaxInt32 {

--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -453,6 +453,19 @@ func TestGenerateResourceRequests(t *testing.T) {
 				Coresreq:         60,
 			},
 		},
+		{
+			name: "oversized memory request exceeds int32 range",
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"metax-tech.com/sgpu":    resource.MustParse("1"),
+						"metax-tech.com/vmemory": resource.MustParse("2100001"),
+					},
+				},
+			},
+
+			expected: device.ContainerDeviceRequest{},
+		},
 	} {
 		t.Run(ts.name, func(t *testing.T) {
 			metaxSDevice := &MetaxSDevices{}

--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -454,7 +454,7 @@ func TestGenerateResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name: "oversized memory request exceeds int32 range",
+			name: "oversized memory request exceeds int32 range (no unit, pre-multiply guard)",
 			container: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -463,7 +463,29 @@ func TestGenerateResourceRequests(t *testing.T) {
 					},
 				},
 			},
-
+			expected: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized sgpu count exceeds int32 range",
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"metax-tech.com/sgpu": resource.MustParse("2200000000"),
+					},
+				},
+			},
+			expected: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized vcore exceeds int32 range",
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"metax-tech.com/sgpu":  resource.MustParse("1"),
+						"metax-tech.com/vcore": resource.MustParse("2200000000"),
+					},
+				},
+			},
 			expected: device.ContainerDeviceRequest{},
 		},
 	} {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`GenerateResourceRequests` in the hygon and metax-sgpu device backends converts user-controlled `int64` resource limits (device count, memory, cores) into `int32` fields on `ContainerDeviceRequest` (`Nums`, `Memreq`, `Coresreq`) without bounds checking. A resource limit exceeding `math.MaxInt32` silently wraps to an incorrect small or negative value that flows into `Fit()`, causing the scheduler to incorrectly assess device availability and potentially schedule pods onto overcommitted devices.

This PR adds range guards that return an empty `ContainerDeviceRequest{}` (the existing rejection sentinel) before any `int32()` narrowing, matching the overflow protection already implemented in the enflame, iluvatar, mthreads, and amd backends.

**Which issue(s) this PR fixes**:
Fixes #2383

**Special notes for your reviewer**:

- The hygon fix guards three conversion points: device count, memory pre-factor, and memory post-factor (after `MemoryFactor` multiplication).
- The metax-sgpu fix guards three conversion points: device count, core, and memory.
- Test coverage includes both pre-factor overflow (`16Gi` exceeds `MaxInt32` directly) and post-factor overflow (raw value `3000000` fits in int32, but `3000000 * 1024` overflows), plus an out-of-range memory case for metax-sgpu.
- Follows the same validation pattern introduced in #2285.

**Does this PR introduce a user-facing change?**:

```
Oversized device resource requests (e.g. hygon.com/dcumem: 16Gi, or metax-tech.com/vmemory exceeding the int32 range) are now correctly rejected instead of silently wrapping to an incorrect memory value.
```

AI assistance disclosure: I used an AI tool for codebase navigation and review support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for device counts, memory, and core resource requests to reject negative or oversized values.
  * Prevented integer overflow when converting memory requests, including values affected by memory scaling.
  * Invalid resource requests now return an empty device request instead of producing incorrect results.
* **Tests**
  * Added regression coverage for oversized and overflow-prone resource requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->