### PR TITLE
fix(scheduler): don't cache a nil NodeUsage when node is missing from snapshot

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -849,10 +849,6 @@ func (s *Scheduler) getNodesUsage(nodes *[]string, task *corev1.Pod) (*map[strin
 		}
 		usage, ok := overallnodeMap[node.ID]
 		if !ok {
-			// GetNode() succeeded but the node is absent from the overallnodeMap snapshot
-			// (e.g. registered between the ListNodes() snapshot and this lookup, or filtered
-			// out of ListNodes() by a nil Node). Treat it as unavailable instead of caching a
-			// nil *NodeUsage, which would later be dereferenced unconditionally by the scorer.
 			klog.V(5).InfoS("node usage not found in snapshot", "node", nodeID)
 			failedNodes[nodeID] = "node usage unavailable"
 			continue

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -847,7 +847,17 @@ func (s *Scheduler) getNodesUsage(nodes *[]string, task *corev1.Pod) (*map[strin
 			failedNodes[nodeID] = "node unregistered"
 			continue
 		}
-		cachenodeMap[node.ID] = overallnodeMap[node.ID]
+		usage, ok := overallnodeMap[node.ID]
+		if !ok {
+			// GetNode() succeeded but the node is absent from the overallnodeMap snapshot
+			// (e.g. registered between the ListNodes() snapshot and this lookup, or filtered
+			// out of ListNodes() by a nil Node). Treat it as unavailable instead of caching a
+			// nil *NodeUsage, which would later be dereferenced unconditionally by the scorer.
+			klog.V(5).InfoS("node usage not found in snapshot", "node", nodeID)
+			failedNodes[nodeID] = "node usage unavailable"
+			continue
+		}
+		cachenodeMap[node.ID] = usage
 	}
 	return &cachenodeMap, &overallnodeMap, failedNodes, nil
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -130,6 +130,47 @@ func Test_getNodesUsage(t *testing.T) {
 	assert.Equal(t, v.Devices.DeviceLists[0].Device.Usedcores, int32(20))
 }
 
+// Regression: ListNodes() silently skips nodes whose Node field is nil, while GetNode()
+// does not apply that same filter and returns success. Before the fix, getNodesUsage()
+// blindly assigned cachenodeMap[id] = overallnodeMap[id] for every node GetNode() accepted,
+// so a node present in nodeManager but absent from the ListNodes() snapshot produced a nil
+// *NodeUsage entry with no corresponding failedNodes record. That nil is later dereferenced
+// unconditionally by calcScoreWithOptions (viewStatus(*node)), panicking the scheduler.
+func Test_getNodesUsage_NodeMissingFromSnapshotIsNotCachedAsNil(t *testing.T) {
+	nodeMage := newNodeManager()
+	nodeMage.addNode("node1", &device.NodeInfo{
+		ID:   "node1",
+		Node: nil,
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID:      "GPU0",
+				Index:   0,
+				Count:   10,
+				Devmem:  1024,
+				Devcore: 100,
+				Numa:    1,
+				Mode:    "hami",
+				Health:  true,
+			}},
+		},
+	})
+	podMap := device.NewPodManager()
+	s := Scheduler{
+		nodeManager: nodeMage,
+		podManager:  podMap,
+	}
+	nodes := []string{"node1"}
+	cachenodeMap, _, failedNodes, err := s.getNodesUsage(&nodes, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 0, len(*cachenodeMap))
+	v, present := (*cachenodeMap)["node1"]
+	assert.Assert(t, !present, "node1 must not be cached at all, got %v", v)
+	_, failed := failedNodes["node1"]
+	assert.Assert(t, failed, "node1 should be recorded as a failed node")
+}
+
 func Test_getNodesUsage_StalePodDeviceAllocation(t *testing.T) {
 	t.Run("StaleOnly", func(t *testing.T) {
 		nodeMage := newNodeManager()


### PR DESCRIPTION
## Summary

`getNodesUsage()` (`pkg/scheduler/scheduler.go`) snapshots all nodes via `ListNodes()` into `overallnodeMap`, then for each candidate node calls `GetNode(nodeID)` and did:

```go
cachenodeMap[node.ID] = overallnodeMap[node.ID]
```

with no check that the key exists. Two ways this goes wrong:

1. **Deterministic:** `ListNodes()` silently skips any node whose `Node` field is nil (`nodes.go:138`), but `GetNode()` applies no such filter and still returns success (`nodes.go:113-131`). So a node accepted by `GetNode()` but filtered out of the `ListNodes()` snapshot gets cached as a **nil `*NodeUsage`**, with nothing recorded in `failedNodes`.
2. **Racy:** the same nil-map outcome is reachable if a node registers in the window between the `ListNodes()` snapshot and the later per-node `GetNode()` call.

That `cachenodeMap` feeds `calcScore` → `calcScoreWithOptions`, which ranges over the map and calls `viewStatus(*node)` unconditionally per node — a nil entry panics the scoring goroutine. Nothing in this package recovers goroutine panics, so the panic takes down the whole scheduler process (a live filter-request denial-of-service, not just a bad score).

## Fix

Check the snapshot lookup explicitly; if the node is missing from the snapshot, record it in `failedNodes` instead of caching `nil`.

## Test plan

- [x] Added `Test_getNodesUsage_NodeMissingFromSnapshotIsNotCachedAsNil`, which reproduces the bug deterministically via the `ListNodes()`/`GetNode()` nil-`Node` divergence (no need to race goroutines) and asserts the node is neither cached nor silently dropped.
- [x] `go test ./pkg/scheduler/... -short --race -count=1` passes, including existing `Test_getNodesUsage*` tests.
- [x] `golangci-lint run ./pkg/scheduler/...` passes (0 issues).
- [x] `hack/verify-license.sh` and `hack/verify-import-aliases.sh` pass.
- Scoped to the scheduler extender's in-memory node cache; no device hardware involved, so unit testing applies per the hardware-validation gate in CONTRIBUTING.md.

## AI assistance disclosure

This PR was written primarily by Claude Code (bug identification, fix, and tests), reviewed and submitted by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling accuracy as pods terminate or complete initialization.
  * Removed stale device allocations and vendor information when devices are no longer available.
  * Improved NVIDIA node health cleanup when nodes are deleted.
  * Made device selection consistent and safely recover when a lock cannot be acquired.
  * Improved handling of MIG reservations and unavailable node usage information.

* **Tests**
  * Added regression coverage for stale allocations, initialization usage changes, device lock recovery, and missing node data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->