### PR TITLE
fix(util): handle nil node gracefully in utility functions to prevent…

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -137,6 +137,9 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 }
 
 func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
 	type patchMetadata struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 	}
@@ -235,6 +238,9 @@ func MarkAnnotationsToDelete(devType string, nn string) error {
 }
 
 func RemoveNodeAnnotation(node *corev1.Node, annotationKeys ...string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
 	annos := make(map[string]any, len(annotationKeys))
 	for _, key := range annotationKeys {
 		annos[key] = nil
@@ -284,6 +290,9 @@ func AllContainersCreated(pod *corev1.Pod) bool {
 
 // EmitNodeWarningEvent emits a Warning event on the given Node with deduplication.
 func EmitNodeWarningEvent(node *corev1.Node, reason, message string, dedupWindow time.Duration) {
+	if node == nil {
+		return
+	}
 	c := client.GetClient()
 	if c == nil {
 		klog.Warningf("cannot emit node event for %s: Kubernetes client not initialized", node.Name)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -797,6 +797,15 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 	}
 	dedupWindow := time.Hour
 
+	t.Run("nil node does nothing", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset()
+		EmitNodeWarningEvent(nil, reason, msg1, dedupWindow)
+		events, err := client.KubeClient.CoreV1().Events(corev1.NamespaceDefault).List(
+			context.TODO(), metav1.ListOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(events.Items))
+	})
+
 	t.Run("no existing event creates new event", func(t *testing.T) {
 		client.KubeClient = fake.NewClientset()
 
@@ -872,5 +881,45 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 		assert.NilError(t, err)
 		// Old event still present plus one new event.
 		assert.Equal(t, 2, len(events.Items))
+	})
+}
+
+func TestPatchNodeAnnotations(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+
+	t.Run("patch nil node", func(t *testing.T) {
+		err := PatchNodeAnnotations(nil, map[string]string{"foo": "bar"})
+		assert.ErrorContains(t, err, "node is nil")
+	})
+
+	t.Run("patch valid node", func(t *testing.T) {
+		err := PatchNodeAnnotations(node, map[string]string{"foo": "bar"})
+		assert.NilError(t, err)
+	})
+}
+
+func TestRemoveNodeAnnotation(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+
+	t.Run("remove nil node", func(t *testing.T) {
+		err := RemoveNodeAnnotation(nil, "foo")
+		assert.ErrorContains(t, err, "node is nil")
+	})
+
+	t.Run("remove valid node", func(t *testing.T) {
+		err := RemoveNodeAnnotation(node, "foo")
+		assert.NilError(t, err)
 	})
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -894,12 +894,12 @@ func TestPatchNodeAnnotations(t *testing.T) {
 	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 
 	t.Run("patch nil node", func(t *testing.T) {
-		err := PatchNodeAnnotations(nil, map[string]string{"foo": "bar"})
+		err := PatchNodeAnnotations(nil, map[string]string{"hami.io/foo": "bar"})
 		assert.ErrorContains(t, err, "node is nil")
 	})
 
 	t.Run("patch valid node", func(t *testing.T) {
-		err := PatchNodeAnnotations(node, map[string]string{"foo": "bar"})
+		err := PatchNodeAnnotations(node, map[string]string{"hami.io/foo": "bar"})
 		assert.NilError(t, err)
 	})
 }
@@ -914,12 +914,12 @@ func TestRemoveNodeAnnotation(t *testing.T) {
 	client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 
 	t.Run("remove nil node", func(t *testing.T) {
-		err := RemoveNodeAnnotation(nil, "foo")
+		err := RemoveNodeAnnotation(nil, "hami.io/foo")
 		assert.ErrorContains(t, err, "node is nil")
 	})
 
 	t.Run("remove valid node", func(t *testing.T) {
-		err := RemoveNodeAnnotation(node, "foo")
+		err := RemoveNodeAnnotation(node, "hami.io/foo")
 		assert.NilError(t, err)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR mirrors the hardening done in #2499, but applies it to `*corev1.Node` pointers in the `pkg/util` package. 

Currently, several node utility functions immediately attempt to access `node.Name` without checking if the pointer is `nil`. If a `nil` node is passed (e.g. from an informer cache miss or mocked unit test), this causes a fatal `panic` and crashes the component.

This PR:
1. Adds defensive `nil` checks to `PatchNodeAnnotations`, `RemoveNodeAnnotation`, and `EmitNodeWarningEvent`.
2. Adds corresponding unit tests for all 3 functions to ensure they return safely on `nil` inputs.

**Which issue(s) this PR fixes**:
Fixes #2525 

**Special notes for your reviewer**:
The new unit tests can be found in `pkg/util/util_test.go`. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing nodes when updating or removing annotations.
  * Prevented warning events from being emitted when no node is provided.
  * Added clear error reporting for invalid annotation operations.

* **Tests**
  * Added coverage for missing-node scenarios and valid node operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->