### PR TITLE
fix(device): hand out copies from PodManager instead of stored pointers

### DIFF
--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -649,3 +649,101 @@ func TestTakeAndDeletePodIsAtomic(t *testing.T) {
 	assert.False(t, ok2)
 	assert.Nil(t, pi2)
 }
+
+// The metrics collector scrapes on its own goroutine while the pod informer
+// keeps calling AddPod. Copying only the map would leave the collector holding
+// the stored *PodInfo, whose Devices field AddPod rewrites in place.
+func TestGetScheduledPodsCopiesEntries(t *testing.T) {
+	pm := NewPodManager()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "copy-uid",
+			Name:      "copy-pod",
+			Namespace: "default",
+		},
+	}
+	devices := func(mem int32) PodDevices {
+		return PodDevices{
+			"NVIDIA": PodSingleDevice{{{UUID: "dev-0", Usedmem: mem, Usedcores: 10}}},
+		}
+	}
+	pm.AddPod(pod, "node1", devices(1))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Go(func() {
+		for i := int32(0); ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				pm.AddPod(pod, "node1", devices(i))
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for range 20000 {
+			scheduled, _ := pm.GetScheduledPods()
+			for _, pi := range scheduled {
+				for _, single := range pi.Devices {
+					for _, ctr := range single {
+						for _, d := range ctr {
+							_ = d.Usedmem
+							_ = pi.Namespace
+						}
+					}
+				}
+			}
+		}
+		close(stop)
+	})
+
+	wg.Wait()
+}
+
+// A caller must not be able to reach into the manager through what it hands back.
+func TestGetScheduledPodsReturnsDetachedEntries(t *testing.T) {
+	pm := NewPodManager()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "detach-uid", Name: "detach-pod", Namespace: "default"},
+	}
+	pm.AddPod(pod, "node1", PodDevices{
+		"NVIDIA": PodSingleDevice{{{UUID: "dev-0", Usedmem: 100, Usedcores: 10}}},
+	})
+
+	scheduled, err := pm.GetScheduledPods()
+	assert.NoError(t, err)
+	scheduled["detach-uid"].Devices["NVIDIA"][0][0].Usedmem = 999
+	scheduled["detach-uid"].NodeID = "tampered"
+
+	again, _ := pm.GetScheduledPods()
+	assert.Equal(t, int32(100), again["detach-uid"].Devices["NVIDIA"][0][0].Usedmem)
+	assert.Equal(t, "node1", again["detach-uid"].NodeID)
+}
+
+func TestGetPodReturnsDetachedCopy(t *testing.T) {
+	pm := NewPodManager()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "getpod-uid", Name: "getpod", Namespace: "default"},
+	}
+	pm.AddPod(pod, "node1", PodDevices{
+		"NVIDIA": PodSingleDevice{{{UUID: "dev-0", Usedmem: 100, Usedcores: 10}}},
+	})
+
+	pi, ok := pm.GetPod(pod)
+	assert.True(t, ok)
+	pi.Devices["NVIDIA"][0][0].Usedmem = 999
+	pi.NodeID = "tampered"
+
+	again, ok := pm.GetPod(pod)
+	assert.True(t, ok)
+	assert.Equal(t, int32(100), again.Devices["NVIDIA"][0][0].Usedmem)
+	assert.Equal(t, "node1", again.NodeID)
+
+	missing, ok := pm.GetPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "nope"}})
+	assert.False(t, ok)
+	assert.Nil(t, missing)
+}

--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -110,12 +110,18 @@ func (m *PodManager) DelPod(pod *corev1.Pod) {
 	}
 }
 
+// GetPod returns a copy. AddPod and UpdatePod write to the stored PodInfo in
+// place, so handing out the pointer would let the caller read it while the
+// informer is rewriting it.
 func (m *PodManager) GetPod(pod *corev1.Pod) (*PodInfo, bool) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
 	pi, ok := m.pods[pod.UID]
-	return pi, ok
+	if !ok {
+		return nil, false
+	}
+	return pi.DeepCopy(), true
 }
 
 func (m *PodManager) TakeAndDeletePod(pod *corev1.Pod) (*PodInfo, bool) {
@@ -235,9 +241,13 @@ func (m *PodManager) GetScheduledPods() (map[k8stypes.UID]*PodInfo, error) {
 		"podCount", podCount,
 	)
 
-	// Return a shallow copy of the pods map to avoid race conditions.
-	// This prevents a "concurrent map iteration and map write" fatal error.
+	// Copy the entries, not just the map. Copying the map alone keeps callers
+	// off the manager's own map, but leaves them holding the stored *PodInfo,
+	// which AddPod and UpdatePod write to in place. The metrics collector ranges
+	// over Devices after this returns, by which point the read lock is gone.
 	podsCopy := make(map[k8stypes.UID]*PodInfo, podCount)
-	maps.Copy(podsCopy, m.pods)
+	for uid, pi := range m.pods {
+		podsCopy[uid] = pi.DeepCopy()
+	}
 	return podsCopy, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`PodManager.GetScheduledPods` copies the map but returns the same `*PodInfo`
pointers it stores:

```go
// Return a shallow copy of the pods map to avoid race conditions.
// This prevents a "concurrent map iteration and map write" fatal error.
podsCopy := make(map[k8stypes.UID]*PodInfo, podCount)
maps.Copy(podsCopy, m.pods)
```

That does keep callers off the manager's own map, but `AddPod` writes to the
stored structs in place:

```go
m.pods[pod.UID].Devices = devices   // pods.go:72
```

and `UpdatePod` does the same with `pi.Pod`.

The only caller is the Prometheus collector in `cmd/scheduler/metrics.go`, which
runs on the scrape goroutine and ranges over `val.Devices` and reads
`val.Namespace` **after** `GetScheduledPods` has returned and the read lock is
gone. The pod informer calls `AddPod` on every pod add and update. The pointer
handoff is synchronised; the field reads are not.

`go test ./pkg/device/ --race` reports it on master:

```
WARNING: DATA RACE
Write at 0x00c000243a18 by goroutine 10:
  (*PodManager).AddPod()   pkg/device/pods.go:72
Previous read at 0x00c000243a18 by goroutine 11:
  ... ranging val.Devices, as the collector does
```

with a second report on the devices map itself, `mapIterStart` against
`mapassign_faststr`.

**The fix**

Copy the entries as well as the map, reusing the `PodInfo.DeepCopy` that
`ListPodsInfo` in the same file already relies on. `GetPod` gets the same
treatment: it has no non-test callers today, but it returns the stored pointer
in exactly the same way and is the same trap for the next caller.

This mirrors #2333, which made `nodeManager.GetNode` return a deep copy for the
node cache.

**Tests**

`TestGetScheduledPodsCopiesEntries` drives `AddPod` on one goroutine while a
second does what the collector does. `TestGetScheduledPodsReturnsDetachedEntries`
and `TestGetPodReturnsDetachedCopy` mutate what was handed back and assert the
manager's own state is untouched. All three fail on master, the first with five
`DATA RACE` reports, and pass here.

**Which issue(s) this PR fixes**:
Fixes #2471

**Special notes for your reviewer**:

The cost is a deep copy per scrape rather than a map copy. `ListPodsInfo`
already pays exactly that, so this is not a new class of cost, but it is worth
naming: on a large cluster the collector now copies every tracked pod's device
list once per scrape interval.

The cheaper alternative is to hold the read lock while the collector builds its
metric values, which avoids the copy but holds the lock across metric
construction. I went with the copy because it matches `ListPodsInfo` and #2333,
and keeps the locking discipline inside the manager rather than spreading it to
callers. Happy to switch if you would rather have the other trade.

Not validated on real hardware. The change is confined to the scheduler's
in-memory pod cache and is covered by unit tests, which CONTRIBUTING allows for
scheduler-scoped changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

---

AI assistance disclosure: this change was developed with Claude Code — spotting
the race, the fix, and the tests. Flagging the extent up front per CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod data retrieval to prevent callers from unintentionally modifying cached state.
  * Added safer handling for concurrent pod updates and scheduled-pod reads.
  * Missing pod lookups continue to be handled reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->