### PR TITLE
test(scheduler): add unit tests for metrics helper functions

### DIFF
--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -215,3 +215,112 @@ nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"
 		t.Fatalf("unexpected collecting result:\n%s", err)
 	}
 }
+
+func TestNormalizeAMDCoreMetrics(t *testing.T) {
+	tests := []struct {
+		name          string
+		deviceType    string
+		total         int32
+		allocated     int32
+		wantTotal     float64
+		wantAllocated float64
+	}{
+		{
+			name:          "non-AMD device is passed through unchanged",
+			deviceType:    "NVIDIA",
+			total:         4,
+			allocated:     3,
+			wantTotal:     4,
+			wantAllocated: 3,
+		},
+		{
+			name:          "AMD device with non-positive total is passed through unchanged",
+			deviceType:    "AMD",
+			total:         0,
+			allocated:     0,
+			wantTotal:     0,
+			wantAllocated: 0,
+		},
+		{
+			name:          "AMD device is normalized to a 0-100 percentage",
+			deviceType:    "AMD",
+			total:         64,
+			allocated:     32,
+			wantTotal:     normalizedCoreLimit,
+			wantAllocated: 50,
+		},
+		{
+			name:          "AMD device type matching is case-insensitive and normalization rounds up",
+			deviceType:    "amd-instinct",
+			total:         3,
+			allocated:     1,
+			wantTotal:     normalizedCoreLimit,
+			wantAllocated: 34,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTotal, gotAllocated := normalizeAMDCoreMetrics(tt.deviceType, tt.total, tt.allocated)
+			if gotTotal != tt.wantTotal || gotAllocated != tt.wantAllocated {
+				t.Errorf("normalizeAMDCoreMetrics(%q, %d, %d) = (%v, %v), want (%v, %v)",
+					tt.deviceType, tt.total, tt.allocated, gotTotal, gotAllocated, tt.wantTotal, tt.wantAllocated)
+			}
+		})
+	}
+}
+
+func TestSendMetric(t *testing.T) {
+	desc := prometheus.NewDesc("hami_test_metric", "test metric", []string{"label"}, nil)
+	ch := make(chan prometheus.Metric, 1)
+
+	if err := sendMetric(ch, desc, prometheus.GaugeValue, 1, "value"); err != nil {
+		t.Fatalf("sendMetric returned unexpected error: %v", err)
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected a metric to be sent on the channel")
+	}
+
+	// Supplying the wrong number of label values makes NewConstMetric fail,
+	// and sendMetric must surface that error instead of sending on the channel.
+	if err := sendMetric(ch, desc, prometheus.GaugeValue, 1); err == nil {
+		t.Fatal("expected sendMetric to return an error for mismatched labels")
+	}
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent on error")
+	default:
+	}
+}
+
+func TestSendLegacyMetric(t *testing.T) {
+	ch := make(chan prometheus.Metric, 1)
+
+	// A nil descriptor means the legacy metric is disabled; sendLegacyMetric
+	// must no-op rather than panic or send a metric.
+	sendLegacyMetric(ch, nil, prometheus.GaugeValue, 1, "value")
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent for a nil descriptor")
+	default:
+	}
+
+	desc := prometheus.NewDesc("hami_test_legacy_metric", "test legacy metric", []string{"label"}, nil)
+
+	// sendLegacyMetric logs and swallows errors from sendMetric rather than panicking.
+	sendLegacyMetric(ch, desc, prometheus.GaugeValue, 1)
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent when sendMetric errors")
+	default:
+	}
+
+	sendLegacyMetric(ch, desc, prometheus.GaugeValue, 1, "value")
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected a metric to be sent on the channel")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds direct unit tests for `normalizeAMDCoreMetrics`, `sendMetric`, and `sendLegacyMetric` in `cmd/scheduler/metrics.go`. These three helpers had no direct test coverage — they were only exercised indirectly through the collector-level `Collect`/`Gather` tests, so their branches (AMD vs. non-AMD normalization, non-positive total, the `sendMetric` error path on mismatched labels, and the nil-descriptor no-op in `sendLegacyMetric`) weren't independently verified.

This is a small, standalone piece of the metrics gap analysis discussed in #2126 (test coverage for the existing scheduler metrics surface before further changes are layered on top).

**Which issue(s) this PR fixes**:
Relates to #2126

**Special notes for your reviewer**:

Test-only change, no production code touched. Ran locally:
```
go test ./cmd/scheduler/... -short --race -count=1
golangci-lint run ./cmd/scheduler/...
```

**Does this PR introduce a user-facing change?**:
```
None
```

**AI assistance disclosure**: This PR was written primarily by Claude Code (test cases and implementation), based on my own review of the existing metrics.go coverage gaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for AMD core metric normalization, including case handling, invalid totals, non-AMD metrics, and percentage rounding.
  * Added validation for metric submission behavior, ensuring valid metrics are sent while invalid data is rejected safely.
  * Added coverage for legacy metric handling, including nil descriptors, error suppression, and successful submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->