### PR TITLE
fix(scheduler): set LimitSet in the remaining ResourceQuota test fixtures

### DIFF
--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -486,13 +486,13 @@ func TestFitResourceQuotaNonNvidia(t *testing.T) {
 	// One MLU vmemory unit is 256 MiB, so a limit of 100 units leaves room for
 	// 25600 MiB. Comparing the request against the raw 100 would deny every pod.
 	qm.Quotas["mlu-mem"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
 	}
 	qm.Quotas["mlu-core"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50},
+		"cambricon.com/mlu.smlu.vcore": &device.Quota{Used: 20, Limit: 50, LimitSet: true},
 	}
 	qm.Quotas["dcu-mem"] = &device.DeviceQuota{
-		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000},
+		"hygon.com/dcumem": &device.Quota{Used: 0, Limit: 1000, LimitSet: true},
 	}
 	t.Cleanup(func() {
 		for _, ns := range []string{"mlu-mem", "mlu-core", "dcu-mem"} {
@@ -590,7 +590,7 @@ func TestFitResourceQuotaCountsEveryDevice(t *testing.T) {
 	qm := device.NewQuotaManager()
 	// 60 units is 15360 MiB of headroom.
 	qm.Quotas["mlu-multi"] = &device.DeviceQuota{
-		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60},
+		"cambricon.com/mlu.smlu.vmemory": &device.Quota{Used: 0, Limit: 60, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "mlu-multi") })
 
@@ -649,7 +649,7 @@ func TestFitResourceQuotaAscendMemoryFactor(t *testing.T) {
 
 	qm := device.NewQuotaManager()
 	qm.Quotas["ascend"] = &device.DeviceQuota{
-		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192},
+		"huawei.com/Ascend910B-memory": &device.Quota{Used: 0, Limit: 8192, LimitSet: true},
 	}
 	t.Cleanup(func() { delete(qm.Quotas, "ascend") })
 


### PR DESCRIPTION
## What this fixes

#2313 added a `LimitSet` flag to `device.Quota` and switched `FitQuota` to gate on `LimitSet` instead of `Limit != 0`, so an explicitly configured zero limit is honored as a hard block. That PR updated `TestFitResourceQuota`'s fixture to set `LimitSet: true` to match, but three sibling tests in the same file also build `device.Quota` values directly and were missed:

- `TestFitResourceQuotaNonNvidia`
- `TestFitResourceQuotaCountsEveryDevice`
- `TestFitResourceQuotaAscendMemoryFactor`

Their fixtures default to `LimitSet: false`, so `FitQuota` now treats their configured limits as "not set" and admits every pod — the denial assertions in all three tests currently fail on master:

```
--- FAIL: TestFitResourceQuotaNonNvidia
    webhook_test.go:561: fitResourceQuota() = true, want false
--- FAIL: TestFitResourceQuotaCountsEveryDevice
    webhook_test.go:602: fitResourceQuota() = true, want false: two devices should each count against the quota
--- FAIL: TestFitResourceQuotaAscendMemoryFactor
    webhook_test.go:683: fitResourceQuota() = true, want false: the request exceeds the scaled limit
```

I ran into this while rebasing an unrelated PR (#2174) onto current master — `make test` fails on a clean master checkout with no other changes involved.

## Fix

Set `LimitSet: true` on the five affected fixture entries across the three tests, matching what `AddQuota` produces and mirroring the fix already applied to `TestFitResourceQuota`.

## Testing

- `go test ./pkg/scheduler/... -run TestFitResourceQuota -race -count=1` passes (all four `TestFitResourceQuota*` tests).
- `go test ./... ` scoped to `pkg/scheduler/...` passes.
- Test-fixture-only change, no production code touched.

## AI disclosure

This PR was written primarily by Claude Code (Anthropic), used to investigate the codebase, identify the bug, implement the fix, and verify it. I reviewed and verified the change before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quota test scenarios to explicitly mark configured limits as enforced.
  * Improved coverage for non-NVIDIA, multi-device, and Ascend quota behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->