### PR TITLE
test(scheduler): add regression tests for quota metrics collector

### DIFF
--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -408,3 +408,72 @@ hami_node_gpu_mig_instance_info{compute_instance_id="0",device_index="0",device_
 		t.Fatalf("unexpected collecting result:\n%s", err)
 	}
 }
+
+func TestClusterManagerCollectorQuotaMetrics(t *testing.T) {
+	// Regression coverage for collectQuotaMetrics: verify per-namespace quota
+	// usage is exported as hami_resource_quota_used, and as legacy QuotaUsed
+	// when LegacyMetrics is enabled.
+	const (
+		ns       = "team-a"
+		memName  = "nvidia.com/gpumem"
+		coreName = "nvidia.com/gpucore"
+	)
+
+	qm := device.NewQuotaManager()
+	qm.Quotas[ns] = &device.DeviceQuota{
+		memName:  &device.Quota{Used: 4096, Limit: 8192, LimitSet: true},
+		coreName: &device.Quota{Used: 50, Limit: 100, LimitSet: true},
+	}
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	provider := &fakeMetricsProvider{
+		nodeUsage:    map[string]*schedulerpkg.NodeUsage{},
+		quotaManager: qm,
+		podManager:   device.NewPodManager(),
+	}
+
+	t.Run("non-legacy", func(t *testing.T) {
+		collector := ClusterManagerCollector{
+			ClusterManager:  &ClusterManager{LegacyMetrics: false},
+			metricsProvider: provider,
+		}
+		want := `
+# HELP hami_resource_quota_used resourcequota usage for a certain device
+# TYPE hami_resource_quota_used gauge
+hami_resource_quota_used{limit="100",namespace="team-a",quota_name="nvidia.com/gpucore"} 50
+hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/gpumem"} 4096
+`
+		if err := promtestutil.CollectAndCompare(
+			collector,
+			strings.NewReader(want),
+			"hami_resource_quota_used",
+		); err != nil {
+			t.Fatalf("unexpected non-legacy collecting result:\n%s", err)
+		}
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		collector := ClusterManagerCollector{
+			ClusterManager:  &ClusterManager{LegacyMetrics: true},
+			metricsProvider: provider,
+		}
+		want := `
+# HELP QuotaUsed resourcequota usage for a certain device
+# TYPE QuotaUsed gauge
+QuotaUsed{limit="100",quotaName="nvidia.com/gpucore",quotanamespace="team-a"} 50
+QuotaUsed{limit="8192",quotaName="nvidia.com/gpumem",quotanamespace="team-a"} 4096
+# HELP hami_resource_quota_used resourcequota usage for a certain device
+# TYPE hami_resource_quota_used gauge
+hami_resource_quota_used{limit="100",namespace="team-a",quota_name="nvidia.com/gpucore"} 50
+hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/gpumem"} 4096
+`
+		if err := promtestutil.CollectAndCompare(
+			collector,
+			strings.NewReader(want),
+			"hami_resource_quota_used",
+			"QuotaUsed",
+		); err != nil {
+			t.Fatalf("unexpected legacy collecting result:\n%s", err)
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

This PR adds regression tests for `collectQuotaMetrics` in the scheduler Prometheus collector.
The test:
- seeds `QuotaManager` with gpumem/gpucore usage for namespace `team-a`
- checks `hami_resource_quota_used` when `LegacyMetrics: false`
- checks both `hami_resource_quota_used` and `QuotaUsed` when `LegacyMetrics: true`
- uses the same `fakeMetricsProvider` and `CollectAndCompare` pattern as #2204 and #2527

**Which issue(s) this PR fixes**:
Fixes part of #2334

**Special notes for your reviewer**:
Test-only. No production code change. 

**Does this PR introduce a user-facing change?**:
No

 **Validation:**
- `go test ./cmd/scheduler/... -run TestClusterManagerCollectorQuotaMetrics -short -count=1`
- `make verify` 

**AI assistance disclosure:**
I have used Cursor to explore existing tests in `metrics_test.go` and `quota_test.go`.
I wrote the test myself, fixed the rebase conflict with #2378, and ran the tests locally.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for quota metric collection.
  * Verified GPU memory and core quota metrics in both legacy and non-legacy modes, including expected values and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->