### PR TITLE
fix(kunlun): avoid index-out-of-range panic in devicepick on nodes with fewer than 8 XPUs

### DIFF
--- a/pkg/device/kunlun/topo.go
+++ b/pkg/device/kunlun/topo.go
@@ -208,7 +208,7 @@ func delta(have, want []int) []int {
 func devicepick(devices []*device.DeviceUsage, start int, request device.ContainerDeviceRequest, fitFn FitFn) []int {
 	count := int(request.Nums)
 	res := []int{}
-	for t := start; t < 8; t++ {
+	for t := start; t < len(devices); t++ {
 		if fitFn(devices[t], request) {
 			res = append(res, int(devices[t].Index))
 			if len(res) == count {

--- a/pkg/device/kunlun/topo_test.go
+++ b/pkg/device/kunlun/topo_test.go
@@ -256,6 +256,19 @@ func TestDevicepick(t *testing.T) {
 	}
 }
 
+// TestDevicepick_FewerThanEightDevices guards against a regression where the
+// scan loop was hard-coded to `t < 8` and indexed devices[t] directly,
+// panicking with index out of range on nodes that report fewer than 8 XPUs.
+func TestDevicepick_FewerThanEightDevices(t *testing.T) {
+	devices := newDevices(0, 1, 2, 3, 4, 5, 6, 7)[:4] // node with only 4 XPUs, all busy
+
+	got := devicepick(devices, 0, req(2), fitAvailable)
+	want := []int{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("devicepick(start=0, count=2) = %v, want %v", got, want)
+	}
+}
+
 func TestGraghSelect_AllEightAvailable(t *testing.T) {
 	devices := newDevices() // none used
 	got := graghSelect(devices, req(8), fitAvailable)


### PR DESCRIPTION
## What this fixes

`devicepick` in `pkg/device/kunlun/topo.go` scans a node's Kunlun XPU devices with:

```go
func devicepick(devices []*device.DeviceUsage, start int, request device.ContainerDeviceRequest, fitFn FitFn) []int {
    count := int(request.Nums)
    res := []int{}
    for t := start; t < 8; t++ {
        if fitFn(devices[t], request) {
```

The loop bound is hard-coded to `8` and `devices[t]` is indexed directly, which assumes every node reports exactly 8 Kunlun devices. `devices` is actually built from the node's device annotation via `device.UnMarshalNodeDevices` (see `graghSelect`'s caller in `vdevice.go` / `device.go`), so its length reflects whatever the node actually registers. A node with fewer than 8 Kunlun XPUs (e.g. a 4-XPU node) causes `devicepick` to index past the end of the slice, panicking the scheduler extender with `index out of range` when `graghSelect` falls through to it.

## Fix

Bound the loop by `len(devices)` instead of the hard-coded `8`.

## Testing

- Added `TestDevicepick_FewerThanEightDevices`, simulating a 4-device node. Confirmed it panics against the old code (`index out of range [4] with length 4`) and passes with the fix.
- `go test ./pkg/device/kunlun/... -race -count=1` passes.
- This is scheduler-extender scoring/selection logic, not device-plugin/container isolation code, so per the contribution guide's testing policy, unit tests are the appropriate validation here — I don't have Kunlun hardware to validate against.

## AI disclosure

This PR was written primarily by Geminy, used to investigate the codebase, identify the bug, implement the fix, and write the regression test. I reviewed and verified the change before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device selection for lists containing fewer than eight devices.
  * Prevented errors when all available devices are busy; no devices are returned in that case.
  * Device selection now evaluates all available entries instead of stopping prematurely, helping ensure eligible devices are considered across varying list sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->