### PR TITLE
fix(monitor): ignore unrelated files when loading cache

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -230,7 +230,14 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(files) > 2 {
+	matchedFiles := 0
+	for _, val := range files {
+		if strings.Contains(val.Name(), "libvgpu.so") ||
+			strings.Contains(val.Name(), ".cache") {
+			matchedFiles++
+		}
+	}
+	if matchedFiles > 2 {
 		return nil, errors.New("cache num not matched")
 	}
 	if len(files) == 0 {

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -233,7 +233,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 	matchedFiles := 0
 	for _, val := range files {
 		if strings.Contains(val.Name(), "libvgpu.so") ||
-			strings.Contains(val.Name(), ".cache") {
+			strings.HasSuffix(val.Name(), ".cache") {
 			matchedFiles++
 		}
 	}
@@ -248,7 +248,7 @@ func loadCache(fpath string) (*ContainerUsage, error) {
 		if strings.Contains(val.Name(), "libvgpu.so") {
 			continue
 		}
-		if !strings.Contains(val.Name(), ".cache") {
+		if !strings.HasSuffix(val.Name(), ".cache") {
 			continue
 		}
 		cacheFile = filepath.Join(fpath, val.Name())

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -217,6 +217,19 @@ func Test_loadCache(t *testing.T) {
 		assert.ErrorContains(t, err, "cache num not matched")
 	})
 
+	t.Run("ignores unrelated files when one cache file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+		writeCacheFile(t, dir, "notes.txt", []byte("x"))
+		writeCacheFile(t, dir, "debug.log", []byte("x"))
+
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
 	t.Run("empty directory", func(t *testing.T) {
 		usage, err := loadCache(t.TempDir())
 		assert.NilError(t, err)

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -230,6 +230,19 @@ func Test_loadCache(t *testing.T) {
 		defer func() { _ = syscall.Munmap(usage.data) }()
 	})
 
+	t.Run("ignores files that contain cache suffix in the middle", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCacheFile(t, dir, "x.cache", headerBytes(v1CacheFileSize, SharedRegionMagicFlag, 1, 0))
+		writeCacheFile(t, dir, "debug.cache.bak", []byte("x"))
+		writeCacheFile(t, dir, "trace.cache.tmp", []byte("x"))
+
+		usage, err := loadCache(dir)
+		assert.NilError(t, err)
+		assert.Assert(t, usage != nil)
+		assert.Assert(t, usage.Info != nil)
+		defer func() { _ = syscall.Munmap(usage.data) }()
+	})
+
 	t.Run("empty directory", func(t *testing.T) {
 		usage, err := loadCache(t.TempDir())
 		assert.NilError(t, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

`loadCache()` currently validates the number of directory entries before filtering out files that are unrelated to cache loading.

As a result, a container directory can contain a valid cache file but still be rejected when additional unrelated entries are present.

For example, a directory containing:

```text
libvgpu.so
<valid>.cache
<unrelated-file>
```

may be rejected because the raw directory entry count is checked before identifying the actual cache files.

This PR changes `loadCache()` to:

- ignore `libvgpu.so`;
- ignore entries that do not have the `.cache` suffix;
- validate the number of cache files after filtering;
- preserve the existing behavior for valid cache layouts.

A regression test is added to verify that an unrelated file does not prevent a valid cache from being loaded.

**Which issue(s) this PR fixes:**

Fixes #2515

Related to #2126.

**Special notes for your reviewer:**

The change is limited to cache-file selection in `loadCache()` and does not change the cache format or mmap behavior.

Validation performed:

```text
go test ./pkg/monitor/nvidia -count=1
go test -race ./pkg/monitor/nvidia -count=1
make verify
git diff --check
```

**Does this PR introduce a user-facing change?:**

```text
Fix: vGPUmonitor can load a valid cache when the container directory also contains unrelated files.
```

---

AI assistance was used only for wording suggestions and verification guidance. I made the final decisions, reviewed the changes, and ran the checks myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache detection to ignore unrelated files when enforcing cache file limits.
  * Recognized only valid cache filenames ending in `.cache`.
  * Ensured valid cache usage loads and processes correctly when unrelated files or misleading filenames are present.

* **Tests**
  * Added coverage for ignoring unrelated files and filenames containing `.cache` in the middle.
  * Verified successful cache initialization and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->