### PR TITLE
fix(device): skip empty comma-separated members in shared CheckType

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -698,7 +698,8 @@ func CheckType(annos map[string]string, cardType, useKey, noUseKey string) bool 
 	cardType = strings.ToUpper(cardType)
 	match := func(list string) bool {
 		return slices.ContainsFunc(strings.Split(list, ","), func(t string) bool {
-			return strings.Contains(cardType, strings.ToUpper(t))
+			t = strings.TrimSpace(t)
+			return t != "" && strings.Contains(cardType, strings.ToUpper(t))
 		})
 	}
 	if inuse, ok := annos[useKey]; ok && strings.TrimSpace(inuse) != "" {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1515,6 +1515,26 @@ func TestCheckType(t *testing.T) {
 			cardType: "NVIDIA-A100",
 			want:     false,
 		},
+		// Regression: a trailing/leading/double comma leaves an empty split member, and
+		// strings.Contains(cardType, "") is always true, so it must not match every card.
+		{
+			name:     "nouse with trailing comma only excludes named type",
+			annos:    map[string]string{noUseKey: "V100,"},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "nouse with leading comma only excludes named type",
+			annos:    map[string]string{noUseKey: ",V100"},
+			cardType: "NVIDIA-A100",
+			want:     true,
+		},
+		{
+			name:     "use with trailing comma matches named type only",
+			annos:    map[string]string{useKey: "V100,"},
+			cardType: "NVIDIA-A100",
+			want:     false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`device.CheckType()` (`pkg/device/devices.go`), the shared helper used by the nvidia and hygon backends for `use-gputype`/`nouse-gputype` annotations, splits the annotation value on `,` without filtering empty members:

```go
match := func(list string) bool {
    return slices.ContainsFunc(strings.Split(list, ","), func(t string) bool {
        return strings.Contains(cardType, strings.ToUpper(t))
    })
}
```

A trailing, leading, or doubled comma (e.g. `"A100,"`) produces an empty split element, and `strings.Contains(cardType, "")` is always `true`. So:

- `nvidia.com/nouse-gputype: "A100,"` excludes **every** GPU on the node, not just A100.
- `nvidia.com/use-gputype: "A100,"` matches **every** card type, not just A100.

This mirrors an equivalent bug already fixed for AMD's local `checkAMDType` in #2395, but that fix didn't cover this shared helper (used by nvidia/hygon).

## Fix

Trim and skip empty members before matching, in both the use and nouse branches.

## Test plan

- [x] Added regression cases to `TestCheckType` in `pkg/device/devices_test.go` for trailing-comma, leading-comma, and use-list-with-trailing-comma inputs.
- [x] `go test ./pkg/device/... -short --race -count=1` passes.
- [x] `golangci-lint run ./pkg/device/...` passes (0 issues).
- [x] `hack/verify-license.sh` and `hack/verify-import-aliases.sh` pass.
- Scoped to the scheduler-extender annotation-parsing path; no device hardware involved, so unit testing applies per the hardware-validation gate in CONTRIBUTING.md.

## AI assistance disclosure

This PR was written primarily by Claude Code (bug identification, fix, and tests), reviewed and submitted by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device type filtering when annotations contain leading or trailing commas.
  * Empty type constraints are now ignored, while explicitly listed types continue to be allowed or excluded correctly.

* **Tests**
  * Added regression coverage for device type matching and exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->