### PR TITLE
fix(monitor): clamp DeviceNum to maxDevices to prevent scrape-path panic

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -78,7 +78,7 @@ func (s Spec) DeviceMax() int {
 }
 
 func (s Spec) DeviceNum() int {
-	return int(s.sr.num)
+	return int(min(s.sr.num, uint64(maxDevices)))
 }
 
 // activeProcs returns the process slots currently in use. procnum is read from

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -48,6 +48,8 @@ func TestSpec_DeviceNum(t *testing.T) {
 	tests := []specTest{
 		{name: "device num is 4", spec: &Spec{sr: &sharedRegionT{num: 4}}, expected: 4},
 		{name: "device num is 8", spec: &Spec{sr: &sharedRegionT{num: 8}}, expected: 8},
+		{name: "num larger than maxDevices is clamped", spec: &Spec{sr: &sharedRegionT{num: 9999}}, expected: maxDevices},
+		{name: "high-bit uint64 num is clamped not negative", spec: &Spec{sr: &sharedRegionT{num: 0x8000000000000001}}, expected: maxDevices},
 	}
 
 	for _, tt := range tests {

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -92,7 +92,7 @@ func (s Spec) DeviceMax() int {
 }
 
 func (s Spec) DeviceNum() int {
-	return int(s.sr.num)
+	return int(min(s.sr.num, uint64(maxDevices)))
 }
 
 // activeProcs returns the process slots currently in use. procnum is read from

--- a/pkg/monitor/nvidia/v1/spec_test.go
+++ b/pkg/monitor/nvidia/v1/spec_test.go
@@ -134,6 +134,24 @@ func Test_DeviceNum(t *testing.T) {
 			},
 			want: int(4),
 		},
+		{
+			name: "num larger than maxDevices is clamped",
+			args: &Spec{
+				sr: &sharedRegionT{
+					num: 9999,
+				},
+			},
+			want: maxDevices,
+		},
+		{
+			name: "high-bit uint64 num is clamped not negative",
+			args: &Spec{
+				sr: &sharedRegionT{
+					num: 0x8000000000000001,
+				},
+			},
+			want: maxDevices,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`DeviceNum()` in `v0/spec.go` and `v1/spec.go` returns `int(s.sr.num)` ,  an
unclamped raw read from the shared-memory region. `collectContainerMetrics` in
`cmd/vGPUmonitor/metrics.go` loops `for i := range c.Info.DeviceNum()` and
calls `DeviceUUID(i)` and `DeviceMemoryLimit(i)`, which index into `[16]uuid`
and `[16]uint64` arrays respectively. When `sr.num` exceeds 16 due to a
version mismatch or a partial libvgpu write, every Prometheus scrape causes an
index out of range panic that crashes vGPUmonitor and silences all GPU metrics
on that node.

- `pkg/monitor/nvidia/v0/spec.go`: `DeviceNum()` now returns `min(int(s.sr.num), maxDevices)`
- `pkg/monitor/nvidia/v1/spec.go`: same
- `pkg/monitor/nvidia/v0/spec_test.go`: added `"num larger than maxDevices is clamped"` to `TestSpec_DeviceNum`
- `pkg/monitor/nvidia/v1/spec_test.go`: added the same to `Test_DeviceNum`; also tightened existing table entries to inline form
- All tests pass: `go test ./pkg/monitor/nvidia/... -count=1`

This applies the same `min(_, maxDevices)` guard already used in `activeProcs()`
(via `#2282`) and the setter loops (via `#2362`) to the getter that drives the
scrape loop.

**Which issue(s) this PR fixes:**
Part of #2126 (LFX observability hardening - vGPU monitor stability)

**Special notes for your reviewer:**
`DeviceUUID(i)` and `DeviceMemoryLimit(i)` are called immediately after the
`DeviceNum()` loop bound, both access fixed-size `[16]` arrays so `i >= 16`
is an out-of-bounds panic, not a silent wrong value.

**Does this PR introduce a user-facing change?**
Yes vGPUmonitor no longer panics when `sr.num` exceeds 16; per-device GPU
metrics continue to be reported correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GPU device count reporting when the detected count exceeds the supported maximum.
  - Device counts are now safely limited to the maximum supported value, preventing invalid or unexpectedly large counts in monitoring results.
  - Applied consistently across supported NVIDIA monitoring versions.

- **Tests**
  - Added coverage to verify that excessive device counts are properly capped.

**AI Disclosure:**
AI assistance was used for code inspection and draft formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->