### PR TITLE
fix(ascend): reject over-capacity memory on requests-only pods

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -132,6 +132,15 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		return false, nil
 	}
 
+	// Requests/Limits may be nil when the pod only set one of them. Init
+	// before SuperPod or memory writes so requests-only pods do not panic.
+	if ctr.Resources.Requests == nil {
+		ctr.Resources.Requests = corev1.ResourceList{}
+	}
+	if ctr.Resources.Limits == nil {
+		ctr.Resources.Limits = corev1.ResourceList{}
+	}
+
 	reqNum := count.Value()
 	if dev.config.CommonWord == Ascend910CType && dev.config.SuperPod {
 		if reqNum == 1 {
@@ -185,14 +194,6 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		if trimMem != dev.config.MemoryAllocatable {
 			return true, errors.New("vNPU not supported for multiple devices")
 		}
-	}
-	// Requests/Limits may be nil when the pod only set one of them; writing
-	// to a nil map panics.
-	if ctr.Resources.Requests == nil {
-		ctr.Resources.Requests = corev1.ResourceList{}
-	}
-	if ctr.Resources.Limits == nil {
-		ctr.Resources.Limits = corev1.ResourceList{}
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -116,7 +116,12 @@ func (dev *Devices) CommonWord() string {
 }
 
 func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
+	// Match GenerateResourceRequests: honor device count on requests when
+	// limits omit it so over-capacity memory checks still run.
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceName)]
+	if !ok {
+		count, ok = ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceName)]
+	}
 	if !ok {
 		if dev.config.OverwriteEnv {
 			ctr.Env = append(ctr.Env, corev1.EnvVar{
@@ -163,6 +168,9 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 
 	trimMem := dev.config.MemoryAllocatable
 	memory, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)]
+	if !ok {
+		memory, ok = ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)]
+	}
 	if ok {
 		if isHAMiCore {
 			trimMem = memory.Value()
@@ -178,10 +186,13 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 			return true, errors.New("vNPU not supported for multiple devices")
 		}
 	}
-	// Requests may be nil when the pod declares only limits; writing to a
-	// nil map panics.
+	// Requests/Limits may be nil when the pod only set one of them; writing
+	// to a nil map panics.
 	if ctr.Resources.Requests == nil {
 		ctr.Resources.Requests = corev1.ResourceList{}
+	}
+	if ctr.Resources.Limits == nil {
+		ctr.Resources.Limits = corev1.ResourceList{}
 	}
 	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
@@ -313,6 +324,7 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 		if n, ok := v.AsInt64(); ok {
 			klog.Info("Found AscendDevices devices")
 			memnum := 0
+			memoryRequested := false
 			mem, ok := ctr.Resources.Limits[ascendResourceMem]
 			if !ok {
 				mem, ok = ctr.Resources.Requests[ascendResourceMem]
@@ -320,6 +332,7 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 			if ok {
 				memnums, ok := mem.AsInt64()
 				if ok {
+					memoryRequested = true
 					if dev.config.MemoryFactor > 1 {
 						rawMemnums := memnums
 						memnums = memnums * int64(dev.config.MemoryFactor)
@@ -339,7 +352,13 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 						memnum = int(memnums)
 					} else {
 						m, _ := dev.trimMemory(memnums)
-						memnum = int(m)
+						if m <= 0 {
+							// Over capacity: keep the original size. Collapsing to
+							// 0 would look like "no memory" and default to 100%.
+							memnum = int(memnums)
+						} else {
+							memnum = int(m)
+						}
 					}
 				}
 			}
@@ -354,8 +373,9 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 				}
 			}
 
+			// Whole-card default only when memory was not requested at all.
 			mempnum := 0
-			if memnum == 0 {
+			if !memoryRequested {
 				mempnum = 100
 			}
 

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1211,6 +1211,26 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Coresreq:         int32(0),
 			},
 		},
+		{
+			// Over-capacity memory under requests only must not become whole-card.
+			// Regression for https://github.com/Project-HAMi/HAMi/issues/2532
+			name: "over-capacity memory in requests only is not whole-card default",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("65536"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             "Ascend910A",
+				Memreq:           int32(65536),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(0),
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1246,6 +1266,41 @@ func Test_GenerateResourceRequests(t *testing.T) {
 
 			assert.Equal(t, result, test.want)
 		})
+	}
+}
+
+func Test_MutateAdmission_RequestsOnlyOverCapacityMemory(t *testing.T) {
+	// https://github.com/Project-HAMi/HAMi/issues/2532
+	dev := Devices{
+		config: VNPUConfig{
+			CommonWord:         "Ascend910A",
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryAllocatable:  int64(32768),
+			MemoryCapacity:     int64(32768),
+			Templates: []Template{
+				{Name: "vir02", Memory: int64(2184), AICore: int32(2)},
+				{Name: "vir04", Memory: int64(4369), AICore: int32(4)},
+				{Name: "vir08", Memory: int64(8738), AICore: int32(8)},
+				{Name: "vir16", Memory: int64(17476), AICore: int32(16)},
+			},
+		},
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"huawei.com/Ascend910A":        resource.MustParse("1"),
+				"huawei.com/Ascend910A-memory": resource.MustParse("65536"),
+			},
+		},
+	}
+	pod := corev1.Pod{}
+	ok, err := dev.MutateAdmission(&ctr, &pod)
+	if err == nil {
+		t.Fatalf("expected over-capacity requests-only memory to fail admission, got ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(err.Error(), "is invalid") {
+		t.Fatalf("expected invalid memory error, got %v", err)
 	}
 }
 

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1304,6 +1304,42 @@ func Test_MutateAdmission_RequestsOnlyOverCapacityMemory(t *testing.T) {
 	}
 }
 
+// SuperPod reqNum==1 writes Limits; requests-only pods must not panic on a nil Limits map.
+func Test_MutateAdmission_SuperPodRequestsOnlyNoPanic(t *testing.T) {
+	dev := Devices{
+		config: VNPUConfig{
+			CommonWord:         Ascend910CType,
+			ResourceName:       "huawei.com/Ascend910C",
+			ResourceMemoryName: "huawei.com/Ascend910C-memory",
+			MemoryAllocatable:  int64(65536),
+			MemoryCapacity:     int64(65536),
+			SuperPod:           true,
+			Templates: []Template{
+				{Name: "vir02", Memory: int64(8192), AICore: int32(2)},
+			},
+		},
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"huawei.com/Ascend910C": resource.MustParse("1"),
+			},
+		},
+	}
+	pod := corev1.Pod{}
+	ok, err := dev.MutateAdmission(&ctr, &pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected admission to handle device request")
+	}
+	// SuperPod rounds 1 -> 2 and writes Limits even when only Requests were set.
+	if got := ctr.Resources.Limits["huawei.com/Ascend910C"]; got.Value() != 2 {
+		t.Fatalf("expected SuperPod to set Limits device count to 2, got %v", got)
+	}
+}
+
 func Test_GenerateResourceRequests_VNPUCoreMode(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
﻿**Description of the change**

Ascend admission rejected over-capacity memory under limits but not under requests only. MutateAdmission returned early when the device count was missing from limits so the memory check never ran. GenerateResourceRequests fell back to requests and called trimMemory but treated a zero result (over capacity) as "no memory requested" and set MemPercentagereq to 100.

This change:

1. Makes MutateAdmission fall back to requests for device count and memory (same as GenerateResourceRequests).
2. Only applies the whole-card memory default when memory was not requested.
3. Keeps an over-capacity explicit request as Memreq instead of collapsing it to the whole-card path.
4. Adds regression tests for both paths.

**Benefits**

- Requests-only pods with impossible Ascend memory fail admission like limits-only pods.
- Scheduler path no longer rewrites invalid memory into a full card.

**Possible drawbacks**

- Pods that previously scheduled with requests-only over-capacity memory will now be rejected. That matches intended validation.

**Applicable issues**

- fixes #2532

**Additional information**

go test ./pkg/device/ascend -run GenerateResourceRequests/MutateAdmission_RequestsOnly passes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource allocation now falls back to requested values when limits are not provided.
  * Prevented failures when resource configurations are initially empty.
  * Preserved explicitly requested memory values, including values above capacity.
  * Invalid over-capacity memory requests are now correctly rejected.
  * Whole-card defaults are applied only when no memory request is specified.
  * Improved requests-only allocation handling, including correct device-count rounding.

* **Tests**
  * Added regression coverage for requests-only memory configurations, over-capacity requests, and empty resource limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->