### PR TITLE
fix(scheduler): serialize Filter device selection to prevent double GPU allocation

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -78,6 +78,10 @@ type Scheduler struct {
 
 	lock   sync.RWMutex
 	synced bool
+
+	// filterLock serializes device selection in Filter so concurrent requests
+	// cannot reserve the same device (issue #2232).
+	filterLock sync.Mutex
 }
 
 func NewScheduler() *Scheduler {
@@ -953,31 +957,70 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		"pod", klog.KObj(args.Pod),
 		"reason", "request does not contain full nodes",
 		"nodeNamesLen", nodeNamesLen(args.NodeNames))
+	// selectAndCommitDevice holds filterLock during selection; the annotation
+	// patch below runs outside it (issue #2232).
+	selection, err := s.selectAndCommitDevice(args, resourceReqs)
+	if err != nil {
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		return nil, err
+	}
+	if selection.chosen == nil {
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
+		return &extenderv1.ExtenderFilterResult{
+			FailedNodes: selection.failedNodes,
+		}, nil
+	}
+	m := selection.chosen
+	// Patch the annotation outside the lock; roll back the cache on failure.
+	if err = util.PatchPodAnnotations(args.Pod, selection.annotations); err != nil {
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		if selection.added {
+			s.quotaManager.RmUsage(args.Pod, m.Devices)
+		}
+		s.podManager.DelPod(args.Pod)
+		return nil, err
+	}
+	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, selection.nodeList)
+	s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringSucceed, successMsg, nil)
+	res := extenderv1.ExtenderFilterResult{NodeNames: &[]string{m.NodeID}}
+	return &res, nil
+}
+
+// filterSelection holds a Filter reservation; chosen is nil when no node fits
+// (failedNodes then carries the per-node reasons).
+type filterSelection struct {
+	chosen      *policy.NodeScore
+	annotations map[string]string
+	added       bool
+	nodeList    []*policy.NodeScore
+	failedNodes map[string]string
+}
+
+// selectAndCommitDevice selects a device and commits it to the cache under
+// filterLock. It does not publish the pod annotation; the caller patches it.
+func (s *Scheduler) selectAndCommitDevice(args extenderv1.ExtenderArgs, resourceReqs device.PodDeviceRequests) (*filterSelection, error) {
+	s.filterLock.Lock()
+	defer s.filterLock.Unlock()
+
+	selection := &filterSelection{}
 	if pi, ok := s.podManager.TakeAndDeletePod(args.Pod); ok {
 		s.quotaManager.RmUsage(args.Pod, pi.Devices)
 	}
 	nodeUsage, _, failedNodes, err := s.getNodesUsage(args.NodeNames, args.Pod)
 	if err != nil {
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
 		return nil, err
 	}
 	if len(failedNodes) != 0 {
-		klog.V(5).InfoS("Nodes failed during usage retrieval",
-			"nodes", failedNodes)
+		klog.V(5).InfoS("Nodes failed during usage retrieval", "nodes", failedNodes)
 	}
 	nodeScores, err := s.calcScore(nodeUsage, resourceReqs, args.Pod, failedNodes)
 	if err != nil {
-		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		return nil, err
+		return nil, fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
 	}
 	if len((*nodeScores).NodeList) == 0 {
-		klog.V(4).InfoS("No available nodes meet the required scores",
-			"pod", args.Pod.Name)
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
-		return &extenderv1.ExtenderFilterResult{
-			FailedNodes: failedNodes,
-		}, nil
+		klog.V(4).InfoS("No available nodes meet the required scores", "pod", args.Pod.Name)
+		selection.failedNodes = failedNodes
+		return selection, nil
 	}
 	klog.V(4).Infoln("nodeScores_len=", len((*nodeScores).NodeList))
 	sort.Sort(nodeScores)
@@ -990,29 +1033,17 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 	annotations := make(map[string]string)
 	annotations[util.AssignedNodeAnnotations] = m.NodeID
 	annotations[util.AssignedTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
-
 	for _, val := range device.GetDevices() {
 		val.PatchAnnotations(args.Pod, &annotations, m.Devices)
 	}
-
-	added := s.podManager.AddPod(args.Pod, m.NodeID, m.Devices)
-	if added {
+	selection.chosen = m
+	selection.annotations = annotations
+	selection.nodeList = nodeScores.NodeList
+	selection.added = s.podManager.AddPod(args.Pod, m.NodeID, m.Devices)
+	if selection.added {
 		s.quotaManager.AddUsage(args.Pod, m.Devices)
 	}
-
-	err = util.PatchPodAnnotations(args.Pod, annotations)
-	if err != nil {
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		if added {
-			s.quotaManager.RmUsage(args.Pod, m.Devices)
-		}
-		s.podManager.DelPod(args.Pod)
-		return nil, err
-	}
-	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, nodeScores.NodeList)
-	s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringSucceed, successMsg, nil)
-	res := extenderv1.ExtenderFilterResult{NodeNames: &[]string{m.NodeID}}
-	return &res, nil
+	return selection, nil
 }
 
 func (s *Scheduler) filterSimulation(args extenderv1.ExtenderArgs, resourceReqs device.PodDeviceRequests) (*extenderv1.ExtenderFilterResult, error) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1762,6 +1763,163 @@ func Test_Filter_EvictsStaleEntry(t *testing.T) {
 	for _, v := range *s.quotaManager.GetResourceQuota()[pod.Namespace] {
 		assert.Equal(t, int64(0), v.Used)
 	}
+}
+
+// Test_Filter_ConcurrentNoDoubleAllocation asserts that concurrent Filter
+// calls do not reserve the same device (issue #2232). Each device holds one
+// pod, so the 8 pods must each get a distinct device id.
+func Test_Filter_ConcurrentNoDoubleAllocation(t *testing.T) {
+	const numPods = 8
+
+	require.NoError(t, config.InitDevicesWithConfig(&config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultGPUNum:                1,
+		},
+	}))
+
+	client.KubeClient = fake.NewClientset()
+	t.Cleanup(func() { client.KubeClient = nil })
+	s := NewScheduler()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// One node with numPods devices; each device fits exactly one pod.
+	deviceInfos := make([]device.DeviceInfo, 0, numPods)
+	for i := range numPods {
+		deviceInfos = append(deviceInfos, device.DeviceInfo{
+			ID:           fmt.Sprintf("device-%d", i),
+			Index:        uint(i),
+			Count:        10,
+			Devmem:       8000,
+			Devcore:      100,
+			Mode:         "hami",
+			Type:         nvidia.NvidiaGPUDevice,
+			Health:       true,
+			DeviceVendor: nvidia.NvidiaGPUDevice,
+		})
+	}
+	s.addNode("node1", &device.NodeInfo{
+		ID:   "node1",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: deviceInfos,
+		},
+	})
+
+	// Create the pods in the fake apiserver so PatchPodAnnotations succeeds.
+	pods := make([]*corev1.Pod, numPods)
+	for i := range numPods {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("pod-%d", i),
+				UID:  types.UID(fmt.Sprintf("uid-%d", i)),
+				Annotations: map[string]string{
+					util.GPUSchedulerPolicyAnnotationKey:  util.GPUSchedulerPolicyBinpack.String(),
+					util.NodeSchedulerPolicyAnnotationKey: util.NodeSchedulerPolicyBinpack.String(),
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "gpu-burn",
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+						"hami.io/gpumem":   *resource.NewQuantity(5000, resource.BinarySI),
+						"hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+					}},
+				}},
+			},
+		}
+		pods[i] = pod
+		_, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	nodeNames := []string{"node1"}
+
+	// Barrier so all goroutines enter Filter simultaneously.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range numPods {
+		wg.Add(1)
+		go func(pod *corev1.Pod) {
+			defer wg.Done()
+			<-start
+			_, _ = s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &nodeNames})
+		}(pods[i])
+	}
+	close(start)
+	wg.Wait()
+
+	// Every pod must have been annotated with a distinct device id.
+	seen := make(map[string]string, numPods) // deviceID -> podName
+	for _, pod := range pods {
+		refreshed, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(t.Context(), pod.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		allocated, err := device.DecodePodDevices(device.InRequestDevices, refreshed.Annotations)
+		require.NoError(t, err, "decoding devices for pod %s", pod.Name)
+		single, ok := allocated[nvidia.NvidiaGPUDevice]
+		require.True(t, ok && len(single) > 0 && len(single[0]) > 0, "pod %s has no allocated device", pod.Name)
+		deviceID := single[0][0].UUID
+		require.NotEmpty(t, deviceID, "pod %s has empty device id", pod.Name)
+		if other, dup := seen[deviceID]; dup {
+			t.Fatalf("device %s double-allocated to pod %s and pod %s", deviceID, other, pod.Name)
+		}
+		seen[deviceID] = pod.Name
+	}
+	require.Len(t, seen, numPods, "expected each pod on a distinct device")
+}
+
+// Test_Filter_RollbackOnPatchFailure verifies that when the annotation patch
+// fails, Filter rolls back the reservation it just committed to the cache.
+func Test_Filter_RollbackOnPatchFailure(t *testing.T) {
+	require.NoError(t, config.InitDevicesWithConfig(&config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:  "hami.io/gpu",
+			ResourceMemoryName: "hami.io/gpumem",
+			ResourceCoreName:   "hami.io/gpucores",
+			DefaultGPUNum:      1,
+		},
+	}))
+	// Empty clientset: the pod is unknown to the apiserver, so PatchPodAnnotations fails.
+	client.KubeClient = fake.NewClientset()
+	t.Cleanup(func() { client.KubeClient = nil })
+
+	s := NewScheduler()
+	s.addNode("node1", &device.NodeInfo{
+		ID:   "node1",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID: "device1", Index: 0, Count: 10, Devmem: 8000, Devcore: 100,
+				Mode: "hami", Type: nvidia.NvidiaGPUDevice, Health: true, DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-fail", UID: "uid-fail"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "c",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"hami.io/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+				"hami.io/gpumem": *resource.NewQuantity(1000, resource.BinarySI),
+			}},
+		}}},
+	}
+
+	_, err := s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &[]string{"node1"}})
+	require.Error(t, err, "expected patch failure to surface as an error")
+
+	_, inCache := s.podManager.GetPod(pod)
+	require.False(t, inCache, "reservation must be rolled back when the annotation patch fails")
 }
 
 func TestFilterUsesTemplateNodesWithoutSideEffects(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

Fixes #2232 — *并发创建 pod 情况下，存在 pod 中卡 id 的注解和实际 pod 中使用卡的 id 不一致问题* (under concurrent pod creation, the GPU id annotated on a pod is inconsistent with the GPU id the pod actually uses).

The reported consequence is duplicate card allocation: the shared card gets over-allocated (causing OOM) while other idle cards cannot be handed out.

### Root cause

The scheduler extender is served over HTTP with **one goroutine per request** and provides no cross-request serialization guarantee. In `Filter`, the device-selection critical section was not atomic:

1. read node usage (`getNodesUsage`)
2. pick the best node/device (`calcScore`)
3. commit the reservation to the pod cache (`podManager.AddPod`)
4. publish the allocation onto the pod annotation (`PatchPodAnnotations`)

Under concurrent pod creation (e.g. a multi-replica Deployment), two `Filter` calls can both read the same free GPU in step 1 *before* either commits it in step 3, so both pods are annotated with the **same card id**.

In the normal kube-scheduler flow scheduling cycles are already serialized, which is why the problem only surfaces under concurrent/re-entrant extender requests.

### Fix

Add a `filterLock` and move the in-memory critical section (steps 1–3) into a `selectAndCommitDevice` helper that owns the lock through a single `defer Unlock`, so two pods can never reserve the same device. The lock is released before step 4 (`PatchPodAnnotations`), so concurrent Filters are never blocked on the apiserver round trip; the on-failure rollback runs outside the lock and is safe because the pod/quota managers have their own locks. The simulation path (`filterSimulation`) does not reserve devices and is unchanged.

This keeps the change minimal — it does **not** move reservation from `Filter` to `Bind` (the larger redesign from #2273 is tracked via the #2264 design discussion).

### Test

- `Test_Filter_ConcurrentNoDoubleAllocation` fires 8 pods at `Filter` simultaneously and asserts each is annotated with a **distinct** device id. Without the lock it reliably reports `device device-7 double-allocated to pod pod-0 and pod pod-2`; with the lock it passes (`-race`).
- `Test_Filter_RollbackOnPatchFailure` verifies the cache reservation is rolled back when the annotation patch fails.

### Validation

Scoped to the scheduler extender, so per CONTRIBUTING's hardware-validation gate this is validated with unit tests (including a `-race` regression test) rather than physical GPU hardware. `make verify` (license, import-aliases, golangci-lint) and `go test -race ./pkg/scheduler/...` pass locally.

**Which issue(s) this PR fixes:**
Fixes #2232

**Special notes for your reviewer:**
- A single `defer Unlock` in the helper means any early return added there in future can never leak the lock.
- A per-pod-UID lock was considered but not added: kube-scheduler runs one scheduling cycle at a time, so a pod UID is not filtered concurrently; the reproduced race is between *different* pods, which the global `filterLock` closes.

**Does this PR introduce a user-facing change?**
```release-note
Fixed a race in the scheduler extender's Filter that could assign the same GPU to multiple pods created concurrently (e.g. a multi-replica Deployment), causing duplicate card allocation and OOM. Device allocation in Filter is now serialized.
```

**AI assistance disclosure:**
This PR was written with AI assistance for codebase analysis, implementation and test generation. I reviewed, built and tested the change myself (`make verify`, `go test -race`) and can explain the locking semantics. Per CONTRIBUTING.md, disclosure belongs in the PR description only — no AI co-author trailers are used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent scheduling operations from assigning the same GPU to multiple pods.
  * Improved consistency of device usage tracking, scoring, reservations, cache updates, and pod annotations during live scheduling.
  * Released tentative GPU reservations when pod annotation updates fail.
  * Reduced the risk of conflicting GPU allocations when multiple pods are scheduled simultaneously.

* **Tests**
  * Added coverage verifying distinct GPU assignments during concurrent scheduling.
  * Added coverage confirming failed annotation updates return an error and remove tentative reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->