### PR TITLE
fix(device-plugin): guard Allocate() against empty DevicesIds to prevent process-crashing panic

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -602,6 +602,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 
 	for idx, req := range reqs.ContainerRequests {
+		if len(req.DevicesIds) == 0 {
+			PodAllocationFailed(nodename, current, NodeLockNvidia)
+			return nil, fmt.Errorf("invalid allocation request: container request %d has no DevicesIds", idx)
+		}
+
 		// If the devices being allocated are replicas, then (conditionally)
 		// error out if more than one resource is being allocated.
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1456,6 +1456,8 @@ func TestAllocate_EmptyDevicesIdsAndRegression(t *testing.T) {
 			require.Equal(t, tc.expectSuccess, successCalled, "PodAllocationTrySuccess invoked mismatch")
 		})
 	}
+}
+
 type mockListAndWatchServer struct {
 	grpc.ServerStream
 	sendErrs []error

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1308,3 +1308,152 @@ func TestMigCurrentConfigsNeverNil(t *testing.T) {
 		require.False(t, cfg.MigEnabled)
 	}
 }
+
+func TestAllocate_EmptyDevicesIdsAndRegression(t *testing.T) {
+	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"envvar"})
+	deviceIDStrategy := v1.DeviceIDStrategyUUID
+	memScale := 1.0
+	logLevel := nvidia.Error
+	expectedNodeName := "node-a"
+	t.Setenv(util.NodeNameEnvName, expectedNodeName)
+
+	mockRM := &rm.ResourceManagerMock{
+		DevicesFunc: func() rm.Devices {
+			return rm.Devices{
+				"MIG-12345": &rm.Device{},
+			}
+		},
+		ResourceFunc: func() v1.ResourceName {
+			return v1.ResourceName("nvidia.com/mig-1g.5gb")
+		},
+	}
+
+	plugin := &NvidiaDevicePlugin{
+		rm: mockRM,
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							DeviceIDStrategy: &deviceIDStrategy,
+						},
+					},
+				},
+			},
+		},
+		deviceListStrategies: deviceListStrategies,
+		schedulerConfig: nvidia.NvidiaConfig{
+			NodeDefaultConfig: nvidia.NodeDefaultConfig{
+				DeviceMemoryScaling: &memScale,
+				LogLevel:            &logLevel,
+			},
+		},
+	}
+
+	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	previousGetPendingPod := getPendingPod
+	defer func() { getPendingPod = previousGetPendingPod }()
+
+	previousEraseNextDeviceTypeFromAnnotation := eraseNextDeviceTypeFromAnnotation
+	defer func() { eraseNextDeviceTypeFromAnnotation = previousEraseNextDeviceTypeFromAnnotation }()
+
+	previousPodAllocationFailed := podAllocationFailed
+	defer func() { podAllocationFailed = previousPodAllocationFailed }()
+
+	previousPodAllocationTrySuccess := podAllocationTrySuccess
+	defer func() { podAllocationTrySuccess = previousPodAllocationTrySuccess }()
+
+	testCases := []struct {
+		name               string
+		containerRequests  []*kubeletdevicepluginv1beta1.ContainerAllocateRequest
+		podAnnotation      string
+		expectError        bool
+		expectErrorMessage string
+		expectFailedCalled bool
+		expectSuccess      bool
+	}{
+		{
+			name: "Empty DevicesIds returns error and invokes PodAllocationFailed",
+			containerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+				{DevicesIds: []string{}},
+			},
+			expectError:        true,
+			expectErrorMessage: "has no DevicesIds",
+			expectFailedCalled: true,
+			expectSuccess:      false,
+		},
+		{
+			name: "Non-MIG allocation succeeds",
+			containerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+				{DevicesIds: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0"}},
+			},
+			podAnnotation:      "GPU-annotated-a,NVIDIA,3000,50:;",
+			expectError:        false,
+			expectFailedCalled: false,
+			expectSuccess:      true,
+		},
+		{
+			name: "MIG allocation succeeds",
+			containerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+				{DevicesIds: []string{"MIG-12345"}},
+			},
+			expectError:        false,
+			expectFailedCalled: false,
+			expectSuccess:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "pod-uid",
+					Annotations: map[string]string{
+						"hami.io/vgpu-devices-to-allocate": tc.podAnnotation,
+					},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+			}
+
+			getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+			eraseNextDeviceTypeFromAnnotation = func(string, corev1.Pod) error { return nil }
+
+			failedCalled := false
+			podAllocationFailed = func(nodeName string, failedPod *corev1.Pod, lockName string) {
+				failedCalled = true
+				require.Equal(t, expectedNodeName, nodeName)
+				require.Equal(t, pod, failedPod)
+				require.Equal(t, NodeLockNvidia, lockName)
+			}
+
+			successCalled := false
+			podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {
+				successCalled = true
+			}
+
+			request := &kubeletdevicepluginv1beta1.AllocateRequest{
+				ContainerRequests: tc.containerRequests,
+			}
+
+			response, err := plugin.Allocate(context.Background(), request)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Nil(t, response)
+				if tc.expectErrorMessage != "" {
+					require.Contains(t, err.Error(), tc.expectErrorMessage)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, response)
+			}
+			require.Equal(t, tc.expectFailedCalled, failedCalled, "PodAllocationFailed invoked mismatch")
+			require.Equal(t, tc.expectSuccess, successCalled, "PodAllocationTrySuccess invoked mismatch")
+		})
+	}
+}
+


### PR DESCRIPTION
### Summary
In `pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go`, `Allocate()` iterates over `reqs.ContainerRequests` and accesses `req.DevicesIds[0]` without checking if `DevicesIds` is empty. If a request with an empty `DevicesIds` slice is received, Go panics with `runtime error: index out of range [0]`. Because the gRPC server has no panic-recovery interceptor, this crashes the entire `nvidia-device-plugin` process — affecting every pod on the node waiting on GPU allocation, not just the one triggering the bad request.

This PR adds a guard at the top of the `ContainerRequests` loop:
- Calls `PodAllocationFailed(nodename, current, NodeLockNvidia)` to clean up node locks and pod status annotations.
- Returns `nil, fmt.Errorf("invalid allocation request: container request %d has no DevicesIds", idx)` for a clean gRPC error instead of a crash.

Fixes #2405

### Changes
- **`pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go`**: add `len(req.DevicesIds) == 0` check before `req.DevicesIds[0]` is accessed.
- **`pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go`**: add table-driven unit test `TestAllocate_EmptyDevicesIdsAndRegression` covering:
  1. Empty `DevicesIds` → non-nil error, no panic, `PodAllocationFailed` invoked (asserted directly, not just the error return).
  2. Existing non-MIG allocation path still succeeds unchanged.
  3. Existing MIG allocation path still succeeds unchanged.

### Test Matrix & Verification Status
- **Local (Windows)**: `go test` and `make verify` cannot compile `pkg/device-plugin/nvidiadevice/nvinternal/plugin` locally due to pre-existing CGo / Linux-only dependencies (`go-nvml`, `nvidia-container-toolkit`, `opencontainers/cgroups` using `syscall.Mmap` / `unix.Mkdev`). This occurs identically on an unmodified `master` checkout.
- **CI**: full compilation, `go test`, and `make verify` will run on Linux runners.

### AI Assistance Disclosure
I used AI assistance (Claude) to identify this panic risk, implement the guard, and draft the regression test. I reviewed the diff, ran the test suite where locally possible, and take full responsibility for the final change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented allocation requests with no device IDs from causing failures.
  * Added clear validation errors identifying the affected request.
  * Ensured allocation locks are released when validation fails.
  * Preserved successful allocation behavior for standard and MIG devices.

* **Tests**
  * Added regression coverage for empty device requests, failure handling, and successful standard and MIG allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->