### PR TITLE
Add unit tests for CheckHealth and ScoreNode in awsneuron

### DIFF
--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -575,6 +575,19 @@ func Test_graphSelect(t *testing.T) {
 	}
 }
 
+func Test_CheckHealth(t *testing.T) {
+	dev := AWSNeuronDevices{}
+	ok, needRestart := dev.CheckHealth(AWSNeuronDevice, &corev1.Node{})
+	assert.Equal(t, ok, true)
+	assert.Equal(t, needRestart, true)
+}
+
+func Test_ScoreNode(t *testing.T) {
+	dev := AWSNeuronDevices{}
+	score := dev.ScoreNode(&corev1.Node{}, device.PodSingleDevice{}, nil, "")
+	assert.Equal(t, score, float32(0))
+}
+
 func TestDevices_Fit(t *testing.T) {
 	config := AWSNeuronConfig{
 		ResourceCountName: "aws.amazon.com/neuron",


### PR DESCRIPTION
Add Test_CheckHealth and Test_ScoreNode to pkg/device/awsneuron/device_test.go to verify the CheckHealth and ScoreNode methods exist and return expected values, consistent with the pattern used across all other device packages.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for AWS Neuron device health checks.
  * Added coverage verifying node scoring when no devices are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->