### PR TITLE
fix(cambricon): release node lock with Patch instead of Update

### DIFF
--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -1403,3 +1403,52 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 		})
 	}
 }
+
+// Test_ReleaseNodeLockUsesPatch pins the verb used to clear the lock. The
+// scheduler ServiceAccount holds get/list/patch/watch on nodes and not update,
+// so a release that reaches for Update is rejected and the lock is never
+// cleared, leaving the node unschedulable for MLU past the expiry. The fake
+// clientset does not enforce RBAC, so the deny has to be injected.
+func Test_ReleaseNodeLockUsesPatch(t *testing.T) {
+	dev := InitMLUDevice(CambriconConfig{
+		ResourceCountName:  "cambricon.com/mlu",
+		ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+		ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+	})
+
+	ctx := context.Background()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-verb-01", Annotations: map[string]string{}},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-verb-01", Namespace: "default"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "ctr",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				corev1.ResourceName(MLUResourceCount): resource.MustParse("1"),
+			}},
+		}}},
+	}
+
+	clientset := fake.NewClientset(node)
+	clientset.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "nodes"}, node.Name,
+			fmt.Errorf(`cannot update resource "nodes" in API group "" at the cluster scope`))
+	})
+	client.KubeClient = clientset
+	t.Cleanup(func() { client.KubeClient = nil })
+
+	assert.NoError(t, dev.LockNode(node, pod))
+	locked, err := clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locked.Annotations[DsmluLockTime], "setNodeLock should have recorded the lock")
+
+	assert.NoError(t, dev.ReleaseNodeLock(locked, pod), "release must not need the update verb")
+
+	released, err := clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, released.Annotations, DsmluLockTime, "lock annotation must be gone from the apiserver")
+
+	assert.NoError(t, dev.LockNode(released, pod), "node should be lockable again after release")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #2475

### Summary

`ReleaseNodeLock` in the cambricon backend cleared `cambricon.com/dsmlu.lock` with `Nodes().Update()`. The hami-scheduler ServiceAccount is granted `get, list, patch, watch` on nodes and not `update`, so the call is rejected, the retry loop burns its five attempts and the annotation stays on the node.

**Impact:**

- The lock is never released, so it survives past the 2 minute expiry.
- `LockNode` releases before re-locking once expired. It hits the same rejection and returns before reaching `setNodeLock`, so the node stops accepting MLU pods.
- Recovery needs an operator to delete the annotation by hand.

### Fix

Release with a strategic merge patch setting the annotation to null. `setNodeLock` a few lines above already patches, and `pkg/util/nodelock` does the same, so this brings the pair in line with the rest of the tree. A merge patch also carries no resourceVersion, so the retry loop retries instead of replaying one stale object.

### Test Plan

- `Test_ReleaseNodeLockUsesPatch` drives the real path with a fake client that rejects `update` on nodes the way RBAC does, then asserts the annotation is gone from the apiserver and the node can be locked again. Fails on master, passes here.
- The existing `Test_ReleaseNodeLock` only covers the two early returns and never reaches the client, which is why this went unnoticed.
- `go test ./pkg/device/... -short --race -count=1` passes
- `go test ./pkg/scheduler/... -short --race -count=1` passes
- `go vet`, `gofmt`, `goimports -local` clean
- Not run on MLU hardware, I do not have any. The failing path is scheduler side.

### Notes for the reviewer

Overlaps #2329, which rewrites this function for the three causes in #2251. Different root cause, so I kept the diff to the two call sites. Happy to rebase once that lands.

I left the `delete` on the caller's node alone even though it is the informer race from #2251, since #2329 already covers it and I did not want two PRs editing the same line.

### AI Assistance Disclosure

This PR was written primarily by Claude Code (bug identification, fix, and tests), reviewed and submitted by me.

**Does this PR introduce a user-facing change?**:

```release-note
Fix Cambricon MLU node locks never being released, which left nodes unable to schedule MLU pods until the lock annotation was removed manually.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that device node locks can be released through a patch operation when standard node updates are unavailable.
  * Confirmed lock annotations are removed correctly and that the node can be locked again afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->