### PR TITLE
fix(scheduler): serialize pod quota updates to avoid double counting

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -78,6 +78,12 @@ type Scheduler struct {
 
 	lock   sync.RWMutex
 	synced bool
+
+	// podMu serializes podAdd/podDelete/podRe-Add cycles between Filter()
+	// and the pod informer callbacks. Without it, onAddPod() could fire
+	// between Filter()'s TakeAndDeletePod and its subsequent AddPod,
+	// double-counting quota usage.
+	podMu sync.Mutex
 }
 
 func NewScheduler() *Scheduler {
@@ -146,6 +152,9 @@ func (s *Scheduler) onAddPod(obj any) {
 	if !ok {
 		return
 	}
+	s.podMu.Lock()
+	defer s.podMu.Unlock()
+
 	if util.IsPodInTerminatedState(pod) {
 		if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 			s.quotaManager.RmUsage(pod, pi.Devices)
@@ -195,6 +204,8 @@ func (s *Scheduler) onDelPod(obj any) {
 	if !ok {
 		return
 	}
+	s.podMu.Lock()
+	defer s.podMu.Unlock()
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}
@@ -797,6 +808,8 @@ func (s *Scheduler) getPodUsage() (map[string]device.PodUseDeviceStat, error) {
 }
 
 func (s *Scheduler) cleanupStalePodAllocation(pod *corev1.Pod) {
+	s.podMu.Lock()
+	defer s.podMu.Unlock()
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok && len(pi.Devices) > 0 {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}
@@ -953,6 +966,11 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		"pod", klog.KObj(args.Pod),
 		"reason", "request does not contain full nodes",
 		"nodeNamesLen", nodeNamesLen(args.NodeNames))
+
+	// Keep the pod absent from the manager for the complete usage calculation.
+	// Informer callbacks must not re-add it with stale devices in this window.
+	s.podMu.Lock()
+	defer s.podMu.Unlock()
 	if pi, ok := s.podManager.TakeAndDeletePod(args.Pod); ok {
 		s.quotaManager.RmUsage(args.Pod, pi.Devices)
 	}


### PR DESCRIPTION
**What does this PR do?**

Fixes #2478.

Synchronizes pod device/quota accounting between `Scheduler.Filter()` and the pod informer callbacks. A dedicated `podMu` mutex now serializes the `TakeAndDeletePod → recompute → AddPod` cycle in `Filter()` and all informer handlers (`onAddPod`, `onDelPod`, `cleanupStalePodAllocation`) that mutate `PodManager` + `QuotaManager`.

**Why is this fix needed?**

Without the lock, `onAddPod` could fire between `Filter()`'s `TakeAndDeletePod` (line 956) and its subsequent `AddPod` (line 998). Since the `PodManager` keys pods by UID:

1. `Filter` deletes the pod from the cache.
2. `onAddPod` re-adds it with stale devices and calls `AddUsage(stale_devices)`.
3. `Filter`'s later `AddPod(new_devices)` returns `added=false`, so the new usage is never recorded while the stale usage stays counted.

This causes double-counted / leaked quota usage that is never cleaned up.

**Description**

- Add `Scheduler.podMu sync.Mutex`.
- Hold it across the whole `Filter()` live-path usage window.
- Acquire it in `onAddPod`, `onDelPod`, and `cleanupStalePodAllocation`.

**Validation**

- `go test ./pkg/scheduler/... -short -count=1` passes.
- `go test -race ./pkg/scheduler/... -short -count=1` passes.

**AI assistance disclosure**

This PR was written primarily by opencode (an AI coding assistant). Per CONTRIBUTING.md, AI assistance is disclosed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling consistency when pods are added, deleted, or cleaned up.
  * Prevented stale resource allocations from affecting quota and usage calculations.
  * Reduced the risk of conflicting updates during concurrent pod events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->