### PR TITLE
fix(ascend): guard nil Requests in MutateAdmission

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -178,6 +178,11 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 			return true, errors.New("vNPU not supported for multiple devices")
 		}
 	}
+	// Requests may be nil when the pod declares only limits; writing to a
+	// nil map panics.
+	if ctr.Resources.Requests == nil {
+		ctr.Resources.Requests = corev1.ResourceList{}
+	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -707,6 +707,86 @@ func Test_MutateAdmission(t *testing.T) {
 	}
 }
 
+func Test_MutateAdmission_NilRequests(t *testing.T) {
+	// Regression test: a pod that declares only limits (no requests block)
+	// must not panic when MutateAdmission writes the trimmed memory request.
+	tests := []struct {
+		name       string
+		ctr        corev1.Container
+		wantMemory string
+	}{
+		{
+			name: "memory limit set, requests block absent",
+			ctr: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("8738"),
+					},
+				},
+			},
+			wantMemory: "8738",
+		},
+		{
+			name: "count only, no memory limit, requests block absent",
+			ctr: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910A": resource.MustParse("1"),
+					},
+				},
+			},
+			wantMemory: "32768", // defaults to whole-card MemoryAllocatable
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := Devices{
+				config: VNPUConfig{
+					ResourceName:       "huawei.com/Ascend910A",
+					ResourceMemoryName: "huawei.com/Ascend910A-memory",
+					MemoryAllocatable:  int64(32768),
+					MemoryCapacity:     int64(32768),
+					Templates: []Template{
+						{
+							Name:   "vir02",
+							Memory: int64(2184),
+							AICore: int32(2),
+						}, {
+							Name:   "vir04",
+							Memory: int64(4369),
+							AICore: int32(4),
+						}, {
+							Name:   "vir08",
+							Memory: int64(8738),
+							AICore: int32(8),
+						}, {
+							Name:   "vir16",
+							Memory: int64(17476),
+							AICore: int32(16),
+						},
+					},
+				},
+			}
+			pod := corev1.Pod{}
+			result, err := dev.MutateAdmission(&test.ctr, &pod)
+			if err != nil {
+				t.Fatalf("exec MutateAdmission method expect no error, but got %v", err)
+			}
+			if !result {
+				t.Fatalf("exec MutateAdmission method expect return is true, but got is false")
+			}
+			got, ok := test.ctr.Resources.Requests[corev1.ResourceName("huawei.com/Ascend910A-memory")]
+			if !ok {
+				t.Fatalf("expect memory request to be set, but it is absent")
+			}
+			if got.String() != test.wantMemory {
+				t.Fatalf("expect memory request %s, but got %s", test.wantMemory, got.String())
+			}
+		})
+	}
+}
+
 func Test_MutateAdmission910C(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
### What this PR does / why we need it

`MutateAdmission` in the ascend backend writes the trimmed memory quantity
into `ctr.Resources.Requests` unconditionally. When a container declares only
`limits` (no `requests` block), `Requests` is a nil map and the write panics
(`assignment to entry in nil map`) inside the admission webhook.

This initializes `Requests` before the write, mirroring the guard the kunlun
backend already uses for the identical write
(`pkg/device/kunlun/vdevice.go`), and the pattern merged for mthreads in
#2254. After this, no backend under `pkg/device/` writes to
`Resources.Requests` unguarded.

Also adds `Test_MutateAdmission_NilRequests`: two regression cases (memory
limit without a requests block; count-only without a requests block), both of
which panic on master today.

### Which issue(s) this PR fixes

Fixes #2415

### Special notes for your reviewer

The existing `Test_MutateAdmission` never hits this path with nil Requests:
the only case reaching the write is the only fixture that explicitly sets a
`Requests` block. The new test covers exactly the gap.

### AI assistance disclosure

This PR was developed with AI assistance (Claude); the bug was found by an
automated audit of unguarded map writes across `pkg/device/`, and the fix and
tests were human-reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pod admission when resource requests are missing but memory limits are specified.
  * Memory requests are now populated correctly without errors or crashes, including when default card allocation applies.
  * Improved handling for pods that define only memory limits.

* **Tests**
  * Added coverage for admission scenarios with absent resource requests.
  * Verified both explicit memory limits and default card allocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->