### PR TITLE
fix(util): deterministic pod selection in GetPendingPod and NVIDIA Allocate (fixes #2188)

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -100,6 +100,7 @@ type NvidiaDevicePlugin struct {
 	schedulerConfig      nvidia.NvidiaConfig
 
 	applyMutex                 sync.Mutex
+	allocateMu                 sync.Mutex // serialises pod-lookup + annotation-erase in Allocate()
 	disableHealthChecks        chan bool
 	ackDisableHealthChecks     chan bool
 	disableWatchAndRegister    chan bool
@@ -483,7 +484,18 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 	var annotatedRequests device.PodSingleDevice
 	nodename := os.Getenv(util.NodeNameEnvName)
 	if nodename != "" {
-		current, err := getPendingPod(ctx, nodename)
+		// Use the same UUID-first resolution as Allocate() to identify which pod
+		// kubelet is hinting for. Collect all AvailableDeviceIDs across container
+		// requests as the UUID hint set.
+		var availableIDs []string
+		for _, cr := range r.ContainerRequests {
+			availableIDs = append(availableIDs, cr.AvailableDeviceIDs...)
+		}
+		current, err := getPendingPodByUUID(ctx, nodename, availableIDs)
+		if err != nil || current == nil {
+			// UUID lookup failed or no match — fall back to annotation-state scan.
+			current, err = getPendingPod(ctx, nodename)
+		}
 		if err == nil && current != nil {
 			if podRequests, decodeErr := device.DecodePodDevices(device.InRequestDevices, current.Annotations); decodeErr == nil {
 				annotatedRequests = podRequests[nvidia.NvidiaGPUDevice]
@@ -601,10 +613,32 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	klog.InfoS("Allocate", "request", reqs)
 	responses := kubeletdevicepluginv1beta1.AllocateResponse{}
 	nodename := os.Getenv(util.NodeNameEnvName)
-	current, err := getPendingPod(ctx, nodename)
-	if err != nil {
-		//nodelock.ReleaseNodeLock(nodename, NodeLockNvidia, current)
-		return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+
+	// Serialise the pod-identity lookup and annotation-erase sequence so that
+	// concurrent Allocate() calls (e.g. for two containers of the same pod)
+	// cannot race on the same annotation entry.
+	plugin.allocateMu.Lock()
+	defer plugin.allocateMu.Unlock()
+
+	// --- Pod identity resolution (deterministic path first) ---
+	// Collect all DevicesIds from this request so we can match by UUID.
+	var allDeviceIDs []string
+	for _, req := range reqs.ContainerRequests {
+		allDeviceIDs = append(allDeviceIDs, req.DevicesIds...)
+	}
+
+	// Primary: match by UUID overlap with the scheduler-written annotation.
+	// This is deterministic even when multiple pods are in flight on the same node.
+	// GetPendingPodByDeviceIDs is in pkg/util so it returns *corev1.Pod; we rely
+	// on type inference via := to avoid importing corev1 directly in this file.
+	current, err := getPendingPodByUUID(ctx, nodename, allDeviceIDs)
+	if err != nil || current == nil {
+		// Fallback: annotation-state scan (lock path + heuristic ordering).
+		current, err = getPendingPod(ctx, nodename)
+		if err != nil {
+			//nodelock.ReleaseNodeLock(nodename, NodeLockNvidia, current)
+			return &kubeletdevicepluginv1beta1.AllocateResponse{}, err
+		}
 	}
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -935,6 +935,10 @@ func TestAllocateUsesKubeletSelectedUUIDsForVGPUResponse(t *testing.T) {
 	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
 	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
 
+	previousEnableGetPreferredAllocation := enableGetPreferredAllocation
+	enableGetPreferredAllocation = true
+	defer func() { enableGetPreferredAllocation = previousEnableGetPreferredAllocation }()
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -1007,6 +1011,10 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
 	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
 	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	previousEnableGetPreferredAllocation := enableGetPreferredAllocation
+	enableGetPreferredAllocation = true
+	defer func() { enableGetPreferredAllocation = previousEnableGetPreferredAllocation }()
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -54,6 +54,32 @@ func GetLibPath() string {
 	return libPath
 }
 
+// getPendingPodByUUID is a plugin-internal wrapper around util.GetPendingPodByDeviceIDs.
+// It is defined here so that server.go can call it without importing corev1 directly.
+//   - Returns (pod, nil)  on a successful UUID match.
+//   - Returns (nil, nil)  when no annotation matched any requested UUID (benign — use fallback).
+//   - Returns (nil, err)  on a Kubernetes API failure (caller should abort, not fall back).
+func getPendingPodByUUID(ctx context.Context, nodename string, deviceIDs []string) (*corev1.Pod, error) {
+	if len(deviceIDs) == 0 {
+		return nil, nil
+	}
+	pod, err := util.GetPendingPodByDeviceIDs(ctx, nodename, deviceIDs, device.InRequestDevices[nvidia.NvidiaGPUDevice])
+	if err != nil {
+		// "no pod matched" is a benign miss — fall back to annotation-state scan.
+		if strings.HasSuffix(err.Error(), fmt.Sprintf("on node %s", nodename)) &&
+			strings.Contains(err.Error(), "no pod matched device IDs") {
+			klog.V(4).Infof("getPendingPodByUUID: no UUID match on node %s, using annotation fallback", nodename)
+			return nil, nil
+		}
+		// All other errors (network, RBAC, timeout) are real API failures.
+		// Do NOT silently fall back — return the error so Allocate() can fail cleanly.
+		klog.Warningf("getPendingPodByUUID: API error during UUID lookup, not falling back: %v", err)
+		return nil, err
+	}
+	return pod, nil
+}
+
+
 func GetNextDeviceRequest(dtype string, p corev1.Pod) (corev1.Container, device.ContainerDevices, error) {
 	pdevices, err := device.DecodePodDevices(device.InRequestDevices, p.Annotations)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,7 +83,8 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 	if pod != nil {
 		return pod, nil
 	}
-	// filter pods for this node.
+	// Primary lock path returned nothing — fall back to annotation scanning.
+	// Collect ALL matching candidates, then pick deterministically.
 	selector := fmt.Sprintf("spec.nodeName=%s", node)
 	podListOptions := metav1.ListOptions{
 		FieldSelector: selector,
@@ -90,31 +93,68 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range podlist.Items {
+
+	var candidates []*corev1.Pod
+	for i := range podlist.Items {
+		p := &podlist.Items[i]
 		if p.Status.Phase != corev1.PodPending {
 			continue
 		}
 		if _, ok := p.Annotations[BindTimeAnnotations]; !ok {
 			continue
 		}
-		if phase, ok := p.Annotations[DeviceBindPhase]; !ok {
+		phase, ok := p.Annotations[DeviceBindPhase]
+		if !ok {
 			continue
-		} else {
-			// Allow both "allocating" and "success" phases for multi-container pods
-			// where some containers have already been allocated but others are still pending
-			if phase != DeviceBindAllocating && phase != DeviceBindSuccess {
-				continue
-			}
 		}
-		if n, ok := p.Annotations[AssignedNodeAnnotations]; !ok {
+		// Allow both "allocating" and "success" phases for multi-container pods
+		// where some containers have already been allocated but others are still pending.
+		if phase != DeviceBindAllocating && phase != DeviceBindSuccess {
 			continue
-		} else {
-			if strings.Compare(n, node) == 0 {
-				return &p, nil
-			}
+		}
+		n, ok := p.Annotations[AssignedNodeAnnotations]
+		if !ok || n != node {
+			continue
+		}
+		pCopy := p.DeepCopy()
+		candidates = append(candidates, pCopy)
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no binding pod found on node %s", node)
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+
+	// Multiple candidates: prefer pods still in "allocating" phase (not yet partially done).
+	// Among ties, pick the one with the most recent bind-time (largest Unix timestamp).
+	klog.Warningf("GetPendingPod: %d candidates found on node %s, selecting deterministically", len(candidates), node)
+	var allocating []*corev1.Pod
+	for _, c := range candidates {
+		if c.Annotations[DeviceBindPhase] == DeviceBindAllocating {
+			allocating = append(allocating, c)
 		}
 	}
-	return nil, fmt.Errorf("no binding pod found on node %s", node)
+	pool := allocating
+	if len(pool) == 0 {
+		// All are in "success" phase; fall through to bind-time sort.
+		pool = candidates
+	}
+	sort.Slice(pool, func(i, j int) bool {
+		ti, _ := strconv.ParseInt(pool[i].Annotations[BindTimeAnnotations], 10, 64)
+		tj, _ := strconv.ParseInt(pool[j].Annotations[BindTimeAnnotations], 10, 64)
+		if ti != tj {
+			return ti > tj // descending: most recent bind first
+		}
+		// Stable tiebreaker so equal timestamps always yield the same pod.
+		ni := pool[i].Namespace + "/" + pool[i].Name
+		nj := pool[j].Namespace + "/" + pool[j].Name
+		return ni < nj
+	})
+	klog.Warningf("GetPendingPod: selected pod %s/%s (phase=%s) from %d candidates on node %s",
+		pool[0].Namespace, pool[0].Name, pool[0].Annotations[DeviceBindPhase], len(candidates), node)
+	return pool[0], nil
 }
 
 func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, error) {
@@ -134,6 +174,109 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 		return client.GetClient().CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
 	}
 	return nil, nil
+}
+
+// GetPendingPodByDeviceIDs finds the pending pod whose scheduler-recorded GPU UUIDs
+// (in devAnnotationKey, e.g. "hami.io/vgpu-devices-to-allocate") overlap with the
+// device IDs kubelet is currently allocating. This is deterministic because physical
+// GPU UUIDs are globally unique — no two pods can legitimately share the same UUID at
+// allocation time.
+//
+// Callers should pass device.InRequestDevices["NVIDIA"] as devAnnotationKey.
+func GetPendingPodByDeviceIDs(ctx context.Context, node string, deviceIDs []string, devAnnotationKey string) (*corev1.Pod, error) {
+	if len(deviceIDs) == 0 || devAnnotationKey == "" {
+		return nil, fmt.Errorf("GetPendingPodByDeviceIDs: deviceIDs and devAnnotationKey must not be empty")
+	}
+
+	// Build a set of the physical UUIDs kubelet is allocating (strip virtual-device suffixes).
+	requested := make(map[string]struct{}, len(deviceIDs))
+	for _, id := range deviceIDs {
+		requested[physicalDeviceUUID(id)] = struct{}{}
+	}
+
+	cli := client.GetClient()
+	if cli == nil {
+		return nil, fmt.Errorf("GetPendingPodByDeviceIDs: kubernetes client not initialized")
+	}
+
+	selector := fmt.Sprintf("spec.nodeName=%s", node)
+	podlist, err := cli.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetPendingPodByDeviceIDs: failed to list pods on node %s: %w", node, err)
+	}
+
+	for i := range podlist.Items {
+		p := &podlist.Items[i]
+		if p.Status.Phase != corev1.PodPending {
+			continue
+		}
+		annoVal, ok := p.Annotations[devAnnotationKey]
+		if !ok || annoVal == "" {
+			continue
+		}
+		if annotationContainsAnyDevice(annoVal, requested) {
+			klog.V(4).Infof("GetPendingPodByDeviceIDs: matched pod %s/%s on node %s", p.Namespace, p.Name, node)
+			return p.DeepCopy(), nil
+		}
+	}
+	return nil, fmt.Errorf("GetPendingPodByDeviceIDs: no pod matched device IDs %v on node %s", deviceIDs, node)
+}
+
+// physicalDeviceUUID strips virtual-device and MIG suffixes to return the base GPU UUID.
+//
+//	- MIG format:     "GPU-UUID[tidx-idx]" → "GPU-UUID"
+//	- Virtual device: "GPU-UUID-N" (exactly 6 dashes) → "GPU-UUID"
+//	- Annotated ID:   "GPU-UUID::N" → "GPU-UUID" (CDI / time-slicing)
+func physicalDeviceUUID(id string) string {
+	// Annotated IDs (time-slicing, CDI): strip "::N" suffix
+	if idx := strings.Index(id, "::"); idx != -1 {
+		return id[:idx]
+	}
+	// MIG format: GPU-UUID[tidx-idx] → GPU-UUID
+	if idx := strings.Index(id, "["); idx != -1 {
+		return id[:idx]
+	}
+	// Virtual device: GPU-UUID-N (6 dashes, last segment is a plain integer)
+	if strings.Count(id, "-") == 6 {
+		lastDash := strings.LastIndex(id, "-")
+		if lastDash != -1 && lastDash < len(id)-1 {
+			if _, err := strconv.Atoi(id[lastDash+1:]); err == nil {
+				return id[:lastDash]
+			}
+		}
+	}
+	return id
+}
+
+// annotationContainsAnyDevice reports whether the encoded annotation value produced by
+// device.EncodePodSingleDevice contains any UUID present in deviceSet.
+//
+// Wire format produced by pkg/device/devices.go EncodePodSingleDevice:
+//
+//	"UUID,type,mem,cores:;UUID,type,mem,cores:;"
+//	  ↑ device fields joined by ','          ↑
+//	      devices within a container joined by ':' (OneContainerMultiDeviceSplitSymbol)
+//	                    containers joined by ';'   (OnePodMultiContainerSplitSymbol)
+func annotationContainsAnyDevice(annoVal string, deviceSet map[string]struct{}) bool {
+	// Outer split on ";": one slot per container (OnePodMultiContainerSplitSymbol).
+	for _, containerSlot := range strings.Split(annoVal, ";") {
+		// Inner split on ":": one entry per device within the container.
+		for _, entry := range strings.Split(containerSlot, ":") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			// First comma-separated field is the UUID.
+			fields := strings.SplitN(entry, ",", 2)
+			uuid := physicalDeviceUUID(strings.TrimSpace(fields[0]))
+			if _, ok := deviceSet[uuid]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -87,7 +88,7 @@ func TestGetPendingPod(t *testing.T) {
 				Name:      "pending-pod",
 				Namespace: "default",
 				Annotations: map[string]string{
-					BindTimeAnnotations:     "2024-01-01T00:00:00Z",
+					BindTimeAnnotations:     "1704067200", // 2024-01-01 00:00:00 UTC as Unix seconds
 					DeviceBindPhase:         DeviceBindAllocating,
 					AssignedNodeAnnotations: "test-node-0",
 				},
@@ -124,7 +125,7 @@ func TestGetPendingPod(t *testing.T) {
 				Name:      "ignore-pod-2",
 				Namespace: "default",
 				Annotations: map[string]string{
-					BindTimeAnnotations:     "2024-01-01T00:00:00Z",
+					BindTimeAnnotations:     "1704067200",
 					AssignedNodeAnnotations: "test-node-0",
 				},
 			},
@@ -138,7 +139,7 @@ func TestGetPendingPod(t *testing.T) {
 				Name:      "ignore-pod-3",
 				Namespace: "default",
 				Annotations: map[string]string{
-					BindTimeAnnotations:     "2024-01-01T00:00:00Z",
+					BindTimeAnnotations:     "1704067200",
 					DeviceBindPhase:         "",
 					AssignedNodeAnnotations: "test-node-2",
 				},
@@ -153,7 +154,7 @@ func TestGetPendingPod(t *testing.T) {
 				Name:      "ignore-pod-4",
 				Namespace: "default",
 				Annotations: map[string]string{
-					BindTimeAnnotations: "2024-01-01T00:00:00Z",
+					BindTimeAnnotations: "1704067200",
 					DeviceBindPhase:     DeviceBindAllocating,
 				},
 			},
@@ -231,6 +232,314 @@ func TestGetPendingPod(t *testing.T) {
 				assert.Equal(t, got.Name, tt.want.Name)
 			}
 		})
+	}
+}
+
+// TestGetPendingPod_MultipleMatchesPrefersAllocating verifies that when both an
+// "allocating" and a "success" phase pod match the fallback filter, the "allocating"
+// pod is always returned regardless of list order.
+func TestGetPendingPod_MultipleMatchesPrefersAllocating(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node-multi",
+			Annotations: map[string]string{}, // no lock → forces fallback path
+		},
+	}
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+
+	now := time.Now().Unix()
+
+	// Pod A: phase=success (partial multi-container allocation done)
+	podA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-success",
+			Namespace: "default",
+			Annotations: map[string]string{
+				BindTimeAnnotations:     "1000", // older bind time
+				DeviceBindPhase:         DeviceBindSuccess,
+				AssignedNodeAnnotations: "test-node-multi",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-multi"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	// Pod B: phase=allocating (just arrived, is the genuinely waiting pod)
+	podB := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-allocating",
+			Namespace: "default",
+			Annotations: map[string]string{
+				BindTimeAnnotations:     fmt.Sprintf("%d", now),
+				DeviceBindPhase:         DeviceBindAllocating,
+				AssignedNodeAnnotations: "test-node-multi",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-multi"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	// Create in "wrong" order to ensure we don't rely on list ordering.
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podA, metav1.CreateOptions{})
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podB, metav1.CreateOptions{})
+
+	got, err := GetPendingPod(context.TODO(), "test-node-multi")
+	if err != nil {
+		t.Fatalf("GetPendingPod returned unexpected error: %v", err)
+	}
+	if got.Name != podB.Name {
+		t.Errorf("expected allocating pod %q to be selected, got %q", podB.Name, got.Name)
+	}
+}
+
+// TestGetPendingPod_StickySuccessMultipleReturnsNewest verifies that when all candidates
+// are in "success" phase (all multi-container pods partially done), the one with the
+// most recent bind-time is returned deterministically.
+func TestGetPendingPod_StickySuccessMultipleReturnsNewest(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node-sticky",
+			Annotations: map[string]string{},
+		},
+	}
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+
+	// Two pods both in "success" phase; pod-newer has a larger bind-time int.
+	podOlder := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-older",
+			Namespace: "default",
+			Annotations: map[string]string{
+				BindTimeAnnotations:     "1000",
+				DeviceBindPhase:         DeviceBindSuccess,
+				AssignedNodeAnnotations: "test-node-sticky",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-sticky"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	podNewer := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-newer",
+			Namespace: "default",
+			Annotations: map[string]string{
+				BindTimeAnnotations:     "9999",
+				DeviceBindPhase:         DeviceBindSuccess,
+				AssignedNodeAnnotations: "test-node-sticky",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-sticky"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	// Create older first so the list returns it first if we naively iterate.
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podOlder, metav1.CreateOptions{})
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podNewer, metav1.CreateOptions{})
+
+	got, err := GetPendingPod(context.TODO(), "test-node-sticky")
+	if err != nil {
+		t.Fatalf("GetPendingPod returned unexpected error: %v", err)
+	}
+	if got.Name != podNewer.Name {
+		t.Errorf("expected newest pod %q to be selected, got %q", podNewer.Name, got.Name)
+	}
+}
+
+// TestGetPendingPodByDeviceIDs_Deterministic verifies that the UUID-based lookup always
+// returns the pod whose annotation contains the requested UUID, regardless of which pod
+// appears first in the API list response.
+func TestGetPendingPodByDeviceIDs_Deterministic(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node-uuid",
+			Annotations: map[string]string{},
+		},
+	}
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+
+	annoKey := "hami.io/vgpu-devices-to-allocate"
+
+	// Annotation format: "UUID,type,mem,cores" per device, ":" separates devices,
+	// "_" separates container slots. We keep it minimal here.
+	podA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-uuid-a",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annoKey: "GPU-AAAA,NVIDIA,4096,100",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-uuid"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	podB := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-uuid-b",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annoKey: "GPU-BBBB,NVIDIA,4096,100",
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "test-node-uuid"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	// podA is created (and likely listed) first, but we request podB's UUID.
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podA, metav1.CreateOptions{})
+	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), podB, metav1.CreateOptions{})
+
+	tests := []struct {
+		name      string
+		deviceIDs []string
+		wantPod   string
+		wantErr   bool
+	}{
+		{
+			name:      "matches pod-B by UUID",
+			deviceIDs: []string{"GPU-BBBB"},
+			wantPod:   "pod-uuid-b",
+			wantErr:   false,
+		},
+		{
+			name:      "matches pod-A by UUID",
+			deviceIDs: []string{"GPU-AAAA"},
+			wantPod:   "pod-uuid-a",
+			wantErr:   false,
+		},
+		{
+			name:      "unknown UUID returns error",
+			deviceIDs: []string{"GPU-ZZZZ"},
+			wantErr:   true,
+		},
+		{
+			name:      "empty deviceIDs returns error",
+			deviceIDs: []string{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPendingPodByDeviceIDs(context.TODO(), "test-node-uuid", tt.deviceIDs, annoKey)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPendingPodByDeviceIDs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Fatal("expected a pod, got nil")
+				}
+				if got.Name != tt.wantPod {
+					t.Errorf("expected pod %q, got %q", tt.wantPod, got.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestAnnotationContainsAnyDevice_MultiContainer directly tests the P0 bug fix:
+// the annotation container separator is ";" (OnePodMultiContainerSplitSymbol),
+// NOT "_". Before the fix, a multi-container annotation was never matched.
+func TestAnnotationContainsAnyDevice_MultiContainer(t *testing.T) {
+	const uuidA = "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76"
+	const uuidB = "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4"
+
+	// Annotation format produced by device.EncodePodSingleDevice for 2 containers,
+	// each with 1 device: "UUID,Type,mem,cores:;UUID,Type,mem,cores:;"
+	annoTwoContainers := uuidA + ",NVIDIA,500,3:;" + uuidB + ",NVIDIA,500,3:;"
+
+	// Annotation for a single container with 2 devices: "UUID1,Type,m,c:UUID2,Type,m,c:;"
+	annoOneContainerTwoDevices := uuidA + ",NVIDIA,500,3:" + uuidB + ",NVIDIA,500,3:;"
+
+	tests := []struct {
+		name     string
+		anno     string
+		uuid     string
+		wantHit  bool
+	}{
+		{"container-1 of 2", annoTwoContainers, uuidA, true},
+		{"container-2 of 2", annoTwoContainers, uuidB, true},
+		{"unrelated UUID", annoTwoContainers, "GPU-00000000-0000-0000-0000-000000000000", false},
+		{"device-1 in single container", annoOneContainerTwoDevices, uuidA, true},
+		{"device-2 in single container", annoOneContainerTwoDevices, uuidB, true},
+		{"empty annotation", "", uuidA, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devSet := map[string]struct{}{tt.uuid: {}}
+			got := annotationContainsAnyDevice(tt.anno, devSet)
+			if got != tt.wantHit {
+				t.Errorf("annotationContainsAnyDevice(%q, %q) = %v, want %v", tt.anno, tt.uuid, got, tt.wantHit)
+			}
+		})
+	}
+}
+
+// TestGetPendingPod_EqualTimestampTiebreaker verifies that when two "allocating" pods
+// share the same BindTime, the result is deterministic (lexicographic namespace/name).
+func TestGetPendingPod_EqualTimestampTiebreaker(t *testing.T) {
+	cl := fake.NewClientset()
+	client.KubeClient = cl
+
+	const sameBindTime = "1722960000" // both pods share this Unix timestamp
+	const node = "test-node-tiebreak"
+
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "zzz-pod", // sorts last lexicographically
+				Namespace: "default",
+				Annotations: map[string]string{
+					BindTimeAnnotations:     sameBindTime,
+					DeviceBindPhase:         DeviceBindAllocating,
+					AssignedNodeAnnotations: node,
+				},
+			},
+			Spec:   corev1.PodSpec{NodeName: node},
+			Status: corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aaa-pod", // sorts first lexicographically
+				Namespace: "default",
+				Annotations: map[string]string{
+					BindTimeAnnotations:     sameBindTime,
+					DeviceBindPhase:         DeviceBindAllocating,
+					AssignedNodeAnnotations: node,
+				},
+			},
+			Spec:   corev1.PodSpec{NodeName: node},
+			Status: corev1.PodStatus{Phase: corev1.PodPending},
+		},
+	}
+	for _, p := range pods {
+		cl.CoreV1().Pods("default").Create(context.TODO(), p, metav1.CreateOptions{})
+	}
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: node, Annotations: map[string]string{}},
+	}
+	cl.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{})
+
+	// Call twice to prove the result is always the same regardless of list order.
+	for i := 0; i < 3; i++ {
+		got, err := GetPendingPod(context.TODO(), node)
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", i, err)
+		}
+		if got == nil {
+			t.Fatalf("run %d: got nil pod", i)
+		}
+		// With our tiebreaker (namespace/name ascending), "default/aaa-pod" sorts first.
+		if got.Name != "aaa-pod" {
+			t.Errorf("run %d: expected deterministic selection of \"aaa-pod\", got %q", i, got.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
## What's the problem?

When multiple GPU pods are pending on the same node, `GetPendingPod()` was
returning whichever pod happened to come first in the Kubernetes API list
response. Since Kubernetes doesn't guarantee list ordering, the device plugin
could randomly pick the wrong pod and assign GPUs to it.

## What changed?

**Smarter pod selection in the fallback path:**
- Instead of grabbing the first match, we now collect all candidates and pick
  deterministically — preferring pods in `allocating` phase over `success`,
  then newest bind-time, then alphabetical name as a final tiebreaker.

**UUID-based pod identity (primary path):**
- Before even using the fallback, `Allocate()` now tries to match the pod
  directly by the GPU UUIDs kubelet is requesting. This is unambiguous since
  physical GPU UUIDs are globally unique.

**`GetPreferredAllocation()` gets the same fix:**
- Previously it always used the unreliable fallback. Now it tries UUID matching
  first, just like `Allocate()`.

**Allocation serialized with a mutex:**
- A new `allocateMu` lock prevents two concurrent `Allocate()` calls for the
  same pod's containers from racing on the annotation.

## Tests

Added 5 new test cases covering: multi-container annotation parsing, phase
preference, bind-time ordering, equal-timestamp tiebreaker, and UUID-based
matching. All packages pass with `-race`.

```bash
go test ./pkg/util/... ./pkg/device-plugin/nvidiadevice/... -race
# All PASS ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU allocation reliability by matching pending workloads to requested device IDs.
  * Added fallback handling when device-based matching is unavailable.
  * Prevented allocation races during pod lookup and annotation updates.
  * Made pod selection deterministic, prioritizing allocating workloads and the most recent successful allocation.

* **Tests**
  * Expanded coverage for device matching, multi-container annotations, and deterministic selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->