### PR TITLE
fix(monitor): use IsValidUUID to skip uninitialised device UUIDs in scrape path

### DIFF
--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -64,15 +64,17 @@ func (s *stubInfo) DeviceMemoryOffset(int) uint64        { return 0 }
 func (s *stubInfo) DeviceMemoryTotal(i int) uint64       { return slot(s.total, i) }
 func (s *stubInfo) DeviceSmUtil(i int) uint64            { return slot(s.smUtil, i) }
 func (s *stubInfo) SetDeviceSmLimit(uint64)              {}
-func (s *stubInfo) IsValidUUID(i int) bool               { return i < len(s.uuids) }
-func (s *stubInfo) DeviceMemoryLimit(i int) uint64       { return slot(s.limit, i) }
-func (s *stubInfo) SetDeviceMemoryLimit(uint64)          {}
-func (s *stubInfo) LastKernelTime() int64                { return s.lastKernel }
-func (s *stubInfo) GetPriority() int                     { return s.priority }
-func (s *stubInfo) GetRecentKernel() int32               { return 1 }
-func (s *stubInfo) SetRecentKernel(int32)                {}
-func (s *stubInfo) GetUtilizationSwitch() int32          { return 0 }
-func (s *stubInfo) SetUtilizationSwitch(int32)           {}
+func (s *stubInfo) IsValidUUID(i int) bool {
+	return i >= 0 && i < len(s.uuids) && len(s.uuids[i]) > 0 && s.uuids[i][0] != 0
+}
+func (s *stubInfo) DeviceMemoryLimit(i int) uint64 { return slot(s.limit, i) }
+func (s *stubInfo) SetDeviceMemoryLimit(uint64)    {}
+func (s *stubInfo) LastKernelTime() int64          { return s.lastKernel }
+func (s *stubInfo) GetPriority() int               { return s.priority }
+func (s *stubInfo) GetRecentKernel() int32         { return 1 }
+func (s *stubInfo) SetRecentKernel(int32)          {}
+func (s *stubInfo) GetUtilizationSwitch() int32    { return 0 }
+func (s *stubInfo) SetUtilizationSwitch(int32)     {}
 
 func TestCheckFunctionsHighPriority(t *testing.T) {
 	sw := map[string]UtilizationPerDevice{"gpu-0": {0, 1}}

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -428,14 +428,13 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 
 	// Iterate through each device
 	for i := range c.Info.DeviceNum() {
-		uuid := c.Info.DeviceUUID(i)
-		if len(uuid) < 40 {
-			klog.Warningf("Device %d in Pod %s/%s, Container %s has invalid UUID length %d (shared memory not yet initialised); skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name, len(uuid))
+		if !c.Info.IsValidUUID(i) {
+			klog.Warningf("Device %d in Pod %s/%s, Container %s UUID not yet initialised; skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name)
 			continue
 		}
-		uuid = uuid[0:40] // Ensure UUID is truncated to 40 characters
+		uuid := c.Info.DeviceUUID(i)[0:40]
 		if !utf8.ValidString(uuid) {
-			klog.Warningf("Device %d in Pod %s/%s, Container %s has invalid UTF-8 UUID (shared memory not yet initialised); skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name)
+			klog.Warningf("Device %d in Pod %s/%s, Container %s has invalid UTF-8 UUID; skipping until next scrape", i, pod.Namespace, pod.Name, ctr.Name)
 			continue
 		}
 

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -133,13 +133,13 @@ func TestCollectContainerMetricsBadInput(t *testing.T) {
 	if _, err := collectContainer(t, &nvidia.ContainerUsage{}, 0); err == nil {
 		t.Error("nil ContainerUsage.Info should return an error")
 	}
-	short := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{"gpu-short"}}}
-	metrics, err := collectContainer(t, short, 0)
+	uninit := &nvidia.ContainerUsage{Info: &stubInfo{uuids: []string{"\x00" + strings.Repeat("\x00", 39)}}}
+	metrics, err := collectContainer(t, uninit, 0)
 	if err != nil {
-		t.Fatalf("a UUID shorter than 40 chars should be skipped, not error: %v", err)
+		t.Fatalf("uninitialized UUID should be skipped, not error: %v", err)
 	}
 	if len(metrics) != 0 {
-		t.Errorf("got %d metrics for a short UUID, want 0", len(metrics))
+		t.Errorf("got %d metrics for an uninitialized UUID, want 0", len(metrics))
 	}
 }
 


### PR DESCRIPTION
## Summary

`collectContainerMetrics` guarded against uninitialized device UUIDs with
`len(uuid) < 40`. This check is dead code: `DeviceUUID()` returns
`string(s.sr.uuids[i].uuid[:])` where `uuid` is `[96]byte`, so `len` is
always 96 and the condition never fires.

The consequence: a container that is starting up, whose UUID slot has not yet
been written by libvgpu, passes through the guard with 40 null bytes emitted
as a Prometheus `device_uuid` label value instead of being skipped.

`IsValidUUID(i)` already exists in the `UsageInfo` interface and checks
`uuid[0] != 0` - the correct "has libvgpu written this slot?" test. It is
already used this way in `feedback.go` (line 86). This PR applies the same
pattern to the scrape path.

**Changes:**
- `cmd/vGPUmonitor/metrics.go`: replace `len(uuid) < 40` with
  `!c.Info.IsValidUUID(i)`; move the check before `DeviceUUID` to match
  `feedback.go` and avoid a string allocation on uninitialized slots;
  collapse `uuid := c.Info.DeviceUUID(i)[0:40]` into one statement
- `cmd/vGPUmonitor/feedback_test.go`: update `stubInfo.IsValidUUID` from
  `i < len(s.uuids)` (always true within the loop) to check `uuid[0] != 0`,
  matching the real implementation
- `cmd/vGPUmonitor/metrics_container_test.go`: replace the "short UUID" test
  case (tests a scenario that cannot occur in production since `DeviceUUID`
  always returns 96 bytes) with an uninitialized-UUID case (null first byte)
  that actually exercises the guard

**Which issue(s) this PR fixes:**
Part of #2126 (LFX observability hardening - Prometheus metric label correctness)

**Special notes for your reviewer:**
PR #2364 changed `return` → `continue` for this check, but the check itself
was always unreachable. This PR makes the guard fire for the case it was
written for. The `utf8.ValidString` check underneath is left unchanged.

**Does this PR introduce a user-facing change?**
Yes containers in the startup phase no longer emit metrics with null-byte
`device_uuid` labels; those device slots are silently skipped until libvgpu
writes a valid UUID.

**AI Disclosure:**
AI assistance was used for code inspection and draft formatting; all logic,
test cases, and verification were manually reviewed and validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device UUID validation to ignore uninitialized or invalid device entries.
  - Prevented malformed UUID data from generating incorrect container metrics.
  - Ensured valid UUID values are safely handled and limited to the supported length.
  - Added safeguards for invalid text encoding in device identifiers.
  - Updated monitoring behavior so invalid device data is skipped without producing errors.
  - Confirmed that skipped invalid entries do not create misleading or incomplete monitoring results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->