### PR TITLE
fix(device-plugin): update device cache only after successful annotation patch

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -49,6 +49,12 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
+var (
+	getNode              = util.GetNode
+	patchNodeAnnotations = util.PatchNodeAnnotations
+	getAPIDevices        = (*NvidiaDevicePlugin).getAPIDevices
+)
+
 // int8Slice wraps an []int8 with more functions.
 type int8Slice []int8
 
@@ -191,14 +197,14 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 // RegisterInAnnotation scans devices and patches node annotations.
 // Returns (changed, error) where changed indicates whether the annotation was actually updated.
 func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
-	devices := plugin.getAPIDevices()
+	devices := getAPIDevices(plugin)
 
 	// Log compact summary at V(3); full details at V(5)
 	klog.V(3).Infof("Discovered %d device(s) for registration", len(*devices))
 	klog.V(5).InfoS("Device details", "devices", devices)
 
 	annos := make(map[string]string)
-	node, err := util.GetNode(util.NodeName)
+	node, err := getNode(util.NodeName)
 	if err != nil {
 		klog.Errorln("get node error", err.Error())
 		return false, err
@@ -208,7 +214,6 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 		klog.V(3).Info("Device info unchanged, skipping annotation update")
 		return false, nil
 	}
-	plugin.deviceCache = encodeddevices
 
 	var data []byte
 	if os.Getenv("ENABLE_TOPOLOGY_SCORE") == "true" {
@@ -236,12 +241,13 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 	}
 	klog.Infof("Updating node annotations with %d device(s)", len(*devices))
 	klog.V(3).Infof("Annotation content: %v", annos)
-	err = util.PatchNodeAnnotations(node, annos)
-
+	err = patchNodeAnnotations(node, annos)
 	if err != nil {
 		klog.Errorln("patch node error", err.Error())
+		return true, err
 	}
-	return true, err
+	plugin.deviceCache = encodeddevices
+	return true, nil
 }
 
 func (plugin *NvidiaDevicePlugin) WatchAndRegister(disableNVML <-chan bool, ackDisableWatchAndRegister chan<- bool) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package plugin
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 )
 
@@ -279,3 +283,80 @@ func timeAfter(d time.Duration) <-chan struct{} {
 	}()
 	return ch
 }
+
+func TestRegisterInAnnotation_DeviceCacheOrder(t *testing.T) {
+	previousGetAPIDevices := getAPIDevices
+	defer func() { getAPIDevices = previousGetAPIDevices }()
+
+	previousGetNode := getNode
+	defer func() { getNode = previousGetNode }()
+
+	previousPatchNodeAnnotations := patchNodeAnnotations
+	defer func() { patchNodeAnnotations = previousPatchNodeAnnotations }()
+
+	dummyDevices := []*device.DeviceInfo{
+		{
+			ID:     "GPU-12345",
+			Index:  0,
+			Count:  10,
+			Devmem: 8192,
+			Type:   "NVIDIA-Tesla T4",
+		},
+	}
+
+	getAPIDevices = func(p *NvidiaDevicePlugin) *[]*device.DeviceInfo {
+		return &dummyDevices
+	}
+
+	getNode = func(name string) (*corev1.Node, error) {
+		return &corev1.Node{}, nil
+	}
+
+	plugin := &NvidiaDevicePlugin{
+		deviceCache: "",
+	}
+
+	// 1. When patchNodeAnnotations fails, deviceCache should NOT be updated.
+	patchErr := errors.New("transient API server error")
+	patchNodeAnnotations = func(node *corev1.Node, annotations map[string]string) error {
+		return patchErr
+	}
+
+	changed, err := plugin.RegisterInAnnotation()
+	if !changed {
+		t.Error("expected changed to be true on patch attempt")
+	}
+	if err != patchErr {
+		t.Errorf("expected error %v, got %v", patchErr, err)
+	}
+	if plugin.deviceCache != "" {
+		t.Errorf("expected deviceCache to remain empty on failure, got %q", plugin.deviceCache)
+	}
+
+	// 2. When patchNodeAnnotations succeeds, deviceCache SHOULD be updated.
+	patchNodeAnnotations = func(node *corev1.Node, annotations map[string]string) error {
+		return nil
+	}
+
+	changed, err = plugin.RegisterInAnnotation()
+	if !changed {
+		t.Error("expected changed to be true on successful patch")
+	}
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	expectedCache := device.MarshalNodeDevices(dummyDevices)
+	if plugin.deviceCache != expectedCache {
+		t.Errorf("expected deviceCache to be %q, got %q", expectedCache, plugin.deviceCache)
+	}
+
+	// 3. Next call with unchanged devices returns (false, nil) due to matching cache.
+	changed, err = plugin.RegisterInAnnotation()
+	if changed {
+		t.Error("expected changed to be false on second attempt with unchanged devices")
+	}
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

This PR fixes a retry issue in `RegisterInAnnotation()` caused by updating `plugin.deviceCache` before `PatchNodeAnnotations()` completed successfully.

Previously, `plugin.deviceCache` was assigned to the newly encoded device information before attempting to patch the Kubernetes node annotations. If `PatchNodeAnnotations()` failed (for example due to a transient API server timeout, network interruption, or rate limiting), the cache still reflected the new state even though the node annotations were never updated.

On the next iteration of `WatchAndRegister()`, the newly generated device information matched the cached value, causing `RegisterInAnnotation()` to conclude that nothing had changed and skip the annotation update. As a result, retries were prevented until the discovered device list changed again, potentially leaving node GPU annotations stale or missing.

This PR resolves the issue by:

* Updating `plugin.deviceCache` only after `PatchNodeAnnotations()` succeeds.
* Leaving the cache unchanged when patching fails so the existing retry loop can retry the annotation update on the next iteration.
* Returning `(true, err)` on patch failure to indicate that registration was attempted but did not complete successfully.
* Introducing package-level function variables (`getNode`, `patchNodeAnnotations`, and `getAPIDevices`) to enable isolated unit testing without requiring Kubernetes API servers or NVML.
* Adding `TestRegisterInAnnotation_DeviceCacheOrder` to verify that the cache is only updated after a successful annotation patch and that retries continue after failures.

## Which issue(s) this PR fixes

Fixes #2418

## Special notes for your reviewer

* No behavior changes on successful registration.
* Ensures transient failures while patching node annotations do not prevent future retry attempts.
* Verified locally with the added unit tests covering both successful and failed annotation updates.

## AI assistance disclosure

I consulted ChatGPT during the initial investigation and discussion of the retry behavior. The final implementation, unit tests, validation, commit message, and PR description were completed, reviewed, and verified by me. I take full responsibility for the final contribution.

## Does this PR introduce a user-facing change?

```text
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device registration reliability by updating cached device information only after annotation changes succeed.
  * Prevented failed annotation updates from leaving stale or inconsistent device state.
  * Avoided reporting changes when registration is repeated without device differences.

* **Tests**
  * Added coverage for device-cache behavior across failed, successful, and repeated registration attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->