### PR TITLE
fix(scheduler): prevent concurrent over-allocation and quota leak in Filter (#1330, #1896)

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -365,7 +365,8 @@ func (cc ClusterManagerCollector) collectPodAndContainerInfo(ch chan<- prometheu
 		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
 	}
 
-	pods, err := cc.ClusterManager.PodLister.List(labels.SelectorFromSet(labels.Set{util.AssignedNodeAnnotations: nodeName}))
+	labelValue := util.SafeLabelValue(nodeName)
+	pods, err := cc.ClusterManager.PodLister.List(labels.SelectorFromSet(labels.Set{util.AssignedNodeAnnotations: labelValue}))
 	if err != nil {
 		klog.Errorf("Failed to list pods for node %s: %v", nodeName, err)
 		return fmt.Errorf("failed to list pods: %w", err)
@@ -509,7 +510,8 @@ func (cc ClusterManagerCollector) collectPodAndContainerMigInfo(ch chan<- promet
 		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
 	}
 
-	pods, err := cc.ClusterManager.PodLister.List(labels.SelectorFromSet(labels.Set{util.AssignedNodeAnnotations: nodeName}))
+	labelValue := util.SafeLabelValue(nodeName)
+	pods, err := cc.ClusterManager.PodLister.List(labels.SelectorFromSet(labels.Set{util.AssignedNodeAnnotations: labelValue}))
 	if err != nil {
 		klog.Errorf("Failed to list pods for node %s: %v", nodeName, err)
 		return fmt.Errorf("failed to list pods: %w", err)

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -66,5 +71,47 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 	if _, err := regLegacy.Gather(); err != nil {
 		t.Errorf("Gather failed (legacy): %v", err)
+	}
+}
+
+func TestLongNodeNamePodSelector(t *testing.T) {
+	longNodeName := "node-" + strings.Repeat("a", 60) // 65 chars > 63
+	safeLabel := util.SafeLabelValue(longNodeName)
+
+	t.Setenv(util.NodeNameEnvName, longNodeName)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-long-node",
+			Namespace: "default",
+			Labels: map[string]string{
+				util.AssignedNodeAnnotations: safeLabel,
+			},
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informerFactory.Core().V1().Pods()
+	podInformer.Informer()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	nodeNameEnv := os.Getenv(util.NodeNameEnvName)
+	labelValue := util.SafeLabelValue(nodeNameEnv)
+	selector := labels.SelectorFromSet(labels.Set{util.AssignedNodeAnnotations: labelValue})
+
+	pods, err := podInformer.Lister().List(selector)
+	if err != nil {
+		t.Fatalf("Failed to list pods using selector: %v", err)
+	}
+
+	if len(pods) != 1 {
+		t.Fatalf("Expected 1 pod matched by selector for long node name, got %d", len(pods))
+	}
+	if pods[0].Name != "test-pod-long-node" {
+		t.Errorf("Expected pod name 'test-pod-long-node', got %q", pods[0].Name)
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -76,6 +76,12 @@ type Scheduler struct {
 	eventRecorder  record.EventRecorder
 	started        uint32 // 0 = false, 1 = true
 
+	// filterMutex synchronizes capacity checks (Fit/FitQuota) and allocation commits
+	// (AddPod/AddUsage) in Filter() across concurrent Extender calls, preventing
+	// over-allocation of node devices and namespace quotas (upstream #1330).
+	// It also ensures symmetric rollback on annotation failure (upstream #1896).
+	filterMutex sync.Mutex
+
 	lock   sync.RWMutex
 	synced bool
 }
@@ -147,9 +153,11 @@ func (s *Scheduler) onAddPod(obj any) {
 		return
 	}
 	if util.IsPodInTerminatedState(pod) {
+		s.filterMutex.Lock()
 		if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 			s.quotaManager.RmUsage(pod, pi.Devices)
 		}
+		s.filterMutex.Unlock()
 		return
 	}
 	if util.IsPodTerminating(pod) {
@@ -162,9 +170,15 @@ func (s *Scheduler) onAddPod(obj any) {
 		klog.ErrorS(err, "failed to decode pod devices", "pod", klog.KObj(pod))
 		return
 	}
+	s.filterMutex.Lock()
+	// AddPod returns true only if the pod was not already present in podManager cache.
+	// If the pod was already tracked (e.g., allocated previously by Filter()), AddPod
+	// updates the cached pod devices in-place and returns false, preventing onAddPod
+	// from double-counting quota usage via AddUsage.
 	if s.podManager.AddPod(pod, nodeID, podDev) {
 		s.quotaManager.AddUsage(pod, podDev)
 	}
+	s.filterMutex.Unlock()
 }
 
 func (s *Scheduler) onUpdatePod(_, newObj any) {
@@ -195,9 +209,11 @@ func (s *Scheduler) onDelPod(obj any) {
 	if !ok {
 		return
 	}
+	s.filterMutex.Lock()
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}
+	s.filterMutex.Unlock()
 }
 
 // onDelNode handles node delete events. It removes any in-memory per-node
@@ -796,10 +812,18 @@ func (s *Scheduler) getPodUsage() (map[string]device.PodUseDeviceStat, error) {
 	return podUsageStat, nil
 }
 
-func (s *Scheduler) cleanupStalePodAllocation(pod *corev1.Pod) {
+// cleanupStalePodAllocationLocked removes any existing cache entry for pod
+// and adjusts quota usage. Caller MUST hold s.filterMutex.
+func (s *Scheduler) cleanupStalePodAllocationLocked(pod *corev1.Pod) {
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok && len(pi.Devices) > 0 {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}
+}
+
+func (s *Scheduler) cleanupStalePodAllocation(pod *corev1.Pod) {
+	s.filterMutex.Lock()
+	defer s.filterMutex.Unlock()
+	s.cleanupStalePodAllocationLocked(pod)
 }
 
 func (s *Scheduler) lockAllDevices(node *corev1.Node, pod *corev1.Pod) error {
@@ -915,6 +939,53 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 	return &extenderv1.ExtenderBindingResult{Error: ""}, nil
 }
 
+// tryAllocate holds s.filterMutex to perform capacity check and allocation atomically (upstream #1330).
+// It returns (filterResult, bestNode, error). If filterResult or error is non-nil, allocation was not made.
+func (s *Scheduler) tryAllocate(args extenderv1.ExtenderArgs, resourceReqs device.PodDeviceRequests) (*extenderv1.ExtenderFilterResult, *policy.NodeScore, error) {
+	s.filterMutex.Lock()
+	defer s.filterMutex.Unlock()
+
+	s.cleanupStalePodAllocationLocked(args.Pod)
+
+	nodeUsage, _, failedNodes, err := s.getNodesUsage(args.NodeNames, args.Pod)
+	if err != nil {
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		return nil, nil, err
+	}
+	if len(failedNodes) != 0 {
+		klog.V(5).InfoS("Nodes failed during usage retrieval", "nodes", failedNodes)
+	}
+	nodeScores, err := s.calcScore(nodeUsage, resourceReqs, args.Pod, failedNodes)
+	if err != nil {
+		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
+		return nil, nil, err
+	}
+	if len((*nodeScores).NodeList) == 0 {
+		klog.V(4).InfoS("No available nodes meet the required scores", "pod", args.Pod.Name)
+		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
+		return &extenderv1.ExtenderFilterResult{
+			FailedNodes: failedNodes,
+		}, nil, nil
+	}
+	klog.V(4).Infoln("nodeScores_len=", len((*nodeScores).NodeList))
+	sort.Sort(nodeScores)
+	m := (*nodeScores).NodeList[len((*nodeScores).NodeList)-1]
+
+	if s.podManager.AddPod(args.Pod, m.NodeID, m.Devices) {
+		s.quotaManager.AddUsage(args.Pod, m.Devices)
+	}
+
+	return nil, m, nil
+}
+
+// rollbackAllocation rolls back podManager and quotaManager allocations on annotation patch failure (upstream #1896).
+func (s *Scheduler) rollbackAllocation(pod *corev1.Pod) {
+	s.filterMutex.Lock()
+	defer s.filterMutex.Unlock()
+	s.cleanupStalePodAllocationLocked(pod)
+}
+
 func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFilterResult, error) {
 	klog.InfoS("Starting schedule filter process", "pod", args.Pod.Name, "uuid", args.Pod.UID, "namespace", args.Pod.Namespace)
 	resourceReqs := device.Resourcereqs(args.Pod)
@@ -953,65 +1024,36 @@ func (s *Scheduler) Filter(args extenderv1.ExtenderArgs) (*extenderv1.ExtenderFi
 		"pod", klog.KObj(args.Pod),
 		"reason", "request does not contain full nodes",
 		"nodeNamesLen", nodeNamesLen(args.NodeNames))
-	if pi, ok := s.podManager.TakeAndDeletePod(args.Pod); ok {
-		s.quotaManager.RmUsage(args.Pod, pi.Devices)
+
+	filterRes, bestNode, err := s.tryAllocate(args, resourceReqs)
+	if err != nil || filterRes != nil {
+		return filterRes, err
 	}
-	nodeUsage, _, failedNodes, err := s.getNodesUsage(args.NodeNames, args.Pod)
-	if err != nil {
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		return nil, err
-	}
-	if len(failedNodes) != 0 {
-		klog.V(5).InfoS("Nodes failed during usage retrieval",
-			"nodes", failedNodes)
-	}
-	nodeScores, err := s.calcScore(nodeUsage, resourceReqs, args.Pod, failedNodes)
-	if err != nil {
-		err := fmt.Errorf("calcScore failed %v for pod %v", err, args.Pod.Name)
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		return nil, err
-	}
-	if len((*nodeScores).NodeList) == 0 {
-		klog.V(4).InfoS("No available nodes meet the required scores",
-			"pod", args.Pod.Name)
-		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", fmt.Errorf("no available node, %d nodes do not meet", len(*args.NodeNames)))
-		return &extenderv1.ExtenderFilterResult{
-			FailedNodes: failedNodes,
-		}, nil
-	}
-	klog.V(4).Infoln("nodeScores_len=", len((*nodeScores).NodeList))
-	sort.Sort(nodeScores)
-	m := (*nodeScores).NodeList[len((*nodeScores).NodeList)-1]
+
 	klog.InfoS("Scheduling pod to node",
 		"podNamespace", args.Pod.Namespace,
 		"podName", args.Pod.Name,
-		"nodeID", m.NodeID,
-		"devices", m.Devices)
+		"nodeID", bestNode.NodeID,
+		"devices", bestNode.Devices)
 	annotations := make(map[string]string)
-	annotations[util.AssignedNodeAnnotations] = m.NodeID
+	annotations[util.AssignedNodeAnnotations] = bestNode.NodeID
 	annotations[util.AssignedTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
 
 	for _, val := range device.GetDevices() {
-		val.PatchAnnotations(args.Pod, &annotations, m.Devices)
+		val.PatchAnnotations(args.Pod, &annotations, bestNode.Devices)
 	}
 
-	added := s.podManager.AddPod(args.Pod, m.NodeID, m.Devices)
-	if added {
-		s.quotaManager.AddUsage(args.Pod, m.Devices)
-	}
-
+	// PatchPodAnnotations performs K8s API network call, executed outside filterMutex.
+	// If it fails, roll back both podManager and quotaManager under filterMutex (upstream #1896).
 	err = util.PatchPodAnnotations(args.Pod, annotations)
 	if err != nil {
 		s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringFailed, "", err)
-		if added {
-			s.quotaManager.RmUsage(args.Pod, m.Devices)
-		}
-		s.podManager.DelPod(args.Pod)
+		s.rollbackAllocation(args.Pod)
 		return nil, err
 	}
-	successMsg := genSuccessMsg(len(*args.NodeNames), m.NodeID, nodeScores.NodeList)
+	successMsg := genSuccessMsg(len(*args.NodeNames), bestNode.NodeID, []*policy.NodeScore{bestNode})
 	s.recordScheduleFilterResultEvent(args.Pod, EventReasonFilteringSucceed, successMsg, nil)
-	res := extenderv1.ExtenderFilterResult{NodeNames: &[]string{m.NodeID}}
+	res := extenderv1.ExtenderFilterResult{NodeNames: &[]string{bestNode.NodeID}}
 	return &res, nil
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2450,7 +2450,7 @@ func Test_Filter_Bug1896_QuotaRollbackOnPatchFailure(t *testing.T) {
 // This is a regression test for upstream bug #1330.
 //
 // The test loops 100 times to make any surviving race statistically visible.
-// Run with: go test ./pkg/scheduler/... -race -run Test_Filter_Bug1330
+// Run with: go test ./pkg/scheduler/... -race -run Test_Filter_Bug1330.
 func Test_Filter_Bug1330_NoConcurrentOverAllocation(t *testing.T) {
 	setupNvidiaConfigForTest(t)
 
@@ -2461,11 +2461,11 @@ func Test_Filter_Bug1330_NoConcurrentOverAllocation(t *testing.T) {
 
 	const (
 		ns          = "race-test-ns"
-		concurrency = 5  // pods racing to claim the only GPU slot
-		iterations  = 100 // repeat to expose statistical races
+		concurrency = 5   // Pods racing to claim the only GPU slot.
+		iterations  = 100 // Repeat to expose statistical races.
 	)
 
-	for iter := 0; iter < iterations; iter++ {
+	for iter := range iterations {
 		// Fresh scheduler per iteration.
 		s := NewScheduler()
 
@@ -2692,7 +2692,7 @@ func Test_Filter_FitFailureReleasesLockCleanly(t *testing.T) {
 	acquired := make(chan struct{})
 	go func() {
 		s.filterMutex.Lock()
-		s.filterMutex.Unlock()
+		s.filterMutex.Unlock() //nolint:staticcheck // SA2001: intentional synchronization point to verify filterMutex was cleanly unlocked after Fit failure
 		close(acquired)
 	}()
 
@@ -2718,7 +2718,7 @@ func BenchmarkFilter(b *testing.B) {
 	informerFactory.WaitForCacheSync(s.stopCh)
 
 	nodeNames := make([]string, nodeCount)
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		name := fmt.Sprintf("bench-node-%d", i)
 		nodeNames[i] = name
 		s.addNode(name, &device.NodeInfo{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2306,4 +2307,569 @@ func Test_Bind_PodGroupPodNonContentionErrorDoesNotRetry(t *testing.T) {
 	require.Contains(t, res.Error, "apiserver 500")
 	require.Equal(t, int32(1), mock.lockCalls.Load(),
 		"non-contention error must not trigger retry")
+}
+
+func setupNvidiaConfigForTest(t testing.TB) {
+	oldDevicesMap := maps.Clone(device.DevicesMap)
+	oldDevicesToHandle := append([]string{}, device.DevicesToHandle...)
+	t.Cleanup(func() {
+		device.DevicesMap = oldDevicesMap
+		device.DevicesToHandle = oldDevicesToHandle
+	})
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("Failed to initialize devices: %v", err)
+	}
+}
+
+// Test_Filter_Bug1896_QuotaRollbackOnPatchFailure verifies that when
+// util.PatchPodAnnotations returns an error after AddPod/AddUsage have
+// already committed the allocation, Filter rolls back BOTH podManager and
+// quotaManager, leaving quota usage at its pre-call level.
+// This is a regression test for upstream bug #1896.
+func Test_Filter_Bug1896_QuotaRollbackOnPatchFailure(t *testing.T) {
+	setupNvidiaConfigForTest(t)
+
+	const ns = "default"
+
+	// Add a quota limit so quotaManager has a real entry to roll back.
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	require.True(t, ok)
+	memResourceName := nvidiaDevice.GetResourceNames().ResourceMemoryName
+	require.NotEmpty(t, memResourceName)
+
+	s := NewScheduler()
+	s.onAddQuota(&corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-quota", Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits." + memResourceName): *resource.NewQuantity(100000, resource.BinarySI),
+			},
+		},
+	})
+
+	// Add a node with one GPU (8 GiB memory).
+	s.addNode("node1", &device.NodeInfo{
+		ID:   "node1",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID:           "gpu0",
+				Index:        0,
+				Count:        10,
+				Devmem:       8192,
+				Devcore:      100,
+				Health:       true,
+				Type:         nvidia.NvidiaGPUDevice,
+				DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+
+	// Record quota usage before the call.
+	quotaBefore := func() int64 {
+		q := s.quotaManager.GetResourceQuota()
+		nsq, ok := q[ns]
+		if !ok {
+			return 0
+		}
+		entry, ok := (*nsq)[memResourceName]
+		if !ok {
+			return 0
+		}
+		return entry.Used
+	}
+	require.Equal(t, int64(0), quotaBefore(), "pre-condition: quota must be zero before test")
+
+	// Use a fake KubeClient whose Patch calls always fail — this makes
+	// util.PatchPodAnnotations return an error, simulating a transient API failure
+	// AFTER AddPod/AddUsage have already committed the allocation.
+	client.KubeClient = fake.NewClientset()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "patch-fail-pod",
+			Namespace: ns,
+			UID:       "patch-fail-uid",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "gpu-container",
+				Image: "ubuntu",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+						"hami.io/gpumem":   *resource.NewQuantity(2048, resource.BinarySI),
+						"hami.io/gpucores": *resource.NewQuantity(20, resource.BinarySI),
+					},
+				},
+			}},
+		},
+	}
+	// Do NOT add the pod to the fake client — PatchPodAnnotations will fail
+	// because the pod does not exist in the API server.
+
+	nodeNames := []string{"node1"}
+	_, err := s.Filter(extenderv1.ExtenderArgs{
+		Pod:       pod,
+		NodeNames: &nodeNames,
+	})
+
+	// Filter must return an error because PatchPodAnnotations failed.
+	require.Error(t, err, "Filter must propagate PatchPodAnnotations error")
+
+	// Bug #1896: quota must be rolled back to zero.
+	require.Equal(t, int64(0), quotaBefore(),
+		"quota usage must be fully rolled back after PatchPodAnnotations failure (Bug #1896)")
+
+	// The pod must no longer be in the podManager cache.
+	_, inCache := s.podManager.GetPod(pod)
+	require.False(t, inCache,
+		"pod must be removed from podManager cache after PatchPodAnnotations failure")
+}
+
+// Test_Filter_Bug1330_NoConcurrentOverAllocation verifies that concurrent
+// Filter() calls for multiple pods against a node/namespace with capacity for
+// only ONE pod never admit more than one pod.
+// This is a regression test for upstream bug #1330.
+//
+// The test loops 100 times to make any surviving race statistically visible.
+// Run with: go test ./pkg/scheduler/... -race -run Test_Filter_Bug1330
+func Test_Filter_Bug1330_NoConcurrentOverAllocation(t *testing.T) {
+	setupNvidiaConfigForTest(t)
+
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	require.True(t, ok)
+	memResourceName := nvidiaDevice.GetResourceNames().ResourceMemoryName
+	require.NotEmpty(t, memResourceName)
+
+	const (
+		ns          = "race-test-ns"
+		concurrency = 5  // pods racing to claim the only GPU slot
+		iterations  = 100 // repeat to expose statistical races
+	)
+
+	for iter := 0; iter < iterations; iter++ {
+		// Fresh scheduler per iteration.
+		s := NewScheduler()
+
+		// Set a quota that fits exactly ONE pod request (pod requests 2 GiB, quota = 2 GiB).
+		s.onAddQuota(&corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "gpu-quota", Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceName("limits." + memResourceName): *resource.NewQuantity(2048, resource.BinarySI),
+				},
+			},
+		})
+
+		// Node has a single GPU with exactly 2 GiB of memory.
+		s.addNode("node-race", &device.NodeInfo{
+			ID:   "node-race",
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-race"}},
+			Devices: map[string][]device.DeviceInfo{
+				nvidia.NvidiaGPUDevice: {{
+					ID:           "gpu-race",
+					Index:        0,
+					Count:        1,
+					Devmem:       2048,
+					Devcore:      100,
+					Health:       true,
+					Type:         nvidia.NvidiaGPUDevice,
+					DeviceVendor: nvidia.NvidiaGPUDevice,
+				}},
+			},
+		})
+
+		// Fake API server — pods are pre-created so PatchPodAnnotations succeeds.
+		client.KubeClient = fake.NewClientset()
+		s.kubeClient = client.KubeClient
+		informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+		s.podLister = informerFactory.Core().V1().Pods().Lister()
+		informerFactory.Start(s.stopCh)
+		informerFactory.WaitForCacheSync(s.stopCh)
+
+		pods := make([]*corev1.Pod, concurrency)
+		for i := range pods {
+			pods[i] = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("race-pod-%d-%d", iter, i),
+					Namespace: ns,
+					UID:       types.UID(fmt.Sprintf("race-uid-%d-%d", iter, i)),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "gpu-container",
+						Image: "ubuntu",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+								"hami.io/gpumem":   *resource.NewQuantity(2048, resource.BinarySI),
+								"hami.io/gpucores": *resource.NewQuantity(20, resource.BinarySI),
+							},
+						},
+					}},
+				},
+			}
+			client.KubeClient.CoreV1().Pods(ns).Create(
+				context.Background(), pods[i], metav1.CreateOptions{},
+			)
+		}
+
+		nodeNames := []string{"node-race"}
+		var admitted atomic.Int32
+
+		// Launch concurrency goroutines all calling Filter at the same time.
+		var wg sync.WaitGroup
+		for i := range pods {
+			wg.Add(1)
+			go func(pod *corev1.Pod) {
+				defer wg.Done()
+				result, err := s.Filter(extenderv1.ExtenderArgs{
+					Pod:       pod,
+					NodeNames: &nodeNames,
+				})
+				if err == nil && result != nil && result.NodeNames != nil && len(*result.NodeNames) > 0 {
+					admitted.Add(1)
+				}
+			}(pods[i])
+		}
+		wg.Wait()
+
+		admittedCount := admitted.Load()
+		require.LessOrEqualf(t, admittedCount, int32(1),
+			"iteration %d: admitted %d pods against a node/quota with capacity for 1 (Bug #1330)",
+			iter, admittedCount)
+
+		close(s.stopCh)
+	}
+}
+
+// Test_Filter_NonContendingPodsBothEventuallyAdmitted verifies that two pods requesting
+// distinct resources in different namespaces/nodes are both successfully admitted
+// (processed sequentially under filterMutex).
+func Test_Filter_NonContendingPodsBothEventuallyAdmitted(t *testing.T) {
+	setupNvidiaConfigForTest(t)
+
+	s := NewScheduler()
+	client.KubeClient = fake.NewClientset()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// Add two distinct nodes with GPU resources.
+	s.addNode("node-a", &device.NodeInfo{
+		ID:   "node-a",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID: "gpu-a", Index: 0, Count: 10, Devmem: 8192, Devcore: 100, Health: true, Type: nvidia.NvidiaGPUDevice, DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+	s.addNode("node-b", &device.NodeInfo{
+		ID:   "node-b",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID: "gpu-b", Index: 0, Count: 10, Devmem: 8192, Devcore: 100, Health: true, Type: nvidia.NvidiaGPUDevice, DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+
+	podA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a", UID: "uid-a"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c1", Image: "ubuntu",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hami.io/gpu": *resource.NewQuantity(1, resource.BinarySI), "hami.io/gpumem": *resource.NewQuantity(1024, resource.BinarySI), "hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+					},
+				},
+			}},
+		},
+	}
+	podB := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns-b", UID: "uid-b"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c1", Image: "ubuntu",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hami.io/gpu": *resource.NewQuantity(1, resource.BinarySI), "hami.io/gpumem": *resource.NewQuantity(1024, resource.BinarySI), "hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+					},
+				},
+			}},
+		},
+	}
+	client.KubeClient.CoreV1().Pods("ns-a").Create(context.Background(), podA, metav1.CreateOptions{})
+	client.KubeClient.CoreV1().Pods("ns-b").Create(context.Background(), podB, metav1.CreateOptions{})
+
+	nodesA := []string{"node-a"}
+	resA, errA := s.Filter(extenderv1.ExtenderArgs{Pod: podA, NodeNames: &nodesA})
+	require.NoError(t, errA)
+	require.NotNil(t, resA)
+	require.Equal(t, []string{"node-a"}, *resA.NodeNames)
+
+	nodesB := []string{"node-b"}
+	resB, errB := s.Filter(extenderv1.ExtenderArgs{Pod: podB, NodeNames: &nodesB})
+	require.NoError(t, errB)
+	require.NotNil(t, resB)
+	require.Equal(t, []string{"node-b"}, *resB.NodeNames)
+}
+
+// Test_Filter_FitFailureReleasesLockCleanly verifies that when calcScore/Fit fails
+// inside tryAllocate (e.g. no nodes have sufficient capacity), filterMutex is released
+// cleanly without leaving phantom state in podManager or quotaManager.
+func Test_Filter_FitFailureReleasesLockCleanly(t *testing.T) {
+	setupNvidiaConfigForTest(t)
+
+	s := NewScheduler()
+	client.KubeClient = fake.NewClientset()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// Node with only 1 GiB GPU memory.
+	s.addNode("node-small", &device.NodeInfo{
+		ID:   "node-small",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-small"}},
+		Devices: map[string][]device.DeviceInfo{
+			nvidia.NvidiaGPUDevice: {{
+				ID: "gpu0", Index: 0, Count: 1, Devmem: 1024, Devcore: 100, Health: true, Type: nvidia.NvidiaGPUDevice, DeviceVendor: nvidia.NvidiaGPUDevice,
+			}},
+		},
+	})
+
+	// Pod requesting 4 GiB GPU memory (exceeds node capacity).
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "huge-pod", Namespace: "default", UID: "huge-uid"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "c1", Image: "ubuntu",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"hami.io/gpu": *resource.NewQuantity(1, resource.BinarySI), "hami.io/gpumem": *resource.NewQuantity(4096, resource.BinarySI), "hami.io/gpucores": *resource.NewQuantity(20, resource.BinarySI),
+					},
+				},
+			}},
+		},
+	}
+	client.KubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+
+	nodes := []string{"node-small"}
+	res, err := s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &nodes})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.NodeNames == nil || len(*res.NodeNames) == 0, "no node should fit")
+
+	// Ensure no phantom allocation was created in podManager.
+	_, inCache := s.podManager.GetPod(pod)
+	require.False(t, inCache, "pod must not be recorded in podManager cache when Fit fails")
+
+	// Ensure lock can be acquired immediately (proving filterMutex was unlocked).
+	acquired := make(chan struct{})
+	go func() {
+		s.filterMutex.Lock()
+		s.filterMutex.Unlock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		// Success: lock was cleanly released.
+	case <-time.After(time.Second):
+		t.Fatal("filterMutex was not released after Fit failure")
+	}
+}
+
+// BenchmarkFilter measures Filter() latency and lock throughput over 200 candidate nodes.
+func BenchmarkFilter(b *testing.B) {
+	setupNvidiaConfigForTest(b)
+
+	const nodeCount = 200
+	s := NewScheduler()
+	client.KubeClient = fake.NewClientset()
+	s.kubeClient = client.KubeClient
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	nodeNames := make([]string, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		name := fmt.Sprintf("bench-node-%d", i)
+		nodeNames[i] = name
+		s.addNode(name, &device.NodeInfo{
+			ID:   name,
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			Devices: map[string][]device.DeviceInfo{
+				nvidia.NvidiaGPUDevice: {{
+					ID:           fmt.Sprintf("gpu-%d", i),
+					Index:        0,
+					Count:        100,
+					Devmem:       32768,
+					Devcore:      100,
+					Health:       true,
+					Type:         nvidia.NvidiaGPUDevice,
+					DeviceVendor: nvidia.NvidiaGPUDevice,
+				}},
+			},
+		})
+	}
+
+	b.Run("Uncontended", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("bench-pod-%d", i),
+					Namespace: "default",
+					UID:       types.UID(fmt.Sprintf("bench-uid-%d", i)),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c1",
+						Image: "ubuntu",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+								"hami.io/gpumem":   *resource.NewQuantity(1024, resource.BinarySI),
+								"hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+							},
+						},
+					}},
+				},
+			}
+			client.KubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+			_, _ = s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &nodeNames})
+		}
+	})
+
+	b.Run("ContendedParallel", func(b *testing.B) {
+		var podCounter atomic.Int64
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				idx := podCounter.Add(1)
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("par-pod-%d", idx),
+						Namespace: "default",
+						UID:       types.UID(fmt.Sprintf("par-uid-%d", idx)),
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "c1",
+							Image: "ubuntu",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+									"hami.io/gpumem":   *resource.NewQuantity(1024, resource.BinarySI),
+									"hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+								},
+							},
+						}},
+					},
+				}
+				client.KubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+				_, _ = s.Filter(extenderv1.ExtenderArgs{Pod: pod, NodeNames: &nodeNames})
+			}
+		})
+	})
+}
+
+// Test_onAddPod_AlreadyTrackedPodDoesNotDoubleCountQuota verifies that when onAddPod
+// is called for a pod that is already tracked in podManager (e.g., via Filter or an
+// earlier informer event), AddPod returns false and onAddPod does NOT call AddUsage
+// a second time.
+func Test_onAddPod_AlreadyTrackedPodDoesNotDoubleCountQuota(t *testing.T) {
+	setupNvidiaConfigForTest(t)
+
+	const ns = "double-count-ns"
+	s := NewScheduler()
+
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	require.True(t, ok)
+	memResourceName := nvidiaDevice.GetResourceNames().ResourceMemoryName
+
+	s.onAddQuota(&corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "quota1", Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits." + memResourceName): *resource.NewQuantity(100000, resource.BinarySI),
+			},
+		},
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tracked-pod",
+			Namespace: ns,
+			UID:       "tracked-uid",
+			Annotations: map[string]string{
+				util.AssignedNodeAnnotations: "node1",
+			},
+		},
+	}
+
+	podDev := device.PodDevices{
+		nvidia.NvidiaGPUDevice: device.PodSingleDevice{
+			{
+				{
+					Idx:       0,
+					UUID:      "gpu0",
+					Type:      nvidia.NvidiaGPUDevice,
+					Usedmem:   2048,
+					Usedcores: 20,
+				},
+			},
+		},
+	}
+
+	// 1. Add pod to podManager and quotaManager directly (simulating prior Filter allocation).
+	added := s.podManager.AddPod(pod, "node1", podDev)
+	require.True(t, added, "initial AddPod must return true for new pod")
+	s.quotaManager.AddUsage(pod, podDev)
+
+	getUsage := func() int64 {
+		q := s.quotaManager.GetResourceQuota()
+		if nsq, ok := q[ns]; ok {
+			if entry, ok := (*nsq)[memResourceName]; ok {
+				return entry.Used
+			}
+		}
+		return 0
+	}
+
+	initialUsage := getUsage()
+	require.Greater(t, initialUsage, int64(0), "quota usage should be recorded initially")
+
+	// 2. Trigger onAddPod (simulating informer resync or event for already-tracked pod).
+	s.onAddPod(pod)
+
+	usageAfterInformerEvent := getUsage()
+	require.Equal(t, initialUsage, usageAfterInformerEvent,
+		"quota usage must NOT be double-counted when onAddPod runs for an already-tracked pod")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -174,6 +174,9 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	p.Metadata.Annotations = annotations
 	label := make(map[string]string)
 	if v, ok := annotations[AssignedNodeAnnotations]; ok && v != "" {
+		// Note: Kubernetes node names are valid RFC 1123 DNS subdomains, so in practice
+		// the realistic failure mode for node names here is exceeding the 63-character
+		// label value length limit (validation.LabelValueMaxLength), not invalid characters.
 		if errs := validation.IsValidLabelValue(v); len(errs) == 0 {
 			label[AssignedNodeAnnotations] = v
 			p.Metadata.Labels = label

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 )
 
@@ -173,8 +174,12 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	p.Metadata.Annotations = annotations
 	label := make(map[string]string)
 	if v, ok := annotations[AssignedNodeAnnotations]; ok && v != "" {
-		label[AssignedNodeAnnotations] = v
-		p.Metadata.Labels = label
+		if errs := validation.IsValidLabelValue(v); len(errs) == 0 {
+			label[AssignedNodeAnnotations] = v
+			p.Metadata.Labels = label
+		} else {
+			klog.Warningf("Node name %s is not a valid label value (errs: %v), omitting label %s for pod %s/%s", v, errs, AssignedNodeAnnotations, pod.Namespace, pod.Name)
+		}
 	}
 
 	bytes, err := json.Marshal(p)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,9 +18,12 @@ package util
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,8 +39,35 @@ import (
 )
 
 var (
-	HandshakeAnnos map[string]string
+	HandshakeAnnos    map[string]string
+	nonLabelCharRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 )
+
+// SafeLabelValue converts an arbitrary string into a valid Kubernetes label value
+// that satisfies validation.IsValidLabelValue (<= 63 chars, valid charset, starting
+// and ending with an alphanumeric character). If the input is already a valid label value,
+// it is returned unchanged. Otherwise, a valid label value is deterministically derived
+// using a prefix of the sanitized input combined with a SHA-256 hash of the original input.
+func SafeLabelValue(value string) string {
+	if errs := validation.IsValidLabelValue(value); len(errs) == 0 {
+		return value
+	}
+
+	hashBytes := sha256.Sum256([]byte(value))
+	hash := hex.EncodeToString(hashBytes[:])[:10]
+
+	sanitized := nonLabelCharRegex.ReplaceAllString(value, "-")
+	maxPrefixLen := validation.LabelValueMaxLength - 1 - len(hash)
+	if len(sanitized) > maxPrefixLen {
+		sanitized = sanitized[:maxPrefixLen]
+	}
+
+	prefix := strings.Trim(sanitized, "._-")
+	if prefix == "" {
+		return hash
+	}
+	return prefix + "-" + hash
+}
 
 func init() {
 	HandshakeAnnos = make(map[string]string)
@@ -174,15 +204,15 @@ func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {
 	p.Metadata.Annotations = annotations
 	label := make(map[string]string)
 	if v, ok := annotations[AssignedNodeAnnotations]; ok && v != "" {
-		// Note: Kubernetes node names are valid RFC 1123 DNS subdomains, so in practice
-		// the realistic failure mode for node names here is exceeding the 63-character
-		// label value length limit (validation.LabelValueMaxLength), not invalid characters.
-		if errs := validation.IsValidLabelValue(v); len(errs) == 0 {
-			label[AssignedNodeAnnotations] = v
-			p.Metadata.Labels = label
-		} else {
-			klog.Warningf("Node name %s is not a valid label value (errs: %v), omitting label %s for pod %s/%s", v, errs, AssignedNodeAnnotations, pod.Namespace, pod.Name)
+		derived := SafeLabelValue(v)
+		if derived != v {
+			// Note: Kubernetes node names are valid RFC 1123 DNS subdomains, so in practice
+			// the realistic failure mode for node names here is exceeding the 63-character
+			// label value length limit (validation.LabelValueMaxLength), not invalid characters.
+			klog.V(4).Infof("Derived safe label value %q from node name %q for pod %s/%s", derived, v, pod.Namespace, pod.Name)
 		}
+		label[AssignedNodeAnnotations] = derived
+		p.Metadata.Labels = label
 	}
 
 	bytes, err := json.Marshal(p)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,51 +329,92 @@ func TestGetAllocatePodByNode(t *testing.T) {
 func TestPatchPodAnnotations(t *testing.T) {
 	client.KubeClient = fake.NewClientset()
 
-	// Create test pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "default",
-		},
-	}
-
-	client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+	longNodeName := "node-" + strings.Repeat("a", 60) // 65 chars > 63
+	invalidCharNodeName := "invalid_node_name!"       // <= 63 chars but contains invalid label character '!'
 
 	tests := []struct {
-		name        string
-		pod         *corev1.Pod
-		annotations map[string]string
-		wantErr     bool
+		name         string
+		podName      string
+		annotations  map[string]string
+		wantErr      bool
+		wantLabel    bool
+		expectedNode string
 	}{
 		{
-			name: "patch with valid annotations",
-			pod:  pod,
+			name:    "normal short node name",
+			podName: "pod-short",
 			annotations: map[string]string{
 				"test-key":              "test-value",
 				AssignedNodeAnnotations: "node1",
 			},
-			wantErr: false,
+			wantErr:      false,
+			wantLabel:    true,
+			expectedNode: "node1",
 		},
 		{
-			name: "patch non-existent pod",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "non-existent",
-					Namespace: "default",
-				},
+			name:    "node name > 63 chars",
+			podName: "pod-long",
+			annotations: map[string]string{
+				AssignedNodeAnnotations: longNodeName,
 			},
+			wantErr:      false,
+			wantLabel:    false,
+			expectedNode: longNodeName,
+		},
+		{
+			name:    "node name with invalid label characters but <= 63 chars",
+			podName: "pod-invalid",
+			annotations: map[string]string{
+				AssignedNodeAnnotations: invalidCharNodeName,
+			},
+			wantErr:      false,
+			wantLabel:    false,
+			expectedNode: invalidCharNodeName,
+		},
+		{
+			name:    "patch non-existent pod",
+			podName: "non-existent",
 			annotations: map[string]string{
 				"test-key": "test-value",
 			},
-			wantErr: true,
+			wantErr:   true,
+			wantLabel: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := PatchPodAnnotations(tt.pod, tt.annotations)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.podName,
+					Namespace: "default",
+				},
+			}
+			if !tt.wantErr {
+				client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+			}
+
+			err := PatchPodAnnotations(pod, tt.annotations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PatchPodAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				updatedPod, err := client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get pod after patch: %v", err)
+				}
+				if tt.expectedNode != "" {
+					assert.Equal(t, updatedPod.Annotations[AssignedNodeAnnotations], tt.expectedNode)
+				}
+				if tt.wantLabel {
+					assert.Equal(t, updatedPod.Labels[AssignedNodeAnnotations], tt.expectedNode)
+				} else {
+					if updatedPod.Labels != nil {
+						_, exists := updatedPod.Labels[AssignedNodeAnnotations]
+						assert.Equal(t, exists, false)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
@@ -332,12 +333,13 @@ func TestPatchPodAnnotations(t *testing.T) {
 	longNodeName := "node-" + strings.Repeat("a", 60) // 65 chars > 63
 
 	tests := []struct {
-		name         string
-		podName      string
-		annotations  map[string]string
-		wantErr      bool
-		wantLabel    bool
-		expectedNode string
+		name          string
+		podName       string
+		annotations   map[string]string
+		wantErr       bool
+		wantLabel     bool
+		expectedLabel string
+		expectedNode  string
 	}{
 		{
 			name:    "normal short node name",
@@ -346,9 +348,10 @@ func TestPatchPodAnnotations(t *testing.T) {
 				"test-key":              "test-value",
 				AssignedNodeAnnotations: "node1",
 			},
-			wantErr:      false,
-			wantLabel:    true,
-			expectedNode: "node1",
+			wantErr:       false,
+			wantLabel:     true,
+			expectedLabel: "node1",
+			expectedNode:  "node1",
 		},
 		{
 			name:    "node name > 63 chars",
@@ -356,9 +359,10 @@ func TestPatchPodAnnotations(t *testing.T) {
 			annotations: map[string]string{
 				AssignedNodeAnnotations: longNodeName,
 			},
-			wantErr:      false,
-			wantLabel:    false,
-			expectedNode: longNodeName,
+			wantErr:       false,
+			wantLabel:     true,
+			expectedLabel: SafeLabelValue(longNodeName),
+			expectedNode:  longNodeName,
 		},
 		{
 			name:    "patch non-existent pod",
@@ -397,7 +401,7 @@ func TestPatchPodAnnotations(t *testing.T) {
 					assert.Equal(t, updatedPod.Annotations[AssignedNodeAnnotations], tt.expectedNode)
 				}
 				if tt.wantLabel {
-					assert.Equal(t, updatedPod.Labels[AssignedNodeAnnotations], tt.expectedNode)
+					assert.Equal(t, updatedPod.Labels[AssignedNodeAnnotations], tt.expectedLabel)
 				} else {
 					if updatedPod.Labels != nil {
 						_, exists := updatedPod.Labels[AssignedNodeAnnotations]
@@ -407,6 +411,54 @@ func TestPatchPodAnnotations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSafeLabelValue(t *testing.T) {
+	t.Run("short valid input returned unchanged", func(t *testing.T) {
+		input := "short-node-1"
+		got := SafeLabelValue(input)
+		assert.Equal(t, got, input)
+		errs := validation.IsValidLabelValue(got)
+		assert.Equal(t, len(errs), 0)
+	})
+
+	t.Run("input > 63 chars produces valid, deterministic output <= 63 chars", func(t *testing.T) {
+		input := "node-" + strings.Repeat("a", 60)
+		got1 := SafeLabelValue(input)
+		got2 := SafeLabelValue(input)
+
+		assert.Equal(t, got1, got2)
+		if len(got1) > validation.LabelValueMaxLength {
+			t.Errorf("SafeLabelValue length %d exceeds max length %d", len(got1), validation.LabelValueMaxLength)
+		}
+		errs := validation.IsValidLabelValue(got1)
+		assert.Equal(t, len(errs), 0)
+	})
+
+	t.Run("input with invalid characters produces valid label value", func(t *testing.T) {
+		// Note: This tests the helper's general-purpose string-to-label robustness.
+		// Real Kubernetes node names are valid DNS subdomains and will not contain such characters.
+		arbitraryInvalidCharsInput := "arbitrary@invalid#chars!"
+		got := SafeLabelValue(arbitraryInvalidCharsInput)
+
+		errs := validation.IsValidLabelValue(got)
+		assert.Equal(t, len(errs), 0)
+	})
+
+	t.Run("two different long inputs with same prefix produce different outputs", func(t *testing.T) {
+		prefix := "node-" + strings.Repeat("a", 60)
+		input1 := prefix + "-cluster1"
+		input2 := prefix + "-cluster2"
+
+		got1 := SafeLabelValue(input1)
+		got2 := SafeLabelValue(input2)
+
+		if got1 == got2 {
+			t.Errorf("Expected different outputs for different inputs with same prefix, got %q", got1)
+		}
+		assert.Equal(t, len(validation.IsValidLabelValue(got1)), 0)
+		assert.Equal(t, len(validation.IsValidLabelValue(got2)), 0)
+	})
 }
 
 func Test_IsPodInTerminatedState(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -330,7 +330,6 @@ func TestPatchPodAnnotations(t *testing.T) {
 	client.KubeClient = fake.NewClientset()
 
 	longNodeName := "node-" + strings.Repeat("a", 60) // 65 chars > 63
-	invalidCharNodeName := "invalid_node_name!"       // <= 63 chars but contains invalid label character '!'
 
 	tests := []struct {
 		name         string
@@ -360,16 +359,6 @@ func TestPatchPodAnnotations(t *testing.T) {
 			wantErr:      false,
 			wantLabel:    false,
 			expectedNode: longNodeName,
-		},
-		{
-			name:    "node name with invalid label characters but <= 63 chars",
-			podName: "pod-invalid",
-			annotations: map[string]string{
-				AssignedNodeAnnotations: invalidCharNodeName,
-			},
-			wantErr:      false,
-			wantLabel:    false,
-			expectedNode: invalidCharNodeName,
 		},
 		{
 			name:    "patch non-existent pod",


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

This PR fixes two concurrency and state-consistency issues in the HAMi Kubernetes scheduler's `Filter()` extender path.

1. **Bug #1330 — Concurrent capacity check and commit race**

   `Scheduler.Filter()` previously performed `Fit` / `FitQuota` checks separately from `podManager.AddPod` / `quotaManager.AddUsage`. Since `Filter()` can be invoked concurrently for different pods, multiple requests could pass the same capacity check before either one committed its allocation.

   This could result in GPU memory, device cores, or quota resources being over-allocated beyond the available capacity.

2. **Bug #1896 — Missing quota rollback on annotation patch failure**

   If `util.PatchPodAnnotations()` failed after the allocation had already been committed, the existing error path could remove the pod allocation without rolling back the corresponding quota usage.

   This left stale quota accounting in memory and could cause subsequent pods to be incorrectly rejected even though the resources were actually available.

### Which issue(s) this PR fixes

Fixes #1330
Fixes #1896

---

### Key Technical Changes

1. **Atomic `Filter()` allocation with `filterMutex`**

   * Added `filterMutex sync.Mutex` to `Scheduler`.
   * Protected the complete allocation critical section from stale allocation cleanup through candidate evaluation, node scoring, and `AddPod` / `AddUsage`.
   * Structured the allocation flow into `tryAllocate()` and `rollbackAllocation()`.

2. **Deadlock-safe stale allocation cleanup**

   * Split `cleanupStalePodAllocation()` into:

     * `cleanupStalePodAllocationLocked()` for callers already holding `filterMutex`.
     * `cleanupStalePodAllocation()` as the locking entry point.
   * This avoids recursive locking while keeping the existing cleanup path safe.

3. **Symmetric allocation rollback**

   * If `PatchPodAnnotations()` fails after a successful allocation, `rollbackAllocation()` now removes the pod from `podManager` and rolls back its usage from `quotaManager` under the same mutex.
   * This keeps scheduler and quota state consistent after failed scheduling attempts.

4. **Informer event accounting audit**

   * Verified that `onAddPod` only calls `quotaManager.AddUsage()` when `podManager.AddPod()` actually records a new pod.
   * Existing pods are therefore not double-counted during informer resync/events.

---

### Verification — Race Detector

Verified under a CGO-enabled Linux environment (`go1.26.5 linux/amd64`, 12 logical cores).

The following scheduler tests pass under the Go race detector:

```text
=== RUN   Test_Filter_Bug1896_QuotaRollbackOnPatchFailure
--- PASS: Test_Filter_Bug1896_QuotaRollbackOnPatchFailure (0.45s)

=== RUN   Test_Filter_Bug1330_NoConcurrentOverAllocation
--- PASS: Test_Filter_Bug1330_NoConcurrentOverAllocation (2.29s)

=== RUN   Test_Filter_NonContendingPodsBothEventuallyAdmitted
--- PASS: Test_Filter_NonContendingPodsBothEventuallyAdmitted (0.02s)

=== RUN   Test_Filter_FitFailureReleasesLockCleanly
--- PASS: Test_Filter_FitFailureReleasesLockCleanly (0.01s)

=== RUN   Test_onAddPod_AlreadyTrackedPodDoesNotDoubleCountQuota
--- PASS: Test_onAddPod_AlreadyTrackedPodDoesNotDoubleCountQuota (0.00s)

PASS
ok github.com/Project-HAMi/HAMi/pkg/scheduler 3.818s
```

The tests cover concurrent over-allocation prevention, quota rollback after patch failure, non-contending scheduling, lock release on failed allocation, and duplicate quota accounting during informer events.

### AI Disclosure

AI tools like Claude were used during the development of this PR for code review, debugging assistance, and exploring potential concurrency issues.

All proposed changes were manually reviewed, implemented, and verified by the contributor. The fix was validated with the Go race detector and the relevant scheduler tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for nodes with names exceeding Kubernetes label limits.
  - Prevented scheduler race conditions that could cause over-allocation or duplicate quota accounting.
  - Ensured failed allocation updates correctly roll back capacity and quota changes.
  - Preserved independent pod admissions during concurrent scheduling.

- **Reliability**
  - Added deterministic sanitization for node labels while preserving valid names.
  - Improved handling of missing pods and annotation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->