### PR TITLE
fix(ascend): reject over-capacity memory requests instead of defaulting to whole card

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -339,6 +340,13 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 						memnum = int(memnums)
 					} else {
 						m, _ := dev.trimMemory(memnums)
+						if m <= 0 {
+							// No template and not the whole card can serve this
+							// request. Carry the requested value through so Fit
+							// rejects it, rather than letting the zero fall
+							// through to the whole-card default below.
+							m = min(memnums, math.MaxInt32)
+						}
 						memnum = int(m)
 					}
 				}

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1447,6 +1447,45 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 			},
 		},
 		{
+			name: "factor scales the request past MemoryCapacity",
+			dev: Devices{
+				config: VNPUConfig{
+					CommonWord:         "Ascend910A",
+					ResourceName:       "huawei.com/Ascend910A",
+					ResourceMemoryName: "huawei.com/Ascend910A-memory",
+					MemoryAllocatable:  int64(32768),
+					MemoryCapacity:     int64(32768),
+					MemoryFactor:       int32(1000),
+					Templates: []Template{
+						{
+							Name:   "vir02",
+							Memory: int64(2184),
+							AICore: int32(2),
+						}, {
+							Name:   "vir04",
+							Memory: int64(4369),
+							AICore: int32(4),
+						}, {
+							Name:   "vir08",
+							Memory: int64(8738),
+							AICore: int32(8),
+						}, {
+							Name:   "vir16",
+							Memory: int64(17476),
+							AICore: int32(16),
+						},
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             "Ascend910A",
+				Memreq:           int32(128000),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(0),
+			},
+		},
+		{
 			name: "factor 0",
 			dev: Devices{
 				config: VNPUConfig{

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -19,6 +19,7 @@ package ascend
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -1225,6 +1226,42 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Nums:             int32(1),
 				Type:             "Ascend910A",
 				Memreq:           int32(65536),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(0),
+			},
+		},
+		{
+			name: "resourcememoryname larger than MemoryCapacity on the limits path is carried through too",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("65536"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             "Ascend910A",
+				Memreq:           int32(65536),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(0),
+			},
+		},
+		{
+			name: "resourcememoryname above int32 max is clamped instead of wrapping to zero",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("2147483648"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             "Ascend910A",
+				Memreq:           int32(math.MaxInt32),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(0),
 			},

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1211,6 +1211,24 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Coresreq:         int32(0),
 			},
 		},
+		{
+			name: "resourcememoryname larger than MemoryCapacity is carried through, not defaulted to the whole card",
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("65536"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(1),
+				Type:             "Ascend910A",
+				Memreq:           int32(65536),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(0),
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`trimMemory` returns `0` when an Ascend memory request exceeds every template and the card capacity. `GenerateResourceRequests` dropped that zero, and the whole-card default below it reads a zero as "no memory requested", so an unsatisfiable request became a request for 100% of a card and scheduled.

`MutateAdmission` already rejects this on the limits path, but it returns early when the device count is absent from `limits`, so a pod declaring resources under `requests` only never reaches that check.

This carries the requested value through when `trimMemory` returns `0`, so `Fit` rejects it. The value is clamped to `MaxInt32` because the `int32` narrowing at the return would otherwise wrap a large quantity back to zero and reintroduce the same bug.

**Which issue(s) this PR fixes**:

Fixes #2532

**Special notes for your reviewer**:

#2532 offers a second approach: make `MutateAdmission` fall back to `requests` so the existing rejection covers both shapes. That closes the bypass at its root, but it changes admission behaviour for every Ascend pod, so I took the narrower change here. Happy to switch to it or add it alongside if you prefer.

Verified with a regression case added to the existing `Test_GenerateResourceRequests` table. All `pkg/device/...` packages pass. I could not run `--race` or build `pkg/device/nvidia` locally because both need Linux, so CI covers those.

Per CONTRIBUTING.md, I used AI assistance while investigating and preparing this change. I verified the behaviour myself and can explain it.

**Does this PR introduce a user-facing change?**:

An Ascend memory request larger than the device capacity is now rejected instead of being silently scheduled as a whole-card request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved custom memory requests that exceed the configured memory capacity instead of replacing them with a whole-card allocation.
  - Capped exceptionally large memory requests at the supported maximum value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->