### PR TITLE
fix(scheduler): persist per-node failure reasons as pod annotation wh…

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -949,7 +949,7 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		klog.V(5).InfoS("Nodes failed during usage retrieval",
 			"nodes", failedNodes)
 	}
-	nodeScores, err := s.calcScore(nodeUsage, resourceReqs, args.Pod, failedNodes)
+	nodeScores, failureReason, err := s.calcScore(nodeUsage, resourceReqs, args.Pod, failedNodes)
 	if err != nil {
 		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
@@ -959,6 +959,15 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		klog.V(4).InfoS("No available nodes meet the required scores",
 			"pod", args.Pod.Name)
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
+		failureAnnotation := formatFailureReasons(failureReason)
+		if failureAnnotation != "" {
+			annErr := util.PatchPodAnnotations(args.Pod, map[string]string{
+				util.SchedulingFailureReasonsAnnotation: failureAnnotation,
+			})
+			if annErr != nil {
+				klog.ErrorS(annErr, "Failed to patch scheduling failure reasons annotation", "pod", klog.KObj(args.Pod))
+			}
+		}
 		return &extenderv1.ExtenderFilterResult{
 			FailedNodes: failedNodes,
 		}, nil
@@ -1011,7 +1020,7 @@ func (s *Scheduler) filterSimulation(args extenderv1.ExtenderArgs, resourceReqs 
 		"pod", klog.KObj(args.Pod),
 		"candidateNodes", len(*nodeUsage),
 		"failedNodes", len(failedNodes))
-	nodeScores, err := s.calcScoreWithOptions(nodeUsage, resourceReqs, args.Pod, failedNodes, false, true)
+	nodeScores, _, err := s.calcScoreWithOptions(nodeUsage, resourceReqs, args.Pod, failedNodes, false, true)
 	if err != nil {
 		return nil, fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
 	}

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -90,11 +90,11 @@ func fitInDevices(node *NodeUsage, requests device.ContainerDeviceRequests, pod 
 	return true, ""
 }
 
-func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string) (*policy.NodeScoreList, error) {
+func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string) (*policy.NodeScoreList, map[string][]string, error) {
 	return s.calcScoreWithOptions(nodes, resourceReqs, task, failedNodes, true, false)
 }
 
-func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string, recordEvents bool, detailedFailureReason bool) (*policy.NodeScoreList, error) {
+func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string, recordEvents bool, detailedFailureReason bool) (*policy.NodeScoreList, map[string][]string, error) {
 	userNodePolicy := config.NodeSchedulerPolicy
 	if task.GetAnnotations() != nil {
 		if value, ok := task.GetAnnotations()[util.NodeSchedulerPolicyAnnotationKey]; ok {
@@ -188,7 +188,7 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 	wg.Wait()
 	close(errCh)
 
-	// only pod scheduler failure will record failure event
+	// Record failure events for all-failed case (existing behavior)
 	if recordEvents && len(res.NodeList) == 0 {
 		for reasonType, failureNodes := range failureReason {
 			sort.Strings(failureNodes)
@@ -201,5 +201,24 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 	for e := range errCh {
 		errorsSlice = append(errorsSlice, e)
 	}
-	return &res, utilerrors.NewAggregate(errorsSlice)
+	return &res, failureReason, utilerrors.NewAggregate(errorsSlice)
+}
+
+// formatFailureReasons turns the per-reason failure map into a single
+// human-readable string suitable for a pod annotation. Each entry shows the
+// number of nodes that failed for a given reason and their names, sorted
+// alphabetically. Example output:
+//
+//	"3 nodes CardInsufficientMemory(node1,node2,node3), 1 nodes CardTypeMismatch(node4)"
+func formatFailureReasons(reasons map[string][]string) string {
+	if len(reasons) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(reasons))
+	for reasonType, nodes := range reasons {
+		sort.Strings(nodes)
+		parts = append(parts, fmt.Sprintf("%d nodes %s(%s)", len(nodes), reasonType, strings.Join(nodes, ",")))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "; ")
 }

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -2634,7 +2634,7 @@ func Test_calcScore(t *testing.T) {
 				s.addNode(nodeName, &device.NodeInfo{ID: nodeName, Node: nodeUsage.Node, Devices: devices})
 			}
 			failedNodes := map[string]string{}
-			got, gotErr := s.calcScore(test.args.nodes, test.args.nums, test.args.task, failedNodes)
+			got, _, gotErr := s.calcScore(test.args.nodes, test.args.nums, test.args.task, failedNodes)
 			assert.DeepEqual(t, test.wants.err, gotErr)
 			wantMap := make(map[string]*policy.NodeScore)
 			for index, node := range (*(test.wants.want)).NodeList {
@@ -3658,4 +3658,196 @@ func Test_fitInDevices_MultiTypePartition(t *testing.T) {
 	assert.Equal(t, (*devinput)["mockA"][0][0].UUID, "uuid-a")
 	assert.Equal(t, len((*devinput)["mockB"][0]), 1)
 	assert.Equal(t, (*devinput)["mockB"][0][0].UUID, "uuid-b")
+}
+
+func Test_formatFailureReasons(t *testing.T) {
+	tests := []struct {
+		name     string
+		reasons  map[string][]string
+		expected string
+	}{
+		{
+			name:     "nil map returns empty string",
+			reasons:  nil,
+			expected: "",
+		},
+		{
+			name:     "empty map returns empty string",
+			reasons:  map[string][]string{},
+			expected: "",
+		},
+		{
+			name: "single reason type",
+			reasons: map[string][]string{
+				"CardInsufficientMemory": {"node3", "node1", "node2"},
+			},
+			expected: "3 nodes CardInsufficientMemory(node1,node2,node3)",
+		},
+		{
+			name: "multiple reason types sorted alphabetically",
+			reasons: map[string][]string{
+				"CardTypeMismatch":      {"node4"},
+				"CardInsufficientMemory": {"node2", "node1", "node3"},
+			},
+			expected: "3 nodes CardInsufficientMemory(node1,node2,node3); 1 nodes CardTypeMismatch(node4)",
+		},
+		{
+			name: "node names sorted within each reason",
+			reasons: map[string][]string{
+				"NumaNotFit": {"node-c", "node-a", "node-b"},
+			},
+			expected: "3 nodes NumaNotFit(node-a,node-b,node-c)",
+		},
+		{
+			name: "single node single reason",
+			reasons: map[string][]string{
+				"CardNotHealth": {"node1"},
+			},
+			expected: "1 nodes CardNotHealth(node1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatFailureReasons(tt.reasons)
+			assert.Equal(t, result, tt.expected)
+		})
+	}
+}
+
+func Test_calcScore_returnsFailureReasons(t *testing.T) {
+	s := &Scheduler{}
+
+	// Create a node with insufficient memory (Totalmem=50, Memreq=1000)
+	nodes := map[string]*NodeUsage{
+		"node1": {
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+			},
+			NodeInfo: &device.NodeInfo{},
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceInfo{
+					{
+						Device: device.DeviceUsage{
+							ID:        "gpu-0",
+							Used:      0,
+							Count:     8,
+							Usedcore:  0,
+							Usedmem:   0,
+							Totalmem:  50,
+							Totalcore: 8,
+							Type:      "nvidia.com/gpu",
+							Health:    true,
+						},
+						Scorer: func(score *float32) {},
+					},
+				},
+			},
+		},
+	}
+
+	resourceReqs := device.PodDeviceRequests{
+		"test-container": {
+			"nvidia": {Nums: 1, Type: "nvidia.com/gpu", Memreq: 1000, MemPercentagereq: 0, Coresreq: 0},
+		},
+	}
+
+	failedNodes := map[string]string{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	nodeScores, failureReason, err := s.calcScore(&nodes, resourceReqs, pod, failedNodes)
+
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(nodeScores.NodeList), 0)
+	assert.Equal(t, len(failedNodes), 1)
+	assert.Equal(t, failedNodes["node1"], common.NodeUnfitPod)
+
+	// failureReason should be populated even though all nodes failed
+	assert.Assert(t, failureReason != nil)
+	_, hasInsufficientMemory := failureReason[common.CardInsufficientMemory]
+	assert.Assert(t, hasInsufficientMemory, "expected CardInsufficientMemory in failureReason")
+	assert.Equal(t, len(failureReason[common.CardInsufficientMemory]), 1)
+	assert.Equal(t, failureReason[common.CardInsufficientMemory][0], "node1")
+}
+
+func Test_calcScore_returnsFailureReasonsWhenSomeNodesFit(t *testing.T) {
+	s := &Scheduler{}
+
+	nodes := map[string]*NodeUsage{
+		"node1": {
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+			},
+			NodeInfo: &device.NodeInfo{},
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceInfo{
+					{
+						Device: device.DeviceUsage{
+							ID:        "gpu-0",
+							Used:      0,
+							Count:     8,
+							Usedcore:  0,
+							Usedmem:   0,
+							Totalmem:  100000,
+							Totalcore: 8,
+							Type:      "nvidia.com/gpu",
+							Health:    true,
+						},
+						Scorer: func(score *float32) {},
+					},
+				},
+			},
+		},
+		"node2": {
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+			},
+			NodeInfo: &device.NodeInfo{},
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceInfo{
+					{
+						Device: device.DeviceUsage{
+							ID:        "gpu-1",
+							Used:      0,
+							Count:     8,
+							Usedcore:  0,
+							Usedmem:   0,
+							Totalmem:  50,
+							Totalcore: 8,
+							Type:      "nvidia.com/gpu",
+							Health:    true,
+						},
+						Scorer: func(score *float32) {},
+					},
+				},
+			},
+		},
+	}
+
+	resourceReqs := device.PodDeviceRequests{
+		"test-container": {
+			"nvidia": {Nums: 1, Type: "nvidia.com/gpu", Memreq: 1000, MemPercentagereq: 0, Coresreq: 0},
+		},
+	}
+
+	failedNodes := map[string]string{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	nodeScores, failureReason, err := s.calcScore(&nodes, resourceReqs, pod, failedNodes)
+
+	assert.Equal(t, err, nil)
+	// node1 fits, node2 fails
+	assert.Equal(t, len(nodeScores.NodeList), 1)
+	assert.Equal(t, nodeScores.NodeList[0].NodeID, "node1")
+
+	// failureReason should still be populated with the failing node
+	assert.Assert(t, failureReason != nil)
+	_, hasInsufficientMemory := failureReason[common.CardInsufficientMemory]
+	assert.Assert(t, hasInsufficientMemory, "expected CardInsufficientMemory in failureReason even when some nodes fit")
+	assert.Equal(t, len(failureReason[common.CardInsufficientMemory]), 1)
+	assert.Equal(t, failureReason[common.CardInsufficientMemory][0], "node2")
 }

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -85,6 +85,11 @@ const (
 	NodeSchedulerPolicyAnnotationKey = "hami.io/node-scheduler-policy"
 	// GPUSchedulerPolicyAnnotationKey is user set Pod annotation to change this default GPU policy.
 	GPUSchedulerPolicyAnnotationKey = "hami.io/gpu-scheduler-policy"
+
+	// SchedulingFailureReasonsAnnotation is set on a pod when no node fits,
+	// recording the aggregated per-reason failure breakdown so operators can
+	// diagnose why a pod is stuck Pending without reading scheduler logs.
+	SchedulingFailureReasonsAnnotation = "hami.io/scheduling-failure-reasons"
 )
 
 func (s SchedulerPolicyName) String() string {


### PR DESCRIPTION
…en scheduling fails

When a GPU pod cannot be scheduled, the scheduler already computes the exact per-node failure reasons (CardInsufficientMemory, CardTypeMismatch, etc.) but only records them as ephemeral Kubernetes events when ALL nodes fail. Operators frequently cannot find these events because they age out, leaving pods stuck in Pending with no diagnostic information.

This change:
- Always builds the failureReason map in calcScoreWithOptions regardless of whether some nodes fit
- Returns the failureReason map from calcScore and calcScoreWithOptions
- Persists the aggregated failure reasons as a hami.io/scheduling-failure-reasons pod annotation when no node fits
- Adds formatFailureReasons helper for human-readable formatting

Example annotation value:
  '3 nodes CardInsufficientMemory(node1,node2,node3); 1 nodes CardTypeMismatch(node4)'

Fixes #2286

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pods that cannot be scheduled now receive an annotation summarizing why nodes were rejected.
  * Failure details are consistently formatted and sorted for easier troubleshooting.

* **Bug Fixes**
  * Scheduling failures now preserve device-specific rejection reasons, including when some nodes remain viable.
  * Failure-reporting issues no longer change the scheduling result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->