### PR TITLE
fix(scheduler): make ResourceQuota update atomic to prevent enforcement gap

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -253,6 +253,74 @@ func (q *QuotaManager) DelQuota(quota *corev1.ResourceQuota) {
 	}
 }
 
+// UpdateQuota atomically removes old quota limits and applies new ones under
+// a single lock acquisition. This prevents a window where FitQuota sees zeroed
+// limits (treated as "no limit") between a DelQuota and AddQuota pair.
+func (q *QuotaManager) UpdateQuota(oldQuota, newQuota *corev1.ResourceQuota) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	// Remove old limits
+	if oldQuota != nil {
+		for idx, val := range oldQuota.Spec.Hard {
+			_, ok := val.AsInt64()
+			if !ok {
+				continue
+			}
+			if !strings.HasPrefix(idx.String(), "limits.") {
+				continue
+			}
+			dn := strings.TrimPrefix(idx.String(), "limits.")
+			if !IsManagedQuota(dn) {
+				continue
+			}
+			if dq, ok := q.Quotas[oldQuota.Namespace]; ok {
+				if quotaInfo, ok := (*dq)[dn]; ok {
+					quotaInfo.Limit = 0
+				}
+			}
+		}
+	}
+
+	// Apply new limits
+	if newQuota != nil {
+		for idx, val := range newQuota.Spec.Hard {
+			value, ok := val.AsInt64()
+			if !ok {
+				continue
+			}
+			if !strings.HasPrefix(idx.String(), "limits.") {
+				continue
+			}
+			dn := strings.TrimPrefix(idx.String(), "limits.")
+			if !IsManagedQuota(dn) {
+				continue
+			}
+			if q.Quotas[newQuota.Namespace] == nil {
+				q.Quotas[newQuota.Namespace] = &DeviceQuota{}
+			}
+			dp := q.Quotas[newQuota.Namespace]
+			_, ok := (*dp)[dn]
+			if !ok {
+				(*dp)[dn] = &Quota{
+					Used:  0,
+					Limit: value,
+				}
+			}
+			(*dp)[dn].Limit = value
+			klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
+		}
+	}
+
+	if klog.V(4).Enabled() {
+		for _, val := range q.Quotas {
+			for idx, val1 := range *val {
+				klog.V(4).Infoln("after val=", idx, ":", val1)
+			}
+		}
+	}
+}
+
 func (q *QuotaManager) GetResourceQuota() map[string]*DeviceQuota {
 	quotasCopy := make(map[string]*DeviceQuota)
 	q.mutex.RLock()

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -253,6 +253,107 @@ func TestAddQuotaAndDelQuota(t *testing.T) {
 	}
 }
 
+func TestUpdateQuotaAtomicity(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "testns"
+	deviceName := "NVIDIA"
+	memName := "nvidia.com/gpumem"
+
+	// Set up initial quota with limit 1000
+	qm.Quotas[ns] = &DeviceQuota{
+		memName: &Quota{Used: 1000, Limit: 1000},
+	}
+
+	oldQuota := &corev1.ResourceQuota{}
+	oldQuota.Namespace = ns
+	oldQuota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName): *resource.NewQuantity(1000, resource.DecimalSI),
+	}
+
+	newQuota := &corev1.ResourceQuota{}
+	newQuota.Namespace = ns
+	newQuota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName): *resource.NewQuantity(1000, resource.DecimalSI),
+	}
+
+	// Drive UpdateQuota in a loop while calling FitQuota concurrently.
+	// FitQuota must NEVER succeed because the namespace is at its limit.
+	var wrongAdmits int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Updater goroutine: repeatedly apply the same update
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				qm.UpdateQuota(oldQuota, newQuota)
+			}
+		}
+	}()
+
+	// Reader goroutine: FitQuota must always return false (at limit)
+	for i := 0; i < 200000; i++ {
+		if qm.FitQuota(ns, 1, 1, 0, deviceName) {
+			wrongAdmits++
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+
+	if wrongAdmits > 0 {
+		t.Errorf("FitQuota admitted %d times out of 200000 while quota was at limit — UpdateQuota is not atomic", wrongAdmits)
+	}
+}
+
+func TestUpdateQuotaBasic(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "testns"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+
+	// Set up initial quota
+	qm.Quotas[ns] = &DeviceQuota{
+		memName:  &Quota{Used: 0, Limit: 100},
+		coreName: &Quota{Used: 0, Limit: 10},
+	}
+
+	oldQuota := &corev1.ResourceQuota{}
+	oldQuota.Namespace = ns
+	oldQuota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName):  *resource.NewQuantity(100, resource.DecimalSI),
+		corev1.ResourceName("limits." + coreName): *resource.NewQuantity(10, resource.DecimalSI),
+	}
+
+	// Update to new limits
+	newQuota := &corev1.ResourceQuota{}
+	newQuota.Namespace = ns
+	newQuota.Spec.Hard = corev1.ResourceList{
+		corev1.ResourceName("limits." + memName):  *resource.NewQuantity(200, resource.DecimalSI),
+		corev1.ResourceName("limits." + coreName): *resource.NewQuantity(20, resource.DecimalSI),
+	}
+
+	qm.UpdateQuota(oldQuota, newQuota)
+
+	if (*qm.Quotas[ns])[memName].Limit != 200 {
+		t.Errorf("UpdateQuota: expected memory limit 200, got %d", (*qm.Quotas[ns])[memName].Limit)
+	}
+	if (*qm.Quotas[ns])[coreName].Limit != 20 {
+		t.Errorf("UpdateQuota: expected core limit 20, got %d", (*qm.Quotas[ns])[coreName].Limit)
+	}
+	// Used should be preserved
+	if (*qm.Quotas[ns])[memName].Used != 0 {
+		t.Errorf("UpdateQuota: expected Used 0, got %d", (*qm.Quotas[ns])[memName].Used)
+	}
+}
+
 func TestDelQuotaNonLimitsKey(t *testing.T) {
 	initTest()
 	qm := NewQuotaManager()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -251,8 +251,21 @@ func (s *Scheduler) onAddQuota(obj any) {
 }
 
 func (s *Scheduler) onUpdateQuota(oldObj, newObj any) {
-	s.onDelQuota(oldObj)
-	s.onAddQuota(newObj)
+	oldQuota, _ := oldObj.(*corev1.ResourceQuota)
+	newQuota, _ := newObj.(*corev1.ResourceQuota)
+
+	// Handle tombstone for old object
+	if t, ok := oldObj.(cache.DeletedFinalStateUnknown); ok {
+		oldQuota, _ = t.Obj.(*corev1.ResourceQuota)
+	}
+
+	// Validate new object
+	if newQuota == nil {
+		s.onDelQuota(oldObj)
+		return
+	}
+
+	s.quotaManager.UpdateQuota(oldQuota, newQuota)
 }
 
 func (s *Scheduler) onDelQuota(obj any) {


### PR DESCRIPTION
## fix(scheduler): make ResourceQuota update atomic to prevent enforcement gap

### Problem

onUpdateQuota calls DelQuota then AddQuota as two separate lock
acquisitions. Between the two calls, FitQuota sees Limit == 0 and
treats it as "no limit", wrongly admitting pods. This fires on every
pod event in the namespace since the quota controller rewrites
status.used on each pod create/delete, plus the 1-hour informer resync.

### Solution

Add QuotaManager.UpdateQuota(old, new) that performs both operations
under a single lock, eliminating the enforcement window. Update
onUpdateQuota to call it instead of the separate handlers.

### Verification

    go test ./pkg/device/... -run "TestUpdateQuota" -short --race -count=1 -v

TestUpdateQuotaAtomicity drives concurrent FitQuota (200k calls) while
UpdateQuota races. Zero wrong admits confirms the fix.

Closes #2385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource quota updates are now applied atomically, preserving existing usage while updating limits.
  * Invalid quota updates safely fall back to removing the previous quota.
* **Bug Fixes**
  * Prevented quota checks from temporarily allowing admissions when usage has reached a limit during concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->