### PR TITLE
fix(metrics): remove changing values like 'limit' from metric labels to prevent Prometheus crash

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -259,12 +259,20 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	quotaUsedDesc := prometheus.NewDesc(
 		"hami_resource_quota_used",
 		"resourcequota usage for a certain device",
-		[]string{"namespace", "quota_name", "limit"}, nil,
+		[]string{"namespace", "quota_name"}, nil,
+	)
+	quotaLimitDesc := prometheus.NewDesc(
+		"hami_resource_quota_limit",
+		"Configured hard limit for a resource quota",
+		[]string{"namespace", "quota_name"}, nil,
 	)
 	for ns, val := range cc.metricsProvider.GetQuotaManager().GetResourceQuota() {
 		for quotaname, q := range *val {
-			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
+			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname); err != nil {
 				klog.V(4).Infof("Failed to send quotaUsedDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
+				klog.V(4).Infof("Failed to send quotaLimitDesc metric: %v", err)
 			}
 			if legacy {
 				sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -215,3 +215,42 @@ nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"
 		t.Fatalf("unexpected collecting result:\n%s", err)
 	}
 }
+
+func TestQuotaMetricHasNoLimitLabel(t *testing.T) {
+	qm := device.NewQuotaManager()
+	qm.Quotas["test-namespace"] = &device.DeviceQuota{
+		"test-quota": &device.Quota{
+			Limit: 10,
+			Used:  3,
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{
+			LegacyMetrics: false,
+		},
+		metricsProvider: &fakeSchedulerMetricsProvider{
+			nodeUsage:    map[string]*schedulerpkg.NodeUsage{},
+			quotaManager: qm,
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_resource_quota_limit Configured hard limit for a resource quota
+# TYPE hami_resource_quota_limit gauge
+hami_resource_quota_limit{namespace="test-namespace",quota_name="test-quota"} 10
+# HELP hami_resource_quota_used resourcequota usage for a certain device
+# TYPE hami_resource_quota_used gauge
+hami_resource_quota_used{namespace="test-namespace",quota_name="test-quota"} 3
+`
+
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_resource_quota_limit",
+		"hami_resource_quota_used",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
This PR fixes a high-cardinality issue in the Prometheus metrics exported by both `scheduler` and `vGPUmonitor`. 
It removes dynamic values that were incorrectly being passed as metric labels, and instead exports them as standard metric values.

 **Why is this needed?**
 
Exporting dynamic or configurable values (like quota `limit`) as labels is a known Prometheus anti-pattern. 
Every time an admin updates a quota limit, Prometheus creates an entirely new time-series, leaving the old one. 

In large clusters with frequent changes, this causes "Label Explosion" (High Cardinality) which consumes excessive memory and can eventually lead to Prometheus crashing (OOM kills). 
To improve monitoring and dashboards , cleaning up this metric hygiene is essential so that the dashboards can run efficiently at scale.

**How does this PR fix it?**
1) **Scheduler Quota Metrics**: Dropped the `limit` label from the `hami_resource_quota_used` metric.
    and Created a brand new dedicated gauge `hami_resource_quota_limit` to track the limit value separately.

2.)**vGPUmonitor Legacy Metrics**:  Trimmed `Device_memory_desc_of_container` from 9 labels down to 5. 
   & Removed the redundant dynamic labels (`context`, `module`, `data`, `offset`) since these values are already properly exported as standard values in the newer metrics (e.g. `hami_vgpu_memory_context_bytes`).

Added `TestQuotaMetricHasNoLimitLabel` in scheduler tests to ensure the label is successfully dropped.
Added `TestLegacyCtrDeviceMemoryDescHasFiveLabels` in vGPUmonitor tests to prevent future label count regressions.
Passed local tests and verified metrics output formatting.

**AI Disclosure**:
 I used an AI assistant to help me write the code. However, the logic behind fixing the metrics, finding the root cause of the bug, and running the local tests was entirely done and verified by me to make sure everything works .



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Resource quota metrics now expose configured limits separately from quota usage.
  * Simplified metric labels for clearer, more consistent monitoring data.
  * Reduced unnecessary labels in legacy container device-memory metrics to improve metric usability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->