### PR TITLE
fix(server): preserve per-container device index in Kunlun/Mthreads P…

### DIFF
--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -87,20 +87,28 @@ func (dev *KunlunDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, e
 	return nodedevices, nil
 }
 
+// PatchAnnotations writes the generic hami.io/*-allocated annotation (all
+// containers, correct) and the vendor-specific BAIDU_COM_DEVICE_IDX
+// annotation. The vendor key encodes one index-list per container, joined
+// with the same OnePodMultiContainerSplitSymbol (";") used elsewhere in the
+// package, so multi-container pods no longer lose earlier containers'
+// indices to the last container's value. Single-container output is
+// unchanged (no trailing delimiter) to preserve the existing annotation
+// contract for any external consumer already parsing a bare index.
 func (dev *KunlunDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]string, pd device.PodDevices) map[string]string {
 	devlist, ok := pd[KunlunGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[KunlunGPUDevice]] = device.EncodePodSingleDevice(devlist)
+
+		parts := make([]string, 0, len(devlist))
 		for _, dp := range devlist {
-			annoKey := KunlunDeviceSelection
 			value := ""
 			for _, val := range dp {
 				value = value + fmt.Sprint(val.Idx) + ","
 			}
-			if len(value) > 0 {
-				(*annoinput)[annoKey] = strings.TrimRight(value, ",")
-			}
+			parts = append(parts, strings.TrimRight(value, ","))
 		}
+		(*annoinput)[KunlunDeviceSelection] = strings.Join(parts, device.OnePodMultiContainerSplitSymbol)
 	}
 	return *annoinput
 }

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -78,6 +78,21 @@ func TestKunlunDevices_Fit_NumaNotFit(t *testing.T) {
 	assert.Equal(t, reason, "1/8 "+common.NumaNotFit)
 }
 
+func TestKunlunDevices_PatchAnnotations(t *testing.T) {
+	annoinput := map[string]string{}
+	dev := &KunlunDevices{}
+	pd := device.PodDevices{
+		KunlunGPUDevice: device.PodSingleDevice{
+			device.ContainerDevices{{Idx: 0, UUID: "kunlun-0", Type: KunlunGPUDevice, Usedmem: 1000, Usedcores: 10}},
+			device.ContainerDevices{{Idx: 3, UUID: "kunlun-3", Type: KunlunGPUDevice, Usedmem: 2000, Usedcores: 20}},
+		},
+	}
+
+	got := dev.PatchAnnotations(&corev1.Pod{}, &annoinput, pd)
+	assert.Equal(t, got[device.SupportDevices[KunlunGPUDevice]], "kunlun-0,kunlun,1000,10:;kunlun-3,kunlun,2000,20:;")
+	assert.Equal(t, got[KunlunDeviceSelection], "0;3")
+}
+
 func Test_graphSelect(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -152,25 +152,36 @@ func (dev *MthreadsDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo,
 	return nodedevices, nil
 }
 
+// PatchAnnotations writes the generic hami.io/*-allocated annotation and the
+// vendor-specific mthreads.com/gpu-index annotation. The vendor key encodes
+// one index-list per container, joined with the same
+// OnePodMultiContainerSplitSymbol (";") used elsewhere in the package, so
+// multi-container pods no longer lose earlier containers' indices to the
+// last container's value. Single-container output is unchanged (no trailing
+// delimiter) to preserve the existing annotation contract. The predicate
+// time/node annotations are left exactly as before (still set inside the
+// loop, once per container that has a device) - fixing their redundant
+// per-container overwrite is out of scope for this fix.
 func (dev *MthreadsDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]string, pd device.PodDevices) map[string]string {
 	devlist, ok := pd[MthreadsGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[MthreadsGPUDevice]] = device.EncodePodSingleDevice(devlist)
+
+		parts := make([]string, 0, len(devlist))
 		for _, dp := range devlist {
+			value := ""
+			for _, val := range dp {
+				value = value + fmt.Sprint(val.Idx) + ","
+			}
+			parts = append(parts, strings.TrimRight(value, ","))
+
 			if len(dp) > 0 {
-				value := ""
-				for _, val := range dp {
-					value = value + fmt.Sprint(val.Idx) + ","
-				}
-				if len(value) > 0 {
-					(*annoinput)[MthreadsAssignedGPUIndex] = strings.TrimRight(value, ",")
-					//(*annoinput)[MthreadsAssignedNode]=
-					tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
-					(*annoinput)[MthreadsPredicateTime] = tmp
-					(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
-				}
+				tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
+				(*annoinput)[MthreadsPredicateTime] = tmp
+				(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
 			}
 		}
+		(*annoinput)[MthreadsAssignedGPUIndex] = strings.Join(parts, device.OnePodMultiContainerSplitSymbol)
 	}
 	klog.Infoln("annoinput", (*annoinput))
 	return *annoinput

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -394,8 +394,28 @@ func Test_PatchAnnotations(t *testing.T) {
 			},
 			want: map[string]string{
 				device.SupportDevices[MthreadsGPUDevice]: "test1,Mthreads,1000,1:;",
-				"mthreads.com/gpu-index":                 "0",
-				"mthreads.com/predicate-node":            "",
+				MthreadsAssignedGPUIndex:                 "0",
+				MthreadsAssignedNode:                     "",
+			},
+		},
+		{
+			name: "multi-container devices preserve each container index",
+			args: struct {
+				annoinput *map[string]string
+				pd        device.PodDevices
+			}{
+				annoinput: &map[string]string{},
+				pd: device.PodDevices{
+					MthreadsGPUDevice: device.PodSingleDevice{
+						device.ContainerDevices{{Idx: 0, UUID: "test1", Type: MthreadsGPUDevice, Usedmem: 1000, Usedcores: 1}},
+						device.ContainerDevices{{Idx: 2, UUID: "test2", Type: MthreadsGPUDevice, Usedmem: 2000, Usedcores: 2}},
+					},
+				},
+			},
+			want: map[string]string{
+				device.SupportDevices[MthreadsGPUDevice]: "test1,Mthreads,1000,1:;test2,Mthreads,2000,2:;",
+				MthreadsAssignedGPUIndex:                 "0;2",
+				MthreadsAssignedNode:                     "",
 			},
 		},
 	}
@@ -403,9 +423,9 @@ func Test_PatchAnnotations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dev := MthreadsDevices{}
 			result := dev.PatchAnnotations(&corev1.Pod{}, test.args.annoinput, test.args.pd)
-			assert.Equal(t, result[dev.CommonWord()], test.want[dev.CommonWord()])
-			assert.Equal(t, result["mthreads.com/gpu-index"], test.want["mthreads.com/gpu-index"])
-			assert.Equal(t, result["mthreads.com/predicate-node"], test.want["mthreads.com/predicate-node"])
+			assert.Equal(t, result[device.SupportDevices[MthreadsGPUDevice]], test.want[device.SupportDevices[MthreadsGPUDevice]])
+			assert.Equal(t, result[MthreadsAssignedGPUIndex], test.want[MthreadsAssignedGPUIndex])
+			assert.Equal(t, result[MthreadsAssignedNode], test.want[MthreadsAssignedNode])
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2463.

This patch updates Kunlun and Mthreads PatchAnnotations so vendor-specific device index annotations are written as a container-delimited list instead of overwriting the previous container’s value.

Changed:
- pkg/device/kunlun/device.go
- pkg/device/kunlun/device_test.go
- pkg/device/mthreads/device.go
- pkg/device/mthreads/device_test.go

Validation:
- go test ./pkg/device/kunlun
- go test ./pkg/device/mthreads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU device allocation annotations for pods with multiple containers.
  * Each container now retains its assigned device indices, preventing allocation details from being mixed across containers.
  * Preserved existing behavior for single-container pods.
  * Updated allocation metadata and assigned-node information consistently for Kunlun and Mthreads GPUs.
  * Added validation covering multi-container GPU assignments and generated device-selection annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->