### PR TITLE
feat: add hami_gpu_device_health metric to scheduler

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -144,6 +144,11 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		"Realized MIG instance identity and scheduler placement",
 		[]string{"node", "device_uuid", "device_index", "mig_uuid", "profile", "gpu_instance_id", "compute_instance_id", "placement_start", "placement_size"}, nil,
 	)
+	nodeGPUDeviceHealthDesc := prometheus.NewDesc(
+		"hami_gpu_device_health",
+		"GPU device health status (1=healthy, 0=unhealthy)",
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+	)
 
 	// Legacy metric descriptors (only created when legacy mode is enabled)
 	var (
@@ -264,6 +269,16 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index)); err != nil {
 					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
 				}
+			}
+
+			healthVal := float64(0)
+			if devs.Device.Health {
+				healthVal = 1
+			}
+			if err := sendMetric(ch, nodeGPUDeviceHealthDesc, prometheus.GaugeValue,
+				healthVal, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+			); err != nil {
+				klog.V(4).Infof("Failed to send nodeGPUDeviceHealthDesc metric: %v", err)
 			}
 
 			if legacy {

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -477,3 +477,57 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 		}
 	})
 }
+
+func TestCollectNodeMetricsDeviceHealth(t *testing.T) {
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-healthy-0",
+							Index:     0,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    true,
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-unhealthy-1",
+							Index:     1,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{LegacyMetrics: false},
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: device.NewQuotaManager(),
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_gpu_device_health GPU device health status (1=healthy, 0=unhealthy)
+# TYPE hami_gpu_device_health gauge
+hami_gpu_device_health{device_index="0",device_type="NVIDIA",device_uuid="GPU-healthy-0",node="node-1"} 1
+hami_gpu_device_health{device_index="1",device_type="NVIDIA",device_uuid="GPU-unhealthy-1",node="node-1"} 0
+`
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_gpu_device_health",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
`DeviceUsage.Health` already exists — device plugins set it through `CheckHealth()`, and the scheduler uses it internally to skip unhealthy devices when scoring. But it's never actually exposed anywhere. Right now if a GPU goes unhealthy, the only way to notice is digging through node annotations by hand — Prometheus has zero visibility into it.

This adds `hami_gpu_device_health` as a gauge (1 = healthy, 0 = unhealthy) inside `collectNodeMetrics`, with labels `node`, `device_uuid`, `device_index`, `device_type` — same set as `hami_gpu_memory_limit_bytes`, so it joins cleanly with the metrics that already exist.

**What this gets you:** alert on `hami_gpu_device_health == 0` and page someone, build a Grafana panel showing device status per node, or line up unhealthy-device events against spikes in scheduling failures — which right now you basically can't do without going device by device.

Used the same 0/1 gauge pattern `hami_mig_device_info` already uses for boolean state, so nothing new stylistically. No legacy metric added since there wasn't a health metric in legacy mode to begin with.

One note for whoever reviews — `nodeGPUDeviceHealthDesc` is declared as a local variable inside the function, matching every other descriptor in there. None of them are package-level, so I kept it consistent.

Test added: `TestCollectNodeMetricsDeviceHealth`, one healthy device and one unhealthy device, checks both come out with the right value. Followed the same structure as `TestAMDCoreAllocatedRatioNormalization` already in that file.

> Used Claude to help spot the gap and draft the patch — I went through the code myself and understand it, happy to explain any part of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a node-level Prometheus metric reporting the health of each GPU device.
  * Reports `1` for healthy devices and `0` for unhealthy devices, with node, UUID, index, and device type details.

* **Tests**
  * Added coverage validating health metrics for healthy and unhealthy NVIDIA devices, including labels and reported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->