### PR TITLE
Fix client test ignoring TEST_WITH_REAL_CLUSTER

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -23,14 +23,14 @@ resolved it. The existing NVIDIA LD_PRELOAD path is unchanged.
 
 **Advantages of CU masking, compared to hardware partitioning (CPX/NPS).**
 Masking (`HSA_CU_MASK`) assigns fine-grained, hardware-valid per-pod CU
-partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+partitioning at container start ([AMD Docs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html)).
 On the other hand, hardware partitioning (CPX/NPS) slices only at fixed XCD
 granularity and is set per physical GPU.
 
 **WGP pairing and rollout scope.** ROCm documents that not every CU mask is
 valid on every device: on GPUs where two CUs form a Work Group Processor
 (WGP) and kernels run in WGP mode, disabling only one CU of a pair is
-invalid ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html)).
+invalid ([setting CUs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html)).
 WGP is an **RDNA** construct (GFX10+); HIP describes it under the RDNA hardware
 model ([HIP hardware implementation](https://rocm.docs.amd.com/projects/HIP/en/latest/understand/hardware_implementation.html)).
 **CDNA** devices (e.g. Instinct MI300X, `gfx942`) keep independent CUs and are
@@ -162,7 +162,7 @@ residual interference remains (as reported in #1707).
 - **WGP-aware CU allocation is phased.** First ship CU partitioning on
   non-WGP devices (CDNA / Instinct). RDNA (GFX10+) devices need WGP pair
   alignment when building `HSA_CU_MASK`
-  ([setting CUs](https://rocm.docs.amd.com/en/latest/how-to/setting-cus.html))
+  ([setting CUs](https://rocm.docs.amd.com/en/latest/reference/system-optimization/gpu-isolation.html))
   and land in a follow-up.
 
 ## 7. Multi-GPU validation required

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -152,9 +152,9 @@ func TestClientWithOptions(t *testing.T) {
 // TestClientRealNodePerformance tests the performance with a real Kubernetes cluster if available.
 func TestClientRealNodePerformance(t *testing.T) {
 
-	skipRealClusterTest := true
+	skipRealClusterTest := os.Getenv("TEST_WITH_REAL_CLUSTER") != "true"
 	// Skip this test by default as it requires a real Kubernetes cluster.
-	if skipRealClusterTest == true {
+	if skipRealClusterTest {
 		t.Skip("Skipping real cluster test. Set TEST_WITH_REAL_CLUSTER=true to run this test.")
 	}
 


### PR DESCRIPTION
**What happened:**
The `TestClientRealNodePerformance` test in `client_test.go` was intended to be skipped unless `TEST_WITH_REAL_CLUSTER=true` is set. However, it was completely ignoring the environment variable because the skip boolean was hardcoded to `true`. 

**What you expected to happen:**
The test should properly read the environment variable and only skip if it's not set to true. 

**How to reproduce it:**
Run `TEST_WITH_REAL_CLUSTER=true go test ./pkg/util/client/...` and notice that the real cluster performance test is still skipped.

**Proposed Solution:**
Updated the code to actually use `os.Getenv("TEST_WITH_REAL_CLUSTER")` and cleaned up the boolean check.

---
*Note: I used an AI assistant to help identify this bug and draft the initial code fix.*

Fixes #2520 
