### PR TITLE
fix(plugin): don't cache node annotation as up-to-date when the patch fails

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -273,7 +273,6 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 		klog.V(3).Info("Device info unchanged, skipping annotation update")
 		return false, nil
 	}
-	plugin.deviceCache = encodeddevices
 
 	var data []byte
 	if os.Getenv("ENABLE_TOPOLOGY_SCORE") == "true" {
@@ -305,8 +304,10 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 
 	if err != nil {
 		klog.Errorln("patch node error", err.Error())
+		return true, err
 	}
-	return true, err
+	plugin.deviceCache = encodeddevices
+	return true, nil
 }
 
 func (plugin *NvidiaDevicePlugin) WatchAndRegister(disableNVML <-chan bool, ackDisableWatchAndRegister chan<- bool) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -89,6 +89,9 @@ func GetNumaNode(d nvml.Device) (bool, int, error) {
 // nvmlInit is overridable in tests to simulate NVML init failures without a real driver.
 var nvmlInit = nvml.Init
 
+// calculateGPUScore is overridable in tests to simulate topology-score calculation failures.
+var calculateGPUScore = nvidia.CalculateGPUScore
+
 func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 	devs := plugin.Devices()
 	klog.V(5).InfoS("getAPIDevices", "devices", devs)
@@ -276,7 +279,7 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 
 	var data []byte
 	if os.Getenv("ENABLE_TOPOLOGY_SCORE") == "true" {
-		gpuScore, hasAsymmetry, err := nvidia.CalculateGPUScore(device.GetDevicesUUIDList(*devices))
+		gpuScore, hasAsymmetry, err := calculateGPUScore(device.GetDevicesUUIDList(*devices))
 		if err != nil {
 			klog.ErrorS(err, "calculate gpu topo score error")
 			return false, err

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -30,6 +30,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
@@ -230,6 +231,54 @@ func TestRegisterInAnnotationRetriesAfterPatchFailure(t *testing.T) {
 	}
 	if !changed {
 		t.Fatal("second RegisterInAnnotation() changed = false, want true (patch should be retried, not skipped)")
+	}
+}
+
+// TestRegisterInAnnotationDoesNotPoisonCacheOnScoreError verifies that a
+// failure computing the topology score (ENABLE_TOPOLOGY_SCORE=true) does not
+// poison deviceCache either: the cache is only written after every step,
+// including score calculation, completes successfully - matching the
+// patch-failure behavior verified above.
+func TestRegisterInAnnotationDoesNotPoisonCacheOnScoreError(t *testing.T) {
+	originalInit := nvmlInit
+	originalShutdown := nvml.Shutdown
+	nvmlInit = func() nvml.Return { return nvml.SUCCESS }
+	nvml.Shutdown = func() nvml.Return { return nvml.SUCCESS }
+	defer func() {
+		nvmlInit = originalInit
+		nvml.Shutdown = originalShutdown
+	}()
+
+	originalCalculateGPUScore := calculateGPUScore
+	calculateGPUScore = func([]string) (nvidia.ListDeviceScore, bool, error) {
+		return nil, false, fmt.Errorf("simulated topology score failure")
+	}
+	defer func() { calculateGPUScore = originalCalculateGPUScore }()
+
+	t.Setenv("ENABLE_TOPOLOGY_SCORE", "true")
+
+	previousKubeClient := client.KubeClient
+	previousNodeName := util.NodeName
+	util.NodeName = "test-node"
+	defer func() {
+		client.KubeClient = previousKubeClient
+		util.NodeName = previousNodeName
+	}()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	client.KubeClient = fake.NewSimpleClientset(node)
+
+	plugin := &NvidiaDevicePlugin{rm: &rm.ResourceManagerMock{DevicesFunc: func() rm.Devices { return rm.Devices{} }}}
+
+	changed, err := plugin.RegisterInAnnotation()
+	if err == nil {
+		t.Fatal("RegisterInAnnotation() error = nil, want error from failed score calculation")
+	}
+	if changed {
+		t.Fatal("RegisterInAnnotation() changed = true, want false (no patch was attempted)")
+	}
+	if plugin.deviceCache != "" {
+		t.Fatalf("deviceCache = %q after a failed score calculation, want unchanged (empty)", plugin.deviceCache)
 	}
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -17,13 +17,21 @@ limitations under the License.
 package plugin
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
 
 func TestInt8SliceString(t *testing.T) {
@@ -168,6 +176,60 @@ func TestWatchAndRegisterDisableSignal(t *testing.T) {
 		// Success: received the ack
 	case <-timeAfter(3 * time.Second):
 		t.Fatal("timed out waiting for disable ack from WatchAndRegister")
+	}
+}
+
+// TestRegisterInAnnotationRetriesAfterPatchFailure verifies that a failed
+// node-annotation patch does not poison deviceCache: the next call must
+// still see the device info as "changed" and retry the patch, instead of
+// silently early-returning forever because deviceCache already matches.
+func TestRegisterInAnnotationRetriesAfterPatchFailure(t *testing.T) {
+	originalInit := nvmlInit
+	originalShutdown := nvml.Shutdown
+	nvmlInit = func() nvml.Return { return nvml.SUCCESS }
+	nvml.Shutdown = func() nvml.Return { return nvml.SUCCESS }
+	defer func() {
+		nvmlInit = originalInit
+		nvml.Shutdown = originalShutdown
+	}()
+
+	previousKubeClient := client.KubeClient
+	previousNodeName := util.NodeName
+	util.NodeName = "test-node"
+	defer func() {
+		client.KubeClient = previousKubeClient
+		util.NodeName = previousNodeName
+	}()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	fakeClient := fake.NewSimpleClientset(node)
+	fakeClient.PrependReactor("patch", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated patch failure")
+	})
+	client.KubeClient = fakeClient
+
+	plugin := &NvidiaDevicePlugin{rm: &rm.ResourceManagerMock{DevicesFunc: func() rm.Devices { return rm.Devices{} }}}
+
+	changed, err := plugin.RegisterInAnnotation()
+	if err == nil {
+		t.Fatal("RegisterInAnnotation() error = nil, want error from failed patch")
+	}
+	if !changed {
+		t.Fatal("RegisterInAnnotation() changed = false, want true (a patch was attempted)")
+	}
+	if plugin.deviceCache != "" {
+		t.Fatalf("deviceCache = %q after a failed patch, want unchanged (empty)", plugin.deviceCache)
+	}
+
+	// A second call with the same device set must retry the patch (and
+	// surface the same error) rather than treating deviceCache as already
+	// up to date.
+	changed, err = plugin.RegisterInAnnotation()
+	if err == nil {
+		t.Fatal("second RegisterInAnnotation() error = nil, want the retry to also surface the patch failure")
+	}
+	if !changed {
+		t.Fatal("second RegisterInAnnotation() changed = false, want true (patch should be retried, not skipped)")
 	}
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -180,6 +180,54 @@ func TestWatchAndRegisterDisableSignal(t *testing.T) {
 	}
 }
 
+// TestRegisterInAnnotationUpdatesCacheOnSuccessfulPatch verifies the happy
+// path: once PatchNodeAnnotations succeeds, deviceCache is updated to the
+// newly patched value and the call reports changed=true with no error.
+func TestRegisterInAnnotationUpdatesCacheOnSuccessfulPatch(t *testing.T) {
+	originalInit := nvmlInit
+	originalShutdown := nvml.Shutdown
+	nvmlInit = func() nvml.Return { return nvml.SUCCESS }
+	nvml.Shutdown = func() nvml.Return { return nvml.SUCCESS }
+	defer func() {
+		nvmlInit = originalInit
+		nvml.Shutdown = originalShutdown
+	}()
+
+	previousKubeClient := client.KubeClient
+	previousNodeName := util.NodeName
+	util.NodeName = "test-node"
+	defer func() {
+		client.KubeClient = previousKubeClient
+		util.NodeName = previousNodeName
+	}()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	client.KubeClient = fake.NewSimpleClientset(node)
+
+	plugin := &NvidiaDevicePlugin{rm: &rm.ResourceManagerMock{DevicesFunc: func() rm.Devices { return rm.Devices{} }}}
+
+	changed, err := plugin.RegisterInAnnotation()
+	if err != nil {
+		t.Fatalf("RegisterInAnnotation() error = %v, want nil on a successful patch", err)
+	}
+	if !changed {
+		t.Fatal("RegisterInAnnotation() changed = false, want true (a patch was applied)")
+	}
+	if plugin.deviceCache == "" {
+		t.Fatal("deviceCache is empty after a successful patch, want it set to the patched device string")
+	}
+
+	// A second call with the same device set must now see deviceCache as
+	// up to date and skip re-patching.
+	changed, err = plugin.RegisterInAnnotation()
+	if err != nil {
+		t.Fatalf("second RegisterInAnnotation() error = %v, want nil", err)
+	}
+	if changed {
+		t.Fatal("second RegisterInAnnotation() changed = true, want false (device info unchanged, patch should be skipped)")
+	}
+}
+
 // TestRegisterInAnnotationRetriesAfterPatchFailure verifies that a failed
 // node-annotation patch does not poison deviceCache: the next call must
 // still see the device info as "changed" and retry the patch, instead of


### PR DESCRIPTION
## What this PR does

Fixes `RegisterInAnnotation` in the NVIDIA device plugin so a failed node-annotation patch is retried on the next cycle instead of being silently swallowed forever.

## Why

`RegisterInAnnotation` (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go`) writes the newly-computed device-info string into `plugin.deviceCache` *before* attempting `util.PatchNodeAnnotations`, and nothing resets it if the patch fails:

```go
encodeddevices := device.MarshalNodeDevices(*devices)
if encodeddevices == plugin.deviceCache {
    return false, nil // "unchanged, skip"
}
plugin.deviceCache = encodeddevices   // cached before the patch is even attempted
...
err = util.PatchNodeAnnotations(node, annos)
if err != nil {
    klog.Errorln("patch node error", err.Error())
}
return true, err   // deviceCache is already poisoned regardless of err
```

`WatchAndRegister` calls this in a loop and does log-and-retry on error:

```go
changed, err := plugin.RegisterInAnnotation()
if err != nil {
    klog.Errorf("Failed to register annotation: %v. Retrying in %v...", err, errorSleepInterval)
    ...
}
```

But the retry never actually re-patches: if the very first patch fails (transient API server error, throttling, conflict — `PatchNodeAnnotations` does a plain `Patch()` call with no retry of its own), `deviceCache` is already set to the value that was supposed to be applied. On the next loop iteration the physical device set hasn't changed, so the recomputed `encodeddevices` matches the poisoned `deviceCache`, and the function hits the early "unchanged, skip" return — `(false, nil)` — with no further patch attempt and no further error log. The node's `hami.io/node-nvidia-register` annotation is left stale (or never written on first registration), so the HAMi scheduler can't see that node's GPUs until the device set later changes or the plugin pod restarts.

## What changed

- Moved the `plugin.deviceCache = encodeddevices` write to after `util.PatchNodeAnnotations` succeeds, so a failed patch leaves the cache untouched and the next `WatchAndRegister` cycle recomputes the same device string, treats it as "changed" again, and retries the patch — matching the retry-on-error logging that already exists in `WatchAndRegister`.
- Added `TestRegisterInAnnotationRetriesAfterPatchFailure` in `register_test.go`, using a fake clientset with a `PrependReactor` that fails the `patch`/`nodes` call. It asserts `deviceCache` stays empty after a failed patch and that a second call retries (returns `changed=true` and surfaces the error again) rather than silently no-op'ing. I confirmed this test fails against the pre-fix code (reverted the `register.go` change locally and reran — `deviceCache` ends up non-empty after the failed patch, exactly as described above).

## Verification

- `go build ./...`
- `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -short --race -count=1` (all pass, including the new regression test)
- `go vet ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/...` (one pre-existing, unrelated `copylocks` warning in `server_test.go:172` confirmed present on master before this change too)
- `golangci-lint run ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/...` (0 issues)
- `hack/verify-license.sh`, `hack/verify-import-aliases.sh` (pass)
- No GPU hardware available — this is a pure control-flow/caching bug in the annotation-patch retry path, validated with a fake Kubernetes clientset rather than real hardware.

## AI assistance disclosure

I used Claude Code to scan the device-plugin registration path for correctness bugs, and it identified this cache-before-confirm ordering issue and drafted the fix plus the regression test (including the fake-clientset `PrependReactor` failure injection). I read through the resulting diff, independently verified the root cause by reverting the fix and confirming the new test fails without it, and take responsibility for the correctness of both the fix and the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device registration reliability when updating node annotations.
  * Failed annotation updates no longer record devices prematurely, allowing registration to retry successfully.
  * Failures while calculating topology scores no longer leave stale registration state.
* **Tests**
  * Added regression coverage for retry behavior after annotation update failures.
  * Added coverage ensuring topology-score errors do not prevent future registration attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->