### PR TITLE
chore(docs): clarify Helm repo URL and link to current documentation …

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
 ```
 
+> **Note:** This URL is the Helm chart repository hosted on GitHub Pages.
+> For documentation, visit [project-hami.io](https://project-hami.io).
+
 Install HAMi:
 
 ```bash

--- a/README_cn.md
+++ b/README_cn.md
@@ -117,6 +117,9 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
 ```
 
+> **注意：** 此 URL 是托管在 GitHub Pages 上的 Helm 图表仓库。
+> 文档请访问 [project-hami.io](https://project-hami.io)。
+
 安装 HAMi：
 
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -117,6 +117,9 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
 ```
 
+> **注意：** この URL は GitHub Pages でホストされている Helm チャートリポジトリです。
+> ドキュメントは [project-hami.io](https://project-hami.io) をご覧ください。
+
 HAMi をインストールします：
 
 ```bash


### PR DESCRIPTION
## Problem

The GitHub Pages website at https://project-hami.github.io/HAMi/ is
outdated (broken images, no favicon, stale content). Users searching the
codebase find references to this URL and assume the project links to
deprecated resources.

However, all 5 references in the repository are `helm repo add` commands
or deploy script defaults — they point to the Helm chart repository
hosted on the gh-pages branch, which IS functional and actively used by
the `call-release-helm.yaml` workflow to distribute chart packages.

## What this PR does

Adds clarifying notes to all three README variants (English, Chinese,
Japanese) after the `helm repo add` command, explaining that:

1. The URL is the Helm chart repository (not a documentation website)
2. Documentation is available at https://project-hami.io

No URLs are changed — the Helm repo is functional and must remain as-is.

## Files changed

- README.md — added note after helm repo add block
- README_cn.md — added note in Chinese
- README_ja.md — added note in Japanese

## Why not change the URLs

The `call-release-helm.yaml` workflow actively pushes chart packages and
generates `index.yaml` at this URL. Changing it would break Helm
installs for all users.

Closes #2381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Helm installation notes in English, Chinese, and Japanese.
  * Clarified that the chart repository is hosted on GitHub Pages.
  * Added links to the project documentation for further details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->