### PR TITLE
fix(device-plugin): validate slice bounds in GetMigUUIDFromSmiOutput

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -161,15 +161,26 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 			continue
 		}
 		klog.Infoln("inspecting", val)
-		num := strings.Split(val, "Device")[1]
+		deviceParts := strings.Split(val, "Device")
+		if len(deviceParts) < 2 {
+			klog.Warningf("unexpected MIG output format, missing Device delimiter: %q", val)
+			continue
+		}
+		num := deviceParts[1]
 		num = strings.Split(num, ":")[0]
 		num = strings.TrimSpace(num)
 		index, err := strconv.Atoi(num)
 		if err != nil {
-			klog.Fatal("atoi failed num=", num)
+			klog.Warningf("failed to parse MIG device index %q: %v", num, err)
+			continue
 		}
 		if index == idx {
-			outputStr := strings.Split(val, ":")[2]
+			colonParts := strings.Split(val, ":")
+			if len(colonParts) < 3 {
+				klog.Warningf("unexpected MIG output format, missing colon fields: %q", val)
+				continue
+			}
+			outputStr := colonParts[2]
 			outputStr = strings.TrimSpace(outputStr)
 			outputStr = strings.TrimRight(outputStr, ")")
 			return outputStr

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -940,3 +940,94 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 		t.Errorf("expected stale config to be removed, stat err: %v", err)
 	}
 }
+
+func Test_GetMigUUIDFromSmiOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		uuid   string
+		idx    int
+		want   string
+	}{
+		{
+			name: "valid MIG output",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)
+  MIG 3g.20gb, Instance ID    1: (Device 1, Name: MIG 3g.20gb, UUID: MIG-uuid-1)`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "MIG-uuid-0",
+		},
+		{
+			name: "valid MIG output, second instance",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)
+  MIG 3g.20gb, Instance ID    1: (Device 1, Name: MIG 3g.20gb, UUID: MIG-uuid-1)`,
+			uuid: "GPU-abc123",
+			idx:  1,
+			want: "MIG-uuid-1",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name:   "no MIG lines",
+			output: "GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)\n",
+			uuid:   "GPU-abc123",
+			idx:    0,
+			want:   "",
+		},
+		{
+			name: "MIG line without Device delimiter",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: malformed line without Device`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "MIG line without enough colons",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Device 0 only two colons`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "MIG line with non-numeric index",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device abc, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-abc123",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "uuid mismatch skips lines",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-other",
+			idx:  0,
+			want: "",
+		},
+		{
+			name: "target index not found",
+			output: `GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-abc123)
+  MIG 3g.20gb, Instance ID    0: (Device 0, Name: MIG 3g.20gb, UUID: MIG-uuid-0)`,
+			uuid: "GPU-abc123",
+			idx:  5,
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetMigUUIDFromSmiOutput(test.output, test.uuid, test.idx)
+			if got != test.want {
+				t.Errorf("GetMigUUIDFromSmiOutput() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2359

GetMigUUIDFromSmiOutput indexes directly into strings.Split() results without checking length. Malformed nvidia-smi output missing the 'Device' delimiter or sufficient colon-separated fields causes an index out of range panic.

Add length validation before each slice access and replace klog.Fatal with Warningf+continue so a single malformed line does not crash the device-plugin.

Also add unit tests covering valid output, empty input, missing delimiters, non-numeric indices, and uuid mismatches.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed NVIDIA MIG device output.
  * Continues scanning when individual device entries contain invalid or incomplete data.
  * Prevents parsing errors from causing incorrect failures when retrieving MIG UUIDs.

* **Tests**
  * Added coverage for valid extraction, instance selection, mismatched GPU UUIDs, malformed output, invalid device indices, and missing instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->