### PR TITLE
fix(ascend): guard nil Requests map in MutateAdmission

### DIFF
--- a/charts/hami/values.schema.json
+++ b/charts/hami/values.schema.json
@@ -1,0 +1,301 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Helm values for the HAMi chart. Constrained to load-bearing type checks only; additionalProperties and required are intentionally omitted for forward-compatibility.",
+  "definitions": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": { "type": "string" },
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" },
+        "pullSecrets": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": { "type": "object" },
+        "requests": { "type": "object" }
+      }
+    },
+    "deviceVendor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "customresources": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  },
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": { "type": "string" },
+        "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
+        "imageTag": { "type": "string" },
+        "gpuHookPath": { "type": "string" },
+        "labels": { "type": "object" },
+        "annotations": { "type": "object" },
+        "managedNodeSelectorEnable": { "type": "boolean" },
+        "managedNodeSelector": { "type": "object" }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "namespaceOverride": { "type": "string" },
+    "resourceName": { "type": "string" },
+    "resourceMem": { "type": "string" },
+    "resourceMemPercentage": { "type": "string" },
+    "resourceCores": { "type": "string" },
+    "resourcePriority": { "type": "string" },
+    "mluResourceName": { "type": "string" },
+    "mluResourceMem": { "type": "string" },
+    "mluResourceCores": { "type": "string" },
+    "dcuResourceName": { "type": "string" },
+    "dcuResourceMem": { "type": "string" },
+    "dcuResourceCores": { "type": "string" },
+    "metaxResourceName": { "type": "string" },
+    "metaxResourceCore": { "type": "string" },
+    "metaxResourceMem": { "type": "string" },
+    "metaxsGPUTopologyAware": { "type": "string" },
+    "enflameResourceNameDRSGCU": { "type": "string" },
+    "enflameResourceNameGCUMemory": { "type": "string" },
+    "enflameResourceNameGCUCore": { "type": "string" },
+    "kunlunResourceName": { "type": "string" },
+    "kunlunResourceVCountName": { "type": "string" },
+    "kunlunResourceVMemoryName": { "type": "string" },
+    "vastaiResourceName": { "type": "string" },
+    "birenResourceName": { "type": "string" },
+    "schedulerName": { "type": "string" },
+    "podSecurityPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "scheduler": {
+      "type": "object",
+      "properties": {
+        "nodeName": { "type": "string" },
+        "overwriteEnv": { "type": "string" },
+        "defaultSchedulerPolicy": { "type": "object" },
+        "metricsBindAddress": { "type": "string" },
+        "forceOverwriteDefaultScheduler": { "type": "boolean" },
+        "livenessProbe": { "type": "boolean" },
+        "leaderElect": { "type": "boolean" },
+        "replicas": { "type": "integer" },
+        "kubeScheduler": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "$ref": "#/definitions/image" },
+            "resources": { "$ref": "#/definitions/resources" },
+            "extraNewArgs": { "type": "array", "items": { "type": "string" } },
+            "extraArgs": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "extender": {
+          "type": "object",
+          "properties": {
+            "image": { "$ref": "#/definitions/image" },
+            "resources": { "$ref": "#/definitions/resources" },
+            "extraArgs": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "nodeLockExpire": { "type": "string" },
+        "podAnnotations": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "admissionWebhook": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "customURL": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "host": { "type": "string" },
+                "port": { "type": "integer" },
+                "path": { "type": "string" }
+              }
+            },
+            "whitelistNamespaces": { "type": "array", "items": { "type": "string" } },
+            "manageNamespaceSelector": { "type": "boolean" },
+            "namespaceSelector": { "type": "object" },
+            "objectSelector": { "type": "object" },
+            "reinvocationPolicy": { "type": "string" },
+            "failurePolicy": { "type": "string" }
+          }
+        },
+        "certManager": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "patch": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "$ref": "#/definitions/image" },
+            "imageNew": { "$ref": "#/definitions/image" },
+            "priorityClassName": { "type": "string" },
+            "podAnnotations": { "type": "object" },
+            "nodeSelector": { "type": "object" },
+            "tolerations": { "type": "array" },
+            "runAsUser": { "type": "integer" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "httpPort": { "type": "integer" },
+            "schedulerPort": { "type": "integer" },
+            "monitorPort": { "type": "integer" },
+            "monitorTargetPort": { "type": "integer" },
+            "httpTargetPort": { "type": "integer" },
+            "labels": { "type": "object" },
+            "annotations": { "type": "object" }
+          }
+        }
+      }
+    },
+    "devicePlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "gpuOperatorToolkitReady": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "hostPath": { "type": "string" },
+            "securityContext": { "type": "object" }
+          }
+        },
+        "image": { "$ref": "#/definitions/image" },
+        "monitor": {
+          "type": "object",
+          "properties": {
+            "image": { "$ref": "#/definitions/image" },
+            "ctrPath": { "type": "string" },
+            "resyncInterval": { "type": "string" },
+            "extraArgs": { "type": "array", "items": { "type": "string" } },
+            "extraEnvs": { "type": "object" },
+            "securityContext": { "type": "object" },
+            "resources": { "$ref": "#/definitions/resources" }
+          }
+        },
+        "deviceSplitCount": { "type": "integer" },
+        "deviceMemoryScaling": { "type": "number" },
+        "deviceCoreScaling": { "type": "number" },
+        "enableNumaTopology": { "type": "boolean" },
+        "preConfiguredDeviceMemory": { "type": "integer" },
+        "nodeConfiguration": {
+          "type": "object",
+          "properties": {
+            "config": { "type": "string" },
+            "externalConfigName": { "type": "string" }
+          }
+        },
+        "runtimeClassName": { "type": "string" },
+        "createRuntimeClass": { "type": "boolean" },
+        "migStrategy": { "type": "string" },
+        "disablecorelimit": { "type": "string" },
+        "passDeviceSpecsEnabled": { "type": "boolean" },
+        "deviceListStrategy": { "type": "string" },
+        "nvidiaHookPath": { "type": ["string", "null"] },
+        "nvidiaDriverRoot": { "type": ["string", "null"] },
+        "gdrcopyEnabled": { "type": ["boolean", "null"] },
+        "gdsEnabled": { "type": ["boolean", "null"] },
+        "mofedEnabled": { "type": ["boolean", "null"] },
+        "extraArgs": { "type": "array", "items": { "type": "string" } },
+        "extraEnvs": { "type": "object" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "httpPort": { "type": "integer" },
+            "labels": { "type": "object" },
+            "annotations": { "type": "object" }
+          }
+        },
+        "pluginPath": { "type": "string" },
+        "libPath": { "type": "string" },
+        "podAnnotations": { "type": "object" },
+        "hostPID": { "type": "boolean" },
+        "hostNetwork": { "type": "boolean" },
+        "securityContext": { "type": "object" },
+        "nvidiaNodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "updateStrategy": { "type": "object" },
+        "resources": { "$ref": "#/definitions/resources" }
+      }
+    },
+    "mockDevicePlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "$ref": "#/definitions/image" }
+      }
+    },
+    "devices": {
+      "type": "object",
+      "properties": {
+        "amd": {
+          "type": "object",
+          "properties": {
+            "customresources": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "awsneuron": {
+          "type": "object",
+          "properties": {
+            "customresources": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "kunlun": { "$ref": "#/definitions/deviceVendor" },
+        "enflame": { "$ref": "#/definitions/deviceVendor" },
+        "mthreads": { "$ref": "#/definitions/deviceVendor" },
+        "vastai": { "$ref": "#/definitions/deviceVendor" },
+        "biren": { "$ref": "#/definitions/deviceVendor" },
+        "nvidia": {
+          "type": "object",
+          "properties": {
+            "gpuCorePolicy": { "type": "string" },
+            "libCudaLogLevel": { "type": "integer" }
+          }
+        },
+        "ascend": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "type": "string" },
+            "imagePullPolicy": { "type": "string" },
+            "extraArgs": { "type": "array", "items": { "type": "string" } },
+            "nodeSelector": { "type": "object" },
+            "tolerations": { "type": "array" },
+            "runtimeClassName": { "type": "string" },
+            "hamiVnpuCore": { "type": "boolean" },
+            "customresources": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "iluvatar": { "$ref": "#/definitions/deviceVendor" }
+      }
+    },
+    "legacyMetrics": { "type": "boolean" },
+    "prometheus": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "device-config": {
+      "type": "object",
+      "properties": {
+        "content": { "type": "string" }
+      }
+    }
+  }
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -161,15 +161,26 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 			continue
 		}
 		klog.Infoln("inspecting", val)
-		num := strings.Split(val, "Device")[1]
+		deviceParts := strings.Split(val, "Device")
+		if len(deviceParts) < 2 {
+			klog.Warningf("unexpected MIG output format, missing Device delimiter: %q", val)
+			continue
+		}
+		num := deviceParts[1]
 		num = strings.Split(num, ":")[0]
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
-			klog.Fatal("atoi failed num=", num)
+			klog.Warningf("failed to parse MIG device index %q: %v", num, err)
+			continue
 		}
 		if index == idx {
-			outputStr := strings.Split(val, ":")[2]
+			colonParts := strings.Split(val, ":")
+			if len(colonParts) < 3 {
+				klog.Warningf("unexpected MIG output format, missing colon fields: %q", val)
+				continue
+			}
+			outputStr := colonParts[2]
 			outputStr = strings.TrimSpace(outputStr)
 			outputStr = strings.TrimRight(outputStr, ")")
 			return outputStr

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -940,3 +940,94 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 		t.Errorf("expected stale config to be removed, stat err: %v", err)
 	}
 }
+
+func Test_GetMigUUIDFromSmiOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		uuid   string
+		idx    int
+		want   string
+	}{
+		{
+			name: "valid MIG output",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)
+  MIG 3g.20gb, Instance ID    1: (Device 1, Name: MIG 3g.20gb, UUID: MIG-uuid-1)`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "MIG-uuid-0",
+		},
+		{
+			name: "valid MIG output, second instance",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)
+  MIG 3g.20gb, Instance ID    1: (Device 1, Name: MIG 3g.20gb, UUID: MIG-uuid-1)`,
+			uuid: "GPU-abc123",
+			idx:  1,
+			want: "MIG-uuid-1",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name:   "no MIG lines",
+			output: "GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)\n",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name: "MIG line without Device delimiter",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: malformed line without Device`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "MIG line without enough colons",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Device 0 only two colons`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "MIG line with non-numeric index",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device abc, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "uuid mismatch skips lines",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-other",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "target index not found",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-abc123",
+			idx:  5,
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetMigUUIDFromSmiOutput(test.output, test.uuid, test.idx)
+			if got != test.want {
+				t.Errorf("GetMigUUIDFromSmiOutput() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -179,6 +179,9 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		}
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
+	if ctr.Resources.Requests == nil {
+		ctr.Resources.Requests = corev1.ResourceList{}
+	}
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 
 	// Set runtime class name if it is not set by user and the runtime class name is configured

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -667,6 +667,24 @@ func Test_MutateAdmission(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "nil Requests does not panic",
+			args: struct {
+				ctr corev1.Container
+				pod corev1.Pod
+			}{
+				ctr: corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"huawei.com/Ascend910A":        resource.MustParse("1"),
+							"huawei.com/Ascend910A-memory": resource.MustParse("8738"),
+						},
+					},
+				},
+				pod: corev1.Pod{},
+			},
+			want: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #2415

ctr.Resources.Requests may be nil when a container declares only resources.limits. The unconditional write at line 182 panics with assignment to entry in nil map. Add a nil guard mirroring the fix already applied to the kunlun backend.

Also add a regression test that reproduces the panic on unpatched master (single-device request with only Limits, no Requests block).

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when valid Ascend resource limits are provided without pre-existing resource requests.
  * Improved handling of malformed GPU partition information by safely skipping invalid entries.

* **New Features**
  * Added Helm values validation with structured checks for global settings, scheduler, webhook, device plugins, vendor devices, metrics, and Prometheus configuration.

* **Tests**
  * Expanded coverage for Ascend resource limits and valid, missing, malformed, and mismatched GPU partition data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->