### PR TITLE
test(vGPUmonitor): expect short UUID to be skipped, not error

### DIFF
--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -134,8 +134,12 @@ func TestCollectContainerMetricsBadInput(t *testing.T) {
 		t.Error("nil ContainerUsage.Info should return an error")
 	}
 	short := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{"gpu-short"}}}
-	if _, err := collectContainer(t, short, 0); err == nil {
-		t.Error("a UUID shorter than 40 chars should return an error")
+	metrics, err := collectContainer(t, short, 0)
+	if err != nil {
+		t.Fatalf("a UUID shorter than 40 chars should be skipped, not error: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("got %d metrics for a short UUID, want 0", len(metrics))
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`TestCollectContainerMetricsBadInput` fails on `master`, which blocks unit tests for every open PR.

Two recently-merged PRs conflict:

- #2364 changed `collectContainerMetrics` to **skip** a device whose UUID is shorter than 40 chars (the shared-memory region is not yet initialised) and continue the scrape, instead of returning an error.
- #2350 added `TestCollectContainerMetricsBadInput`, which still asserts that a short UUID **returns an error** — the old behavior.

#2350 merged after #2364 but kept the pre-#2364 expectation, so the test now fails deterministically on `master`.

This aligns the short-UUID case with the actual behavior: the device is skipped, so `collectContainer` returns no metrics and no error — matching the sibling `TestCollectContainerMetricsSkipsInvalidUTF8UUID`. Test-only change; no production code touched.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

`go test ./cmd/vGPUmonitor/ -count=1` passes with this change.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid devices with short UUIDs are now skipped cleanly without causing errors or emitting invalid metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->