### PR TITLE
test(awsneuron): add unit tests for CheckHealth and ScoreNode

### DIFF
--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -575,6 +575,75 @@ func Test_graphSelect(t *testing.T) {
 	}
 }
 
+func Test_CheckHealth(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  struct {
+			devType string
+			n       *corev1.Node
+		}
+		want1 bool
+		want2 bool
+	}{
+		{
+			name: "always return true",
+			args: struct {
+				devType string
+				n       *corev1.Node
+			}{
+				devType: "",
+				n:       nil,
+			},
+			want1: true,
+			want2: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := &AWSNeuronDevices{}
+			result1, result2 := dev.CheckHealth(test.args.devType, test.args.n)
+			assert.Equal(t, result1, test.want1)
+			assert.Equal(t, result2, test.want2)
+		})
+	}
+}
+
+func Test_ScoreNode(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  struct {
+			node       *corev1.Node
+			podDevices device.PodSingleDevice
+			previous   []*device.DeviceUsage
+			policy     string
+		}
+		want  float32
+	}{
+		{
+			name: "always return 0",
+			args: struct {
+				node       *corev1.Node
+				podDevices device.PodSingleDevice
+				previous   []*device.DeviceUsage
+				policy     string
+			}{
+				node:       nil,
+				podDevices: nil,
+				previous:   nil,
+				policy:     "",
+			},
+			want: 0,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := &AWSNeuronDevices{}
+			result := dev.ScoreNode(test.args.node, test.args.podDevices, test.args.previous, test.args.policy)
+			assert.Equal(t, result, test.want)
+		})
+	}
+}
+
 func TestDevices_Fit(t *testing.T) {
 	config := AWSNeuronConfig{
 		ResourceCountName: "aws.amazon.com/neuron",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
`pkg/device/awsneuron/device_test.go` was missing unit tests for two implemented methods on `AWSNeuronDevices`:
- `CheckHealth`
- `ScoreNode`

This PR adds the missing tests to ensure consistency with the test coverage pattern used across all other device packages (biren, vastai, hygon, etc.). It uses the standard table-driven test structure established in the repository.

**Which issue(s) this PR fixes:**
Fixes #2423 

**Special notes for the reviewer :**
No functional code changes. Testing only.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.

**Does this PR introduce a user-facing change?:**
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for AWS Neuron device health checks with empty inputs.
  * Added coverage confirming zero scoring when no device data is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->