### PR TITLE
docs: update dead AMD ROCm links in amd-vgpu.md

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -23,14 +23,14 @@ resolved it. The existing NVIDIA LD_PRELOAD path is unchanged.
 
 **Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
 Masking (`HSA_CU_MASK`) assigns fine-grained, hardware-valid per-pod CU
-partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html)).
 On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD
 granularity and is set per physical GPU.
 
 **WGP pairing and rollout scope.** ROCm documents that not every CU mask is
 valid on every device: on GPUs where two CUs form a Work Group Processor
 (WGP) and kernels run in WGP mode, disabling only one CU of a pair is
-invalid ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+invalid ([setting CUs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html)).
 WGP is an **RDNA** construct (GFX10+); HIP describes it under the RDNA hardware
 model ([HIP hardware implementation](https://rocm.docs.amd.com/projects/HIP/en/latest/understand/hardware_implementation.html)).
 **CDNA** devices (e.g. Instinct MI300X, `gfx942`) keep independent CUs and are
@@ -162,7 +162,7 @@ residual interference remains (as reported in #1707).
 - **WGP-aware CU allocation is phased.** First ship CU partitioning on
   non-WGP devices (CDNA / Instinct). RDNA (GFX10+) devices need WGP pair
   alignment when building `HSA_CU_MASK`
-  ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html))
+  ([setting CUs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html))
   and land in a follow-up.
 
 ## 7. Multi-GPU validation required


### PR DESCRIPTION
### What this PR does / why we need it:
This PR updates three dead links in `docs/develop/amd-vgpu.md` that point to the AMD ROCm documentation for "setting CUs" (Compute Unit masking). 

The old URL (`https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html`) currently returns a 404 Not Found error because AMD restructured their documentation. This PR points those links to the active ROCm page for GPU isolation and CU masking (`https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html`).

### Which issue(s) this PR fixes:
Fixes #2456 

### Special notes for reviewer:
This is a simple documentation fix. No code changes are involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AMD ROCm guidance links for CU masking and WGP configuration to point to the current GPU isolation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->