### PR TITLE
[Ascend] Requests-only pods skip memory validation, so an over-capacity request

### DIFF
--- a/docs/develop/design.md
+++ b/docs/develop/design.md
@@ -6,7 +6,7 @@ The architecture of HAMi is shown in the figure above. It is organized in the fo
 
 - MutatingWebhook
 
-The MutatingWebhook checks the validity of each task, and set the "schedulerName" to "HAMi scheduler" if the resource requests have been recognized by HAMi
+The MutatingWebhook checks the validity of each task, and set the "schedulerName" to "HAMi scheduler" if the resource limits have been recognized by HAMi
 If Not, the MutatingWebhook does nothing and pass this task to default-scheduler.
 
 - Scheduler


### PR DESCRIPTION
This PR fixes the documentation issue reported in #2532: corrects `requests` to `limits` in `docs/develop/design.md`.

Fixes #2532

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Fixes #2532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the MutatingWebhook documentation to clarify that resource limits determine HAMi scheduler assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->