### PR TITLE
fix(nvidia): stamp flattened UsageList index in MIG UUID suffix

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -695,8 +695,10 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 						}
 						ctr.Usedmem = n.MigUsage.UsageList[usageListIdx].Memory
 						ctr.Usedcores = n.MigUsage.UsageList[usageListIdx].Core
+						// Stamp the flattened UsageList offset (what ExtractMigTemplatesFromUUID
+						// and getNodesUsage read back), not the geometry item index.
 						if !strings.Contains(ctr.UUID, "[") {
-							ctr.UUID = ctr.UUID + "[" + fmt.Sprint(tidx) + "-" + fmt.Sprint(idx) + "]"
+							ctr.UUID = ctr.UUID + "[" + fmt.Sprint(tidx) + "-" + fmt.Sprint(usageListIdx) + "]"
 						}
 						n.MigUsage.Index = int32(tidx)
 						n.MigUsage.UsageList[usageListIdx].InUse = true

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1383,7 +1383,7 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 			},
 			ctr: &device.ContainerDevice{
 				UUID:    "dev-3",
-				Usedmem: 8000, // Requires 8GB, matches second template (idx=1) which should be at UsageList[2]
+				Usedmem: 8000, // matches 2g.10gb at flattened UsageList index 2 (preceded by 1g.5gb x2)
 			},
 			wantUsage: &device.DeviceUsage{
 				Used:      1,
@@ -1393,7 +1393,7 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 			wantErr:    false,
 			checkMig:   true,
 			wantMigIdx: 0,
-			wantUUID:   "dev-3[0-1]",
+			wantUUID:   "dev-3[0-2]",
 		},
 	}
 	for _, tt := range tests {
@@ -1420,22 +1420,14 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 					if tt.ctr.UUID != tt.wantUUID {
 						t.Errorf("expected UUID: %s, got %s", tt.wantUUID, tt.ctr.UUID)
 					}
-					// Verify that the entry at the corresponding index in UsageList is marked as InUse
-					// According to the modified code, should calculate usageListIdx by summing Count of all templates before idx
+					// The suffix's second field is already the flattened UsageList
+					// offset, so use it directly to find the reserved slot.
 					expectedUsageListIdx := -1
 					if strings.Contains(tt.wantUUID, "[") {
 						parts := strings.Split(strings.TrimSuffix(strings.Split(tt.wantUUID, "[")[1], "]"), "-")
 						if len(parts) == 2 {
-							if tidx, err1 := strconv.Atoi(parts[0]); err1 == nil {
-								if idx, err2 := strconv.Atoi(parts[1]); err2 == nil {
-									// Calculate usageListIdx by summing Count of all templates before idx
-									if tidx >= 0 && tidx < len(tt.deviceUsage.MigTemplate) {
-										expectedUsageListIdx = 0
-										for i := 0; i < idx && i < len(tt.deviceUsage.MigTemplate[tidx]); i++ {
-											expectedUsageListIdx += int(tt.deviceUsage.MigTemplate[tidx][i].Count)
-										}
-									}
-								}
+							if pos, err := strconv.Atoi(parts[1]); err == nil {
+								expectedUsageListIdx = pos
 							}
 						}
 					}
@@ -2712,6 +2704,35 @@ func TestAddResourceUsage_MigResetNoFit(t *testing.T) {
 	assert.Equal(t, usage.Usedmem, int32(0))
 	assert.Equal(t, usage.Used, int32(0))
 	assert.Assert(t, !strings.Contains(ctr.UUID, "["))
+}
+
+func TestAddResourceUsage_MigFreshTemplateStampsFlattenedIndex(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{})
+	// An item with Count>1 precedes the one that fits, so the geometry index
+	// and the flattened UsageList offset diverge.
+	usage := &device.DeviceUsage{
+		Mode: MigMode,
+		MigTemplate: []device.Geometry{
+			{
+				{Name: "1g.5gb", Memory: 5120, Core: 14, Count: 2},
+				{Name: "2g.10gb", Memory: 10240, Core: 28, Count: 1},
+			},
+		},
+	}
+	// 6GB only fits the 2g.10gb item (geometry index 1, flattened index 2).
+	ctr := &device.ContainerDevice{UUID: "GPU-0", Usedmem: 6144}
+	err := dev.AddResourceUsage(&corev1.Pod{}, usage, ctr)
+	assert.NilError(t, err)
+	assert.Assert(t, usage.MigUsage.UsageList[2].InUse)
+	assert.Assert(t, !usage.MigUsage.UsageList[0].InUse)
+	assert.Assert(t, !usage.MigUsage.UsageList[1].InUse)
+	assert.Equal(t, ctr.Usedmem, int32(10240))
+
+	// The suffix must round-trip to the slot actually reserved.
+	tidx, pos, err := device.ExtractMigTemplatesFromUUID(ctr.UUID)
+	assert.NilError(t, err)
+	assert.Equal(t, tidx, 0)
+	assert.Equal(t, pos, 2)
 }
 
 func TestCustomFilterRule_MigEmptyUsageWithTemplate(t *testing.T) {


### PR DESCRIPTION
## What this PR does

`AddResourceUsage` records which MIG slot a container got by appending a `[templateIdx-position]` suffix to the device UUID. The two allocation branches disagreed on what `position` means:

- The fresh-template branch (when the geometry is reset) reserved the slot at the flattened `UsageList` offset (`usageListIdx`) but stamped the geometry item index (`idx`) into the UUID.
- The reuse branch stamps the flattened offset.

`ExtractMigTemplatesFromUUID`, and therefore `getNodesUsage`, reads thesuffix as a flattened offset into `UsageList`. When an earlier item in the geometry has `Count > 1`, the geometry index and the flattened offset diverge, so `getNodesUsage` marks a different slot in use than the one that was actually reserved. The allocated slot appears free while an unallocated one appears taken, which can lead to double-booking a MIG instance.

## The fix

Stamp `usageListIdx` in the fresh-template branch so both branches and the reader agree on the meaning of the suffix.

## Why it was not caught earlier

The shipped A100-40GB geometry is `1g.5gb x1, 2g.10gb x3`, where the geometry index and flattened offset of the first fitting slot coincide, so the bug is masked. It surfaces on geometries where an earlier item has `Count > 1`, such as the `2g.10gb x3, 1g.5gb x1` example in docs/develop/dynamic-mig.md.

## Testing

Added `TestAddResourceUsage_MigFreshTemplateStampsFlattenedIndex`, which builds a `1g.5gb x2, 2g.10gb x1` geometry (flattened `UsageList` index 2 = geometry index 1) and asserts the stamped suffix round-trips through `ExtractMigTemplatesFromUUID` to the slot actually reserved. The test fails without the fix (stamps `1`, expects `2`) and passes with it.

Also corrected the existing `TestDevices_AddResourceUsage`: its `Count > 1` case pinned the buggy suffix (`dev-3[0-1]`) while its assertion helper silently re-derived the flattened offset, masking the mismatch. It now expects the flattened suffix (`dev-3[0-2]`) and reads the `UsageList` index directly. Full unit suite run with `-race`.

## AI assistance disclosure

This change was prepared with AI assistance (Claude Opus 4.8). All code and tests were reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Corrected NVIDIA MIG allocation identifiers to consistently match the reserved MIG slot.
* Improved allocation reliability for templates containing repeated geometry configurations.
* Updated MIG usage tracking so allocated slots are represented accurately.

## Tests

* Added coverage for fresh-template allocations.
* Added validation for repeated geometry configurations and correct slot identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->