### PR TITLE
fix(ascend): don't double-apply MemoryFactor across MutateAdmission and GenerateResourceRequests

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -162,19 +162,36 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 
 	trimMem := dev.config.MemoryAllocatable
+	snappedMem := dev.config.MemoryAllocatable
 	memory, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)]
 	if ok {
 		if isHAMiCore {
 			trimMem = memory.Value()
+			snappedMem = trimMem
 		} else {
-			trimMem, _ = dev.trimMemory(memory.Value())
-			if trimMem <= 0 {
-				return false, fmt.Errorf("%s %d is invalid", dev.config.ResourceMemoryName, memory.Value())
+			rawMem := memory.Value()
+			scaledMem := rawMem
+			if dev.config.MemoryFactor > 1 {
+				scaledMem = rawMem * int64(dev.config.MemoryFactor)
+			}
+			snappedMem, _ = dev.trimMemory(scaledMem)
+			if snappedMem <= 0 {
+				return false, fmt.Errorf("%s %d is invalid", dev.config.ResourceMemoryName, rawMem)
+			}
+			// GenerateResourceRequests scales whatever ends up in this field by
+			// MemoryFactor again before trimming it against the same templates.
+			// When a factor is configured, keep the raw (pre-factor) value here
+			// so it isn't scaled a second time downstream; otherwise preserve
+			// the existing behavior of snapping to the matched template/capacity.
+			if dev.config.MemoryFactor > 1 {
+				trimMem = rawMem
+			} else {
+				trimMem = snappedMem
 			}
 		}
 	}
 	if count.Value() > 1 && !isHAMiCore {
-		if trimMem != dev.config.MemoryAllocatable {
+		if snappedMem != dev.config.MemoryAllocatable {
 			return true, errors.New("vNPU not supported for multiple devices")
 		}
 	}

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1439,6 +1439,63 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 	}
 }
 
+// Test_MutateAdmission_Then_GenerateResourceRequests_WithFactor is a
+// regression test for the MutateAdmission -> GenerateResourceRequests
+// pipeline (mutating webhook mutates the container first, then the
+// scheduler reads the mutated container) when MemoryFactor > 1 is
+// configured. Both functions must agree on the matched template: if
+// MutateAdmission snaps the container's memory field to the
+// already-scaled-and-trimmed internal value, GenerateResourceRequests
+// would scale it a second time and overflow every template, silently
+// falling back to a whole-device (100%) request.
+func Test_MutateAdmission_Then_GenerateResourceRequests_WithFactor(t *testing.T) {
+	dev := Devices{
+		config: VNPUConfig{
+			CommonWord:         "Ascend910A",
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryAllocatable:  int64(32768),
+			MemoryCapacity:     int64(32768),
+			MemoryFactor:       int32(100),
+			Templates: []Template{
+				{Name: "vir02", Memory: int64(2184), AICore: int32(2)},
+				{Name: "vir04", Memory: int64(4369), AICore: int32(4)},
+				{Name: "vir08", Memory: int64(8738), AICore: int32(8)},
+				{Name: "vir16", Memory: int64(17476), AICore: int32(16)},
+			},
+		},
+	}
+
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"huawei.com/Ascend910A":        resource.MustParse("1"),
+				"huawei.com/Ascend910A-memory": resource.MustParse("128"),
+			},
+		},
+	}
+	pod := corev1.Pod{}
+
+	found, err := dev.MutateAdmission(&ctr, &pod)
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+
+	// The field must still hold the raw, pre-factor value the user
+	// requested so GenerateResourceRequests can scale it exactly once.
+	mem := ctr.Resources.Limits["huawei.com/Ascend910A-memory"]
+	assert.Equal(t, mem.Value(), int64(128))
+
+	got := dev.GenerateResourceRequests(&ctr)
+	want := device.ContainerDeviceRequest{
+		Nums:             int32(1),
+		Type:             "Ascend910A",
+		Memreq:           int32(17476),
+		MemPercentagereq: int32(0),
+		Coresreq:         int32(0),
+	}
+	assert.Equal(t, got, want)
+}
+
 func TestDevices_LockNode(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What this PR does

Fixes Ascend hard-split (non-hami-core) vNPU requests silently falling back to a whole-device request instead of the intended template, whenever `memoryFactor > 1` is configured.

## Why

`MutateAdmission` (the mutating webhook, runs first and rewrites the pod's container spec) and `GenerateResourceRequests` (the scheduler, reads the already-mutated container) both need to agree on how a pod's memory request maps to a vNPU template - but they didn't, whenever `MemoryFactor > 1` was configured:

- `MutateAdmission` (`pkg/device/ascend/device.go`) called `trimMemory()` directly on the *raw, un-scaled* pod-spec value, and wrote the resulting (already-in-internal-template-units) value back into `ctr.Resources.Limits`/`Requests`.
- `GenerateResourceRequests` then read that *already-converted* value from the (post-webhook) container, multiplied it by `MemoryFactor` again, and trimmed it a second time.

Concretely, with `memoryFactor: 100` and these templates (`vir02: 2184`, `vir04: 4369`, `vir08: 8738`, `vir16: 17476`), a pod requesting `huawei.com/Ascend910A-memory: 128` is meant to land on `vir16` (`128*100=12800 <= 17476`) - and `GenerateResourceRequests` has a dedicated test (`Test_GenerateResourceRequestsFactor`) proving it does that correctly *in isolation*. But through the real pipeline:
1. `MutateAdmission` computes `trimMemory(128)` → matches `vir02` (2184) instead, and writes `2184` back into the container.
2. `GenerateResourceRequests` reads `2184`, multiplies by the factor again → `218400`, which exceeds every template *and* `MemoryCapacity` (32768) → `trimMemory` returns `(0, "")` → `memnum=0` → the fallback `mempnum=100` kicks in, silently requesting the **entire device** instead of a `vir16` slice.

This isn't just a scheduling-accounting bug either: the webhook's own `fitResourceQuota` (`pkg/scheduler/webhook.go:145`) calls `GenerateResourceRequests` to compute quota usage, so the same wrong number (whole-device instead of template-sized) feeds ResourceQuota enforcement too.

All shipped Helm chart configs (`charts/hami/templates/scheduler/device-configmap.yaml`) currently set `memoryFactor: 1` for every Ascend entry, which makes this latent today - but the field is user-configurable and has dedicated test coverage for factor values `> 1`, so any deployment using `memoryFactor > 1` in hard-split mode hits this.

## What changed

- `MutateAdmission` now scales the raw memory value by `MemoryFactor` (matching `GenerateResourceRequests`'s own scaling) before validating it against the templates/capacity. Validation semantics (and the existing multi-device "vNPU not supported for multiple devices" check) are preserved using this correctly-scaled value.
- Crucially, when a factor is configured, `MutateAdmission` writes the **raw, pre-factor** value back into `ctr.Resources.Limits`/`Requests` instead of the trimmed/scaled one - so the field only gets scaled once, downstream, by `GenerateResourceRequests`. Factor `<= 1` behavior (the shipped default) is completely unchanged: the field is still snapped to the matched template/capacity value exactly as before.
- Added `Test_MutateAdmission_Then_GenerateResourceRequests_WithFactor` in `pkg/device/ascend/device_test.go`, which runs the two functions back-to-back (as the real webhook → scheduler pipeline does) with `memoryFactor: 100` and asserts the final `Memreq` is `17476` (`vir16`), not a whole-device fallback. I confirmed this test fails against the pre-fix code (reverted the `device.go` change locally and reran - it fails with `2184 != 128`, i.e. the container field ends up holding the wrongly-pre-trimmed value that later causes the double-scale).

## Verification

- `go build ./...`
- `go test ./pkg/device/ascend/... -short --race -count=1` (all pass, including the new regression test; no existing tests changed behavior)
- `go vet ./pkg/device/ascend/...`
- `golangci-lint run ./pkg/device/ascend/...` (0 issues)
- `hack/verify-license.sh`, `hack/verify-import-aliases.sh` (pass)
- No Ascend hardware available - this is pure webhook/scheduler request-shaping logic, validated with unit tests exercising the exact two-function pipeline described above rather than real hardware.

## AI assistance disclosure

I used Claude Code to scan the Ascend backend for correctness bugs; it identified the MutateAdmission/GenerateResourceRequests scaling mismatch by comparing both functions' handling of `MemoryFactor` and tracing the webhook → scheduler data flow, and drafted the fix and regression test. I read through the resulting diff, independently verified the root cause by reverting the fix and confirming the new test fails without it (and checked the fix doesn't regress the `count.Value() > 1` multi-device check, which also reads the affected variable), and take responsibility for the correctness of both the fix and the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device memory allocation handling when memory scaling is configured.
  * Prevented memory requests from being scaled more than once during resource generation.
  * Added validation to reject requests when no valid scaled allocation is available.
  * Improved multi-device validation to use the finalized allocation value.
* **Tests**
  * Added coverage for scaled memory requests, confirming correct admission and resource allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->