### PR TITLE
test(vgpumonitor): add unit tests for metric-sending helpers

### DIFF
--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -68,3 +68,58 @@ func TestDescribeCollectSync(t *testing.T) {
 		t.Errorf("Gather failed (legacy): %v", err)
 	}
 }
+
+func TestSendMetric(t *testing.T) {
+	desc := prometheus.NewDesc("hami_test_metric", "test metric", []string{"label"}, nil)
+	ch := make(chan prometheus.Metric, 1)
+
+	if err := sendMetric(ch, desc, prometheus.GaugeValue, 1, "value"); err != nil {
+		t.Fatalf("sendMetric returned unexpected error: %v", err)
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected a metric to be sent on the channel")
+	}
+
+	// Supplying the wrong number of label values makes NewConstMetric fail,
+	// and sendMetric must surface that error instead of sending on the channel.
+	if err := sendMetric(ch, desc, prometheus.GaugeValue, 1); err == nil {
+		t.Fatal("expected sendMetric to return an error for mismatched labels")
+	}
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent on error")
+	default:
+	}
+}
+
+func TestSendLegacyMetric(t *testing.T) {
+	ch := make(chan prometheus.Metric, 1)
+
+	// A nil descriptor means the legacy metric is disabled; sendLegacyMetric
+	// must no-op rather than panic or send a metric.
+	sendLegacyMetric(ch, nil, prometheus.GaugeValue, 1, "value")
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent for a nil descriptor")
+	default:
+	}
+
+	desc := prometheus.NewDesc("hami_test_legacy_metric", "test legacy metric", []string{"label"}, nil)
+
+	// sendLegacyMetric logs and swallows errors from sendMetric rather than panicking.
+	sendLegacyMetric(ch, desc, prometheus.GaugeValue, 1)
+	select {
+	case <-ch:
+		t.Fatal("did not expect a metric to be sent when sendMetric errors")
+	default:
+	}
+
+	sendLegacyMetric(ch, desc, prometheus.GaugeValue, 1, "value")
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected a metric to be sent on the channel")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds direct unit tests for `sendMetric` and `sendLegacyMetric` in `cmd/vGPUmonitor/metrics.go`. Both helpers had no direct test coverage — they were only exercised indirectly through the collector-level `Describe`/`Collect` test, so the `sendMetric` error path (mismatched label count) and the nil-descriptor no-op in `sendLegacyMetric` weren't independently verified.

This is a small, standalone piece of the metrics gap analysis discussed in #2126 (test coverage for the existing vGPUmonitor metrics surface before further changes are layered on top). Companion PR for the scheduler side: #2447.

**Which issue(s) this PR fixes**:
Relates to #2126

**Special notes for your reviewer**:

Test-only change, no production code touched. Ran locally:
```
go test ./cmd/vGPUmonitor/... -short --race -count=1
golangci-lint run ./cmd/vGPUmonitor/...
```

**Does this PR introduce a user-facing change?**:
```
None
```

**AI assistance disclosure**: This PR was written primarily by Claude Code (test cases and implementation), based on my own review of the existing metrics.go coverage gaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for metric delivery, including successful submissions and legacy metric handling.
  * Added validation for label-count mismatches and missing legacy descriptors.
  * Verified that expected delivery errors are handled without disrupting monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->