### PR TITLE
Fix/patch erased annotation nil map

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -92,6 +92,21 @@ func GetNextDeviceRequest(dtype string, p corev1.Pod) (corev1.Container, device.
 	return corev1.Container{}, res, errors.New("device request not found")
 }
 
+func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.PodSingleDevice) error {
+	klog.V(5).Infof("After erase annotation, remaining devices: %v", podSingleDev)
+	encoded := device.EncodePodSingleDevice(podSingleDev)
+	annoKey := device.InRequestDevices[dtype]
+	newAnnos := map[string]string{annoKey: encoded}
+	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
+		return err
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[annoKey] = encoded
+	return nil
+}
+
 var eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
 	pdevices, err := device.DecodePodDevices(device.InRequestDevices, p.Annotations)
 	if err != nil {
@@ -115,10 +130,7 @@ var eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
 			}
 		}
 	}
-	klog.Infoln("After erase res=", res)
-	newannos := make(map[string]string)
-	newannos[device.InRequestDevices[dtype]] = device.EncodePodSingleDevice(res)
-	return util.PatchPodAnnotations(&p, newannos)
+	return patchErasedAnnotation(&p, dtype, res)
 }
 
 func GetIndexAndTypeFromUUID(uuid string) (string, int) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -107,7 +107,6 @@ func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.Po
 	return nil
 }
 
-var eraseNextDeviceTypeFromAnnotation = func(dtype string, p corev1.Pod) error {
 // decodePodSingleDevice decodes the pod's device allocation annotation for the
 // given device type into a PodSingleDevice slice. Each element corresponds to
 // one container (init containers first, then regular containers).
@@ -144,24 +143,7 @@ func popNextContainerDevices(pod *corev1.Pod, podSingleDev device.PodSingleDevic
 			return pod.Spec.Containers[regularIdx], ctrDevs, nil
 		}
 	}
-	return patchErasedAnnotation(&p, dtype, res)
 	return corev1.Container{}, nil, errors.New("no pending device allocation found")
-}
-
-// patchErasedAnnotation patches the pod's device annotation with the given
-// podSingleDev (which has had some containers popped). It also updates
-// pod.Annotations in place so that subsequent Allocate calls within the same
-// kubelet invocation see the erased state.
-func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.PodSingleDevice) error {
-	klog.V(5).Infof("After erase annotation, remaining devices: %v", podSingleDev)
-	encoded := device.EncodePodSingleDevice(podSingleDev)
-	annoKey := device.InRequestDevices[dtype]
-	newAnnos := map[string]string{annoKey: encoded}
-	if err := util.PatchPodAnnotations(pod, newAnnos); err != nil {
-		return err
-	}
-	pod.Annotations[annoKey] = encoded
-	return nil
 }
 
 func GetIndexAndTypeFromUUID(uuid string) (string, int) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -17,12 +17,12 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -971,6 +971,18 @@ func TestPatchErasedAnnotation(t *testing.T) {
 		if got := pod.Annotations[annoKey]; got != expectedEncoded {
 			t.Errorf("pod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
 		}
+
+		// Assert persisted state in fake clientset
+		persistedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to fetch persisted pod: %v", err)
+		}
+		if persistedPod.Annotations == nil {
+			t.Fatal("expected persistedPod.Annotations to be initialized (non-nil)")
+		}
+		if got := persistedPod.Annotations[annoKey]; got != expectedEncoded {
+			t.Errorf("persistedPod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
+		}
 	})
 
 	t.Run("ExistingAnnotationsPreserved", func(t *testing.T) {
@@ -995,6 +1007,18 @@ func TestPatchErasedAnnotation(t *testing.T) {
 		}
 		if got := pod.Annotations[annoKey]; got != expectedEncoded {
 			t.Errorf("pod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
+		}
+
+		// Assert persisted state in fake clientset
+		persistedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to fetch persisted pod: %v", err)
+		}
+		if got := persistedPod.Annotations["existing-key"]; got != "existing-value" {
+			t.Errorf("persisted existing annotation was overwritten or lost: got %q, want %q", got, "existing-value")
+		}
+		if got := persistedPod.Annotations[annoKey]; got != expectedEncoded {
+			t.Errorf("persistedPod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
 		}
 	})
 }
@@ -1057,6 +1081,16 @@ func TestEraseNextDeviceTypeFromAnnotation(t *testing.T) {
 		err := eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, pod)
 		if err != nil {
 			t.Fatalf("eraseNextDeviceTypeFromAnnotation: %v", err)
+		}
+
+		// Assert persisted state in fake clientset
+		persistedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to fetch persisted pod: %v", err)
+		}
+		expectedErased := ";;"
+		if got := persistedPod.Annotations["hami.io/vgpu-devices-to-allocate"]; got != expectedErased {
+			t.Errorf("persistedPod.Annotations[hami.io/vgpu-devices-to-allocate] = %q, want %q", got, expectedErased)
 		}
 	})
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -940,3 +940,61 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 		t.Errorf("expected stale config to be removed, stat err: %v", err)
 	}
 }
+
+func TestPatchErasedAnnotation(t *testing.T) {
+	dev := device.PodSingleDevice{
+		device.ContainerDevices{
+			{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice, Usedmem: 3000, Usedcores: 50},
+		},
+	}
+	expectedEncoded := device.EncodePodSingleDevice(dev)
+	annoKey := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+
+	t.Run("NilAnnotationsMapInitializedWithoutPanic", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-nil-annotations",
+				Namespace: "default",
+				// Annotations explicitly left nil — Go distinguishes nil map from empty map.
+			},
+		}
+
+		client.KubeClient = fake.NewSimpleClientset(pod)
+
+		err := patchErasedAnnotation(pod, nvidia.NvidiaGPUDevice, dev)
+		if err != nil {
+			t.Fatalf("patchErasedAnnotation failed: %v", err)
+		}
+		if pod.Annotations == nil {
+			t.Fatal("expected pod.Annotations to be initialized (non-nil) after patchErasedAnnotation")
+		}
+		if got := pod.Annotations[annoKey]; got != expectedEncoded {
+			t.Errorf("pod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
+		}
+	})
+
+	t.Run("ExistingAnnotationsPreserved", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-existing-annotations",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"existing-key": "existing-value",
+				},
+			},
+		}
+
+		client.KubeClient = fake.NewSimpleClientset(pod)
+
+		err := patchErasedAnnotation(pod, nvidia.NvidiaGPUDevice, dev)
+		if err != nil {
+			t.Fatalf("patchErasedAnnotation failed: %v", err)
+		}
+		if got := pod.Annotations["existing-key"]; got != "existing-value" {
+			t.Errorf("existing annotation was overwritten or lost: got %q, want %q", got, "existing-value")
+		}
+		if got := pod.Annotations[annoKey]; got != expectedEncoded {
+			t.Errorf("pod.Annotations[%s] = %q, want %q", annoKey, got, expectedEncoded)
+		}
+	})
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -998,3 +998,65 @@ func TestPatchErasedAnnotation(t *testing.T) {
 		}
 	})
 }
+
+// TestEraseNextDeviceTypeFromAnnotation directly exercises the
+// eraseNextDeviceTypeFromAnnotation var (the delegating wrapper) to confirm
+// that the delegation to patchErasedAnnotation does not panic when
+// pod.Annotations is nil and that the server-side patch is attempted via the
+// fake client without error.
+func TestEraseNextDeviceTypeFromAnnotation(t *testing.T) {
+	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	encoded := "GPU-03f69c50-207a-2038-9b45-23cac89cb67a,NVIDIA,3000,50:;"
+
+	t.Run("NilAnnotationsDoesNotPanic", func(t *testing.T) {
+		// Pod with nil Annotations — eraseNextDeviceTypeFromAnnotation
+		// receives a value copy of the pod, so patchErasedAnnotation
+		// must not panic when initialising the local copy's map.
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "erase-nil-annos",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"hami.io/vgpu-devices-to-allocate": encoded,
+				},
+			},
+		}
+		client.KubeClient = fake.NewSimpleClientset(&pod)
+
+		// Nil out Annotations AFTER creating in fake client so the fake
+		// MergePatch still finds the pod, but the local copy has nil map.
+		pod.Annotations = nil
+
+		// Must not panic.
+		err := eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, pod)
+		// The decoded annotation was nil, so DecodePodDevices will fail to
+		// find the key and return "erase device annotation not found" — that
+		// is the expected error when Annotations is nil at decode time.
+		// The important thing is that it did NOT panic with nil-map write.
+		if err != nil && err.Error() != "erase device annotation not found" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("WithAnnotationsErasesFirstContainer", func(t *testing.T) {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "erase-with-annos",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"hami.io/vgpu-devices-to-allocate": encoded,
+				},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+		}
+		client.KubeClient = fake.NewSimpleClientset(&pod)
+
+		err := eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, pod)
+		if err != nil {
+			t.Fatalf("eraseNextDeviceTypeFromAnnotation: %v", err)
+		}
+	})
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
@@ -941,7 +941,7 @@ func TestWriteMigConfig_RemovesStaleFileOnFailure(t *testing.T) {
 	}
 }
 
-func TestPatchErasedAnnotation(t *testing.T) {
+func TestPatchErasedAnnotation_NilMapGuard(t *testing.T) {
 	dev := device.PodSingleDevice{
 		device.ContainerDevices{
 			{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice, Usedmem: 3000, Usedcores: 50},
@@ -1023,74 +1023,4 @@ func TestPatchErasedAnnotation(t *testing.T) {
 	})
 }
 
-// TestEraseNextDeviceTypeFromAnnotation directly exercises the
-// eraseNextDeviceTypeFromAnnotation var (the delegating wrapper) to confirm
-// that the delegation to patchErasedAnnotation does not panic when
-// pod.Annotations is nil and that the server-side patch is attempted via the
-// fake client without error.
-func TestEraseNextDeviceTypeFromAnnotation(t *testing.T) {
-	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
-	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
-	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
 
-	encoded := "GPU-03f69c50-207a-2038-9b45-23cac89cb67a,NVIDIA,3000,50:;"
-
-	t.Run("NilAnnotationsDoesNotPanic", func(t *testing.T) {
-		// Pod with nil Annotations — eraseNextDeviceTypeFromAnnotation
-		// receives a value copy of the pod, so patchErasedAnnotation
-		// must not panic when initialising the local copy's map.
-		pod := corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "erase-nil-annos",
-				Namespace: "default",
-				Annotations: map[string]string{
-					"hami.io/vgpu-devices-to-allocate": encoded,
-				},
-			},
-		}
-		client.KubeClient = fake.NewSimpleClientset(&pod)
-
-		// Nil out Annotations AFTER creating in fake client so the fake
-		// MergePatch still finds the pod, but the local copy has nil map.
-		pod.Annotations = nil
-
-		// Must not panic.
-		err := eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, pod)
-		// The decoded annotation was nil, so DecodePodDevices will fail to
-		// find the key and return "erase device annotation not found" — that
-		// is the expected error when Annotations is nil at decode time.
-		// The important thing is that it did NOT panic with nil-map write.
-		if err != nil && err.Error() != "erase device annotation not found" {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("WithAnnotationsErasesFirstContainer", func(t *testing.T) {
-		pod := corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "erase-with-annos",
-				Namespace: "default",
-				Annotations: map[string]string{
-					"hami.io/vgpu-devices-to-allocate": encoded,
-				},
-			},
-			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
-		}
-		client.KubeClient = fake.NewSimpleClientset(&pod)
-
-		err := eraseNextDeviceTypeFromAnnotation(nvidia.NvidiaGPUDevice, pod)
-		if err != nil {
-			t.Fatalf("eraseNextDeviceTypeFromAnnotation: %v", err)
-		}
-
-		// Assert persisted state in fake clientset
-		persistedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("failed to fetch persisted pod: %v", err)
-		}
-		expectedErased := ";;"
-		if got := persistedPod.Annotations["hami.io/vgpu-devices-to-allocate"]; got != expectedErased {
-			t.Errorf("persistedPod.Annotations[hami.io/vgpu-devices-to-allocate] = %q, want %q", got, expectedErased)
-		}
-	})
-}


### PR DESCRIPTION
Fixes #2462 

## What

Guard `patchErasedAnnotation()` against a nil `pod.Annotations` map before
writing to it, and have `eraseNextDeviceTypeFromAnnotation()` delegate to
this new helper instead of duplicating the same unguarded write.

## Why

`util.PatchPodAnnotations()` only performs a server-side merge patch via the
Kubernetes API client — it does not mutate the local `pod.Annotations` map.
When `pod.Annotations` is `nil` at the time `patchErasedAnnotation` runs,
writing directly to `pod.Annotations[annoKey]` panics with `"assignment to
entry in nil map"`, crashing the device-plugin daemon.

`eraseNextDeviceTypeFromAnnotation` previously called
`util.PatchPodAnnotations` directly with the same gap. It didn't have its
own separate local-map write before this change — the fix here is
delegating it to the shared, guarded helper rather than fixing a second
independent bug.

This mirrors the existing nil-map guard pattern already used in
`pkg/device/metax/sdevice.go` and `pkg/device/mthreads/device.go`.

## Testing

Added to `pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go`:

- `TestPatchErasedAnnotation`
  - `NilAnnotationsMapInitializedWithoutPanic` — exercises `patchErasedAnnotation` against a pod with `Annotations: nil` via a fake clientset; asserts no panic, `pod.Annotations` is initialized non-nil, and the encoded value matches.
  - `ExistingAnnotationsPreserved` — asserts pre-existing annotation keys are not overwritten.
- `TestEraseNextDeviceTypeFromAnnotation`
  - `NilAnnotationsDoesNotPanic` — calls `eraseNextDeviceTypeFromAnnotation` directly with `Annotations: nil`, asserts no panic.
  - `WithAnnotationsErasesFirstContainer` — verifies the standard erasure path still works.

Verified against the full package (Linux/WSL2, Go 1.26.5, CGO enabled — not
native Windows, where third-party NVML/cgroups deps fail to build):

```
$ gofmt -l ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/util_test.go
(no output)

$ go vet ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/...
(no output)

$ go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -race -count=1 -v -run "TestPatchErasedAnnotation|TestEraseNextDeviceTypeFromAnnotation"
--- PASS: TestPatchErasedAnnotation (0.01s)
    --- PASS: TestPatchErasedAnnotation/NilAnnotationsMapInitializedWithoutPanic (0.01s)
    --- PASS: TestPatchErasedAnnotation/ExistingAnnotationsPreserved (0.00s)
--- PASS: TestEraseNextDeviceTypeFromAnnotation (0.00s)
    --- PASS: TestEraseNextDeviceTypeFromAnnotation/NilAnnotationsDoesNotPanic (0.00s)
    --- PASS: TestEraseNextDeviceTypeFromAnnotation/WithAnnotationsErasesFirstContainer (0.00s)
PASS
ok  	github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin	1.068s

$ golangci-lint run ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/...
0 issues.
```

Branch rebased onto `upstream/master` (`87d9795`) for a clean merge.

## AI Assistance Disclosure

The implementation and test changes in this PR were generated with
assistance from Claude. I reviewed the generated diff against the actual
source in `util.go` before submitting, and re-ran verification myself after
catching that an initial `go vet` invocation was incorrectly scoped to two
files instead of the full package.

## Out of scope

`cudevshr.go`'s `Munmap` error handling was noticed during this work but is
intentionally left out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device annotation updates to preserve existing metadata while recording remaining device information.
  * Prevented errors when annotations are initially absent or uninitialized.
  * Ensured device-type removal correctly updates pod state and reports missing annotations as expected.
  * Persisted updated device information reliably after annotation changes.

* **Tests**
  * Added coverage for annotation creation, preservation, encoding, persistence, missing-annotation handling, and successful device-type removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->