### PR TITLE
fix(device): prevent infinite loop in PlatternMIG on safecast.Convert error

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -520,7 +520,7 @@ func PlatternMIG(n *MigInUse, templates []Geometry, templateIdx int) {
 		for count < int(val.Count) {
 			n.Index, err = safecast.Convert[int32](templateIdx)
 			if err != nil {
-				continue
+				break
 			}
 			n.UsageList = append(n.UsageList, MigTemplateUsage{
 				Name:   val.Name,


### PR DESCRIPTION
… error

The inner loop used 'continue' on conversion error, which returned to the loop condition without incrementing 'count'. Since templateIdx is constant within the inner loop, a failed conversion would fail every iteration, causing an infinite loop.

Changed 'continue' to 'break' to exit the inner loop on error.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template processing so it stops safely when a device value cannot be converted to the expected format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->