### PR TITLE
fix(util): handle nil pod gracefully in utility functions to prevent …

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -161,6 +161,9 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 }
 
 func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
+	if pod == nil {
+		return fmt.Errorf("pod is nil")
+	}
 	type patchMetadata struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 		Labels      map[string]string `json:"labels,omitempty"`
@@ -271,14 +274,23 @@ func GetGPUSchedulerPolicyByPod(defaultPolicy string, task *corev1.Pod) string {
 }
 
 func IsPodInTerminatedState(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
 }
 
 func IsPodTerminating(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	return pod.DeletionTimestamp != nil
 }
 
 func AllContainersCreated(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	return len(pod.Status.ContainerStatuses) >= len(pod.Spec.Containers)
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -366,6 +366,14 @@ func TestPatchPodAnnotations(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "patch nil pod",
+			pod:  nil,
+			annotations: map[string]string{
+				"test-key": "test-value",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -429,6 +437,11 @@ func Test_IsPodInTerminatedState(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "pod is nil",
+			args: nil,
+			want: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -444,6 +457,11 @@ func Test_AllContainersCreated(t *testing.T) {
 		args *corev1.Pod
 		want bool
 	}{
+		{
+			name: "pod is nil",
+			args: nil,
+			want: false,
+		},
 		{
 			name: "all containers created",
 			args: &corev1.Pod{
@@ -725,6 +743,11 @@ func Test_IsPodTerminating(t *testing.T) {
 			args: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
+			want: false,
+		},
+		{
+			name: "pod is nil",
+			args: nil,
 			want: false,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR hardens the `pkg/util` package by adding explicit `nil` checks to several utility functions that accept `*corev1.Pod` pointers. 

Currently, functions like `IsPodTerminating` and `AllContainersCreated` immediately attempt to dereference the pod pointer without checking if it is `nil`. This causes a fatal `panic` and crashes the component if a `nil` pod is passed (e.g., due to an informer cache miss, race condition, or mocked test setup). 

This PR:
1. Adds `nil` checks to `IsPodInTerminatedState`, `IsPodTerminating`, `AllContainersCreated`, and `PatchPodAnnotations`.
2. Adds corresponding table-driven unit tests for all 4 functions to ensure they return safely on `nil` inputs.

**Which issue(s) this PR fixes**:
Fixes #<2498

**Special notes for your reviewer**:
The added unit tests can be found in `pkg/util/util_test.go`. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing pod data to prevent errors when checking pod status or applying annotations.
  * Functions now return appropriate errors or safe false results for empty inputs.

* **Tests**
  * Added coverage for empty pod input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->