### PR TITLE
fix(device-plugin): replace panic with graceful error handling in Get…

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -150,24 +150,28 @@ func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.Po
 func GetIndexAndTypeFromUUID(uuid string) (string, int) {
 	defer nvml.Shutdown()
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml init failed: %s", nvml.ErrorString(nvret)), 
+			"Failed to initialize NVML in GetIndexAndTypeFromUUID", "uuid", uuid, "returnCode", nvret)
+		return "", -1
 	}
 	originuuid := strings.Split(uuid, "[")[0]
 	ndev, ret := nvml.DeviceGetHandleByUUID(originuuid)
 	if ret != nvml.SUCCESS {
-		klog.Error("nvml get handlebyuuid error ret=", ret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml get device handle failed: %s", nvml.ErrorString(ret)), 
+			"Failed to get device handle by UUID", "uuid", originuuid, "returnCode", ret)
+		return "", -1
 	}
 	Model, ret := ndev.GetName()
 	if ret != nvml.SUCCESS {
-		klog.Error("nvml get name error ret=", ret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml get device name failed: %s", nvml.ErrorString(ret)), 
+			"Failed to get device name", "uuid", originuuid, "returnCode", ret)
+		return "", -1
 	}
 	index, ret := ndev.GetIndex()
 	if ret != nvml.SUCCESS {
-		klog.Error("nvml get index error ret=", ret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml get device index failed: %s", nvml.ErrorString(ret)), 
+			"Failed to get device index", "uuid", originuuid, "returnCode", ret)
+		return "", -1
 	}
 	return Model, index
 }
@@ -207,14 +211,16 @@ func GetMigUUIDFromSmiOutput(output string, uuid string, idx int) string {
 func GetMigUUIDFromIndex(uuid string, idx int) string {
 	defer nvml.Shutdown()
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml init failed: %s", nvml.ErrorString(nvret)), 
+			"Failed to initialize NVML in GetMigUUIDFromIndex", "uuid", uuid, "index", idx, "returnCode", nvret)
+		return ""
 	}
 	originuuid := strings.Split(uuid, "[")[0]
 	ndev, ret := nvml.DeviceGetHandleByUUID(originuuid)
 	if ret != nvml.SUCCESS {
-		klog.Error(`nvml get device uuid error ret=`, ret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml get device handle failed: %s", nvml.ErrorString(ret)), 
+			"Failed to get device handle by UUID", "uuid", originuuid, "returnCode", ret)
+		return ""
 	}
 	migdev, ret := nvml.DeviceGetMigDeviceHandleByIndex(ndev, idx)
 	if ret != nvml.SUCCESS {
@@ -233,8 +239,9 @@ func GetMigUUIDFromIndex(uuid string, idx int) string {
 	}
 	res, ret := migdev.GetUUID()
 	if ret != nvml.SUCCESS {
-		klog.Error(`nvml get mig uuid error ret=`, ret)
-		panic(0)
+		klog.ErrorS(fmt.Errorf("nvml get MIG UUID failed: %s", nvml.ErrorString(ret)), 
+			"Failed to get MIG device UUID", "uuid", originuuid, "index", idx, "returnCode", ret)
+		return ""
 	}
 	return res
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -499,6 +499,11 @@ func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevic
 			tmp = append(tmp, val.UUID)
 		} else {
 			devtype, devindex := GetIndexAndTypeFromUUID(val.UUID)
+			if devtype == "" || devindex < 0 {
+				klog.ErrorS(fmt.Errorf("failed to get device info"), 
+					"Skipping device due to GetIndexAndTypeFromUUID failure", "uuid", val.UUID)
+				continue
+			}
 			position, needsreset = nv.GenerateMigTemplate(devtype, devindex, val)
 			if needsreset {
 				nv.ApplyMigTemplate()
@@ -533,7 +538,13 @@ func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevic
 					}
 				}
 			}
-			tmp = append(tmp, GetMigUUIDFromIndex(val.UUID, position))
+			migUUID := GetMigUUIDFromIndex(val.UUID, position)
+			if migUUID == "" {
+				klog.ErrorS(fmt.Errorf("failed to get MIG UUID"), 
+					"Skipping device due to GetMigUUIDFromIndex failure", "uuid", val.UUID, "position", position)
+				continue
+			}
+			tmp = append(tmp, migUUID)
 		}
 	}
 	klog.V(3).Infoln("mig current=", nv.migCurrent, ":", needsreset, "position=", position, "uuid lists", tmp)


### PR DESCRIPTION
…IndexAndTypeFromUUID and GetMigUUIDFromIndex

Replace 7 panic(0) calls with graceful error handling using sentinel return values:
- GetIndexAndTypeFromUUID: returns ("", -1) on any NVML error
- GetMigUUIDFromIndex: returns "" on any NVML error

Both functions are called by GetContainerDeviceStrArray which already checks for these sentinel values and skips failed devices gracefully.

Panic conditions replaced:
1. GetIndexAndTypeFromUUID - NVML init failure
2. GetIndexAndTypeFromUUID - DeviceGetHandleByUUID failure
3. GetIndexAndTypeFromUUID - GetName failure
4. GetIndexAndTypeFromUUID - GetIndex failure
5. GetMigUUIDFromIndex - NVML init failure
6. GetMigUUIDFromIndex - DeviceGetHandleByUUID failure
7. GetMigUUIDFromIndex - GetUUID failure

Enhanced error logging with structured logging (klog.ErrorS) including:
- Human-readable error strings via nvml.ErrorString()
- Context fields (uuid, index, returnCode)
- Proper error wrapping with fmt.Errorf()

This prevents device plugin crashes when NVML queries fail due to:
- Driver not loaded or unavailable
- GPU in bad state
- Invalid/stale UUID references
- Transient hardware issues

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when GPU and MIG device information cannot be retrieved.
  * Prevented unexpected process termination by returning safe fallback values for device lookup failures.
  * Added clearer structured error reporting for these conditions.
  * Prevented invalid device identifiers from being exposed when hardware information is incomplete or unavailable.
  * Improved reliability of device discovery in environments with transient or unsupported GPU management errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->