### PR TITLE
fix/WebHookRoute() Panics on Nil Handler If Webhook Creation Fails

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -148,14 +148,15 @@ var newWebHook = scheduler.NewWebHook
 
 func WebHookRoute() httprouter.Handle {
 	h, err := newWebHook()
-	if err != nil {
-		klog.ErrorS(err, "Failed to create new webhook")
-	}
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infof("Handling webhook request on %s", r.URL.Path)
-		if h == nil {
-			klog.ErrorS(err, "Webhook handler is nil, webhook initialization failed")
-			http.Error(w, "webhook initialization failed", http.StatusInternalServerError)
+		if h == nil || err != nil {
+			errMsg := "Webhook handler is nil, webhook initialization failed"
+			if err != nil {
+				errMsg = fmt.Sprintf("Failed to create new webhook: %v", err)
+			}
+			klog.ErrorS(err, errMsg)
+			http.Error(w, errMsg, http.StatusInternalServerError)
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -144,13 +144,20 @@ func Bind(s *scheduler.Scheduler) httprouter.Handle {
 	}
 }
 
+var newWebHook = scheduler.NewWebHook
+
 func WebHookRoute() httprouter.Handle {
-	h, err := scheduler.NewWebHook()
+	h, err := newWebHook()
 	if err != nil {
 		klog.ErrorS(err, "Failed to create new webhook")
 	}
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infof("Handling webhook request on %s", r.URL.Path)
+		if h == nil {
+			klog.ErrorS(err, "Webhook handler is nil, webhook initialization failed")
+			http.Error(w, "webhook initialization failed", http.StatusInternalServerError)
+			return
+		}
 		h.ServeHTTP(w, r)
 	}
 }

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -97,33 +97,47 @@ func TestWebHookRoute(t *testing.T) {
 }
 
 func TestWebHookRoute_NilHandler(t *testing.T) {
-	// Mock newWebHook to return nil and an error
-	oldNewWebHook := newWebHook
+	origNewWebHook := newWebHook
+	defer func() { newWebHook = origNewWebHook }()
+
 	newWebHook = func() (*admission.Webhook, error) {
-		return nil, errors.New("mock webhook initialization error")
+		return nil, nil
 	}
-	defer func() {
-		newWebHook = oldNewWebHook
-	}()
 
 	handler := WebHookRoute()
-	if handler == nil {
-		t.Fatal("WebHookRoute returned nil handler")
-	}
-
 	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	handler(w, req, nil)
 
 	if w.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
+		t.Errorf("Expected status 500 for nil webhook handler, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Webhook handler is nil") {
+		t.Errorf("Expected response body to contain error string, got %s", w.Body.String())
+	}
+}
+
+func TestWebHookRoute_InitError(t *testing.T) {
+	origNewWebHook := newWebHook
+	defer func() { newWebHook = origNewWebHook }()
+
+	newWebHook = func() (*admission.Webhook, error) {
+		return nil, errors.New("custom init error")
 	}
 
-	expectedBody := "webhook initialization failed\n"
-	if w.Body.String() != expectedBody {
-		t.Errorf("Expected body %q, got %q", expectedBody, w.Body.String())
+	handler := WebHookRoute()
+	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+
+	handler(w, req, nil)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500 for webhook init error, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "custom init error") {
+		t.Errorf("Expected response body to contain error string, got %s", w.Body.String())
+>>>>>>> 4573a99 (added-test-and-suggested-fixes)
 	}
 }
 

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -20,12 +20,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/Project-HAMi/HAMi/pkg/scheduler"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
@@ -90,6 +93,37 @@ func TestWebHookRoute(t *testing.T) {
 
 	if w.Code == 0 {
 		t.Error("Expected a non-zero status code from webhook handler")
+	}
+}
+
+func TestWebHookRoute_NilHandler(t *testing.T) {
+	// Mock newWebHook to return nil and an error
+	oldNewWebHook := newWebHook
+	newWebHook = func() (*admission.Webhook, error) {
+		return nil, errors.New("mock webhook initialization error")
+	}
+	defer func() {
+		newWebHook = oldNewWebHook
+	}()
+
+	handler := WebHookRoute()
+	if handler == nil {
+		t.Fatal("WebHookRoute returned nil handler")
+	}
+
+	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler(w, req, nil)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	expectedBody := "webhook initialization failed\n"
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected body %q, got %q", expectedBody, w.Body.String())
 	}
 }
 

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -137,7 +137,6 @@ func TestWebHookRoute_InitError(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "custom init error") {
 		t.Errorf("Expected response body to contain error string, got %s", w.Body.String())
->>>>>>> 4573a99 (added-test-and-suggested-fixes)
 	}
 }
 


### PR DESCRIPTION


Closes #2485
kind/bug

| Field | Details |
|---|---|
| Location | `pkg/scheduler/routes/route.go` |
| Description | `WebHookRoute()` calls `scheduler.NewWebHook()` at line 148. If it returns an error, the error is only logged at line 150, but `h` will be nil. The returned handler closure at line 154 calls `h.ServeHTTP(w, r)` — calling a method on a nil pointer causes a panic, crashing the entire scheduler process. |
| Reason | Error is logged but not handled — nil `h` is used in the closure without a nil check. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook requests now return a clear HTTP 500 error when initialization fails or no handler is available.
  * Prevented potential server crashes caused by invalid webhook handlers.
  * Improved error handling so failed webhook setup produces a controlled response.

* **Tests**
  * Added coverage for initialization errors and unavailable handlers, including status codes and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### AI disclosure :
- AI assistance is used for code inspection and draft formatting adding tests.