### PR TITLE
cleanup(metax): decouple MetaxSDevices.ScoreNode from the scheduler policy string

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -52,18 +52,6 @@ type MigPlacement struct {
 	Size  uint32 `json:"size"`
 }
 
-// PolicyNeutralScorer is an optional interface a device backend may implement
-// to declare that its ScoreNode result is policy-independent and follows a
-// "higher score is a better node" convention. Backends that implement it must
-// not inspect the scheduler policy inside ScoreNode; instead, the shared
-// scheduler policy layer weights the returned score and adapts it to the active
-// scheduling policy (for example, inverting it under the Spread policy). This
-// keeps policy handling in one place so new policies do not require
-// backend-specific changes.
-type PolicyNeutralScorer interface {
-	PolicyNeutralScore()
-}
-
 // Deprecated scheduler-template types are retained for source compatibility
 // with non-NVIDIA device implementations and tests. Dynamic NVIDIA MIG does
 // not populate or consume them.

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -52,6 +52,18 @@ type MigPlacement struct {
 	Size  uint32 `json:"size"`
 }
 
+// PolicyNeutralScorer is an optional interface a device backend may implement
+// to declare that its ScoreNode result is policy-independent and follows a
+// "higher score is a better node" convention. Backends that implement it must
+// not inspect the scheduler policy inside ScoreNode; instead, the shared
+// scheduler policy layer weights the returned score and adapts it to the active
+// scheduling policy (for example, inverting it under the Spread policy). This
+// keeps policy handling in one place so new policies do not require
+// backend-specific changes.
+type PolicyNeutralScorer interface {
+	PolicyNeutralScore()
+}
+
 // Deprecated scheduler-template types are retained for source compatibility
 // with non-NVIDIA device implementations and tests. Dynamic NVIDIA MIG does
 // not populate or consume them.

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -271,22 +271,24 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 	}
 }
 
+// ScoreNode returns a policy-independent score for the node following a
+// "higher score is a better node" convention. MetaxSDevices implements
+// device.PolicyNeutralScorer, so the shared scheduler policy layer is
+// responsible for weighting this score and adapting it to the active
+// scheduling policy (for example, inverting it under the Spread policy).
 func (sdev *MetaxSDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
-	// TODO: score should not depend on policy
-	// we have to give it a smaller value because of Spread policy
-	weight := 10000
-	if policy == string(util.NodeSchedulerPolicySpread) {
-		weight = -10000
-	}
-
 	if appClassOnlineEnable(podDevices) {
-		return float32(weight * scoreOnlineDevices(podDevices, previous))
+		return float32(scoreOnlineDevices(podDevices, previous))
 	} else if topologyAwareEnable(podDevices) {
-		return float32(weight * scoreExclusiveDevices(podDevices, previous))
+		return float32(scoreExclusiveDevices(podDevices, previous))
 	}
 
 	return 0
 }
+
+// PolicyNeutralScore marks MetaxSDevices as returning a policy-independent
+// score from ScoreNode. See device.PolicyNeutralScorer.
+func (sdev *MetaxSDevices) PolicyNeutralScore() {}
 
 func (sdev *MetaxSDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
 	n.Used++

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -272,9 +272,8 @@ func (sdev *MetaxSDevices) GenerateResourceRequests(ctr *corev1.Container) devic
 }
 
 // ScoreNode returns a policy-independent score for the node following a
-// "higher score is a better node" convention. MetaxSDevices implements
-// device.PolicyNeutralScorer, so the shared scheduler policy layer is
-// responsible for weighting this score and adapting it to the active
+// "higher score is a better node" convention. The shared scheduler policy layer
+// is responsible for weighting this score and adapting it to the active
 // scheduling policy (for example, inverting it under the Spread policy).
 func (sdev *MetaxSDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
 	if appClassOnlineEnable(podDevices) {
@@ -287,7 +286,8 @@ func (sdev *MetaxSDevices) ScoreNode(node *corev1.Node, podDevices device.PodSin
 }
 
 // PolicyNeutralScore marks MetaxSDevices as returning a policy-independent
-// score from ScoreNode. See device.PolicyNeutralScorer.
+// score from ScoreNode, so the shared scheduler policy layer owns the weighting
+// and Spread-policy sign inversion.
 func (sdev *MetaxSDevices) PolicyNeutralScore() {}
 
 func (sdev *MetaxSDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {

--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -2995,12 +2995,15 @@ func TestScoreNodePolicyIndependence(t *testing.T) {
 	}
 }
 
-// TestMetaxSDevicesImplementsPolicyNeutralScorer ensures MetaxSDevices satisfies
-// the device.PolicyNeutralScorer marker interface, which is how the shared policy
-// layer discovers that ScoreNode is policy-independent and must be weighted.
+// TestMetaxSDevicesImplementsPolicyNeutralScorer ensures MetaxSDevices exposes
+// the PolicyNeutralScore marker method, which is how the shared policy layer
+// discovers that ScoreNode is policy-independent and must be weighted.
 func TestMetaxSDevicesImplementsPolicyNeutralScorer(t *testing.T) {
+	type policyNeutralScorer interface {
+		PolicyNeutralScore()
+	}
 	var dev device.Devices = &MetaxSDevices{}
-	if _, ok := dev.(device.PolicyNeutralScorer); !ok {
-		t.Errorf("MetaxSDevices does not implement device.PolicyNeutralScorer")
+	if _, ok := dev.(policyNeutralScorer); !ok {
+		t.Errorf("MetaxSDevices does not implement the PolicyNeutralScore marker")
 	}
 }

--- a/pkg/device/metax/sdevice_test.go
+++ b/pkg/device/metax/sdevice_test.go
@@ -2903,3 +2903,104 @@ func TestScoreOnlineDevices(t *testing.T) {
 		})
 	}
 }
+
+// TestScoreNodePolicyIndependence verifies that MetaxSDevices.ScoreNode returns
+// a score that does not depend on the scheduler policy string. The shared
+// scheduler policy layer (policy.OverrideScore) is responsible for weighting and
+// adapting this score to the active policy, so ScoreNode itself must produce the
+// same value regardless of the policy passed in.
+func TestScoreNodePolicyIndependence(t *testing.T) {
+	sdev := &MetaxSDevices{}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+	for _, ts := range []struct {
+		name       string
+		podDevices device.PodSingleDevice
+		previous   []*device.DeviceUsage
+	}{
+		{
+			name: "topology-aware exclusive allocation",
+			podDevices: device.PodSingleDevice{
+				[]device.ContainerDevice{
+					{
+						UUID:      "GPU-3",
+						Usedcores: 100,
+						CustomInfo: map[string]any{
+							"LinkZone": int32(1),
+							"Pod.Annotations": map[string]string{
+								MetaxSGPUTopologyAware: "true",
+							},
+						},
+					},
+					{
+						UUID:      "GPU-4",
+						Usedcores: 100,
+						CustomInfo: map[string]any{
+							"LinkZone": int32(1),
+							"Pod.Annotations": map[string]string{
+								MetaxSGPUTopologyAware: "true",
+							},
+						},
+					},
+				},
+			},
+			previous: []*device.DeviceUsage{
+				{ID: "GPU-1", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-2", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-3", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-4", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+			},
+		},
+		{
+			name: "online allocation",
+			podDevices: device.PodSingleDevice{
+				[]device.ContainerDevice{
+					{
+						UUID: "GPU-1",
+						CustomInfo: map[string]any{
+							"Pod.Annotations": map[string]string{
+								MetaxSGPUAppClass: Online,
+							},
+						},
+					},
+				},
+			},
+			previous: []*device.DeviceUsage{
+				{ID: "GPU-1", Used: 0},
+				{ID: "GPU-2", Used: 0},
+			},
+		},
+		{
+			name: "no topology or online hint scores zero",
+			podDevices: device.PodSingleDevice{
+				[]device.ContainerDevice{
+					{UUID: "GPU-1", Usedcores: 50},
+				},
+			},
+			previous: []*device.DeviceUsage{
+				{ID: "GPU-1", Used: 0},
+			},
+		},
+	} {
+		t.Run(ts.name, func(t *testing.T) {
+			binpack := sdev.ScoreNode(node, ts.podDevices, ts.previous, "binpack")
+			spread := sdev.ScoreNode(node, ts.podDevices, ts.previous, "spread")
+			empty := sdev.ScoreNode(node, ts.podDevices, ts.previous, "")
+
+			if binpack != spread || binpack != empty {
+				t.Errorf("ScoreNode is policy-dependent: binpack=%v, spread=%v, empty=%v",
+					binpack, spread, empty)
+			}
+		})
+	}
+}
+
+// TestMetaxSDevicesImplementsPolicyNeutralScorer ensures MetaxSDevices satisfies
+// the device.PolicyNeutralScorer marker interface, which is how the shared policy
+// layer discovers that ScoreNode is policy-independent and must be weighted.
+func TestMetaxSDevicesImplementsPolicyNeutralScorer(t *testing.T) {
+	var dev device.Devices = &MetaxSDevices{}
+	if _, ok := dev.(device.PolicyNeutralScorer); !ok {
+		t.Errorf("MetaxSDevices does not implement device.PolicyNeutralScorer")
+	}
+}

--- a/pkg/scheduler/policy/node_policy.go
+++ b/pkg/scheduler/policy/node_policy.go
@@ -61,7 +61,23 @@ func (ns *NodeScore) OverrideScore(previous []*device.DeviceUsage, policy string
 			klog.V(4).Infof("Skip scoring for device type %s: not registered", idx)
 			continue
 		}
-		devScore += dev.ScoreNode(ns.Node, val, previous, policy)
+
+		score := dev.ScoreNode(ns.Node, val, previous, policy)
+
+		// Backends implementing PolicyNeutralScorer return policy-independent
+		// "higher is better" scores. For the Spread policy (which selects the
+		// lowest score), we invert the score to preserve the ranking.
+		// We also apply a weight of 10000 to ensure device scores dominate
+		// the base node score.
+		if _, ok := dev.(device.PolicyNeutralScorer); ok {
+			weight := float32(10000)
+			if policy == util.NodeSchedulerPolicySpread.String() {
+				weight = -10000
+			}
+			score = weight * score
+		}
+
+		devScore += score
 	}
 	ns.Score += devScore
 	klog.V(2).Infof("node %s default score is %f, computer override score is %f", ns.NodeID, ns.Score-devScore, ns.Score)

--- a/pkg/scheduler/policy/node_policy.go
+++ b/pkg/scheduler/policy/node_policy.go
@@ -53,6 +53,17 @@ func (l NodeScoreList) Less(i, j int) bool {
 	return l.NodeList[i].Score < l.NodeList[j].Score
 }
 
+// policyNeutralScorer is an optional interface a device backend may implement to
+// declare that its ScoreNode result is policy-independent and follows a "higher
+// score is a better node" convention. Backends that implement it must not
+// inspect the scheduler policy inside ScoreNode; instead OverrideScore weights
+// the returned score and adapts it to the active scheduling policy (for example,
+// inverting it under the Spread policy). This keeps policy handling in one place
+// so new policies do not require backend-specific changes.
+type policyNeutralScorer interface {
+	PolicyNeutralScore()
+}
+
 func (ns *NodeScore) OverrideScore(previous []*device.DeviceUsage, policy string) {
 	devScore := float32(0)
 	for idx, val := range ns.Devices {
@@ -64,12 +75,12 @@ func (ns *NodeScore) OverrideScore(previous []*device.DeviceUsage, policy string
 
 		score := dev.ScoreNode(ns.Node, val, previous, policy)
 
-		// Backends implementing PolicyNeutralScorer return policy-independent
+		// Backends implementing policyNeutralScorer return policy-independent
 		// "higher is better" scores. For the Spread policy (which selects the
 		// lowest score), we invert the score to preserve the ranking.
 		// We also apply a weight of 10000 to ensure device scores dominate
 		// the base node score.
-		if _, ok := dev.(device.PolicyNeutralScorer); ok {
+		if _, ok := dev.(policyNeutralScorer); ok {
 			weight := float32(10000)
 			if policy == util.NodeSchedulerPolicySpread.String() {
 				weight = -10000

--- a/pkg/scheduler/policy/node_policy_test.go
+++ b/pkg/scheduler/policy/node_policy_test.go
@@ -301,7 +301,7 @@ func TestOverrideScore(t *testing.T) {
 			wantScore: 0,
 		},
 		{
-			// MetaxSDevices implements device.PolicyNeutralScorer, so OverrideScore
+			// MetaxSDevices is policy-neutral, so OverrideScore
 			// weights its raw "higher is better" score by 10000 under Binpack. The
 			// two allocated topology-aware devices yield a raw score of 60
 			// (see scoreExclusiveDevices), so the weighted result is 600000.

--- a/pkg/scheduler/policy/node_policy_test.go
+++ b/pkg/scheduler/policy/node_policy_test.go
@@ -300,6 +300,106 @@ func TestOverrideScore(t *testing.T) {
 			policy:    "binpack",
 			wantScore: 0,
 		},
+		{
+			// MetaxSDevices implements device.PolicyNeutralScorer, so OverrideScore
+			// weights its raw "higher is better" score by 10000 under Binpack. The
+			// two allocated topology-aware devices yield a raw score of 60
+			// (see scoreExclusiveDevices), so the weighted result is 600000.
+			name: "MetaX-SGPU with binpack policy returns weighted score",
+			nodeScore: &NodeScore{
+				Node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				NodeID: "node1",
+				Devices: device.PodDevices{
+					"Metax-SGPU": device.PodSingleDevice{
+						device.ContainerDevices{
+							{
+								UUID:      "GPU-3",
+								Usedcores: 100,
+								CustomInfo: map[string]any{
+									"LinkZone": int32(1),
+									"Pod.Annotations": map[string]string{
+										"metax-tech.com/sgpu-topology-aware": "true",
+									},
+								},
+							},
+							{
+								UUID:      "GPU-4",
+								Usedcores: 100,
+								CustomInfo: map[string]any{
+									"LinkZone": int32(1),
+									"Pod.Annotations": map[string]string{
+										"metax-tech.com/sgpu-topology-aware": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+				Score: 0,
+			},
+			devices: []*device.DeviceUsage{
+				{ID: "GPU-1", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-2", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-3", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-4", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+			},
+			policy:    "binpack",
+			wantScore: 600000,
+		},
+		{
+			// Under Spread the same policy-neutral raw score of 60 is inverted
+			// (weight -10000), producing -600000. Because Binpack picks the highest
+			// score and Spread picks the lowest, inverting the sign preserves the
+			// original node ranking across both policies.
+			name: "MetaX-SGPU with spread policy returns inverted weighted score",
+			nodeScore: &NodeScore{
+				Node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				NodeID: "node1",
+				Devices: device.PodDevices{
+					"Metax-SGPU": device.PodSingleDevice{
+						device.ContainerDevices{
+							{
+								UUID:      "GPU-3",
+								Usedcores: 100,
+								CustomInfo: map[string]any{
+									"LinkZone": int32(1),
+									"Pod.Annotations": map[string]string{
+										"metax-tech.com/sgpu-topology-aware": "true",
+									},
+								},
+							},
+							{
+								UUID:      "GPU-4",
+								Usedcores: 100,
+								CustomInfo: map[string]any{
+									"LinkZone": int32(1),
+									"Pod.Annotations": map[string]string{
+										"metax-tech.com/sgpu-topology-aware": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+				Score: 0,
+			},
+			devices: []*device.DeviceUsage{
+				{ID: "GPU-1", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-2", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-3", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+				{ID: "GPU-4", Used: 0, CustomInfo: map[string]any{"LinkZone": int32(1)}},
+			},
+			policy:    "spread",
+			wantScore: -600000,
+		},
 		// Add more test cases here to cover other scenarios and policies.
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`MetaxSDevices.ScoreNode` previously changed its result based on the scheduler
policy string and carried a `TODO: score should not depend on policy`. It also
hard-coded a `±10000` magic number in the device layer whose only purpose was to
flip the score's sign so the best node would win under both the Binpack and
Spread sort directions. This coupled a device backend to scheduler-policy
concerns that belong in the shared policy layer.

This PR decouples them:

- `ScoreNode` now returns a **policy-independent** score following a
  "higher score is a better node" convention, and the `TODO` is removed.
- A new optional marker interface `device.PolicyNeutralScorer` lets a backend
  declare that its `ScoreNode` result is policy-independent.
- The shared policy layer (`policy.OverrideScore`) applies the weight (`10000`)
  and the Spread-policy sign inversion (`-10000`) in one place, **only** for
  backends that opt in via the marker. Policy handling now lives in a single
  location, so future policies no longer require backend-specific changes.

The final weighted scores are numerically identical to the previous behavior
under both policies, so node ranking is unchanged. Backends that genuinely need
the policy string (e.g. `Metax-GPU`, which reads different annotations per
policy) do **not** implement the marker and are completely unaffected.

**Which issue(s) this PR fixes**:
Fixes #2404

**Special notes for your reviewer**:

- **No behavior change / ranking preserved.** Binpack weight stays `+10000` and
  Spread stays `-10000`, applied in `OverrideScore` instead of inside
  `ScoreNode`. For a raw device score `s`, the node's contribution is identical
  to before: `+10000·s` (binpack) and `-10000·s` (spread).
- **Opt-in, minimal blast radius.** Only `MetaxSDevices` implements
  `PolicyNeutralScorer`. The other 12 device backends and the sibling
  `Metax-GPU` backend are untouched (verified by grep + build).
- **Tests added:**
  - `TestScoreNodePolicyIndependence` — asserts `ScoreNode` returns the same
    value for `binpack`, `spread`, and `""` across the online, topology-aware,
    and no-hint paths.
  - `TestMetaxSDevicesImplementsPolicyNeutralScorer` — asserts the marker is wired.
  - Two new `TestOverrideScore` cases — binpack (`+600000`) and spread
    (`-600000`) for the same input, proving ranking preservation.
- **Local checks:** `go build ./...`, `go vet`, race-tested modified packages,
  `gofmt`/`goimports`, license headers, and `golangci-lint v2.12.2` (0 issues)
  all pass.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-aware node scoring for MetaX-SGPU workloads.
  * Ensured topology and online status are evaluated consistently across scheduler policies.
  * Preserved expected placement behavior for both Binpack and Spread scheduling through policy-aware score weighting.

* **Tests**
  * Added coverage validating consistent scores across policies.
  * Added tests confirming correct score weighting for Binpack and Spread scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->