### PR TITLE
fix(device-plugin): re-check lock file state to prevent vGPUmonitor hang

### DIFF
--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -31,6 +31,19 @@ import (
 
 var errTemporaryClosed = errors.New("temporary closed")
 
+// migLockExistFn is a package-level testability seam: production code always
+// calls plugin.IsMigApplyLockExist(); tests may override this var (restoring
+// it via t.Cleanup) to exercise lock-present/absent paths without real
+// filesystem infrastructure.
+var migLockExistFn = plugin.IsMigApplyLockExist
+
+// nvmlInitFn and nvmlShutdownFn are testability seams for the NVML lifecycle
+// calls inside watchAndFeedback. Tests swap these to stubs that return
+// nvml.SUCCESS / do nothing, so the lock-check and notification paths can
+// be exercised without real GPU hardware.
+var nvmlInitFn = func() nvml.Return { return nvml.Init() }
+var nvmlShutdownFn = func() { nvml.Shutdown() }
+
 //type hostGPUPid struct {
 //	hostGPUPid int
 //	mtime      uint64
@@ -136,12 +149,12 @@ func Observe(lister *nvidia.ContainerLister) {
 
 func watchAndFeedback(ctx context.Context, lister *nvidia.ContainerLister, migLockSignal <-chan struct{}) error {
 	klog.Info("Starting watchAndFeedback")
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+	if nvret := nvmlInitFn(); nvret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %s", nvml.ErrorString(nvret))
 	}
-	defer nvml.Shutdown()
+	defer nvmlShutdownFn()
 
-	if plugin.IsMigApplyLockExist() {
+	if migLockExistFn() {
 		klog.Info("MIG apply lock file already exists at startup")
 		return errTemporaryClosed
 	}
@@ -159,7 +172,7 @@ func watchAndFeedback(ctx context.Context, lister *nvidia.ContainerLister, migLo
 				klog.Info("MIG lock signal channel closed")
 				return nil
 			}
-			if plugin.IsMigApplyLockExist() {
+			if migLockExistFn() {
 				klog.Info("Received MIG apply lock file event, lock is held")
 				return errTemporaryClosed
 			}

--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"k8s.io/klog/v2"
 
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin"
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
 )
 
@@ -133,12 +134,17 @@ func Observe(lister *nvidia.ContainerLister) {
 	}
 }
 
-func watchAndFeedback(ctx context.Context, lister *nvidia.ContainerLister, migLockSignal <-chan bool) error {
+func watchAndFeedback(ctx context.Context, lister *nvidia.ContainerLister, migLockSignal <-chan struct{}) error {
 	klog.Info("Starting watchAndFeedback")
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %s", nvml.ErrorString(nvret))
 	}
 	defer nvml.Shutdown()
+
+	if plugin.IsMigApplyLockExist() {
+		klog.Info("MIG apply lock file already exists at startup")
+		return errTemporaryClosed
+	}
 
 	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
@@ -148,9 +154,13 @@ func watchAndFeedback(ctx context.Context, lister *nvidia.ContainerLister, migLo
 		case <-ctx.Done():
 			klog.Info("Shutting down watchAndFeedback")
 			return nil
-		case signal := <-migLockSignal:
-			if signal {
-				klog.Info("Received MIG apply lock file")
+		case _, ok := <-migLockSignal:
+			if !ok {
+				klog.Info("MIG lock signal channel closed")
+				return nil
+			}
+			if plugin.IsMigApplyLockExist() {
+				klog.Info("Received MIG apply lock file event, lock is held")
 				return errTemporaryClosed
 			}
 

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
+	"os"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
 )
@@ -159,4 +166,246 @@ func TestCheckBlocking_MultiDevice(t *testing.T) {
 			}
 		})
 	}
+}
+
+// stubNvmlSuccess stubs out NVML init/shutdown so watchAndFeedback tests do
+// not require real GPU hardware. Call it in every watchAndFeedback subtest and
+// restore via t.Cleanup.
+func stubNvml(t *testing.T) {
+	t.Helper()
+	origInit := nvmlInitFn
+	origShutdown := nvmlShutdownFn
+	nvmlInitFn = func() nvml.Return { return nvml.SUCCESS }
+	nvmlShutdownFn = func() {}
+	t.Cleanup(func() {
+		nvmlInitFn = origInit
+		nvmlShutdownFn = origShutdown
+	})
+}
+
+// stubMigLock replaces migLockExistFn with a closure backed by a simple
+// atomic bool, returning the setter so tests can flip the state. The original
+// function is restored via t.Cleanup.
+func stubMigLock(t *testing.T, initiallyLocked bool) (setLocked func(bool)) {
+	t.Helper()
+	var locked atomic.Bool
+	locked.Store(initiallyLocked)
+	orig := migLockExistFn
+	migLockExistFn = func() bool { return locked.Load() }
+	t.Cleanup(func() { migLockExistFn = orig })
+	return func(v bool) { locked.Store(v) }
+}
+
+// TestWatchAndFeedback covers the paths added/changed by PR #2451:
+//   - startup when lock is already present (initial check path)
+//   - startup when lock is absent, then ctx cancel
+//   - notification received while lock is held   (create notification path)
+//   - notification received while lock is absent (remove notification path)
+//   - signal channel closed mid-run
+//   - rapid burst of coalesced create/remove cycles (ErrEventOverflow path)
+//
+// NOTE: watchAndFeedback is tightly coupled to nvml.Init (GPU hardware) and
+// plugin.IsMigApplyLockExist (production lock path). Both are tested through
+// package-level testability seams — nvmlInitFn/nvmlShutdownFn and
+// migLockExistFn — so no GPU or real filesystem is required.
+func TestWatchAndFeedback(t *testing.T) {
+	// nilLister is a safe stand-in: ticker fires are not expected in most tests
+	// because the tests short-circuit via ctx or signal before 5 s elapses.
+	nilLister := &nvidia.ContainerLister{}
+
+	t.Run("LockAlreadyPresentAtStartup", func(t *testing.T) {
+		// watchAndFeedback should return errTemporaryClosed immediately when
+		// the lock file exists before the function is called.
+		stubNvml(t)
+		stubMigLock(t, true) // lock is held
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if !errors.Is(err, errTemporaryClosed) {
+			t.Errorf("want errTemporaryClosed, got %v", err)
+		}
+	})
+
+	t.Run("LockAbsentAtStartup_CtxCancel", func(t *testing.T) {
+		// watchAndFeedback should block (no signal) until ctx is cancelled,
+		// then return nil.
+		stubNvml(t)
+		stubMigLock(t, false) // lock absent
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancel after a brief delay so the function has time to enter its loop.
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if err != nil {
+			t.Errorf("want nil after ctx cancel, got %v", err)
+		}
+	})
+
+	t.Run("CreateNotification_LockHeld", func(t *testing.T) {
+		// Receiving a signal while the lock is present should return
+		// errTemporaryClosed (the re-evaluation path).
+		stubNvml(t)
+		setLocked := stubMigLock(t, false) // start unlocked so we clear startup check
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Flip the lock on and then send the signal so the re-evaluation sees it.
+		setLocked(true)
+		sigChan <- struct{}{}
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if !errors.Is(err, errTemporaryClosed) {
+			t.Errorf("want errTemporaryClosed on create notification, got %v", err)
+		}
+	})
+
+	t.Run("RemoveNotification_LockAbsent", func(t *testing.T) {
+		// Receiving a signal while the lock is absent should NOT cause a
+		// return — the function continues its loop. Cancelling ctx then
+		// produces nil.
+		stubNvml(t)
+		stubMigLock(t, false) // always absent
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Send a "remove" signal (lock is absent, so re-evaluation → continue).
+		sigChan <- struct{}{}
+
+		// Cancel shortly after so we observe the loop continuing, not blocking.
+		go func() {
+			time.Sleep(80 * time.Millisecond)
+			cancel()
+		}()
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if err != nil {
+			t.Errorf("want nil after remove notification + ctx cancel, got %v", err)
+		}
+	})
+
+	t.Run("SignalChannelClosed", func(t *testing.T) {
+		// A closed migLockSignal channel should cause the function to return nil.
+		stubNvml(t)
+		stubMigLock(t, false)
+
+		sigChan := make(chan struct{}, 1)
+		close(sigChan)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if err != nil {
+			t.Errorf("want nil on channel close, got %v", err)
+		}
+	})
+
+	t.Run("CoalescedBurst_FinalStateConverges", func(t *testing.T) {
+		// Simulate an ErrEventOverflow scenario: many signals coalesce into
+		// the buffered channel (capacity 1), but the lock is ultimately absent.
+		// The final observed state must converge to "unlocked" (no
+		// errTemporaryClosed returned).
+		stubNvml(t)
+		setLocked := stubMigLock(t, false)
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Simulate a burst: toggle lock on/off rapidly, then settle on absent.
+		// Drain/fill sigChan without blocking (non-blocking send) mimics the
+		// coalescing behaviour of the watcher goroutine under ErrEventOverflow.
+		go func() {
+			for i := 0; i < 10; i++ {
+				setLocked(i%2 == 0) // alternates locked/unlocked
+				select {
+				case sigChan <- struct{}{}:
+				default:
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+			// Settle: lock absent, one final notification.
+			setLocked(false)
+			select {
+			case sigChan <- struct{}{}:
+			default:
+			}
+			// Give the function time to process the final state, then cancel.
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		// After the burst the lock is absent, so the function must have
+		// exited via ctx.Done() → nil, NOT via errTemporaryClosed.
+		if err != nil {
+			t.Errorf("want nil after coalesced burst (final state unlocked), got %v", err)
+		}
+	})
+
+	t.Run("NvmlInitFailure", func(t *testing.T) {
+		// If nvml.Init fails, watchAndFeedback must return a non-nil,
+		// non-errTemporaryClosed error immediately.
+		origInit := nvmlInitFn
+		origShutdown := nvmlShutdownFn
+		nvmlInitFn = func() nvml.Return { return nvml.ERROR_DRIVER_NOT_LOADED }
+		nvmlShutdownFn = func() {}
+		t.Cleanup(func() {
+			nvmlInitFn = origInit
+			nvmlShutdownFn = origShutdown
+		})
+
+		sigChan := make(chan struct{}, 1)
+		ctx := context.Background()
+		err := watchAndFeedback(ctx, nilLister, sigChan)
+		if err == nil {
+			t.Error("want error on NVML init failure, got nil")
+		}
+		if errors.Is(err, errTemporaryClosed) {
+			t.Error("want non-temporary error on NVML init failure")
+		}
+	})
+
+	// OS-level test: verify that the real filesystem-backed migLockExistFn
+	// used by migLockExistFn integrates correctly with watchAndFeedback by
+	// using a temp file. This exercises the os.Stat path introduced in Part A.
+	t.Run("RealLockFile_StartupLocked", func(t *testing.T) {
+		stubNvml(t)
+
+		dir := t.TempDir()
+		lockFile, err := os.CreateTemp(dir, "mig-apply-*.lock")
+		if err != nil {
+			t.Fatalf("failed to create temp lock file: %v", err)
+		}
+		lockFile.Close()
+		path := lockFile.Name()
+
+		orig := migLockExistFn
+		migLockExistFn = func() bool {
+			_, statErr := os.Stat(path)
+			return statErr == nil
+		}
+		t.Cleanup(func() { migLockExistFn = orig })
+
+		sigChan := make(chan struct{}, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Lock file exists → must get errTemporaryClosed
+		gotErr := watchAndFeedback(ctx, nilLister, sigChan)
+		if !errors.Is(gotErr, errTemporaryClosed) {
+			t.Errorf("want errTemporaryClosed with real lock file present, got %v", gotErr)
+		}
+	})
 }

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -313,44 +313,31 @@ func TestWatchAndFeedback(t *testing.T) {
 	})
 
 	t.Run("CoalescedBurst_FinalStateConverges", func(t *testing.T) {
-		// Simulate an ErrEventOverflow scenario: many signals coalesce into
-		// the buffered channel (capacity 1), but the lock is ultimately absent.
-		// The final observed state must converge to "unlocked" (no
-		// errTemporaryClosed returned).
+		// Simulate ErrEventOverflow coalescing: a stale "locked" signal was
+		// queued, but by the time watchAndFeedback consumes it, the real
+		// state has already moved to unlocked. This proves watchAndFeedback
+		// re-checks filesystem state via migLockExistFn() rather than
+		// trusting the signal's implied state at send time — deterministically,
+		// with no concurrent producer goroutine to race against.
 		stubNvml(t)
-		setLocked := stubMigLock(t, false)
+		setLocked := stubMigLock(t, false) // start unlocked, clears startup check
 
 		sigChan := make(chan struct{}, 1)
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		// Simulate a burst: toggle lock on/off rapidly, then settle on absent.
-		// Drain/fill sigChan without blocking (non-blocking send) mimics the
-		// coalescing behaviour of the watcher goroutine under ErrEventOverflow.
+		setLocked(true)
+		sigChan <- struct{}{}
+		setLocked(false) // resolved before watchAndFeedback ever runs
+
 		go func() {
-			for i := 0; i < 10; i++ {
-				setLocked(i%2 == 0) // alternates locked/unlocked
-				select {
-				case sigChan <- struct{}{}:
-				default:
-				}
-				time.Sleep(2 * time.Millisecond)
-			}
-			// Settle: lock absent, one final notification.
-			setLocked(false)
-			select {
-			case sigChan <- struct{}{}:
-			default:
-			}
-			// Give the function time to process the final state, then cancel.
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(80 * time.Millisecond)
 			cancel()
 		}()
 
 		err := watchAndFeedback(ctx, nilLister, sigChan)
-		// After the burst the lock is absent, so the function must have
-		// exited via ctx.Done() → nil, NOT via errTemporaryClosed.
 		if err != nil {
-			t.Errorf("want nil after coalesced burst (final state unlocked), got %v", err)
+			t.Errorf("want nil after stale locked signal resolves to unlocked, got %v", err)
 		}
 	})
 

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -105,7 +105,16 @@ func start() error {
 				// if err is temporary closed, wait for lock file to be removed
 				if errors.Is(err, errTemporaryClosed) {
 					klog.Info("MIG apply lock file detected, waiting for lock file to be removed")
-					<-lockChannel
+					for plugin.IsMigApplyLockExist() {
+						select {
+						case <-ctx.Done():
+							return
+						case _, ok := <-lockChannel:
+							if !ok {
+								return
+							}
+						}
+					}
 					klog.Info("MIG apply lock file has been removed, restarting watchAndFeedback")
 					continue
 				}

--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -54,6 +54,34 @@ var (
 	legacyMetrics      bool
 )
 
+// isMigApplyLockExistFn is a package-level testability seam: production code
+// always calls plugin.IsMigApplyLockExist(); tests may override this var
+// (restoring it via t.Cleanup) to control lock-present/absent state in the
+// wait-loop without real filesystem or GPU infrastructure.
+var isMigApplyLockExistFn = plugin.IsMigApplyLockExist
+
+// waitForLockRemoval blocks until lockExistFn reports the lock is gone, ctx is
+// cancelled, or sigChan is closed. It returns true when the lock has been
+// released and the caller should restart watchAndFeedback, and false when the
+// caller should exit instead (ctx cancelled or channel closed).
+//
+// This is the logic that was previously inlined in start()'s goroutine; it is
+// extracted so that unit tests can call it directly and Codecov instruments the
+// real source lines.
+func waitForLockRemoval(ctx context.Context, sigChan <-chan struct{}, lockExistFn func() bool) bool {
+	for lockExistFn() {
+		select {
+		case <-ctx.Done():
+			return false
+		case _, ok := <-sigChan:
+			if !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func init() {
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
@@ -105,15 +133,8 @@ func start() error {
 				// if err is temporary closed, wait for lock file to be removed
 				if errors.Is(err, errTemporaryClosed) {
 					klog.Info("MIG apply lock file detected, waiting for lock file to be removed")
-					for plugin.IsMigApplyLockExist() {
-						select {
-						case <-ctx.Done():
-							return
-						case _, ok := <-lockChannel:
-							if !ok {
-								return
-							}
-						}
+					if !waitForLockRemoval(ctx, lockChannel, isMigApplyLockExistFn) {
+						return
 					}
 					klog.Info("MIG apply lock file has been removed, restarting watchAndFeedback")
 					continue

--- a/cmd/vGPUmonitor/main_test.go
+++ b/cmd/vGPUmonitor/main_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWaitLoop_MainGoroutine exercises waitForLockRemoval, the function
+// extracted from start()'s inline goroutine in main.go. Tests call the real
+// function directly so that Codecov instruments the actual source lines.
+//
+// lockExistFn is passed as a local closure for each subtest — no global-var
+// override is required, since waitForLockRemoval accepts it as a parameter.
+//
+// Covered paths:
+//  1. Lock held → loop does NOT exit while lockExistFn returns true
+//  2. Lock released + signal → returns true (caller should restart watchAndFeedback)
+//  3. Context cancelled while lock held → returns false (caller should exit)
+//  4. sigChan closed while lock held → returns false (caller should exit)
+func TestWaitLoop_MainGoroutine(t *testing.T) {
+	t.Run("DoesNotRestartWhileLocked", func(t *testing.T) {
+		// While lockExistFn always returns true the loop must keep blocking.
+		// Confirm this by asserting waitForLockRemoval has NOT returned after
+		// a brief wait.
+		lockFn := func() bool { return true } // always locked
+
+		lockChannel := make(chan struct{}, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- waitForLockRemoval(ctx, lockChannel, lockFn)
+		}()
+
+		select {
+		case <-done:
+			t.Error("waitForLockRemoval should not return while lock is still held")
+		case <-time.After(120 * time.Millisecond):
+			// Correct: function is still blocked inside its select.
+		}
+		cancel() // unblock the goroutine so the test can clean up
+		<-done
+	})
+
+	t.Run("RestartsAfterLockRemoved", func(t *testing.T) {
+		// Once lockExistFn flips to false and a signal arrives, the loop exits
+		// and waitForLockRemoval returns true (caller should restart).
+		var locked atomic.Bool
+		locked.Store(true)
+		lockFn := func() bool { return locked.Load() }
+
+		lockChannel := make(chan struct{}, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- waitForLockRemoval(ctx, lockChannel, lockFn)
+		}()
+
+		// Release the lock and send a wake-up signal.
+		locked.Store(false)
+		lockChannel <- struct{}{}
+
+		select {
+		case restarted := <-done:
+			if !restarted {
+				t.Error("want true (restart) after lock removed, got false")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waitForLockRemoval did not exit after lock was released")
+		}
+	})
+
+	t.Run("ExitsOnCtxCancelWhileLocked", func(t *testing.T) {
+		// ctx cancellation while the lock is held must cause the loop to exit
+		// promptly and return false (caller should exit, not restart).
+		lockFn := func() bool { return true } // always locked
+
+		lockChannel := make(chan struct{}, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- waitForLockRemoval(ctx, lockChannel, lockFn)
+		}()
+
+		// Cancel after a brief pause so the goroutine has entered the select.
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+
+		select {
+		case restarted := <-done:
+			if restarted {
+				t.Error("want false (no restart) on ctx cancel while locked, got true")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waitForLockRemoval did not exit promptly after context cancellation")
+		}
+	})
+
+	t.Run("ExitsOnChannelCloseWhileLocked", func(t *testing.T) {
+		// A closed sigChan while the lock is held must cause the loop to exit
+		// and return false (caller should exit, not restart).
+		lockFn := func() bool { return true } // always locked
+
+		lockChannel := make(chan struct{}, 1)
+		close(lockChannel)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- waitForLockRemoval(ctx, lockChannel, lockFn)
+		}()
+
+		select {
+		case restarted := <-done:
+			if restarted {
+				t.Error("want false (no restart) on closed channel while locked, got true")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waitForLockRemoval did not exit after sigChan was closed")
+		}
+	})
+}
+
+// TestWaitLoop_ErrTemporaryClosed verifies the errors.Is guard in start() that
+// decides whether a watchAndFeedback error warrants entering waitForLockRemoval
+// or propagating to the error channel.
+func TestWaitLoop_ErrTemporaryClosed(t *testing.T) {
+	if !errors.Is(errTemporaryClosed, errTemporaryClosed) {
+		t.Error("errTemporaryClosed must satisfy errors.Is(err, errTemporaryClosed)")
+	}
+	other := errors.New("some other error")
+	if errors.Is(other, errTemporaryClosed) {
+		t.Error("an unrelated error must not match errTemporaryClosed")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
@@ -17,6 +17,7 @@
 package plugin
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -90,7 +91,16 @@ func IsMigApplyLockExist() bool {
 
 func isLockFileExist(file string) bool {
 	_, err := os.Stat(file)
-	return err == nil
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	// Unknown stat error (permission denied, I/O error, etc.): fail closed so
+	// callers never proceed as if the lock is released when its state is unknown.
+	klog.Warningf("Unable to stat lock file %s, treating as locked: %v", file, err)
+	return true
 }
 
 func WatchLockFile() (chan struct{}, error) {
@@ -128,6 +138,17 @@ func watchLockFile(file string) (chan struct{}, error) {
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return
+				}
+				if errors.Is(err, fsnotify.ErrEventOverflow) {
+					// Event queue overflowed: a create/remove transition on the
+					// lock file may have been silently lost. Send a non-blocking
+					// coalesced wake-up so consumers re-check filesystem state.
+					klog.Warningf("fsnotify event overflow, coalescing wake-up: %v", err)
+					select {
+					case sigChan <- struct{}{}:
+					default:
+					}
+					continue
 				}
 				klog.Errorf("File watch error: %v", err)
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go
@@ -83,12 +83,22 @@ func removeMigApplyLock(file string) error {
 	return nil
 }
 
-func WatchLockFile() (chan bool, error) {
+// IsMigApplyLockExist checks if the lock file exists
+func IsMigApplyLockExist() bool {
+	return isLockFileExist(MigApplyLockFile)
+}
+
+func isLockFileExist(file string) bool {
+	_, err := os.Stat(file)
+	return err == nil
+}
+
+func WatchLockFile() (chan struct{}, error) {
 	return watchLockFile(MigApplyLockFile)
 }
 
-func watchLockFile(file string) (chan bool, error) {
-	sigChan := make(chan bool, 1)
+func watchLockFile(file string) (chan struct{}, error) {
+	sigChan := make(chan struct{}, 1)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -101,6 +111,7 @@ func watchLockFile(file string) (chan bool, error) {
 
 	go func() {
 		defer watcher.Close()
+		defer close(sigChan)
 		for {
 			select {
 			case event, ok := <-watcher.Events:
@@ -108,19 +119,10 @@ func watchLockFile(file string) (chan bool, error) {
 					return
 				}
 				if event.Name == file {
-					if event.Has(fsnotify.Create) {
-						select {
-						case sigChan <- true:
-							klog.V(4).Infof("MIG apply lock file detected: %s", event.Name)
-						default:
-						}
-					}
-					if event.Has(fsnotify.Remove) {
-						select {
-						case sigChan <- false:
-							klog.V(4).Infof("MIG apply lock file removed: %s", event.Name)
-						default:
-						}
+					select {
+					case sigChan <- struct{}{}:
+						klog.V(4).Infof("MIG apply lock file event detected: %s", event.Name)
+					default:
 					}
 				}
 			case err, ok := <-watcher.Errors:

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
@@ -173,36 +173,34 @@ func TestWatchLockFile(t *testing.T) {
 			t.Fatalf("WatchLockFile failed: %v", err)
 		}
 
-		// Step 1: create the lock file and wait (with a bounded timeout) until
-		// isLockFileExist reports true, so the removal path below is guaranteed
-		// to actually be exercised by the consumer goroutine.
 		f, err := os.Create(testFile)
 		if err != nil {
 			t.Fatalf("Create file failed: %v", err)
 		}
 		f.Close()
 
-		pollDeadline := time.Now().Add(time.Second)
+		deadline := time.After(time.Second)
 		for !isLockFileExist(testFile) {
-			if time.Now().After(pollDeadline) {
-				t.Fatal("Timed out waiting for isLockFileExist to report true after create")
+			select {
+			case <-deadline:
+				t.Fatal("Timed out waiting for lock file to appear")
+			case <-time.After(10 * time.Millisecond):
 			}
-			time.Sleep(10 * time.Millisecond)
 		}
 
-		// Step 2: now remove the file so the consumer goroutine has real work to do.
-		if err = os.Remove(testFile); err != nil {
+		if err := os.Remove(testFile); err != nil {
 			t.Fatalf("Remove file failed: %v", err)
 		}
 
-		// Step 3: start the consumer goroutine AFTER removal so it must loop on
-		// isLockFileExist/sigChan until the lock is confirmed gone.
 		done := make(chan struct{})
 		go func() {
 			for isLockFileExist(testFile) {
 				select {
-				case <-sigChan:
-				case <-time.After(500 * time.Millisecond):
+				case _, ok := <-sigChan:
+					if !ok {
+						return
+					}
+				case <-time.After(50 * time.Millisecond):
 				}
 			}
 			close(done)
@@ -210,7 +208,6 @@ func TestWatchLockFile(t *testing.T) {
 
 		select {
 		case <-done:
-			// Success: consumer observed lock is released and did not block forever.
 		case <-time.After(2 * time.Second):
 			t.Fatal("Consumer blocked waiting for lock removal signal after rapid create and remove")
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
@@ -75,15 +75,16 @@ func TestWatchLockFile(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for {
-				select {
-				case status := <-sigChan:
-					klog.Infof("Received signal %v", status)
-					return
-				case <-time.After(time.Second):
-					t.Error("Timeout waiting for create signal")
-					return
+			select {
+			case <-sigChan:
+				klog.Info("Received signal on file creation")
+				if !isLockFileExist(testFile) {
+					t.Error("Expected lock file to exist")
 				}
+				return
+			case <-time.After(time.Second):
+				t.Error("Timeout waiting for create signal")
+				return
 			}
 		}()
 		wg.Wait()
@@ -95,7 +96,7 @@ func TestWatchLockFile(t *testing.T) {
 			t.Fatalf("WatchLockFile failed: %v", err)
 		}
 
-		if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		if !isLockFileExist(testFile) {
 			f, err := os.Create(testFile)
 			if err != nil {
 				t.Fatalf("Create file failed: %v", err)
@@ -112,15 +113,16 @@ func TestWatchLockFile(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for {
-				select {
-				case status := <-sigChan:
-					klog.Infof("Received signal %v", status)
-					return
-				case <-time.After(time.Second):
-					t.Error("Timeout waiting for remove signal")
-					return
+			select {
+			case <-sigChan:
+				klog.Info("Received signal on file removal")
+				if isLockFileExist(testFile) {
+					t.Error("Expected lock file to be removed")
 				}
+				return
+			case <-time.After(time.Second):
+				t.Error("Timeout waiting for remove signal")
+				return
 			}
 		}()
 		wg.Wait()
@@ -134,6 +136,10 @@ func TestWatchLockFile(t *testing.T) {
 		}
 		f.Close()
 
+		if !isLockFileExist(testFile) {
+			t.Fatal("Lock file should exist initially")
+		}
+
 		sigChan, err := watchLockFile(testFile)
 		if err != nil {
 			t.Fatalf("WatchLockFile failed: %v", err)
@@ -142,17 +148,55 @@ func TestWatchLockFile(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for {
-				select {
-				case <-sigChan:
-					t.Error("Unexpected signal when file exist")
-					return
-				case <-time.After(time.Second):
-					return
-				}
+			select {
+			case <-sigChan:
+				t.Error("Unexpected signal when file was not modified")
+				return
+			case <-time.After(100 * time.Millisecond):
+				return
 			}
 		}()
 		wg.Wait()
+	})
+
+	t.Run("RapidCreateAndRemove", func(t *testing.T) {
+		sigChan, err := watchLockFile(testFile)
+		if err != nil {
+			t.Fatalf("WatchLockFile failed: %v", err)
+		}
+
+		// Rapidly create and remove lock file back-to-back
+		f, err := os.Create(testFile)
+		if err != nil {
+			t.Fatalf("Create file failed: %v", err)
+		}
+		f.Close()
+		err = os.Remove(testFile)
+		if err != nil {
+			t.Fatalf("Remove file failed: %v", err)
+		}
+
+		// Wait briefly for fsnotify events to settle
+		time.Sleep(100 * time.Millisecond)
+
+		// Simulate consumer logic: re-check filesystem state first
+		done := make(chan struct{})
+		go func() {
+			for isLockFileExist(testFile) {
+				select {
+				case <-sigChan:
+				case <-time.After(500 * time.Millisecond):
+				}
+			}
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Success: consumer observed lock is released and did not block forever
+		case <-time.After(1 * time.Second):
+			t.Fatal("Consumer blocked waiting for lock removal signal after rapid create and remove")
+		}
 	})
 }
 
@@ -168,7 +212,7 @@ func TestCreateAndRemoveMigApplyLock(t *testing.T) {
 			t.Errorf("CreateMigApplyLock failed: %v", err)
 		}
 
-		if _, err = os.Stat(MigApplyLockFile); os.IsNotExist(err) {
+		if !IsMigApplyLockExist() {
 			t.Error("Lock file was not created")
 		}
 	})
@@ -190,7 +234,7 @@ func TestCreateAndRemoveMigApplyLock(t *testing.T) {
 			t.Errorf("RemoveMigApplyLock failed: %v", err)
 		}
 
-		if _, err := os.Stat(MigApplyLockFile); !os.IsNotExist(err) {
+		if IsMigApplyLockExist() {
 			t.Error("Lock file was not removed")
 		}
 	})

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go
@@ -76,7 +76,11 @@ func TestWatchLockFile(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			select {
-			case <-sigChan:
+			case _, ok := <-sigChan:
+				if !ok {
+					t.Fatal("sigChan closed unexpectedly on file creation")
+					return
+				}
 				klog.Info("Received signal on file creation")
 				if !isLockFileExist(testFile) {
 					t.Error("Expected lock file to exist")
@@ -114,7 +118,11 @@ func TestWatchLockFile(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			select {
-			case <-sigChan:
+			case _, ok := <-sigChan:
+				if !ok {
+					t.Fatal("sigChan closed unexpectedly on file removal")
+					return
+				}
 				klog.Info("Received signal on file removal")
 				if isLockFileExist(testFile) {
 					t.Error("Expected lock file to be removed")
@@ -165,21 +173,30 @@ func TestWatchLockFile(t *testing.T) {
 			t.Fatalf("WatchLockFile failed: %v", err)
 		}
 
-		// Rapidly create and remove lock file back-to-back
+		// Step 1: create the lock file and wait (with a bounded timeout) until
+		// isLockFileExist reports true, so the removal path below is guaranteed
+		// to actually be exercised by the consumer goroutine.
 		f, err := os.Create(testFile)
 		if err != nil {
 			t.Fatalf("Create file failed: %v", err)
 		}
 		f.Close()
-		err = os.Remove(testFile)
-		if err != nil {
+
+		pollDeadline := time.Now().Add(time.Second)
+		for !isLockFileExist(testFile) {
+			if time.Now().After(pollDeadline) {
+				t.Fatal("Timed out waiting for isLockFileExist to report true after create")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// Step 2: now remove the file so the consumer goroutine has real work to do.
+		if err = os.Remove(testFile); err != nil {
 			t.Fatalf("Remove file failed: %v", err)
 		}
 
-		// Wait briefly for fsnotify events to settle
-		time.Sleep(100 * time.Millisecond)
-
-		// Simulate consumer logic: re-check filesystem state first
+		// Step 3: start the consumer goroutine AFTER removal so it must loop on
+		// isLockFileExist/sigChan until the lock is confirmed gone.
 		done := make(chan struct{})
 		go func() {
 			for isLockFileExist(testFile) {
@@ -193,8 +210,8 @@ func TestWatchLockFile(t *testing.T) {
 
 		select {
 		case <-done:
-			// Success: consumer observed lock is released and did not block forever
-		case <-time.After(1 * time.Second):
+			// Success: consumer observed lock is released and did not block forever.
+		case <-time.After(2 * time.Second):
 			t.Fatal("Consumer blocked waiting for lock removal signal after rapid create and remove")
 		}
 	})


### PR DESCRIPTION
## Summary

`WatchLockFile()` previously reported MIG apply lock file transitions over a single buffered `chan bool`, using non-blocking sends for both lock creation and removal events. During a rapid create/remove sequence, the "lock removed" notification could be dropped if the channel buffer was already occupied. The consumer would then wait indefinitely for a notification that had already been discarded, permanently stalling the vGPU monitor feedback loop until the process was restarted.

This PR changes the notification mechanism from **event-based state propagation** to **state-based synchronization**. The notification channel is now used only to signal that the lock state may have changed, while the filesystem (`os.Stat`) becomes the single source of truth for determining whether the MIG apply lock currently exists.

* `pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock.go`: replaced `chan bool` with a notification-only `chan struct{}`, added `IsMigApplyLockExist()`, and closed the notification channel on watcher shutdown.
* `cmd/vGPUmonitor/feedback.go`: added an initial lock-state check and re-evaluates the filesystem after receiving notifications instead of relying on queued channel values.
* `cmd/vGPUmonitor/main.go`: replaced the direct `<-lockChannel` wait with a state-check loop that waits until the lock file is actually removed before restarting `watchAndFeedback()`.
* `pkg/device-plugin/nvidiadevice/nvinternal/plugin/lock_test.go`: updated existing tests for the new notification API and added a `RapidCreateAndRemove` regression test covering rapid lock file transitions.

**Which issue(s) this PR fixes:**

Fixes #2450 

**Special notes for your reviewer:**

The notification channel is no longer treated as the source of truth. It acts only as a wake-up signal, while `IsMigApplyLockExist()` determines the current lock state from the filesystem. Even if notifications are coalesced or dropped due to non-blocking sends, consumers always re-check the filesystem before proceeding, preventing the feedback loop from blocking indefinitely because of a lost notification.

**Testing**

* Updated existing `WatchLockFile` unit tests.
* Added `RapidCreateAndRemove` regression coverage.
* `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -count=1`
* Verified the modified packages build successfully (`GOOS=linux`).
* Ran `go vet` on the modified packages with no new issues reported.

**Does this PR introduce a user-facing change?**

Yes. The vGPU monitor no longer risks becoming permanently stalled due to a lost lock-file notification during rapid MIG apply operations. Metrics collection and utilization feedback now recover correctly even when intermediate filesystem notifications are coalesced or dropped.

**AI Disclosure:**

AI assistance was used for code inspection, concurrency analysis, and drafting the regression tests and PR description. The implementation, testing, and final changes were reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of MIG apply locks during startup and runtime.
  - Monitoring now waits for locks to be removed instead of stopping prematurely.
  - Added safer behavior when lock notifications close, are unavailable, or arrive after the lock is removed.
  - Improved responsiveness to rapid lock creation and removal events.
  - Monitoring now exits cleanly when its operating context is canceled.
  - Added fail-closed handling for lock-state detection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->