### PR TITLE
fix(util): make GetPendingPod's fallback pod selection deterministic

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -90,7 +93,9 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range podlist.Items {
+	var candidates []*corev1.Pod
+	for i := range podlist.Items {
+		p := &podlist.Items[i]
 		if p.Status.Phase != corev1.PodPending {
 			continue
 		}
@@ -108,13 +113,43 @@ func GetPendingPod(ctx context.Context, node string) (*corev1.Pod, error) {
 		}
 		if n, ok := p.Annotations[AssignedNodeAnnotations]; !ok {
 			continue
-		} else {
-			if strings.Compare(n, node) == 0 {
-				return &p, nil
-			}
+		} else if strings.Compare(n, node) != 0 {
+			continue
 		}
+		candidates = append(candidates, p)
 	}
-	return nil, fmt.Errorf("no binding pod found on node %s", node)
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no binding pod found on node %s", node)
+	}
+	// List() order isn't a stable ordering guarantee, so with more than one
+	// candidate mid-bind on the same node at once, picking "whichever came
+	// back first" is non-deterministic across calls. Break ties by which pod
+	// started binding first (smallest hami.io/bind-time), falling back to
+	// namespace/name so the choice stays deterministic even if a bind-time
+	// value fails to parse.
+	sort.Slice(candidates, func(i, j int) bool {
+		ti, iok := parseBindTime(candidates[i])
+		tj, jok := parseBindTime(candidates[j])
+		if iok && jok && ti != tj {
+			return ti < tj
+		}
+		if iok != jok {
+			return iok
+		}
+		if candidates[i].Namespace != candidates[j].Namespace {
+			return candidates[i].Namespace < candidates[j].Namespace
+		}
+		return candidates[i].Name < candidates[j].Name
+	})
+	return candidates[0], nil
+}
+
+func parseBindTime(p *corev1.Pod) (int64, bool) {
+	t, err := strconv.ParseInt(p.Annotations[BindTimeAnnotations], 10, 64)
+	if err != nil {
+		return math.MaxInt64, false
+	}
+	return t, true
 }
 
 func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, error) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -234,6 +234,59 @@ func TestGetPendingPod(t *testing.T) {
 	}
 }
 
+// TestGetPendingPod_MultipleCandidatesPicksEarliestBindTime covers the case
+// where two or more pods are concurrently mid-bind on the same node, so more
+// than one satisfies every GetPendingPod filter. The pods are created in an
+// order that does not match bind-time order, so a selection that just took
+// whatever the list returned first would not reliably resolve to the pod
+// that actually started binding first.
+func TestGetPendingPod_MultipleCandidatesPicksEarliestBindTime(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+
+	makeCandidate := func(name, bindTime string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Annotations: map[string]string{
+					BindTimeAnnotations:     bindTime,
+					DeviceBindPhase:         DeviceBindAllocating,
+					AssignedNodeAnnotations: "test-node-multi",
+				},
+			},
+			Spec:   corev1.PodSpec{NodeName: "test-node-multi"},
+			Status: corev1.PodStatus{Phase: corev1.PodPending},
+		}
+	}
+
+	// Names are deliberately in the opposite order from bind-time, since the
+	// fake clientset's List() returns items name-sorted: a fix that just took
+	// the first list entry would pass by coincidence if candidate names and
+	// bind-time order matched, so this pins the earliest bind-time to the
+	// alphabetically-last name.
+	podLatest := makeCandidate("pod-a-latest", "300")
+	podMiddle := makeCandidate("pod-m-middle", "200")
+	podEarliest := makeCandidate("pod-z-earliest", "100")
+	for _, p := range []*corev1.Pod{podLatest, podEarliest, podMiddle} {
+		if _, err := client.KubeClient.CoreV1().Pods("default").Create(context.TODO(), p, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("failed to create pod %s: %v", p.Name, err)
+		}
+	}
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-multi", Annotations: map[string]string{}}}
+	if _, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	got, err := GetPendingPod(context.TODO(), "test-node-multi")
+	if err != nil {
+		t.Fatalf("GetPendingPod() error = %v", err)
+	}
+	if got.Name != podEarliest.Name {
+		t.Fatalf("expected the earliest-binding candidate %q, got %q", podEarliest.Name, got.Name)
+	}
+}
+
 func TestGetAllocatePodByNode(t *testing.T) {
 	client.KubeClient = fake.NewClientset()
 


### PR DESCRIPTION
## What this PR does

Makes `GetPendingPod`'s fallback pod-selection deterministic when more than one pod on a node matches the device-bind filters.

## Why

`GetPendingPod` in `pkg/util/util.go` first tries the node-lock annotation, and if that misses, falls back to listing every pod on the node and returning the first one whose phase is `Pending`, whose `hami.io/bind-time` and `hami.io/bind-phase` annotations look right, and whose assigned-node annotation matches. `client-go`'s `List()` gives no ordering guarantee, so "first one that matches" is whatever the API server/informer cache happens to hand back that call.

This function is wired up as `getPendingPod` in the NVIDIA device plugin's `server.go` and used from `Allocate()` and `GetPreferredAllocation()`. If two pods are both mid-bind on the same node at once (which is exactly the state this fallback path exists for), there's currently nothing tying the returned pod to *the* pod kubelet is actually asking about for a given gRPC call - it's whichever one the list returned first, which could change from one call to the next with no correctness argument backing the choice.

## What changed

- `GetPendingPod` now collects every pod that passes the existing filters into a slice instead of returning on the first match.
- The candidates are sorted by parsed `hami.io/bind-time` (set by the scheduler as a Unix timestamp at bind time - see `pkg/scheduler/scheduler.go`), so the pod that actually started binding first wins. If a bind-time value doesn't parse, that candidate sorts last instead of erroring out, and namespace/name is used as a final tiebreaker so the result is always deterministic regardless of list order.
- Added `TestGetPendingPod_MultipleCandidatesPicksEarliestBindTime`, which creates three candidates with bind-times deliberately out of both creation order and alphabetical name order (the fake clientset's `List()` returns pods name-sorted, so I had to control for that to make the test actually mean something). I reverted the `GetPendingPod` change locally and reran it to confirm it fails against the old code - it picks the most-recent binder instead of the earliest.

## Verification

- `go build ./...`
- `go test ./pkg/util/... ./pkg/device-plugin/nvidiadevice/... -short --race -count=1` (all pass, including the new regression test)
- `go vet ./pkg/util/...`
- `golangci-lint run ./pkg/util/...` (0 issues)
- `hack/verify-license.sh`, `hack/verify-import-aliases.sh` (pass)
- This is scheduler/util-side pod-selection logic, not a hardware or in-container isolation path, so I validated it with the unit test above rather than on real GPU hardware.

Fixes #2188

## AI assistance disclosure

I used Claude Code to help trace how `GetPendingPod` is called from the device plugin and to draft the fix and the regression test. I verified the root cause myself by reverting the fix and confirming the new test fails without it, read through the diff, and take responsibility for the correctness of both the fix and the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending workload selection to consistently choose the earliest eligible bind-time candidate.
  * Added deterministic fallback ordering when bind-time data is invalid or unavailable.
  * Improved handling when no eligible pending workloads are found.

* **Tests**
  * Added regression coverage for selecting the correct workload when creation order differs from bind time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->