### PR TITLE
fix(device): reject malformed pod device annotation segments

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -460,25 +460,26 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 	tmpdev := ContainerDevice{}
 	klog.V(5).Infof("Start to decode container device %s", str)
 	for _, val := range cd {
-		if strings.Contains(val, ",") {
-			tmpstr := strings.Split(val, ",")
-			if len(tmpstr) < 4 {
-				return nil, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
-			}
-			tmpdev.UUID = tmpstr[0]
-			tmpdev.Type = tmpstr[1]
-			devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid memory field: %w", err)
-			}
-			tmpdev.Usedmem = int32(devmem)
-			devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid core field: %w", err)
-			}
-			tmpdev.Usedcores = int32(devcores)
-			contdev = append(contdev, tmpdev)
+		if val == "" {
+			continue
 		}
+		tmpstr := strings.Split(val, ",")
+		if len(tmpstr) < 4 {
+			return nil, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
+		}
+		tmpdev.UUID = tmpstr[0]
+		tmpdev.Type = tmpstr[1]
+		devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory field: %w", err)
+		}
+		tmpdev.Usedmem = int32(devmem)
+		devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid core field: %w", err)
+		}
+		tmpdev.Usedcores = int32(devcores)
+		contdev = append(contdev, tmpdev)
 	}
 	klog.V(5).Infof("Finished decoding container devices. Total devices: %d", len(contdev))
 	return contdev, nil

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -298,6 +298,7 @@ func TestDecodePodDevices_BadAnnotation(t *testing.T) {
 	for _, annotation := range []string{
 		"uuid,type,100:;",
 		"malformed:;",
+		"uuid,type,100,invalid:;",
 	} {
 		annos := map[string]string{"hami.io/vgpu-devices-to-allocate": annotation}
 		_, err := DecodePodDevices(checklist, annos)

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -295,9 +295,14 @@ func Test_DecodePodDevices(t *testing.T) {
 
 func TestDecodePodDevices_BadAnnotation(t *testing.T) {
 	checklist := map[string]string{"NVIDIA": "hami.io/vgpu-devices-to-allocate"}
-	annos := map[string]string{"hami.io/vgpu-devices-to-allocate": "uuid,type,100:;"}
-	_, err := DecodePodDevices(checklist, annos)
-	assert.Assert(t, err != nil)
+	for _, annotation := range []string{
+		"uuid,type,100:;",
+		"malformed:;",
+	} {
+		annos := map[string]string{"hami.io/vgpu-devices-to-allocate": annotation}
+		_, err := DecodePodDevices(checklist, annos)
+		assert.Assert(t, err != nil, "annotation %q should be rejected", annotation)
+	}
 }
 
 func TestMarshalNodeDevices(t *testing.T) {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

`DecodeContainerDevices` previously processed an annotation segment only when it contained a comma. Consequently, a non-empty malformed segment such as `malformed` was silently skipped and interpreted as an empty device allocation.

This change skips only truly empty segments. Every non-empty segment now passes through the existing required-field and numeric validation.

A regression test verifies that `DecodePodDevices` rejects `malformed:;` instead of returning an empty allocation without an error.


**Which issue(s) this PR fixes**:
Fixes #2507 

**Special notes for your reviewer**:

This is limited to the shared annotation decoder and its regression test. It introduces no device-specific behavior and requires no GPU hardware.

Validated on macOS with:
- `make verify`
- `go test ./pkg/... -count=1`
- `go test -race ./pkg/device -run 'TestDecodePodDevices_BadAnnotation|Test_DecodePodDevices' -count=1`
- `go test ./pkg/device -run '^$' -fuzz '^FuzzDecodeContainerDevices$' -fuzztime=5s`
- `git diff --check`

All checks passed.



**Does this PR introduce a user-facing change?**:

Malformed non-empty pod-device annotation segments are now rejected instead of being silently interpreted as empty allocations.

AI Disclosure:
Codex assisted with repository analysis, implementation, regression-test development, verification, and drafting this PR description. I reviewed the final code changes and test results before submission.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of device annotations by ignoring empty segments.
  * Invalid annotation formats, memory values, and core values now return clear errors instead of being accepted.
  * Valid device entries continue to be processed as expected.

* **Tests**
  * Expanded validation coverage for malformed device annotations, including incorrect field counts and invalid segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->