### PR TITLE
fix(device): enforce ResourceQuota in Fit() for all backends

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -312,6 +312,11 @@ func (amddevice *AMDDevices) Fit(devices []*device.DeviceUsage, request device.C
 		if memReq <= 0 && dev.Totalmem > 0 {
 			memReq = dev.Totalmem
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memReq), int64(k.Coresreq), AMDDevice, amddevice.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memReq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memReq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memReq)

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -512,6 +512,11 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), k.Type, npu.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -428,6 +428,12 @@ func (neuron *AWSNeuronDevices) Fit(devices []*device.DeviceUsage, request devic
 			continue
 		}
 
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(k.Memreq), int64(k.Coresreq), AWSNeuronDevice, neuron.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", k.Memreq, "coresreq", k.Coresreq)
+			continue
+		}
+
 		if countMaskAvailable(dev.Totalcore)-countMaskAvailable(dev.Usedcores) < k.Coresreq {
 			reason[common.CardInsufficientCore]++
 			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", dev.Totalcore, "device used core", dev.Usedcores, "request cores", k.Coresreq)

--- a/pkg/device/biren/device.go
+++ b/pkg/device/biren/device.go
@@ -219,6 +219,11 @@ func (br *BirenDevices) Fit(devices []*device.DeviceUsage, request device.Contai
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(k.Memreq), int64(k.Coresreq), BirenDevice, br.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", k.Memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if k.Nums > 0 {
 			klog.V(5).InfoS("find fit device", "pod", klog.KObj(pod), "device", dev.ID)
 			k.Nums--

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -378,6 +378,11 @@ func (cam *CambriconDevices) Fit(devices []*device.DeviceUsage, request device.C
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), CambriconMLUDevice, cam.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -431,6 +431,11 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(profileMemoryMiB), int64(profileCorePercent), EnflameVGCUDevice, enf.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", profileMemoryMiB, "coresreq", profileCorePercent)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < profileMemoryMiB {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", profileMemoryMiB)

--- a/pkg/device/enflame/gcu.go
+++ b/pkg/device/enflame/gcu.go
@@ -163,6 +163,12 @@ func (gcuDev *GCUDevices) Fit(devices []*device.DeviceUsage, request device.Cont
 			continue
 		}
 
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(k.Memreq), int64(k.Coresreq), EnflameGCUDevice, gcuDev.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", k.Memreq, "coresreq", k.Coresreq)
+			continue
+		}
+
 		if k.Nums > 0 {
 			klog.V(5).InfoS("find fit device", "pod", klog.KObj(pod), "device", dev.ID)
 			k.Nums--

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -301,6 +301,11 @@ func (dcu *DCUDevices) Fit(devices []*device.DeviceUsage, request device.Contain
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), HygonDCUDevice, dcu.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -317,6 +317,11 @@ func (ilu *IluvatarDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), k.Type, ilu.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -205,6 +205,11 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 			}
 		}
 	}
+	if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(request.Memreq), int64(request.Coresreq), request.Type, kl.GetResourceNames()) {
+		reason[common.ResourceQuotaNotFit]++
+		klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", request.Memreq, "coresreq", request.Coresreq)
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
 	return true, tmpDevs, ""
 }
 

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -271,6 +271,11 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			}
 		}
 	}
+	if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(request.Memreq), int64(request.Coresreq), request.Type, dev.GetResourceNames()) {
+		reason[common.ResourceQuotaNotFit]++
+		klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", request.Memreq, "coresreq", request.Coresreq)
+		return false, tmpDevs, common.GenReason(reason, len(devices))
+	}
 	return true, tmpDevs, ""
 }
 

--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -277,6 +277,11 @@ func (mat *MetaxDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), MetaxGPUDevice, mat.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -371,6 +371,12 @@ func (mats *MetaxSDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			memreq = dev.Totalmem * request.MemPercentagereq / 100
 		}
 
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(request.Coresreq), MetaxSGPUDevice, mats.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", request.Coresreq)
+			continue
+		}
+
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -346,6 +346,11 @@ func (mth *MthreadsDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), MthreadsGPUDevice, mth.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -728,27 +728,6 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 	return nil
 }
 
-func fitQuota(tmpDevs map[string]device.ContainerDevices, allocated *device.PodDevices, ns string, memreq int64, coresreq int64) bool {
-	mem := memreq
-	core := coresreq
-	for _, val := range tmpDevs[NvidiaGPUDevice] {
-		mem += int64(val.Usedmem)
-		core += int64(val.Usedcores)
-	}
-	if allocated != nil {
-		if podSingleDevice, exists := (*allocated)[NvidiaGPUDevice]; exists {
-			for _, containerDevices := range podSingleDevice {
-				for _, val := range containerDevices {
-					mem += int64(val.Usedmem)
-					core += int64(val.Usedcores)
-				}
-			}
-		}
-	}
-	klog.V(4).Infoln("Allocating...", mem, "cores", core)
-	return device.GetLocalCache().FitQuota(ns, mem, MemoryFactor, core, NvidiaGPUDevice)
-}
-
 func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
@@ -812,7 +791,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
-		if !fitQuota(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq)) {
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(memreq), int64(k.Coresreq), NvidiaGPUDevice, nv.GetResourceNames()) {
 			reason[common.ResourceQuotaNotFit]++
 			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
 			continue

--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -88,6 +88,31 @@ func (q *QuotaManager) FitQuota(ns string, memreq int64, memoryFactor int32, cor
 	return true
 }
 
+// FitQuotaForDevice checks whether a pod's total device request (current round
+// plus previously allocated containers) fits the namespace ResourceQuota for the
+// given device type. Every backend should call this from its Fit() method to
+// enforce quota at scheduling time.
+func FitQuotaForDevice(tmpDevs map[string]ContainerDevices, allocated *PodDevices, ns string, memreq int64, coresreq int64, deviceName string, resourceNames ResourceNames) bool {
+	mem := memreq
+	core := coresreq
+	for _, val := range tmpDevs[deviceName] {
+		mem += int64(val.Usedmem)
+		core += int64(val.Usedcores)
+	}
+	if allocated != nil {
+		if podSingleDevice, exists := (*allocated)[deviceName]; exists {
+			for _, containerDevices := range podSingleDevice {
+				for _, val := range containerDevices {
+					mem += int64(val.Usedmem)
+					core += int64(val.Usedcores)
+				}
+			}
+		}
+	}
+	klog.V(4).Infoln("FitQuotaForDevice: device", deviceName, "mem", mem, "cores", core)
+	return GetLocalCache().FitQuota(ns, mem, resourceNames.MemoryFactor, core, deviceName)
+}
+
 func countPodDevices(podDev PodDevices) map[string]int64 {
 	res := make(map[string]int64)
 	for deviceName, podSingle := range podDev {

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -282,3 +282,81 @@ func TestDelQuotaNonLimitsKey(t *testing.T) {
 		t.Errorf("DelQuota: expected memory limit 100 after deleting non-limits quota, got %d", (*qm.Quotas[ns])[memName].Limit)
 	}
 }
+
+func TestFitQuotaForDevice(t *testing.T) {
+	initTest()
+	qm := NewQuotaManager()
+	ns := "testns"
+	deviceName := "NVIDIA"
+	memName := "nvidia.com/gpumem"
+	coreName := "nvidia.com/gpucore"
+	rns := ResourceNames{
+		ResourceMemoryName: memName,
+		ResourceCoreName:   coreName,
+		MemoryFactor:       1,
+	}
+
+	// Set up quota: limit 1000 mem, 100 cores
+	qm.Quotas[ns] = &DeviceQuota{
+		memName:  &Quota{Used: 800, Limit: 1000},
+		coreName: &Quota{Used: 50, Limit: 100},
+	}
+
+	// Should fit: 800 used + 100 requested = 900 <= 1000
+	tmpDevs := map[string]ContainerDevices{}
+	if !FitQuotaForDevice(tmpDevs, nil, ns, 100, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return true when within limits")
+	}
+
+	// Should not fit: 800 used + 300 requested = 1100 > 1000
+	if FitQuotaForDevice(tmpDevs, nil, ns, 300, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return false when memory exceeds limit")
+	}
+
+	// Should not fit cores: 50 used + 60 requested = 110 > 100
+	if FitQuotaForDevice(tmpDevs, nil, ns, 10, 60, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return false when cores exceed limit")
+	}
+
+	// Should account for devices in tmpDevs
+	tmpDevs2 := map[string]ContainerDevices{
+		deviceName: {
+			{Usedmem: 100, Usedcores: 20},
+		},
+	}
+	// 800 + 100 (tmpDevs) + 50 (request) = 950 <= 1000
+	if !FitQuotaForDevice(tmpDevs2, nil, ns, 50, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return true accounting for tmpDevs")
+	}
+	// 800 + 100 (tmpDevs) + 200 (request) = 1100 > 1000
+	if FitQuotaForDevice(tmpDevs2, nil, ns, 200, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return false accounting for tmpDevs")
+	}
+
+	// Should account for allocated devices
+	allocated := PodDevices{
+		deviceName: PodSingleDevice{
+			{
+				{Usedmem: 50, Usedcores: 5},
+			},
+		},
+	}
+	// 800 + 50 (allocated) + 50 (request) = 900 <= 1000
+	if !FitQuotaForDevice(tmpDevs, &allocated, ns, 50, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return true accounting for allocated")
+	}
+	// 800 + 50 (allocated) + 200 (request) = 1050 > 1000
+	if FitQuotaForDevice(tmpDevs, &allocated, ns, 200, 10, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return false accounting for allocated")
+	}
+
+	// Should fit if namespace not present
+	if !FitQuotaForDevice(tmpDevs, nil, "otherns", 5000, 100, deviceName, rns) {
+		t.Error("FitQuotaForDevice should return true if namespace not present")
+	}
+
+	// Should fit if device not in quota
+	if !FitQuotaForDevice(tmpDevs, nil, ns, 5000, 100, "unknown-device", rns) {
+		t.Error("FitQuotaForDevice should return true if device not in quota")
+	}
+}

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -281,6 +281,11 @@ func (va *VastaiDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 				continue
 			}
 		}
+		if !device.FitQuotaForDevice(tmpDevs, allocated, pod.Namespace, int64(k.Memreq), int64(k.Coresreq), VastaiDevice, va.GetResourceNames()) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", k.Memreq, "coresreq", k.Coresreq)
+			continue
+		}
 		if k.Nums > 0 {
 			klog.V(5).InfoS("find fit device", "pod", klog.KObj(pod), "device", dev.ID)
 			if !dieMode {


### PR DESCRIPTION
### Problem

Namespace ResourceQuota enforcement has a race window for every backend
except NVIDIA.

The admission webhook records no device usage — that happens at Filter
time via QuotaManager.AddUsage. So when a burst of pods is created
back-to-back, they all reach the webhook before any has been scheduled,
all read the same Used value, and all pass.

NVIDIA catches this because its Fit() method calls a private fitQuota
helper that re-checks quota after each device assignment. The second
pod in the burst sees the first pod's recorded usage and is correctly
denied when over limit.

Every other backend — cambricon, ascend, hygon, iluvatar, mthreads,
metax, amd, enflame, kunlun, awsneuron, vastai, biren — has no such
check. The whole burst schedules and the namespace ends up over its
limit.

This was identified during review of #2347, which fixed the case where
non-NVIDIA quotas were ignored outright. This is the remaining half.

### Reproducer

1. Register a non-NVIDIA backend (e.g. cambricon).
2. Set a namespace ResourceQuota on
   limits.cambricon.com/mlu.smlu.vmemory sized for ~2 pods.
3. Create a Deployment with 5 replicas requesting that resource.
4. All 5 pods pass admission and schedule. Usage exceeds the limit.
5. Repeat with nvidia.com/gpumem — excess replicas are correctly denied.

### Solution

Extract the accumulate-then-check logic from nvidia's private fitQuota
helper into a shared FitQuotaForDevice function that any backend can
call. Every backend's Fit() method now invokes this shared function
before assigning a device, closing the race.

The shared function:
- Sums memory and core usage from the current allocation round (tmpDevs)
  and from previously allocated containers in the pod (allocated)
- Delegates to QuotaManager.FitQuota with the backend's MemoryFactor

### Files changed

| File | Change |
|------|--------|
| pkg/device/quota.go | New FitQuotaForDevice function |
| pkg/device/quota_test.go | TestFitQuotaForDevice (8 test cases) |
| pkg/device/nvidia/device.go | Removed private fitQuota, use shared function |
| pkg/device/cambricon/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/ascend/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/hygon/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/iluvatar/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/mthreads/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/metax/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/metax/sdevice.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/amd/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/enflame/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/enflame/gcu.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/kunlun/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/kunlun/vdevice.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/awsneuron/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/vastai/device.go | Add FitQuotaForDevice call in Fit() |
| pkg/device/biren/device.go | Add FitQuotaForDevice call in Fit() |

### How to verify

    go test ./pkg/device/... -run TestFitQuotaForDevice -short --race -count=1 -v

Closes #2363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource-quota validation for device allocation across supported accelerator types.
  * Allocation now accounts for requested memory and cores alongside existing device capacity checks.
  * When a candidate exceeds quota, it is skipped so other eligible devices can still be considered.
* **Bug Fixes**
  * Improved allocation failure reporting with quota-specific reasons and diagnostic logging.
* **Tests**
  * Added coverage for quota checks involving temporary allocations, existing allocations, missing quotas, and namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->