### PR TITLE
 Race Condition Between Filter() and onAddPod() Causes Double Counting

### DIFF
--- a/pkg/scheduler/pod_lock.go
+++ b/pkg/scheduler/pod_lock.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sync"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+type refMutex struct {
+	sync.Mutex
+	refCount int
+}
+
+type podLockManager struct {
+	mu    sync.Mutex
+	locks map[k8stypes.UID]*refMutex
+}
+
+func newPodLockManager() *podLockManager {
+	return &podLockManager{
+		locks: make(map[k8stypes.UID]*refMutex),
+	}
+}
+
+func (m *podLockManager) Lock(uid k8stypes.UID) {
+	m.mu.Lock()
+	rm, exists := m.locks[uid]
+	if !exists {
+		rm = &refMutex{}
+		m.locks[uid] = rm
+	}
+	rm.refCount++
+	m.mu.Unlock()
+
+	rm.Lock()
+}
+
+func (m *podLockManager) Unlock(uid k8stypes.UID) {
+	m.mu.Lock()
+	rm, exists := m.locks[uid]
+	if !exists {
+		m.mu.Unlock()
+		return
+	}
+	rm.Unlock()
+	rm.refCount--
+	if rm.refCount == 0 {
+		delete(m.locks, uid)
+	}
+	m.mu.Unlock()
+}

--- a/pkg/scheduler/pod_lock_test.go
+++ b/pkg/scheduler/pod_lock_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func TestPodLockManager_LockUnlock(t *testing.T) {
+	mgr := newPodLockManager()
+	uid := k8stypes.UID("test-uid")
+
+	// Verify locking does not block a single goroutine
+	mgr.Lock(uid)
+	mgr.Unlock(uid)
+
+	// Verify concurrent access blocks and executes sequentially
+	var wg sync.WaitGroup
+	var order []int
+	var mu sync.Mutex
+
+	wg.Add(2)
+
+	mgr.Lock(uid)
+	go func() {
+		defer wg.Done()
+		mgr.Lock(uid)
+		mu.Lock()
+		order = append(order, 2)
+		mu.Unlock()
+		mgr.Unlock(uid)
+	}()
+
+	time.Sleep(50 * time.Millisecond) // Give the goroutine time to start and block
+	mu.Lock()
+	order = append(order, 1)
+	mu.Unlock()
+	mgr.Unlock(uid)
+
+	go func() {
+		defer wg.Done()
+		mgr.Lock(uid)
+		// Should succeed immediately because main locked and unlocked
+		mgr.Unlock(uid)
+	}()
+
+	wg.Wait()
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Errorf("Expected order [1, 2], got %v", order)
+	}
+}
+
+func TestPodLockManager_MemoryLeakClean(t *testing.T) {
+	mgr := newPodLockManager()
+	uid := k8stypes.UID("test-uid")
+
+	mgr.Lock(uid)
+	if len(mgr.locks) != 1 {
+		t.Errorf("Expected 1 lock in map, got %d", len(mgr.locks))
+	}
+	mgr.Unlock(uid)
+
+	if len(mgr.locks) != 0 {
+		t.Errorf("Expected 0 locks in map after unlock, got %d", len(mgr.locks))
+	}
+}


### PR DESCRIPTION
Closes #2478 
Race Condition Between Filter() and onAddPod() Causes Double Counting

| Field | Details |
|-------|---------|
| **Location** | `pkg/scheduler/scheduler.go` |
| **Description** | In `Filter()`, the pod is deleted from the pod manager (line 956), then device usage is recalculated (line 959), then the pod is re-added (line 998). Meanwhile, the pod informer's `onAddPod()` (line 138) can fire concurrently and also call `s.podManager.AddPod()`. Since the PodManager uses UID-based keys, if `onAddPod` fires between line 956 and line 998, the pod could be added twice with different device allocations, leading to double-counted resource usage in the quota manager. |
| **Reason** | No mutex protects the Filter → delete → recalculate → re-add cycle against informer callbacks. The PodManager has its own internal lock, but the *sequence* of operations across Filter and informer is not atomic. |

```mermaid
sequenceDiagram
    participant Filter as Filter()
    participant Informer as onAddPod()
    participant PM as PodManager
    participant QM as QuotaManager
    Filter->>PM: TakeAndDeletePod(pod)
    Note over Filter: Pod removed from cache
    Informer->>PM: AddPod(pod, nodeID, devices_old)
    PM-->>Informer: added=true
    Informer->>QM: AddUsage(pod, devices_old)
    Filter->>PM: AddPod(pod, nodeID, devices_new)
    PM-->>Filter: added=false already exists
    Note over QM: devices_old usage counted but never removed!
```

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability by serializing concurrent operations for each pod.
  * Ensured pod locks are released after successful processing and retried when release initially fails.
  * Cleaned up unused lock state to prevent memory growth.
* **Tests**
  * Added coverage for concurrent pod handling, lock cleanup, successful binding, and lock-release retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling reliability by serializing operations for each pod.
  * Prevented stale pod-lock entries from accumulating over time.
  * Safely ignores unlock attempts for unknown pods.

* **Tests**
  * Added coverage for locking, unlocking, concurrent access, sequential behavior, and lock cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->