### PR TITLE
test: add unit tests for LinkDevice scoring

### DIFF
--- a/pkg/device/metax/score_test.go
+++ b/pkg/device/metax/score_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLinkDeviceScore(t *testing.T) {
+	for _, ts := range []struct {
+		name     string
+		from     *LinkDevice
+		to       *LinkDevice
+		expected int
+	}{
+		{
+			name:     "same uuid returns zero",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 1},
+			to:       &LinkDevice{uuid: "GPU-0", linkZone: 1},
+			expected: 0,
+		},
+		{
+			name:     "from linkZone zero returns zero",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 0},
+			to:       &LinkDevice{uuid: "GPU-1", linkZone: 1},
+			expected: 0,
+		},
+		{
+			name:     "to linkZone zero returns zero",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 1},
+			to:       &LinkDevice{uuid: "GPU-1", linkZone: 0},
+			expected: 0,
+		},
+		{
+			name:     "both linkZone zero returns zero",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 0},
+			to:       &LinkDevice{uuid: "GPU-1", linkZone: 0},
+			expected: 0,
+		},
+		{
+			name:     "same linkZone returns direct link score",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 1},
+			to:       &LinkDevice{uuid: "GPU-1", linkZone: 1},
+			expected: DirectLinkScore,
+		},
+		{
+			name:     "different linkZone returns zero",
+			from:     &LinkDevice{uuid: "GPU-0", linkZone: 1},
+			to:       &LinkDevice{uuid: "GPU-1", linkZone: 2},
+			expected: 0,
+		},
+	} {
+		t.Run(ts.name, func(t *testing.T) {
+			result := ts.from.score(ts.to)
+			if result != ts.expected {
+				t.Errorf("score() failed: result %v, expected %v", result, ts.expected)
+			}
+		})
+	}
+}
+
+func TestLinkDevicesScore(t *testing.T) {
+	for _, ts := range []struct {
+		name     string
+		devs     LinkDevices
+		expected int
+	}{
+		{
+			name:     "empty devices",
+			devs:     LinkDevices{},
+			expected: 0,
+		},
+		{
+			name: "single device",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+			},
+			expected: 0,
+		},
+		{
+			name: "two devices same zone",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+				{uuid: "GPU-1", linkZone: 1},
+			},
+			expected: DirectLinkScore,
+		},
+		{
+			name: "two devices different zone",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+				{uuid: "GPU-1", linkZone: 2},
+			},
+			expected: 0,
+		},
+		{
+			name: "three devices all same zone sums pairwise",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+				{uuid: "GPU-1", linkZone: 1},
+				{uuid: "GPU-2", linkZone: 1},
+			},
+
+			expected: 3 * DirectLinkScore,
+		},
+		{
+			name: "mixed zones only matching pairs score",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+				{uuid: "GPU-1", linkZone: 1},
+				{uuid: "GPU-2", linkZone: 2},
+			},
+
+			expected: DirectLinkScore,
+		},
+		{
+			name: "devices with zero linkZone never score",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 0},
+				{uuid: "GPU-1", linkZone: 0},
+			},
+			expected: 0,
+		},
+	} {
+		t.Run(ts.name, func(t *testing.T) {
+			result := ts.devs.Score()
+			if result != ts.expected {
+				t.Errorf("Score() failed: result %v, expected %v", result, ts.expected)
+			}
+		})
+	}
+}
+
+func TestLinkDevicesString(t *testing.T) {
+	for _, ts := range []struct {
+		name     string
+		devs     LinkDevices
+		expected string
+	}{
+		{
+			name:     "empty devices",
+			devs:     LinkDevices{},
+			expected: "[]",
+		},
+		{
+			name: "non-empty devices produce bracketed output",
+			devs: LinkDevices{
+				{uuid: "GPU-0", linkZone: 1},
+				{uuid: "GPU-1", linkZone: 2},
+			},
+			expected: "",
+		},
+	} {
+		t.Run(ts.name, func(t *testing.T) {
+			result := ts.devs.String()
+			if !strings.HasPrefix(result, "[") || !strings.HasSuffix(result, "]") {
+				t.Errorf("String() failed: result %q is not bracketed", result)
+			}
+			if ts.name == "empty devices" && result != ts.expected {
+				t.Errorf("String() failed: result %v, expected %v", result, ts.expected)
+			}
+			if ts.name == "non-empty devices produce bracketed output" {
+				if !strings.Contains(result, "GPU-0") || !strings.Contains(result, "GPU-1") {
+					t.Errorf("String() failed: result %q does not contain expected uuids", result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/device/metax/score_test.go
+++ b/pkg/device/metax/score_test.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package metax
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestLinkDeviceScore(t *testing.T) {
 	for _, ts := range []struct {
@@ -68,7 +65,7 @@ func TestLinkDeviceScore(t *testing.T) {
 		t.Run(ts.name, func(t *testing.T) {
 			result := ts.from.score(ts.to)
 			if result != ts.expected {
-				t.Errorf("score() failed: result %v, expected %v", result, ts.expected)
+				t.Fatalf("score() failed: result %v, expected %v", result, ts.expected)
 			}
 		})
 	}
@@ -158,26 +155,18 @@ func TestLinkDevicesString(t *testing.T) {
 			expected: "[]",
 		},
 		{
-			name: "non-empty devices produce bracketed output",
+			name: "non-empty devices produce expected output",
 			devs: LinkDevices{
 				{uuid: "GPU-0", linkZone: 1},
 				{uuid: "GPU-1", linkZone: 2},
 			},
-			expected: "",
+			expected: "[{GPU-0 1}{GPU-1 2}]",
 		},
 	} {
 		t.Run(ts.name, func(t *testing.T) {
 			result := ts.devs.String()
-			if !strings.HasPrefix(result, "[") || !strings.HasSuffix(result, "]") {
-				t.Errorf("String() failed: result %q is not bracketed", result)
-			}
-			if ts.name == "empty devices" && result != ts.expected {
-				t.Errorf("String() failed: result %v, expected %v", result, ts.expected)
-			}
-			if ts.name == "non-empty devices produce bracketed output" {
-				if !strings.Contains(result, "GPU-0") || !strings.Contains(result, "GPU-1") {
-					t.Errorf("String() failed: result %q does not contain expected uuids", result)
-				}
+			if result != ts.expected {
+				t.Errorf("String() = %q, expected %q", result, ts.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

This PR adds unit tests for the metax device link scoring logic in
`pkg/device/metax/score.go`.

The scoring functions (`LinkDevice.score()`, `LinkDevices.Score()`, and
`LinkDevices.String()`) previously had no dedicated test coverage.
This change adds table-driven tests covering normal cases and edge cases
without modifying any production code.

Changes (test-only, `pkg/device/metax/score_test.go`):

- Added tests for `LinkDevice.score()`:
  - Same UUID devices
  - Zero `linkZone` values
  - Matching `linkZone` values
  - Different `linkZone` values

- Added tests for `LinkDevices.Score()`:
  - Empty device list
  - Single device
  - Same-zone devices
  - Different-zone devices
  - Pairwise scoring across multiple devices
  - Mixed link zones
  - Zero link zones

- Added tests for `LinkDevices.String()`:
  - Empty device formatting
  - Non-empty device output validation

This improves coverage of metax topology scoring behavior and helps
prevent regressions in scheduler extender link scoring logic.

**Which issue(s) this PR fixes:**

Fixes #2410

**Special notes for your reviewer:**

CI failure appears unrelated to this PR. The failing package is pkg/scheduler, while this PR only adds unit tests for pkg/device/metax/score.go. The new metax tests pass locally with go test ./pkg/device/metax/....

Validation performed locally:

- `go test ./pkg/device/metax/... -run TestLinkDevice -v` — pass
- `gofmt -l pkg/device/metax/score_test.go` — clean
- `go vet ./pkg/device/metax/...` — pass

This PR only adds unit tests and does not change production behavior.

The failure logs point to the scheduler package (`pkg/scheduler`), specifically around the `test-pod-nodefail` path. No scheduler files or production code are changed in this PR.

**Does this PR introduce a user-facing change?:**

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for device link scoring across UUID and link-zone combinations.
  * Added tests for scoring device collections, including empty collections and zero link zones.
  * Added validation for readable device collection output, including brackets and UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->