### PR TITLE
fix(scheduler): keep per-type device allocations aligned to container index

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -135,7 +135,6 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 			// Assume the node is a fit by default. This handles pods with no device
 			// requests, which should be schedulable on any node.
 			ctrfit := true
-			deviceType := ""
 			//This loop is for different container request
 			for ctrid, n := range resourceReqs {
 				sums := 0
@@ -143,21 +142,39 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 					sums += int(k.Nums)
 				}
 
-				// container need no device and we have got certain deviceType
-				if sums == 0 && deviceType != "" {
-					score.Devices[deviceType] = append(score.Devices[deviceType], device.ContainerDevices{})
+				// container needs no device: keep every type discovered so far aligned
+				// to this container index by appending a trailing empty slot to each.
+				if sums == 0 {
+					for idx := range score.Devices {
+						for len(score.Devices[idx]) <= ctrid {
+							score.Devices[idx] = append(score.Devices[idx], device.ContainerDevices{})
+						}
+					}
 					continue
 				}
 				klog.V(5).InfoS("fitInDevices", "pod", klog.KObj(task), "node", nodeID)
+				requestedTypes := make(map[string]bool, len(n))
+				for _, k := range n {
+					requestedTypes[k.Type] = true
+				}
 				fit, reason := fitInDevices(node, n, task, nodeInfo, &score.Devices)
-				// found certain deviceType, fill missing empty allocation for containers before this
+				// keep every device type's allocation list aligned to container index:
+				// - types this container just requested: fitInDevices appended the real
+				//   entry at the tail, so pad any missing leading slots in front of it.
+				// - types only requested by earlier containers: append one trailing
+				//   empty slot for this container.
 				for idx := range score.Devices {
-					deviceType = idx
-					for len(score.Devices[idx]) <= ctrid {
-						emptyContainerDevices := device.ContainerDevices{}
-						emptyPodSingleDevice := device.PodSingleDevice{}
-						emptyPodSingleDevice = append(emptyPodSingleDevice, emptyContainerDevices)
-						score.Devices[idx] = append(emptyPodSingleDevice, score.Devices[idx]...)
+					if requestedTypes[idx] {
+						for len(score.Devices[idx]) <= ctrid {
+							emptyContainerDevices := device.ContainerDevices{}
+							emptyPodSingleDevice := device.PodSingleDevice{}
+							emptyPodSingleDevice = append(emptyPodSingleDevice, emptyContainerDevices)
+							score.Devices[idx] = append(emptyPodSingleDevice, score.Devices[idx]...)
+						}
+					} else {
+						for len(score.Devices[idx]) <= ctrid {
+							score.Devices[idx] = append(score.Devices[idx], device.ContainerDevices{})
+						}
 					}
 				}
 				ctrfit = fit

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3659,3 +3659,73 @@ func Test_fitInDevices_MultiTypePartition(t *testing.T) {
 	assert.Equal(t, len((*devinput)["mockB"][0]), 1)
 	assert.Equal(t, (*devinput)["mockB"][0][0].UUID, "uuid-b")
 }
+
+// Test_calcScore_MultiTypeContainerAlignment guards against container-index
+// misalignment in calcScoreWithOptions: for a pod whose containers request
+// different device types (container 0 = mockA, container 1 = mockB), each
+// type's per-container allocation list must stay aligned to container index.
+// The bug fixed here prepended a padding slot to every already-discovered
+// type instead of only the type just requested, shifting container 0's real
+// mockA allocation into container 1's slot. See Project-HAMi/HAMi#2335.
+func Test_calcScore_MultiTypeContainerAlignment(t *testing.T) {
+	oldDevicesMap := device.DevicesMap
+	defer func() { device.DevicesMap = oldDevicesMap }()
+	device.DevicesMap = map[string]device.Devices{
+		"mockA": &fitMockDevice{typeName: "mockA", uuid: "uuid-a"},
+		"mockB": &fitMockDevice{typeName: "mockB", uuid: "uuid-b"},
+	}
+
+	nodes := &map[string]*NodeUsage{
+		"node-1": {
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{Device: &device.DeviceUsage{
+						ID: "uuid-a", Type: "mockA",
+						Count: 4, Used: 0, Totalcore: 100, Usedcores: 0, Totalmem: 8192, Usedmem: 0, Health: true,
+					}},
+					{Device: &device.DeviceUsage{
+						ID: "uuid-b", Type: "mockB",
+						Count: 4, Used: 0, Totalcore: 100, Usedcores: 0, Totalmem: 8192, Usedmem: 0, Health: true,
+					}},
+				},
+			},
+		},
+	}
+	// container 0 requests mockA, container 1 requests mockB.
+	resourceReqs := device.PodDeviceRequests{
+		{"mockA-req": device.ContainerDeviceRequest{Nums: 1, Type: "mockA", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+		{"mockB-req": device.ContainerDeviceRequest{Nums: 1, Type: "mockB", Memreq: 1024, MemPercentagereq: 101, Coresreq: 1}},
+	}
+	task := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-multi-type"}}
+
+	s := NewScheduler()
+	s.addNode("node-1", &device.NodeInfo{
+		ID:   "node-1",
+		Node: (*nodes)["node-1"].Node,
+		Devices: map[string][]device.DeviceInfo{
+			"mockA": {{ID: "uuid-a", Type: "mockA"}},
+			"mockB": {{ID: "uuid-b", Type: "mockB"}},
+		},
+	})
+
+	failedNodes := map[string]string{}
+	got, err := s.calcScore(nodes, resourceReqs, task, failedNodes)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, failedNodes, map[string]string{})
+	assert.Equal(t, len(got.NodeList), 1)
+
+	devices := got.NodeList[0].Devices
+
+	// mockA must stay with container 0; container 1's slot must be empty.
+	assert.Equal(t, len(devices["mockA"]), 2)
+	assert.Equal(t, len(devices["mockA"][0]), 1)
+	assert.Equal(t, devices["mockA"][0][0].UUID, "uuid-a")
+	assert.Equal(t, len(devices["mockA"][1]), 0)
+
+	// mockB must stay with container 1; container 0's slot must be empty.
+	assert.Equal(t, len(devices["mockB"]), 2)
+	assert.Equal(t, len(devices["mockB"][0]), 0)
+	assert.Equal(t, len(devices["mockB"][1]), 1)
+	assert.Equal(t, devices["mockB"][1][0].UUID, "uuid-b")
+}


### PR DESCRIPTION
## What this PR does
Fixes container-index misalignment of per-type device allocations in `calcScoreWithOptions` (`pkg/scheduler/score.go`).

## Why
For a pod whose containers request **different** device types (e.g. container 0 requests an NVIDIA GPU, container 1 requests a second vendor's device), the "fill missing empty allocation" step padded missing per-container slots by **prepending** an empty slot to **every already-discovered device type**, not just the type the current container had just requested:

```go
for idx := range score.Devices {
    deviceType = idx
    for len(score.Devices[idx]) <= ctrid {
        ...
        score.Devices[idx] = append(emptyPodSingleDevice, score.Devices[idx]...)
    }
}
```

Once a second device type is discovered at container N, this loop also revisits the *already-correctly-aligned* first type and prepends to it, shifting an earlier container's real allocation into a later container's slot. `PatchAnnotations` → `EncodePodSingleDevice` writes that corrupted list into the pod's annotations verbatim, and the device plugin's `Allocate()` reads it back by container index — so a container can end up being granted a device that the scheduler actually assigned to a *different* container.

A secondary flaw: the no-device-container path (`sums == 0`) only padded one arbitrarily-chosen type (`deviceType`, whatever the last map-iteration happened to set), not every discovered type, so interleaving a no-device container between two different device types also broke alignment.

This was previously reported as #2335, with a fix proposed in #2337 — but #2337 was closed without being merged, so the bug is still present on current master (`3616313`). I hit the same issue independently while reviewing the scheduler package and am resubmitting a fix with a regression test.

## What changed
- Track the device type(s) the *current* container actually requested (from `n`, via each request's `.Type` field — not the map's annotation-name keys).
- Only that type gets the leading-pad treatment (to keep the just-appended real entry aligned at index `ctrid`); every other already-discovered type gets a single trailing empty slot instead of being shifted.
- The no-device-container path now pads *every* discovered type with a trailing empty slot, not just one.
- Added `Test_calcScore_MultiTypeContainerAlignment` in `pkg/scheduler/score_test.go`, covering a 2-container pod where container 0 requests mock type A and container 1 requests mock type B, asserting each type's allocation stays at the correct container index.

## Verification
- `go build ./...`
- `go test ./pkg/scheduler/... -short --race -count=1` (all pass, including the new regression test, which fails against the pre-fix code)
- `go vet ./pkg/scheduler/...`
- `golangci-lint run ./pkg/scheduler/...` (0 issues)
- `hack/verify-import-aliases.sh` (pass)

Fixes #2335

## AI assistance disclosure
This bug was found and the fix + regression test were drafted with AI assistance (Claude Code) under my review. I read and verified the root cause, the fix, and the test, and take responsibility for their correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device allocation scoring across containers requesting different device types.
  * Ensured containers without device requests and those requesting specific types retain correctly aligned allocation slots.
  * Prevented incorrect device placement and scoring outcomes in multi-device-type scheduling scenarios.

* **Tests**
  * Added coverage for multi-type container allocation alignment and successful node scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->