### PR TITLE
bug(monitor): Memory Leak and Unmapped Memory Hazard in Container Lister Cache Cleanup

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -84,10 +84,12 @@ func (c *ContainerUsage) Unmap() error {
 	if c == nil || len(c.data) == 0 {
 		return nil
 	}
-	err := syscall.Munmap(c.data)
+	if err := syscall.Munmap(c.data); err != nil {
+		return err
+	}
 	c.data = nil
 	c.Info = nil
-	return err
+	return nil
 }
 
 type ContainerLister struct {
@@ -211,8 +213,9 @@ func (l *ContainerLister) Update() error {
 			if c, ok := l.containers[entry.Name()]; ok {
 				if err := c.Unmap(); err != nil {
 					klog.Warningf("Failed to unmap container usage data for %s: %v", entry.Name(), err)
+				} else {
+					delete(l.containers, entry.Name())
 				}
-				delete(l.containers, entry.Name())
 			}
 			_ = os.RemoveAll(dirName)
 			continue
@@ -287,7 +290,9 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	}
 	head := (*headerT)(unsafe.Pointer(&usage.data[0]))
 	if head.initializedFlag != SharedRegionMagicFlag {
-		_ = usage.Unmap()
+		if err := usage.Unmap(); err != nil {
+			klog.Warningf("Failed to unmap cache file on invalid magic flag: %v", err)
+		}
 		return nil, fmt.Errorf("cache file magic flag not matched")
 	}
 	if info.Size() == 1197897 {
@@ -298,7 +303,9 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		usage.Info = v1.CastSpec(usage.data)
 	} else {
 		majorVersion, minorVersion := head.majorVersion, head.minorVersion
-		_ = usage.Unmap()
+		if err := usage.Unmap(); err != nil {
+			klog.Warningf("Failed to unmap cache file on unknown size/version: %v", err)
+		}
 		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), majorVersion, minorVersion)
 	}
 	return usage, nil

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -80,6 +80,16 @@ type ContainerUsage struct {
 	Info          UsageInfo
 }
 
+func (c *ContainerUsage) Unmap() error {
+	if c == nil || len(c.data) == 0 {
+		return nil
+	}
+	err := syscall.Munmap(c.data)
+	c.data = nil
+	c.Info = nil
+	return err
+}
+
 type ContainerLister struct {
 	containerPath string
 	containers    map[string]*ContainerUsage
@@ -199,7 +209,9 @@ func (l *ContainerLister) Update() error {
 			}
 			klog.Infof("Removing dirname %s in monitorpath", dirName)
 			if c, ok := l.containers[entry.Name()]; ok {
-				syscall.Munmap(c.data)
+				if err := c.Unmap(); err != nil {
+					klog.Warningf("Failed to unmap container usage data for %s: %v", entry.Name(), err)
+				}
 				delete(l.containers, entry.Name())
 			}
 			_ = os.RemoveAll(dirName)
@@ -275,7 +287,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	}
 	head := (*headerT)(unsafe.Pointer(&usage.data[0]))
 	if head.initializedFlag != SharedRegionMagicFlag {
-		_ = syscall.Munmap(usage.data)
+		_ = usage.Unmap()
 		return nil, fmt.Errorf("cache file magic flag not matched")
 	}
 	if info.Size() == 1197897 {
@@ -286,7 +298,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		usage.Info = v1.CastSpec(usage.data)
 	} else {
 		majorVersion, minorVersion := head.majorVersion, head.minorVersion
-		_ = syscall.Munmap(usage.data)
+		_ = usage.Unmap()
 		return nil, fmt.Errorf("unknown cache file size %d version %d.%d", info.Size(), majorVersion, minorVersion)
 	}
 	return usage, nil

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -267,7 +266,7 @@ func Test_loadCache(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Assert(t, usage != nil)
 		assert.Assert(t, usage.Info != nil)
-		defer func() { _ = syscall.Munmap(usage.data) }()
+		defer func() { _ = usage.Unmap() }()
 	})
 
 	t.Run("v0 cache file (exact legacy size)", func(t *testing.T) {
@@ -277,7 +276,7 @@ func Test_loadCache(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Assert(t, usage != nil)
 		assert.Assert(t, usage.Info != nil)
-		defer func() { _ = syscall.Munmap(usage.data) }()
+		defer func() { _ = usage.Unmap() }()
 	})
 
 	t.Run("open file fails", func(t *testing.T) {
@@ -361,6 +360,8 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.NilError(t, l.Update())
 		_, ok := l.containers[entryName]
 		assert.Equal(t, ok, false)
+		assert.Assert(t, usage.data == nil)
+		assert.Assert(t, usage.Info == nil)
 		_, err = os.Stat(ctrDir)
 		assert.Assert(t, os.IsNotExist(err))
 	})
@@ -430,7 +431,7 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.Equal(t, ok, true)
 		assert.Equal(t, got.PodUID, "uid4")
 		assert.Equal(t, got.ContainerName, "mycontainer")
-		defer func() { _ = syscall.Munmap(got.data) }()
+		defer func() { _ = got.Unmap() }()
 	})
 
 	t.Run("dir without underscore in name is skipped", func(t *testing.T) {
@@ -461,5 +462,36 @@ func Test_ContainerLister_Update(t *testing.T) {
 		}
 		assert.NilError(t, l.Update())
 		assert.Equal(t, len(l.containers), 0)
+	})
+}
+
+func Test_ContainerUsage_Unmap(t *testing.T) {
+	t.Run("nil ContainerUsage", func(t *testing.T) {
+		var c *ContainerUsage
+		assert.NilError(t, c.Unmap())
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		c := &ContainerUsage{}
+		assert.NilError(t, c.Unmap())
+		assert.Assert(t, c.data == nil)
+		assert.Assert(t, c.Info == nil)
+	})
+
+	t.Run("valid mapped data", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.data != nil)
+		assert.Assert(t, usage.Info != nil)
+
+		assert.NilError(t, usage.Unmap())
+		assert.Assert(t, usage.data == nil)
+		assert.Assert(t, usage.Info == nil)
+
+		// Second call is safe and no-op
+		assert.NilError(t, usage.Unmap())
 	})
 }

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -366,6 +366,26 @@ func Test_ContainerLister_Update(t *testing.T) {
 		assert.Assert(t, os.IsNotExist(err))
 	})
 
+	t.Run("old stale dir with unmap error retains container", func(t *testing.T) {
+		dir := t.TempDir()
+		entryName := "missing-pod-uid_ctr"
+		ctrDir := filepath.Join(dir, entryName)
+		assert.NilError(t, os.Mkdir(ctrDir, 0755))
+		old := time.Now().Add(-2 * resyncInterval)
+		assert.NilError(t, os.Chtimes(ctrDir, old, old))
+
+		usage := &ContainerUsage{data: []byte{1, 2, 3}}
+		l := &ContainerLister{
+			containerPath: dir,
+			containers:    map[string]*ContainerUsage{entryName: usage},
+			podLister:     newTestPodLister(),
+		}
+		assert.NilError(t, l.Update())
+		got, ok := l.containers[entryName]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, got, usage)
+	})
+
 	t.Run("already tracked entry is left untouched", func(t *testing.T) {
 		dir := t.TempDir()
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", UID: "uid1"}}
@@ -493,5 +513,12 @@ func Test_ContainerUsage_Unmap(t *testing.T) {
 
 		// Second call is safe and no-op
 		assert.NilError(t, usage.Unmap())
+	})
+
+	t.Run("unmap failure preserves data and returns error", func(t *testing.T) {
+		c := &ContainerUsage{data: []byte{1, 2, 3}}
+		err := c.Unmap()
+		assert.Assert(t, err != nil)
+		assert.Assert(t, c.data != nil)
 	})
 }


### PR DESCRIPTION
Closes #2509 
##  bug(monitor): Memory Leak and Unmapped Memory Hazard in Container Lister Cache Cleanup

| Field | Details |
| :--- | :--- |
| **Description** | When containers terminate or pods are deleted, shared memory directories under `/tmp/vgpu/containers/` are removed from the filesystem. However, `ContainerLister.Update()` deletes entries from `l.containers` without explicitly invoking `syscall.Munmap()` on the backing mmap'd byte slice. |
| **Location** | [`pkg/monitor/nvidia/cudevshr.go`](file:///c:/Users/Hp/HAMi/pkg/monitor/nvidia/cudevshr.go#L195-L225) (in `ContainerLister.Update()`) |
| **Bug / Feature** | **Bug** |
| **Reason** | Deleting a pointer reference in a Go map does not unmap virtual memory pages created via `syscall.Mmap()`. In dense environments with high container turnover, unmapped memory regions remain allocated in RSS, causing a steady memory leak in `vGPUmonitor`. |
| **Proposed Changes** | Add an explicit `Close()` or `Unmap()` method to `ContainerUsage` that calls `syscall.Munmap(c.data)`. Call this method inside `Update()` prior to removing stale container entries from `l.containers`. |

### Before vs. After Architecture

```mermaid
flowchart LR
    subgraph Before["Before: Unmapped Memory Leak Hazard"]
        direction TB
        B1["Pod Termination Event"]
        B2["K8s Deletes Shared Dir
/tmp/vgpu/containers/pod_ctr"]
        B3["Update Loop Scans Filesystem"]
        B4["Detect Missing Directory for PodUID"]
        B5["Execute delete(l.containers, key)"]
        B6["Go Pointer Removed from Map Cache"]
        B7["CRITICAL HAZARD:
c.data NOT Unmapped"]
        B8["OS Virtual Memory Pages Retained in RSS"]
        B9["Continuous Process Memory Leak"]

        B1 --> B2
        B2 --> B3
        B3 --> B4
        B4 --> B5
        B5 --> B6
        B6 --> B7
        B7 --> B8
        B8 --> B9
    end

    Before ==>|Explicit syscall.Munmap Implementation| After

    subgraph After["After: Explicit Munmap & Safe Cleanup"]
        direction TB
        A1["Pod Termination Event"]
        A2["K8s Deletes Shared Dir
/tmp/vgpu/containers/pod_ctr"]
        A3["Update Loop Scans Filesystem"]
        A4["Detect Missing Directory for PodUID"]
        A5["Retrieve ContainerUsage Reference"]
        A6["Invoke c.Unmap()
syscall.Munmap(c.data)"]
        A7["OS Page Table Entry Released Safely"]
        A8["Set c.data = nil & c.Info = nil"]
        A9["Execute delete(l.containers, key)"]
        A10["Zero Memory Leak & Clean Cache Removal"]

        A1 --> A2
        A2 --> A3
        A3 --> A4
        A4 --> A5
        A5 --> A6
        A6 --> A7
        A7 --> A8
        A8 --> A9
        A9 --> A10
    end

    classDef danger fill:#fee2e2,stroke:#ef4444,stroke-width:2px,color:#991b1b;
    classDef success fill:#dcfce7,stroke:#22c55e,stroke-width:2px,color:#166534;
    classDef neutral fill:#f3f4f6,stroke:#4b5563,stroke-width:1.5px,color:#1f2937;

    class B7,B8,B9 danger;
    class A6,A7,A10 success;
    class B1,B2,B3,B4,B5,B6,A1,A2,A3,A4,A5,A8,A9 neutral;
```

### Workflow & Component Diagram

```mermaid
graph TD
    A["ContainerLister.Update() Triggered"] --> B["Acquire l.mutex.Lock()"]
    B --> C["Read Physical Directory Entries: os.ReadDir(/tmp/vgpu/containers)"]
    C --> D["Fetch Active Pod List from K8s InformerCache"]
    D --> E["Build Set of Valid Active PodUIDs"]
    E --> F["Iterate Registered Cache Map: l.containers"]
    F --> G{"Is Container PodUID in Valid Active Set?"}
    G -- "Yes (Active)" --> H["Keep Entry in l.containers Map"]
    G -- "No (Terminated)" --> I{"Check Resync Window TTL Expiry"}
    I -- "Not Expired" --> J["Retain Container Temporarily"]
    I -- "Expired" --> K["Extract ContainerUsage Pointer"]
    K --> L["Check c.data Slice Non-Nil & Mapped"]
    L --> M["Call syscall.Munmap(c.data)"]
    M --> N{"Munmap Succeeded?"}
    N -- "Success" --> O["Clear Pointer c.data = nil"]
    N -- "Error" --> P["Log Klog Warning with Err Details"]
    O & P --> Q["Execute delete(l.containers, key)"]
    Q --> R["Log Info: Purged Container Cache & Unmapped Memory"]
    H & J & R --> S["Release l.mutex.Unlock()"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved cleanup of container usage data when mappings are invalid, outdated, removed, or no longer needed.
* Ensured stale usage information is cleared after successful cleanup.
* Preserved stale entries when cleanup fails, preventing loss of tracking information.
* Added logging when container data cannot be unmapped successfully.

## Tests

* Expanded coverage for empty, repeated, valid, and failed unmapping scenarios.
* Added checks confirming mapped data and usage details are cleared appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->