### PR TITLE
docs: correct stale golangci-lint version references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ make build              # Build all binaries (scheduler, vGPUmonitor, nvidia-dev
 make docker             # Build Docker image
 make tidy               # Run go mod tidy
 make test               # Run unit tests with coverage (output in _output/coverage/)
-make lint               # Run golangci-lint v2.8.0 (via hack/verify-staticcheck.sh)
+make lint               # Run golangci-lint (version pinned in hack/verify-staticcheck.sh)
 make verify             # Run all verification checks (license, lint, import aliases)
 ```
 
@@ -64,7 +64,7 @@ Each device backend provides an `Init*Device(config)` function returning a `devi
 
 - License headers on all `.go` files (`hack/verify-license.sh`, uses `addlicense`)
 - Import aliases must match `hack/.import-aliases` (e.g., `corev1` for `k8s.io/api/core/v1`)
-- golangci-lint v2.8.0 with config in `.golangci.yaml`
+- golangci-lint with config in `.golangci.yaml` (version pinned in `hack/verify-staticcheck.sh`)
 - `goimports` with local prefix `github.com/Project-HAMi/HAMi`
 - Unit tests with race detector
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
CLAUDE.md documented golangci-lint as v2.8.0 in two places (the `make lint`
comment and the CI-checks list), but the authoritative version pinned in
hack/verify-staticcheck.sh — and used by CI (.github/workflows/ci.yaml) — is
v2.12.2. A contributor following the docs could install a linter four minor
releases behind CI and hit "passes locally, fails in CI".

Rather than swap in another literal version that can drift again, both
references now point at the pinned value in hack/verify-staticcheck.sh as the
single source of truth.

**Which issue(s) this PR fixes**:
Fixes #<https://github.com/Project-HAMi/HAMi/issues/2401>

**Special notes for your reviewer**:
Documentation-only; no code or test changes. Two remaining "v2.8.0" strings in
the tree (CHANGELOG.md release heading, docs/general-technical-review.md project
version) refer to the HAMi release version, not golangci-lint, and are left
untouched. This change was made with AI assistance.

**Does this PR introduce a user-facing change?**:
```NONE```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `golangci-lint` version is pinned by the project’s verification tooling rather than documenting a specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->