### PR TITLE
docs: document ResourceQuota interaction for init container accounting.

### DIFF
--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -264,3 +264,17 @@ recomputed on every reconcile directly from `pod.Status.Phase`:
 
     if pod.Status.Phase in (Succeeded, Failed):
         usage = 0
+
+## Interaction with Kubernetes ResourceQuota
+
+If the namespace has a `ResourceQuota` (like `requests.nvidia.com/gpumem`), the
+kube-apiserver checks it first, before the pod reaches HAMi. The apiserver uses the
+same formula `max(sum(app), max(init))`, but it charges this value only once, when
+the pod is created, and it keeps the charge until the pod is deleted. It does not
+know when init containers finish, so the shrink in this design only frees capacity
+inside HAMi. The apiserver quota is never released early.
+
+Because of this, the same pods can run fine without a quota but fail when a quota is
+set. Example: quota is 10000. Pod A (init 8000, app 5000) is charged 8000 for its
+whole lifetime. Pod B (effective 5000) gets rejected with `exceeded quota: ... used: 8k` before HAMi even sees it. This is normal Kubernetes
+behavior and HAMi cannot change it.

--- a/docs/develop/initContainer-design.md
+++ b/docs/develop/initContainer-design.md
@@ -270,11 +270,12 @@ recomputed on every reconcile directly from `pod.Status.Phase`:
 If the namespace has a `ResourceQuota` (like `requests.nvidia.com/gpumem`), the
 kube-apiserver checks it first, before the pod reaches HAMi. The apiserver uses the
 same formula `max(sum(app), max(init))`, but it charges this value only once, when
-the pod is created, and it keeps the charge until the pod is deleted. It does not
-know when init containers finish, so the shrink in this design only frees capacity
-inside HAMi. The apiserver quota is never released early.
+the pod is created, and it keeps the charge while the pod is non-terminal (released
+once the pod reaches `Succeeded`/`Failed` or is deleted). It does not react when
+init containers finish, so the shrink in this design only frees capacity inside
+HAMi. The apiserver quota is not released at that point.
 
 Because of this, the same pods can run fine without a quota but fail when a quota is
-set. Example: quota is 10000. Pod A (init 8000, app 5000) is charged 8000 for its
-whole lifetime. Pod B (effective 5000) gets rejected with `exceeded quota: ... used: 8k` before HAMi even sees it. This is normal Kubernetes
-behavior and HAMi cannot change it.
+set. Example: quota is 10000. Pod A (init 8000, app 5000) is charged 8000 for as
+long as it stays non-terminal, even after its init container exits. Pod B (effective 5000) gets rejected with `exceeded quota: ... used: 8k` before HAMi even sees it. This is normal Kubernetes behavior and HAMi cannot change it.
+


### PR DESCRIPTION
Thia Pr will close the #2533 
Added a section to `docs/develop/initContainer-design.md` explaining the
resource-calculation difference between quota-enabled and non-quota scenarios.
As suggested by @DSFans2014  and @archlitchi  in #1773  [Comment](https://github.com/Project-HAMi/HAMi/pull/1773#discussion_r3747099740)
HAMi shrinks usage after init containers complete, while the kube-apiserver's ResourceQuota plugin holds the effective request for the pod's entire lifetime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how Kubernetes `ResourceQuota` accounts for pod resources when init containers are present.
  - Documented that quota usage remains reserved until pod deletion, even after init containers complete.
  - Added an example explaining why Kubernetes may reject a pod before HAMi processing when quota usage is reserved.
  - Explained that init-container completion changes only HAMi accounting, not Kubernetes quota reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->