### PR TITLE
fix(monitor): add v0.MinSize and fix file-size discriminator for v0 cache

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -278,7 +278,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		_ = syscall.Munmap(usage.data)
 		return nil, fmt.Errorf("cache file magic flag not matched")
 	}
-	if info.Size() == 1197897 {
+	if info.Size() >= int64(v0.MinSize()) && info.Size() < int64(v1.MinSize()) {
 		klog.Infoln("casting......v0")
 		usage.Info = v0.CastSpec(usage.data)
 	} else if head.majorVersion == 1 && info.Size() >= int64(v1.MinSize()) {

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	v0 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v0"
 	v1 "github.com/Project-HAMi/HAMi/pkg/monitor/nvidia/v1"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
@@ -43,6 +44,11 @@ import (
 // every field of the real v1 sharedRegionT; using a smaller fixture would
 // leave usage.Info backed by an out-of-bounds pointer.
 var v1CacheFileSize = v1.MinSize()
+
+// v0CacheFileSize is the minimum byte count for v0.CastSpec to safely
+// dereference every field of the v0 sharedRegionT; using a smaller fixture
+// would leave usage.Info backed by an out-of-bounds pointer.
+var v0CacheFileSize = v0.MinSize()
 
 // fakePodLister is a minimal corelisters.PodLister used to drive Update()'s
 // error path without touching a real (or fake) Kubernetes API server.
@@ -80,6 +86,22 @@ func writeCacheFile(t *testing.T, dir, name string, content []byte) string {
 	p := filepath.Join(dir, name)
 	assert.NilError(t, os.WriteFile(p, content, 0666))
 	return p
+}
+
+// makeV0CacheBytes builds a minimal v0 shared-memory cache payload with the
+// given device count and per-device memory limits. Field offsets are derived
+// from unsafe.Offsetof applied to the unexported v0.sharedRegionT:
+//
+//	num   @ byte 48   (uint64, little-endian)
+//	limit @ byte 1592 (16 × uint64, one per device slot, little-endian)
+func makeV0CacheBytes(numDevices int, limits []uint64) []byte {
+	buf := make([]byte, v0.MinSize())
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(SharedRegionMagicFlag))
+	binary.LittleEndian.PutUint64(buf[48:56], uint64(numDevices))
+	for i, l := range limits {
+		binary.LittleEndian.PutUint64(buf[1592+i*8:1592+(i+1)*8], l)
+	}
+	return buf
 }
 
 func Test_ContainerLister_Accessors(t *testing.T) {
@@ -270,7 +292,17 @@ func Test_loadCache(t *testing.T) {
 		defer func() { _ = syscall.Munmap(usage.data) }()
 	})
 
-	t.Run("v0 cache file (exact legacy size)", func(t *testing.T) {
+	t.Run("v0 cache file (struct-derived size)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(v0CacheFileSize, SharedRegionMagicFlag, 0, 0))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
+	t.Run("v0 cache file (empirical legacy size 1197897)", func(t *testing.T) {
 		dir := t.TempDir()
 		writeCacheFile(t, dir, "x.cache", headerBytes(1197897, SharedRegionMagicFlag, 0, 0))
 		usage, err := loadCache(dir)
@@ -278,6 +310,25 @@ func Test_loadCache(t *testing.T) {
 		assert.Assert(t, usage != nil)
 		assert.Assert(t, usage.Info != nil)
 		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
+	t.Run("v0 cache file (e2e: field data round-trips through loadCache)", func(t *testing.T) {
+		const (
+			wantNum    = 2
+			wantLimit0 = 4 * 1024 * 1024 * 1024
+			wantLimit1 = 2 * 1024 * 1024 * 1024
+		)
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", makeV0CacheBytes(wantNum, []uint64{wantLimit0, wantLimit1}))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+
+		assert.Equal(t, wantNum, usage.Info.DeviceNum())
+		assert.Equal(t, uint64(wantLimit0), usage.Info.DeviceMemoryLimit(0))
+		assert.Equal(t, uint64(wantLimit1), usage.Info.DeviceMemoryLimit(1))
 	})
 
 	t.Run("open file fails", func(t *testing.T) {

--- a/pkg/monitor/nvidia/v0/spec.go
+++ b/pkg/monitor/nvidia/v0/spec.go
@@ -191,6 +191,10 @@ func CastSpec(data []byte) Spec {
 	}
 }
 
+func MinSize() int {
+	return int(unsafe.Sizeof(sharedRegionT{}))
+}
+
 //	func (s *SharedRegionT) UsedMemory(idx int) (uint64, error) {
 //		return 0, nil
 //	}

--- a/pkg/monitor/nvidia/v0/spec_test.go
+++ b/pkg/monitor/nvidia/v0/spec_test.go
@@ -784,3 +784,10 @@ func TestSpec_LastKernelTime(t *testing.T) {
 		})
 	}
 }
+
+func TestV0SharedRegionTLayoutSize(t *testing.T) {
+	const want = 1197896
+	if got := MinSize(); got != want {
+		t.Errorf("MinSize() = %d, want %d; a field was added or removed from v0.sharedRegionT — update the size discriminator in cudevshr.go accordingly", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

The v0 cache-file detector in `loadCache` compared `info.Size() == 1197897`,
but `unsafe.Sizeof(v0.sharedRegionT{}) == 1197896` an off-by-one that
caused any real libvgpu v0 cache file to fall through to the
`"unknown cache file size"` error, silently leaving v0 containers
unmonitored.

Additionally, v0 had no `MinSize()` function, unlike v1, so the detection
threshold was a bare magic number with no programmatic anchor. A future
field addition or removal in the v0 struct would shift the size silently
with no CI signal.

**Three changes:**

- Add `MinSize()` to `pkg/monitor/nvidia/v0/spec.go`, mirroring v1's
  equivalent. Returns `int(unsafe.Sizeof(sharedRegionT{}))`.

- Broaden the detector in `cudevshr.go` from `info.Size() == 1197897` to
  `info.Size() >= int64(v0.MinSize()) && info.Size() < int64(v1.MinSize())`.
  This accepts both the struct-derived size (1197896) and the empirical
  legacy size (1197897), and distinguishes the result from a v1 file
  without relying on the version-header bytes, which map to `smInitFlag`
  in the v0 layout rather than a real version number.

- Add `TestV0SharedRegionTLayoutSize` to `v0/spec_test.go` and add a
  second loadCache test for the struct-derived size in `cudevshr_test.go`,
  so any future struct change breaks CI instead of silently shifting the
  detection boundary.

**Which issue(s) this PR fixes:**
Part of #2126 (LFX observability hardening — v0 cache-file loading)

**Does this PR introduce a user-facing change?**
Yes nodes running older libvgpu (v0 shared-memory format, ~1.2 MB cache
files) that previously got `unknown cache file size` errors will now have
their containers correctly loaded and monitored.

**Special notes for your reviewer:**
The `1197897` constant in the existing test is kept as the "empirical legacy
size" subtest to confirm the range check accepts it. The new "struct-derived
size" subtest covers `1197896`. Both pass.

**AI Disclosure:**
AI assistance was used for code inspection and draft formatting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA cache file detection for older v0 cache files across the supported minimum-size range.
  * Preserved existing detection behavior for v1 cache files.

* **Reliability**
  * Added safeguards to detect unexpected changes in the NVIDIA v0 cache layout size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->