### PR TITLE
feat: add hami_host_gpu_memory_controller_utilization_ratio metric

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -70,6 +70,12 @@ var (
 		[]string{"device_index", "device_uuid", "device_type"}, nil,
 	)
 
+	hostGPUMemoryUtilizationdesc = prometheus.NewDesc(
+		"hami_host_gpu_memory_controller_utilization_ratio",
+		"GPU memory controller utilization ratio (0-100)",
+		[]string{"device_index", "device_uuid", "device_type"}, nil,
+	)
+
 	ctrvGPUdesc = prometheus.NewDesc(
 		"hami_vgpu_memory_used_bytes",
 		"vGPU device memory usage in bytes",
@@ -191,6 +197,7 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ctrvGPUdesc
 	ch <- ctrvGPUlimitdesc
 	ch <- hostGPUUtilizationdesc
+	ch <- hostGPUMemoryUtilizationdesc
 	ch <- ctrDeviceMemorydesc
 	ch <- ctrDeviceUtilizationdesc
 	ch <- ctrDeviceLastKernelDesc
@@ -355,6 +362,13 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(util.Gpu),
 		fmt.Sprint(index), uuid, deviceName,
 	)
+
+	if err := sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
+		float64(util.Memory),
+		fmt.Sprint(index), uuid, deviceName,
+	); err != nil {
+		return fmt.Errorf("nvml send memory controller utilization: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -29,12 +31,10 @@ import (
 
 func TestDescribeCollectSync(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-
 	t.Setenv(util.NodeNameEnvName, "test-node")
 	client := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	podLister := informerFactory.Core().V1().Pods().Lister()
-
 	c := &ClusterManager{
 		Zone:            "test-zone",
 		LegacyMetrics:   false,
@@ -42,15 +42,12 @@ func TestDescribeCollectSync(t *testing.T) {
 		containerLister: &nvidia.ContainerLister{},
 	}
 	cc := ClusterManagerCollector{ClusterManager: c}
-
 	if err := reg.Register(cc); err != nil {
 		t.Fatalf("Failed to register ClusterManagerCollector (non-legacy): %v", err)
 	}
-
 	if _, err := reg.Gather(); err != nil {
 		t.Errorf("Gather failed (non-legacy): %v", err)
 	}
-
 	regLegacy := prometheus.NewPedanticRegistry()
 	cLegacy := &ClusterManager{
 		Zone:            "test-zone-legacy",
@@ -60,7 +57,6 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 	initLegacyDescriptors()
 	ccLegacy := ClusterManagerCollector{ClusterManager: cLegacy}
-
 	if err := regLegacy.Register(ccLegacy); err != nil {
 		t.Fatalf("Failed to register ClusterManagerCollector (legacy): %v", err)
 	}
@@ -70,31 +66,38 @@ func TestDescribeCollectSync(t *testing.T) {
 }
 
 func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
-	t.Setenv(util.NodeNameEnvName, "test-node")
-	client := fake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podLister := informerFactory.Core().V1().Pods().Lister()
-
-	c := &ClusterManager{
-		Zone:            "test-zone",
-		LegacyMetrics:   false,
-		PodLister:       podLister,
-		containerLister: &nvidia.ContainerLister{},
-	}
+	c := &ClusterManager{Zone: "test-zone", LegacyMetrics: false}
 	cc := ClusterManagerCollector{ClusterManager: c}
-
 	descCh := make(chan *prometheus.Desc, 32)
 	cc.Describe(descCh)
 	close(descCh)
-
-	found := false
-	for desc := range descCh {
-		if desc == hostGPUMemoryUtilizationdesc {
-			found = true
-			break
+	for d := range descCh {
+		if strings.Contains(d.String(), "hami_host_gpu_memory_controller_utilization_ratio") {
+			return
 		}
 	}
-	if !found {
-		t.Error("Describe did not emit hostGPUMemoryUtilizationdesc; hami_host_gpu_memory_controller_utilization_ratio will be missing from scrape output")
+	t.Error("hami_host_gpu_memory_controller_utilization_ratio not found in Describe output")
+}
+
+func TestCollectMemoryControllerUtilizationValue(t *testing.T) {
+	const wantVal = float64(73)
+	m, err := prometheus.NewConstMetric(
+		hostGPUMemoryUtilizationdesc,
+		prometheus.GaugeValue,
+		wantVal,
+		"0", "GPU-abc123", "NVIDIA-A100",
+	)
+	if err != nil {
+		t.Fatalf("NewConstMetric: %v", err)
+	}
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if dm.Gauge == nil {
+		t.Fatal("expected gauge metric, got nil")
+	}
+	if *dm.Gauge.Value != wantVal {
+		t.Fatalf("want %v, got %v", wantVal, *dm.Gauge.Value)
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -68,3 +68,33 @@ func TestDescribeCollectSync(t *testing.T) {
 		t.Errorf("Gather failed (legacy): %v", err)
 	}
 }
+
+func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podLister := informerFactory.Core().V1().Pods().Lister()
+
+	c := &ClusterManager{
+		Zone:            "test-zone",
+		LegacyMetrics:   false,
+		PodLister:       podLister,
+		containerLister: &nvidia.ContainerLister{},
+	}
+	cc := ClusterManagerCollector{ClusterManager: c}
+
+	descCh := make(chan *prometheus.Desc, 32)
+	cc.Describe(descCh)
+	close(descCh)
+
+	found := false
+	for desc := range descCh {
+		if desc == hostGPUMemoryUtilizationdesc {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Describe did not emit hostGPUMemoryUtilizationdesc; hami_host_gpu_memory_controller_utilization_ratio will be missing from scrape output")
+	}
+}


### PR DESCRIPTION
Hey, so `GetUtilizationRates()` actually returns two values — `Gpu` (SM utilization) and `Memory` (memory controller utilization). We're already exporting `util.Gpu` as `hami_host_gpu_utilization_ratio`, but `util.Memory` gets pulled from the exact same NVML call and then just gets dropped on the floor. Never used anywhere.

This PR adds it as `hami_host_gpu_memory_controller_utilization_ratio`, same labels as the existing one (`device_index`, `device_uuid`, `device_type`).

**Why bother:** SM utilization and memory controller utilization don't always move together — on memory-bandwidth-heavy stuff like LLM inference they can diverge a lot. Right now you can only see memory controller load if you SSH in and run `nvidia-smi` yourself. With this in, you could alert on something like `hami_host_gpu_memory_controller_utilization_ratio > 90` as an early signal before SM pressure even shows up.

No legacy metric added for this — `util.Memory` was never in legacy mode either, so nothing to break there.

Actual code change is tiny — one new `Desc`, one line in `Describe`, one `sendMetric` call. No new NVML calls, just uses data that's already being fetched.

Added `TestDescribeRegistersMemoryControllerUtilization` to check the descriptor actually shows up in `Describe()`, following the same pattern as the other tests in that file.

> Used Claude to help spot the gap and draft the patch — I went through the code myself and understand it, happy to explain any part of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Prometheus metric for host GPU memory-controller utilization.
  - GPU utilization metrics now include memory utilization data for improved monitoring visibility.

- **Bug Fixes**
  - Improved metric collection error reporting so failures are surfaced instead of being silently ignored.

- **Tests**
  - Added coverage verifying the metric is advertised during scraping and reports the expected utilization value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->