### PR TITLE
fix(ascend): avoid nil-map panic in MutateAdmission on limits-only container

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -179,6 +179,11 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		}
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
+	// A container may declare only limits, leaving Requests nil. Writing to a nil
+	// map panics ("assignment to entry in nil map"), so initialize it first.
+	if ctr.Resources.Requests == nil {
+		ctr.Resources.Requests = corev1.ResourceList{}
+	}
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 
 	// Set runtime class name if it is not set by user and the runtime class name is configured

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -667,6 +667,26 @@ func Test_MutateAdmission(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			// A single-device container declaring only limits (nil Requests) must
+			// not panic on the Requests write; regression for the nil-map panic.
+			name: "limits only, nil requests does not panic",
+			args: struct {
+				ctr corev1.Container
+				pod corev1.Pod
+			}{
+				ctr: corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"huawei.com/Ascend910A":        resource.MustParse("1"),
+							"huawei.com/Ascend910A-memory": resource.MustParse("8738"),
+						},
+					},
+				},
+				pod: corev1.Pod{},
+			},
+			want: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**

`Devices.MutateAdmission` in the ascend backend writes the trimmed memory quantity into `ctr.Resources.Requests` unconditionally. A container declaring only `limits` (no `requests` block) reaches that write with `Requests == nil`, panicking with `assignment to entry in nil map` inside the admission webhook.

This initializes `Requests` before the write and adds a regression test: a single-device, limits-only container that reaches the write path. Existing limits-only cases return early at the multi-device / no-resource checks, which is why the panic was never covered.

**Which issue(s) this PR fixes**

Fixes #2415

**Test**

`go test ./pkg/device/ascend/... -race` — the new case panics without the fix, passes with it.

_This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admission processing for containers that specify resource limits without resource requests.
  * Prevented failures when calculating and recording memory requests in this configuration.

* **Tests**
  * Added regression coverage to verify successful admission without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->