### PR TITLE
fix(leaderelection): use exact hostname match instead of prefix match

### DIFF
--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -166,7 +166,12 @@ func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
+	holder := *lease.Spec.HolderIdentity
+	idx := strings.LastIndex(holder, "_")
+	if idx == -1 {
+		return holder == m.hostname
+	}
+	return holder[:idx] == m.hostname
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -429,6 +429,27 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 		})
 	})
 
+	ginkgo.Context("When another hostname has this hostname as a string prefix", func() {
+		ginkgo.It("isHolderOf should return false, not match on prefix", func() {
+			// Regression: hostname "dev" must not match a lease held by a
+			// different replica whose hostname happens to start with "dev",
+			// e.g. "dev-2", which would previously cause both replicas to
+			// believe they hold the lease.
+			otherHolder := "dev-2_" + string(uuid.NewUUID())
+			lease := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity: &otherHolder,
+				},
+			}
+			result := lm.isHolderOf(lease)
+			g.Expect(result).Should(g.BeFalse())
+		})
+	})
+
 	ginkgo.Context("When observedLease is nil", func() {
 		ginkgo.It("isLeaseValid should return false", func() {
 			lm.observedLease = nil

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -450,6 +450,26 @@ var _ = ginkgo.Describe("Nil checks for lease fields", func() {
 		})
 	})
 
+	ginkgo.Context("When holder identity has no underscore separator", func() {
+		ginkgo.It("isHolderOf should compare the identity exactly", func() {
+			exact := hostname
+			lease := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity: &exact,
+				},
+			}
+			g.Expect(lm.isHolderOf(lease)).Should(g.BeTrue())
+
+			other := hostname + "-2"
+			lease.Spec.HolderIdentity = &other
+			g.Expect(lm.isHolderOf(lease)).Should(g.BeFalse())
+		})
+	})
+
 	ginkgo.Context("When observedLease is nil", func() {
 		ginkgo.It("isLeaseValid should return false", func() {
 			lm.observedLease = nil


### PR DESCRIPTION
## What this fixes

`leaderManager.isHolderOf` decides whether the local scheduler replica currently holds the leader-election lease. It does this by checking whether the lease's `HolderIdentity` string *starts with* the local hostname:

```go
return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
```

`HolderIdentity` is formatted as `hostname + "_" + uuid`, so this is meant to strip the trailing UUID and compare hostnames. The problem is that `strings.HasPrefix` doesn't respect the `_` boundary, so a hostname that is a literal string prefix of another replica's hostname will also match. For example, if two scheduler pods are named `hami-scheduler-1` and `hami-scheduler-11`, the lease held by `hami-scheduler-11` also satisfies `HasPrefix(..., "hami-scheduler-1")`. Both replicas then believe they are the leader at the same time (split-brain), which is exactly what leader election is supposed to prevent.

This is easy to hit in practice since StatefulSet/Deployment pod names are often numeric suffixes of a shared prefix.

## Fix

Split the holder identity on the last `_` and compare the hostname portion exactly, instead of doing a prefix match on the whole string.

## Testing

- Added a regression test (`leaderelection_test.go`) reproducing the collision scenario (`dev` vs `dev-2`) and confirmed it fails against the old code and passes with the fix.
- `go test ./pkg/util/leaderelection/... -race -count=1` passes.
- This is scheduler-extender-only logic (no device/hardware interaction), so per the contribution guide's testing policy, unit tests are the appropriate validation here.

## AI disclosure

This PR was written primarily by Geminy, used to investigate the codebase, identify the bug, implement the fix, and write the regression test. I reviewed and verified the change before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Corrected leader ownership detection to distinguish hostnames that share a common prefix.
- Improved matching for identities with and without instance suffixes, preventing incorrect leader assignments.

## Tests
- Added regression coverage to verify accurate leader ownership detection across supported identity formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->