### PR TITLE
fix(scheduler): copy node info into nodeManager instead of storing the caller's

### DIFF
--- a/pkg/scheduler/nodes.go
+++ b/pkg/scheduler/nodes.go
@@ -68,6 +68,11 @@ func newNodeManager() *nodeManager {
 	}
 }
 
+// addNode copies what it is given. RegisterFromNodeAnnotations builds nodeInfo
+// around a *corev1.Node taken from nodeLister.List, which belongs to the shared
+// informer, and a backend such as cambricon writes to that same object when it
+// releases a node lock. Storing the pointer would leave GetNode and ListNodes
+// deep-copying it while that write happens.
 func (m *nodeManager) addNode(nodeID string, nodeInfo *device.NodeInfo) {
 	if nodeInfo == nil || len(nodeInfo.Devices) == 0 {
 		return
@@ -76,14 +81,26 @@ func (m *nodeManager) addNode(nodeID string, nodeInfo *device.NodeInfo) {
 	defer m.mutex.Unlock()
 	_, ok := m.nodes[nodeID]
 	if ok {
-		if len(nodeInfo.Devices) > 0 {
-			for vendor := range nodeInfo.Devices {
-				m.nodes[nodeID].Devices[vendor] = nodeInfo.Devices[vendor]
-			}
+		for vendor := range nodeInfo.Devices {
+			m.nodes[nodeID].Devices[vendor] = device.DeepCopyDeviceInfos(nodeInfo.Devices[vendor])
 		}
-		m.nodes[nodeID].Node = nodeInfo.Node
+		if nodeInfo.Node != nil {
+			m.nodes[nodeID].Node = nodeInfo.Node.DeepCopy()
+		} else {
+			m.nodes[nodeID].Node = nil
+		}
 	} else {
-		m.nodes[nodeID] = nodeInfo
+		stored := &device.NodeInfo{
+			ID:      nodeInfo.ID,
+			Devices: make(map[string][]device.DeviceInfo, len(nodeInfo.Devices)),
+		}
+		if nodeInfo.Node != nil {
+			stored.Node = nodeInfo.Node.DeepCopy()
+		}
+		for vendor, devices := range nodeInfo.Devices {
+			stored.Devices[vendor] = device.DeepCopyDeviceInfos(devices)
+		}
+		m.nodes[nodeID] = stored
 	}
 }
 

--- a/pkg/scheduler/nodes_test.go
+++ b/pkg/scheduler/nodes_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -504,4 +505,99 @@ func TestGetNode_DeepCopy(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent node, got nil")
 	}
+}
+
+// RegisterFromNodeAnnotations hands addNode a *corev1.Node straight from
+// nodeLister.List, and cambricon's ReleaseNodeLock deletes an annotation from
+// that same shared object. Storing the pointer left GetNode and ListNodes
+// deep-copying it while that delete ran.
+func TestAddNodeCopiesSharedNodeObject(t *testing.T) {
+	m := newNodeManager()
+
+	shared := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{"cambricon.com/dsmlu.lock": "held"},
+		},
+	}
+	m.addNode("node1", &device.NodeInfo{
+		ID:   "node1",
+		Node: shared,
+		Devices: map[string][]device.DeviceInfo{
+			"NVIDIA": {{ID: "dev-0", Count: 10, Devmem: 1024}},
+		},
+	})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				delete(shared.Annotations, "cambricon.com/dsmlu.lock")
+				shared.Annotations["cambricon.com/dsmlu.lock"] = "held"
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for range 20000 {
+			if n, err := m.GetNode("node1"); err == nil && n.Node != nil {
+				_ = n.Node.Annotations
+			}
+			_, _ = m.ListNodes()
+		}
+		close(stop)
+	})
+
+	wg.Wait()
+}
+
+// What the caller keeps must not reach into the manager, and vice versa.
+func TestAddNodeStoresDetachedCopy(t *testing.T) {
+	m := newNodeManager()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Annotations: map[string]string{"k": "v"}},
+	}
+	info := &device.NodeInfo{
+		ID:   "node1",
+		Node: node,
+		Devices: map[string][]device.DeviceInfo{
+			"NVIDIA": {{ID: "dev-0", Count: 10, Devmem: 1024}},
+		},
+	}
+	m.addNode("node1", info)
+
+	// mutate everything the caller still holds
+	node.Annotations["k"] = "tampered"
+	info.Devices["NVIDIA"][0].Devmem = 9999
+
+	got, err := m.GetNode("node1")
+	assert.NilError(t, err)
+	assert.Equal(t, "v", got.Node.Annotations["k"])
+	assert.Equal(t, int32(1024), got.Devices["NVIDIA"][0].Devmem)
+
+	// and the update path must copy too
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Annotations: map[string]string{"k": "v2"}},
+	}
+	info2 := &device.NodeInfo{
+		ID:   "node1",
+		Node: node2,
+		Devices: map[string][]device.DeviceInfo{
+			"NVIDIA": {{ID: "dev-0", Count: 10, Devmem: 2048}},
+		},
+	}
+	m.addNode("node1", info2)
+	node2.Annotations["k"] = "tampered2"
+	info2.Devices["NVIDIA"][0].Devmem = 7777
+
+	got, err = m.GetNode("node1")
+	assert.NilError(t, err)
+	assert.Equal(t, "v2", got.Node.Annotations["k"])
+	assert.Equal(t, int32(2048), got.Devices["NVIDIA"][0].Devmem)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`nodeManager.addNode` stored the `*device.NodeInfo` it was handed, including the
`*corev1.Node` inside it:

```go
} else {
    m.nodes[nodeID] = nodeInfo
}
```

and on the update path assigned the caller's slices and node straight in:

```go
m.nodes[nodeID].Devices[vendor] = nodeInfo.Devices[vendor]
m.nodes[nodeID].Node = nodeInfo.Node
```

The only caller is `RegisterFromNodeAnnotations`, which builds `nodeInfo` around a
node taken from `s.nodeLister.List(...)` — an object owned by the shared informer.

That would be harmless if nothing wrote to it, but something does. `Bind` fetches
the same node out of the same cache, and on the release path cambricon's
`ReleaseNodeLock` deletes an annotation from it:

```go
delete(n.Annotations, DsmluLockTime)   // pkg/device/cambricon/device.go:178
```

Meanwhile `GetNode` and `ListNodes` deep copy the stored node on the Filter and
Bind goroutines. `go test ./pkg/scheduler/ --race` reports the read inside
`(*Node).DeepCopyInto` against that delete.

#2333 fixed the read side of this cache by making `GetNode` return a deep copy.
The write side kept a reference to the shared object, so the copy it makes can
still run while the object is being modified.

**The fix**

Copy `Node` and the device lists when storing, on both the insert and the update
path, reusing `device.DeepCopyDeviceInfos` which `GetNode` and `ListNodes`
already use.

**Tests**

`TestAddNodeCopiesSharedNodeObject` drives the annotation delete on one goroutine
while another calls `GetNode`/`ListNodes`, which is the shape of the real
interleaving. `TestAddNodeStoresDetachedCopy` mutates everything the caller still
holds, on both the insert and the update path, and asserts the manager is
unaffected. Both fail on master with `DATA RACE`, both pass here.

**Which issue(s) this PR fixes**:

None filed — raising the fix directly.

**Special notes for your reviewer**:

Worth being explicit about one thing, since it changes how the bug reads: shared
informers replace objects in their store rather than mutating them in place, so
holding a lister pointer is not automatically a race. What makes this one real is
that HAMi mutates the object itself, in `ReleaseNodeLock`. #2329 is open against
that mutation. If it lands, this race goes quiet, but the manager would still be
holding a reference it does not own, and the next writer brings it back. The two
changes are worth having independently.

`addNode` now costs a deep copy per node per registration cycle. That is the same
cost `GetNode` already pays per call, and registration is far less frequent than
scheduling, so it should not be noticeable.

Not validated on real hardware. The change is confined to the scheduler's
in-memory node cache and is covered by unit tests, which CONTRIBUTING allows for
scheduler-scoped changes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

---

AI assistance disclosure: this change was developed with Claude Code — finding
the race, the fix, and the tests. Flagging the extent up front per CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering and updating nodes by preventing external changes to node metadata and device information from unexpectedly altering stored state.
  * Added safe handling for missing node data.

* **Tests**
  * Added coverage for concurrent registration and updates, including protection against shared-data mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->