### PR TITLE
fix(cambricon): enforce ResourceQuota for percentage/whole-card memory requests

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -321,6 +321,39 @@ func (dev *CambriconDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 	return nil
 }
 
+// fitQuota resolves the pod's hypothetical total usage (this candidate device
+// plus whatever is already tentatively allocated) and checks it against the
+// namespace ResourceQuota. It mirrors the equivalent helper in the nvidia
+// backend so that quota is enforced against the same resolved memory value
+// (including percentage/whole-card requests) that fitResourceQuota misses at
+// admission time, rather than only against explicit vmemory requests.
+func fitQuota(pod *corev1.Pod, tmpDevs map[string]device.ContainerDevices, allocated *device.PodDevices, ns string, devUUID string, memreq int64, coresreq int64) bool {
+	hypo := device.PodDevices{}
+	if allocated != nil {
+		for devType, podSingle := range *allocated {
+			hypo[devType] = append(device.PodSingleDevice{}, podSingle...)
+		}
+	}
+	cur := append(device.ContainerDevices{}, tmpDevs[CambriconMLUDevice]...)
+	cur = append(cur, device.ContainerDevice{
+		UUID:      devUUID,
+		Type:      CambriconMLUDevice,
+		Usedmem:   int32(memreq),
+		Usedcores: int32(coresreq),
+	})
+	hypo[CambriconMLUDevice] = append(hypo[CambriconMLUDevice], cur)
+
+	var mem, core int64
+	for _, ctrDevs := range device.CollapseInitContainerUsage(pod, hypo)[CambriconMLUDevice] {
+		for _, val := range ctrDevs {
+			mem += int64(val.Usedmem)
+			core += int64(val.Usedcores)
+		}
+	}
+
+	return device.GetLocalCache().FitQuota(ns, mem, MemoryFactor, core, CambriconMLUDevice)
+}
+
 func (cam *CambriconDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
@@ -381,6 +414,11 @@ func (cam *CambriconDevices) Fit(devices []*device.DeviceUsage, request device.C
 		if k.MemPercentagereq != 101 && k.Memreq == 0 {
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
+		}
+		if !fitQuota(pod, tmpDevs, allocated, pod.Namespace, dev.ID, int64(memreq), int64(k.Coresreq)) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
+			continue
 		}
 		if dev.Totalmem-dev.Usedmem < memreq {
 			reason[common.CardInsufficientMemory]++

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -1142,6 +1142,79 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+// TestDevices_Fit_ResourceQuotaWholeCardRequest reproduces
+// https://github.com/Project-HAMi/HAMi/issues/2468: a pod that omits the
+// memory resource (which resolves to a MemPercentagereq of 100, i.e. a whole
+// card) carried a Memreq of 0, and Fit only checked device capacity, never
+// the namespace ResourceQuota. That let a single pod consume an entire card's
+// worth of quota while never being charged against it, so the ResourceQuota
+// was left permanently unusable for every other pod in the namespace. This
+// asserts Fit now denies the same request once it is resolved against the
+// quota, matching how a request carrying an equivalent explicit Memreq
+// already behaved.
+func TestDevices_Fit_ResourceQuotaWholeCardRequest(t *testing.T) {
+	config := CambriconConfig{
+		ResourceCountName:  "cambricon.com/mlu",
+		ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+		ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+	}
+	dev := InitMLUDevice(config)
+	device.DevicesMap = map[string]device.Devices{CambriconMLUDevice: dev}
+
+	ns := "cambricon-quota-test-ns"
+	qm := device.NewQuotaManager()
+	qm.AddQuota(&corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "mlu-quota", Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourceName("limits.cambricon.com/mlu.smlu.vmemory"): resource.MustParse("50"),
+			},
+		},
+	})
+	t.Cleanup(func() {
+		qm.DelQuota(&corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "mlu-quota", Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceName("limits.cambricon.com/mlu.smlu.vmemory"): resource.MustParse("50"),
+				},
+			},
+		})
+	})
+
+	devices := []*device.DeviceUsage{{
+		ID:        "dev-0",
+		Index:     0,
+		Used:      0,
+		Count:     100,
+		Usedmem:   0,
+		Totalmem:  40960,
+		Totalcore: 100,
+		Usedcores: 0,
+		Numa:      0,
+		Type:      CambriconMLUDevice,
+		Health:    true,
+	}}
+	// No Memreq set: this is what GenerateResourceRequests returns for a pod
+	// that omits the memory field entirely, i.e. an implicit whole-card ask.
+	request := device.ContainerDeviceRequest{
+		Nums:             1,
+		Memreq:           0,
+		MemPercentagereq: 100,
+		Coresreq:         10,
+		Type:             CambriconMLUDevice,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+
+	fit, _, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	if fit {
+		t.Errorf("expected whole-card request exceeding the namespace's ResourceQuota to be denied, but Fit admitted it (reason=%q)", reason)
+	}
+	if reason != "1/1 ResourceQuotaNotFit" {
+		t.Errorf("expected reason %q, got %q", "1/1 ResourceQuotaNotFit", reason)
+	}
+}
+
 func TestDevices_AddResourceUsage(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What this PR does

Fixes a ResourceQuota bypass for Cambricon when memory is requested by percentage, including the implicit whole-card default a pod gets when it omits the memory field entirely.

## Why

`Fit()` in `pkg/device/cambricon/device.go` resolves `memreq` from either an explicit `Memreq`, or, when that's zero, from `MemPercentagereq` against the candidate device's `Totalmem`. Either way, the only thing that value was ever checked against was device capacity (`dev.Totalmem-dev.Usedmem < memreq`). The namespace `ResourceQuota` was never consulted on this path.

Concretely: a pod that requests `cambricon.com/mlu: 1` with no `vmemory` field gets `Memreq=0`, `MemPercentagereq=100` from `GenerateResourceRequests` - that's the normal way to ask for a whole card. `Fit` resolves that against the real card and hands out the full amount, and the quota manager still records it as used. If the namespace has a tight quota, that one pod consumes it entirely without ever being checked against it, and every subsequent pod in the namespace is denied - including small, well-formed ones that respect the quota.

`fitResourceQuota` in the webhook can't fix this on its own, because it sums `req.Memreq * req.Nums` across containers before a node/card is even chosen, and `Memreq` is 0 for a percentage-based request - the real value only exists once the specific card's `Totalmem` is known, i.e. inside `Fit`.

NVIDIA already handles this correctly: it has a local `fitQuota` helper that resolves the pod's hypothetical total usage and calls `FitQuota` from inside its own `Fit()`, right after `memreq` is resolved. Cambricon didn't have the equivalent.

## What changed

- Added a `fitQuota` helper to `pkg/device/cambricon/device.go`, structurally identical to NVIDIA's: it folds the candidate allocation into whatever's already tentatively allocated for the pod (respecting `CollapseInitContainerUsage` for init-container peak usage), then calls `device.GetLocalCache().FitQuota(...)`.
- Wired it into `Fit()` right after `memreq` is resolved (mirroring where NVIDIA places its own call), before the existing capacity checks. A quota miss now increments `ResourceQuotaNotFit` and moves on to the next candidate device, same as every other rejection reason in this function.
- Added `TestDevices_Fit_ResourceQuotaWholeCardRequest` in `pkg/device/cambricon/device_test.go`, which seeds a namespace quota via `QuotaManager.AddQuota` and asserts a whole-card (`MemPercentagereq=100`) request that exceeds it is now denied with `ResourceQuotaNotFit`. I checked this test does fail against the pre-fix code (reverted the `Fit()` change locally and reran it - it comes back `fit=true`, quota silently ignored).

This only touches the Cambricon backend. The same admission-time gap likely exists for other non-NVIDIA backends that expose a percentage-based memory resource, but I didn't want to bundle a multi-vendor change into one PR - happy to open follow-ups per backend if that's useful.

## Verification

- `go build ./...`
- `go test ./pkg/device/cambricon/... ./pkg/device/... -short --race -count=1` (all pass, including the new regression test)
- `go vet ./pkg/device/cambricon/...`
- `golangci-lint run ./pkg/device/cambricon/...` (0 issues)
- `hack/verify-license.sh`, `hack/verify-import-aliases.sh` (pass)
- No accelerator hardware available - this change is entirely scheduler-side quota bookkeeping (same as the existing NVIDIA `fitQuota` it mirrors), so I validated it with the unit test above rather than on real MLU hardware.

Fixes #2468

## AI assistance disclosure

I ran into this while back in the ResourceQuota test fixtures I touched in #2432, and used Claude Code to help pin down the exact call sites and draft the fix by mirroring NVIDIA's existing `fitQuota`, plus the regression test. I read through the resulting diff, verified the root cause by reverting the `Fit()` change and confirming the new test fails without it, and take responsibility for the correctness of both the fix and the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cambricon device allocation now respects namespace resource quotas before approving requests.
  * Whole-card requests using 100% memory are correctly denied when they exceed the configured memory quota.
  * Allocation decisions now provide a quota-specific rejection reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->