### PR TITLE
fix(vGPUmonitor): clamp corrupt device count from shared memory region

### DIFF
--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -78,7 +78,7 @@ func (s Spec) DeviceMax() int {
 }
 
 func (s Spec) DeviceNum() int {
-	return int(s.sr.num)
+	return int(min(max(s.sr.num, 0), uint64(maxDevices)))
 }
 
 // activeProcs returns the process slots currently in use. procnum is read from
@@ -138,10 +138,8 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := 0; idx < s.DeviceNum(); idx++ {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -158,10 +156,8 @@ func (s Spec) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := 0; idx < s.DeviceNum(); idx++ {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 

--- a/pkg/monitor/nvidia/v1/spec.go
+++ b/pkg/monitor/nvidia/v1/spec.go
@@ -92,7 +92,7 @@ func (s Spec) DeviceMax() int {
 }
 
 func (s Spec) DeviceNum() int {
-	return int(s.sr.num)
+	return int(min(max(s.sr.num, 0), uint64(maxDevices)))
 }
 
 // activeProcs returns the process slots currently in use. procnum is read from
@@ -152,10 +152,8 @@ func (s Spec) DeviceSmUtil(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceSmLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := 0; idx < s.DeviceNum(); idx++ {
 		s.sr.smLimit[idx] = l
-		idx += 1
 	}
 }
 
@@ -172,10 +170,8 @@ func (s Spec) DeviceMemoryLimit(idx int) uint64 {
 }
 
 func (s Spec) SetDeviceMemoryLimit(l uint64) {
-	idx := uint64(0)
-	for idx < s.sr.num {
+	for idx := 0; idx < s.DeviceNum(); idx++ {
 		s.sr.limit[idx] = l
-		idx += 1
 	}
 }
 


### PR DESCRIPTION
DeviceNum() in the v0/v1 shared-memory spec (pkg/monitor/nvidia/{v0,v1}/spec.go) returned int(sr.num) unclamped. num is read from an mmap'd shared-memory cache written by the containerized libvgpu, so a torn/corrupt value (larger than the fixed [16] device arrays) makes collectContainerMetrics (cmd/vGPUmonitor/metrics.go) index out of bounds on every device array, and SetDeviceSmLimit/SetDeviceMemoryLimit write out of bounds - panicking the vGPUmonitor daemonset pod. This clamps DeviceNum() to [0, maxDevices], mirroring the existing activeProcs() hardening, and makes the limit setters iterate the clamped DeviceNum(). Verification: go test ./pkg/monitor/nvidia/v0/ ./pkg/monitor/nvidia/v1/ -short -count=1 passes; added regression cases for num > maxDevices and corrupt math.MaxUint64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA device count handling by enforcing valid device limits.
  * Prevented resource limit operations from exceeding the supported device range.
  * Improved stability when shared device counts are invalid or out of bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->