### PR TITLE
docs: add AWS Neuron device to roadmap support table

### DIFF
--- a/docs/develop/roadmap.md
+++ b/docs/develop/roadmap.md
@@ -12,7 +12,8 @@
 | GPU        | Birentech     | Biren166M        | ✅              | ✅            | ❌                |
 | GPU        | MetaX         | MXC500           | ✅              | ✅            | ❌                |
 | XPU        | Kunlunxin     | P800             | ✅              | ✅            | ❌                |
-| GPU        | Vastai        | VA16             | ✅              | ✅            | ❌              |      
+| GPU        | Vastai        | VA16             | ✅              | ✅            | ❌              |
+| Neuron     | AWS           | Inferentia, Trainium | ❌          | ✅            | ✅              |
 
 
 - [ ] Support video codec processing


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
`docs/develop/roadmap.md` has a device support table listing all hardware
backends supported by HAMi. The AWS Neuron device backend
(`pkg/device/awsneuron/`) is fully implemented in the codebase but was
missing from the table entirely.

This adds the missing row with the correct capabilities derived from the
implementation: core isolation is supported, memory isolation is not (Devmem
is set to 0), and multi-card is supported via topology-aware graph selection.

**Which issue(s) this PR fixes:**
Fixes #2421 

**Special notes for the maintainers**
No code changes. Documentation only.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.

**Does this PR introduce a user-facing change?:**
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to include AWS Neuron support for Inferentia and Trainium.
  * Documented available core isolation and multi-card support, with memory isolation unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->