### PR TITLE
fix(device-plugin): skip devices that do not support event based healthchecking

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -118,10 +118,10 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, eventSet)
-		if ret == nvml.ERROR_NOT_SUPPORTED {
+		switch {
+		case ret == nvml.ERROR_NOT_SUPPORTED:
 			klog.Warningf("Device %v is too old to support healthchecking.", d.ID)
-		}
-		if ret != nvml.SUCCESS {
+		case ret != nvml.SUCCESS:
 			klog.Infof("Marking device %v as unhealthy: %v", d.ID, ret)
 			unhealthy <- d
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_registerevents_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_registerevents_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rm
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	mock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/stretchr/testify/require"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// A device that cannot register events is not faulty, so it must not be marked unhealthy.
+func TestCheckHealthRegisterEvents(t *testing.T) {
+	registerRet := map[string]nvml.Return{
+		"GPU-unsupported": nvml.ERROR_NOT_SUPPORTED,
+		"GPU-failing":     nvml.ERROR_UNKNOWN,
+		"GPU-ok":          nvml.SUCCESS,
+	}
+
+	// checkHealth only waits for events once every device has been registered.
+	var once sync.Once
+	registered := make(chan struct{})
+	eventSet := &mock.EventSet{
+		FreeFunc: func() nvml.Return { return nvml.SUCCESS },
+		WaitFunc: func(uint32) (nvml.EventData, nvml.Return) {
+			once.Do(func() { close(registered) })
+			time.Sleep(time.Millisecond)
+			return nvml.EventData{}, nvml.ERROR_TIMEOUT
+		},
+	}
+	r := &nvmlResourceManager{nvml: &mock.Interface{
+		InitFunc:           func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc:       func() nvml.Return { return nvml.SUCCESS },
+		EventSetCreateFunc: func() (nvml.EventSet, nvml.Return) { return eventSet, nvml.SUCCESS },
+		DeviceGetHandleByUUIDFunc: func(uuid string) (nvml.Device, nvml.Return) {
+			return &mock.Device{
+				GetSupportedEventTypesFunc: func() (uint64, nvml.Return) {
+					return uint64(nvml.EventTypeXidCriticalError), nvml.SUCCESS
+				},
+				RegisterEventsFunc: func(uint64, nvml.EventSet) nvml.Return { return registerRet[uuid] },
+			}, nvml.SUCCESS
+		},
+	}}
+
+	devices := Devices{}
+	for uuid := range registerRet {
+		devices[uuid] = &Device{Device: kubeletdevicepluginv1beta1.Device{
+			ID: uuid, Health: kubeletdevicepluginv1beta1.Healthy}}
+	}
+
+	stop := make(chan interface{})
+	unhealthy := make(chan *Device, len(devices))
+	done := make(chan error, 1)
+	go func() { done <- r.checkHealth(stop, devices, unhealthy, make(chan bool)) }()
+
+	select {
+	case <-registered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("checkHealth did not finish registering devices")
+	}
+	close(stop)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("checkHealth did not return")
+	}
+
+	marked := map[string]bool{}
+	for len(unhealthy) > 0 {
+		marked[(<-unhealthy).ID] = true
+	}
+	require.False(t, marked["GPU-unsupported"], "ERROR_NOT_SUPPORTED means the device cannot be health checked, not that it is unhealthy")
+	require.True(t, marked["GPU-failing"], "any other registration error must still mark the device unhealthy")
+	require.False(t, marked["GPU-ok"], "a device that registered fine must stay healthy")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`nvmlDeviceRegisterEvents` returning `ERROR_NOT_SUPPORTED` means the device cannot report health through the event mechanism, not that it is faulty. The two separate `if`s let that return code fall through into the second branch, so the device is handed to `ListAndWatch` as `Unhealthy` and stops being schedulable. That state is not reversible - `ListAndWatch` carries a `FIXME: there is no way to recover from the Unhealthy state` - and a restart only repeats the same failed registration. The logs contradict themselves: one line says the device is "too old to support healthchecking", the next one marks it unhealthy.

A `switch` makes the two cases exclusive. NVIDIA fixed the same block upstream in k8s-device-plugin (commit `8cd1447`, "Fix healthchecking on old devices").

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Added a test covering the three `RegisterEvents` outcomes. Checked both ways: with `health.go` reverted to master the test fails on the `ERROR_NOT_SUPPORTED` assertion, with the fix the package passes.

I have no card that answers `ERROR_NOT_SUPPORTED` for the mask HAMi asks for, so this is not reproduced end to end on a node. I did probe NVML on our test cluster to confirm the return code is reachable in practice: on a GeForce RTX 4090 D (driver 595.71.05) `nvmlDeviceRegisterEvents` returns `ERROR_NOT_SUPPORTED` for the ECC event bits, and on a Tesla V100 (driver 550.54.15) for a bit outside its supported mask.

This PR was written primarily by Claude Code.

**Does this PR introduce a user-facing change?**:

Devices that do not support event based health checking are no longer reported as unhealthy, so they stay schedulable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Devices remain healthy when event registration is unsupported by the available hardware or driver.
  * Other event registration failures continue to be reported and mark the device unhealthy.

* **Tests**
  * Added coverage for successful, unsupported, and failed event registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->