### PR TITLE
fix(scheduler): use Warningf for device health warning in register

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -429,7 +429,7 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 					klog.V(5).InfoS("Skipping device cleanup for vendor not present in scheduler cache", "nodeName", val.Name, "deviceVendor", devhandsk)
 					continue
 				}
-				klog.Warning("Device is unhealthy, cleaning up node", "nodeName", val.Name, "deviceVendor", devhandsk)
+				klog.Warningf("Device is unhealthy, cleaning up node %s for device vendor %s", val.Name, devhandsk)
 				err := devInstance.NodeCleanUp(val.Name)
 				if err != nil {
 					klog.ErrorS(err, "Node cleanup failed", "nodeName", val.Name, "deviceVendor", devhandsk)


### PR DESCRIPTION
klog.Warning() does not support key-value pairs — it concatenates
all arguments via fmt.Sprint(), so the current call on line 432 of
scheduler.go produces garbled log output like:

```
Device is unhealthy, cleaning up nodenodeNamenode-1deviceVendornvidia.com/gpu
```

Switched to klog.Warningf with format specifiers so the node name and
device vendor are readable in the logs during device health check cleanup.

Before:
```go
klog.Warning("Device is unhealthy, cleaning up node", "nodeName", val.Name, "deviceVendor", devhandsk)
```

After:
```go
klog.Warningf("Device is unhealthy, cleaning up node %s for device vendor %s", val.Name, devhandsk)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages for unhealthy device cleanup by including the affected node name and device vendor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->