### PR TITLE
test(plugin): fix TestGetNumaNode failure caused by existing PCI bus ID

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -97,7 +97,7 @@ func TestGetNumaNode(t *testing.T) {
 
 	t.Run("numa node file is absent", func(t *testing.T) {
 		dev := &nvmlmock.Device{GetPciInfoFunc: func() (nvml.PciInfo, nvml.Return) {
-			return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', '0', '0', '0', '0', ':', '0', '2', ':', '0', '0', '.', '0'}}, nvml.SUCCESS
+			return nvml.PciInfo{BusId: [32]int8{'0', '0', '0', '0', 'D', 'E', 'A', 'D', ':', 'B', 'E', ':', 'E', 'F', '.', '0'}}, nvml.SUCCESS
 		}}
 		hasNode, node, err := GetNumaNode(dev)
 		if err == nil || hasNode || node != 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
The `TestGetNumaNode` test in register_test.go previously hardcoded the PCI bus ID to be `00000000:02:00.0` with the assumption that this device would not exist on the test host (and therefore lack a `/sys/bus/pci/devices/.../numa_node` file). However, on machines where a device actually does exist at `0000:02:00.0` such as local dev environments or specific CI nodes, the `GetNumaNode` function successfully reads the file instead of returning the expected error, causing the test to fail (my own machine had this case and thus the test `./pkg/device-plugin/nvidiadevice/nvinternal/plugin/` kept failing).

Change Made:

- `pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go:` Updated the mocked `PciInfo.BusId` in the test from `00000000:02:00.0` to an impossible bus ID `0000DEAD:BE:EF.0`.

By using `DEAD:BE:EF.0`, we can guarantee that the numa_node sysfs path will never exist on any machine regardless of their local hardware setup, ensuring the error branch is deterministically triggered and the test passes consistently .
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**AI assistance disclosure:**
I saw that `make test` was failing on my machine while doing something and used Gemini Pro 3.1 for investigating some of the recent commits to find the cause.  Verified everything manually before creating the PR.

**Does this PR introduce a user-facing change?**:
No, this only modifies a unit test that might fail for some machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test fixture’s simulated PCI bus ID while preserving existing test behavior and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->