### PR TITLE
fix(test): set LimitSet on quota fixtures added in #2347

### DIFF
--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
master is red on the scheduler unit tests right now. #2313 changed FitQuota to gate on LimitSet instead of `Limit != 0`, so an explicit ResourceQuota of "0" is honored as a hard block. The quota tests added in #2347 build `device.Quota` values directly with only `Limit` set, so once both landed on master those limits read as "not configured" and the over-quota cases got admitted instead of denied. AddQuota sets LimitSet in the real path, so this sets it in the fixtures to match.

Both PRs passed CI on their own base and only conflict once they're on master together, which is why neither run caught it.

Tests this brings back to green:
- TestFitResourceQuotaNonNvidia (mlu and dcu subcases)
- TestFitResourceQuotaCountsEveryDevice
- TestFitResourceQuotaAscendMemoryFactor

**Which issue(s) this PR fixes**:
none filed, this is a master CI regression

**Special notes for your reviewer**:
test-only, no production code touched. `go test ./pkg/scheduler/...` passes locally. #2313 was mine, so this is cleaning up after it.

**AI assistance disclosure**:
I used AI assistance (Claude Code) to bisect which merge combination broke master and to confirm the fix. I read and ran the tests myself.

**Does this PR introduce a user-facing change?**:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quota test fixtures to explicitly mark Cambricon, Hygon, multi-MLU, and Ascend limits as active.
  * Improved test coverage reliability for scheduler webhook quota scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->