### PR TITLE
fix(test): set LimitSet on the webhook quota fixtures to unbreak master

### DIFF
--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

`master` is currently red. Three tests in `pkg/scheduler/webhook_test.go` fail:

```
--- FAIL: TestFitResourceQuotaNonNvidia
    webhook_test.go:561: fitResourceQuota() = true, want false
--- FAIL: TestFitResourceQuotaCountsEveryDevice
--- FAIL: TestFitResourceQuotaAscendMemoryFactor
```

Reproduces on a clean checkout with `go test ./pkg/scheduler/ -run TestFitResourceQuota`.

#2313 added `Quota.LimitSet` and changed `FitQuota` to gate on it rather than
`Limit != 0`, so that an explicit `0` is honoured as a hard block. A `Quota`
built directly as a struct literal, instead of going through `AddQuota`, now
defaults `LimitSet` to false and reads as "no limit configured".

#2313 spotted this and fixed the fixture in `TestFitResourceQuota`. In the
meantime #2347 had added three more tests that build their fixtures the same
way, and those were not updated. Each PR was green on its own; the conflict
only exists once both are on master, so neither CI run could have caught it.

This sets `LimitSet: true` on the remaining five fixtures so they match what
`AddQuota` produces. Test-only, no production code touched.

**Which issue(s) this PR fixes**:

None filed — raising the fix directly since master is broken.

**Special notes for your reviewer**:

Worth considering separately: the same trap is waiting for the next person who
writes a quota test. A small constructor, or making `AddQuota` the only way to
set a limit in tests, would stop it recurring. I have not done that here to keep
this to the minimum needed to get master green.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

---

AI assistance disclosure: this change was developed with Claude Code. Flagging
the extent up front per CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quota test fixtures to correctly indicate configured limits for Cambricon, Hygon, and Ascend devices, including multi-device MLU scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->