### PR TITLE
fix(scheduler): remove stale device vendors on zero-device update

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -504,6 +504,19 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 				s.rmNodeDevices(val.Name, devhandsk)
 				continue
 			}
+			// GetNodeDevices succeeded but reported zero devices: the vendor plugin
+			// is healthy but no longer advertising devices on this node. Remove any
+			// stale entry so the scheduler does not keep offering capacity that no
+			// longer exists.
+			if len(nodedevices) == 0 {
+				if existingNode, getNodeErr := s.GetNode(val.Name); getNodeErr == nil {
+					if _, ok := existingNode.Devices[devhandsk]; ok {
+						klog.V(5).InfoS("Vendor reports zero devices, removing stale cache entry", "nodeName", val.Name, "deviceVendor", devhandsk)
+						s.rmNodeDevices(val.Name, devhandsk)
+					}
+				}
+				continue
+			}
 			if !needUpdate {
 				klog.V(5).InfoS("No update needed for device", "nodeName", val.Name, "deviceVendor", devhandsk)
 				continue

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -511,7 +511,7 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 			if len(nodedevices) == 0 {
 				if existingNode, getNodeErr := s.GetNode(val.Name); getNodeErr == nil {
 					if _, ok := existingNode.Devices[devhandsk]; ok {
-						klog.V(5).InfoS("Vendor reports zero devices, removing stale cache entry", "nodeName", val.Name, "deviceVendor", devhandsk)
+						klog.InfoS("Vendor reports zero devices, removing stale cache entry", "nodeName", val.Name, "deviceVendor", devhandsk)
 						s.rmNodeDevices(val.Name, devhandsk)
 					}
 				}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1077,11 +1077,12 @@ func Test_RegisterFromNodeAnnotations_NIL(t *testing.T) {
 }
 
 type registerMockDevice struct {
-	nodeDevices   []*device.DeviceInfo
-	getNodeErr    error
-	health        bool
-	needUpdate    bool
-	nodeCleanedUp int
+	nodeDevices        []*device.DeviceInfo
+	getNodeErr         error
+	getNodeDevicesFunc func(node corev1.Node) ([]*device.DeviceInfo, error)
+	health             bool
+	needUpdate         bool
+	nodeCleanedUp      int
 }
 
 func (m *registerMockDevice) CommonWord() string { return "mock-vendor" }
@@ -1096,7 +1097,10 @@ func (m *registerMockDevice) NodeCleanUp(_ string) error {
 	return nil
 }
 func (m *registerMockDevice) GetResourceNames() device.ResourceNames { return device.ResourceNames{} }
-func (m *registerMockDevice) GetNodeDevices(_ corev1.Node) ([]*device.DeviceInfo, error) {
+func (m *registerMockDevice) GetNodeDevices(node corev1.Node) ([]*device.DeviceInfo, error) {
+	if m.getNodeDevicesFunc != nil {
+		return m.getNodeDevicesFunc(node)
+	}
 	return m.nodeDevices, m.getNodeErr
 }
 func (m *registerMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error        { return nil }
@@ -1198,6 +1202,169 @@ func TestRegisterSkipsCleanupForUntrackedVendor(t *testing.T) {
 	assert.Equal(t, ok, true)
 	_, ok = nodeInfo.Devices["mock-vendor"]
 	assert.Equal(t, ok, false)
+}
+
+func Test_register_StaleDeviceVendorRemoval(t *testing.T) {
+	oldDevicesMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldDevicesMap })
+
+	vendorA := &registerMockDevice{
+		getNodeDevicesFunc: func(node corev1.Node) ([]*device.DeviceInfo, error) {
+			if node.Name == "node-1" {
+				return []*device.DeviceInfo{
+					{
+						ID:           "gpu-1",
+						DeviceVendor: "vendor-A",
+						Health:       true,
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+		health:     true,
+		needUpdate: true,
+	}
+	vendorB := &registerMockDevice{
+		nodeDevices: []*device.DeviceInfo{},
+		health:      true,
+		needUpdate:  true,
+	}
+	vendorC := &registerMockDevice{
+		getNodeDevicesFunc: func(node corev1.Node) ([]*device.DeviceInfo, error) {
+			if node.Name == "node-1" {
+				return []*device.DeviceInfo{
+					{
+						ID:           "gpu-3",
+						DeviceVendor: "vendor-C",
+						Health:       true,
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+		health:     true,
+		needUpdate: true,
+	}
+	vendorD := &registerMockDevice{
+		nodeDevices: []*device.DeviceInfo{},
+		health:      true,
+		needUpdate:  true,
+	}
+
+	device.DevicesMap = map[string]device.Devices{
+		"vendor-A": vendorA,
+		"vendor-B": vendorB,
+		"vendor-C": vendorC,
+		"vendor-D": vendorD,
+	}
+
+	s := NewScheduler()
+	s.stopCh = make(chan struct{})
+	t.Cleanup(func() { close(s.stopCh) })
+
+	oldKubeClient := client.KubeClient
+	client.KubeClient = fake.NewClientset()
+	t.Cleanup(func() { client.KubeClient = oldKubeClient })
+	s.kubeClient = client.KubeClient
+
+	t.Setenv("POD_NAMESPACE", "default")
+	t.Setenv("POD_NAME", "scheduler-0")
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client.KubeClient, time.Hour)
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+
+	// node-1: present in k8s indexer and pre-populated in scheduler cache
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+	}
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.Background(), node1, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(node1)
+	require.NoError(t, err)
+
+	// node-absent: present in k8s indexer but absent from scheduler cache (exercises GetNode() error branch)
+	nodeAbsent := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-absent",
+		},
+	}
+	_, err = client.KubeClient.CoreV1().Nodes().Create(context.Background(), nodeAbsent, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(nodeAbsent)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scheduler-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				util.HAMiComponentLabel: util.HAMiComponentScheduler,
+			},
+		},
+	}
+	_, err = client.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+	require.NoError(t, err)
+
+	informerFactory.Start(s.stopCh)
+	informerFactory.WaitForCacheSync(s.stopCh)
+
+	// Initial cache state: node-1 has vendor-A, vendor-B, and vendor-C (vendor-D is untracked)
+	s.addNode("node-1", &device.NodeInfo{
+		ID:   "node-1",
+		Node: node1.DeepCopy(),
+		Devices: map[string][]device.DeviceInfo{
+			"vendor-A": {{
+				ID:           "gpu-1",
+				DeviceVendor: "vendor-A",
+				Health:       true,
+			}},
+			"vendor-B": {{
+				ID:           "gpu-2",
+				DeviceVendor: "vendor-B",
+				Health:       true,
+			}},
+			"vendor-C": {{
+				ID:           "gpu-3",
+				DeviceVendor: "vendor-C",
+				Health:       true,
+			}},
+		},
+	})
+
+	// Verify initial state has vendor-A, vendor-B, and vendor-C, but not vendor-D
+	nodeInfo, err := s.GetNode("node-1")
+	require.NoError(t, err)
+	require.Contains(t, nodeInfo.Devices, "vendor-A")
+	require.Contains(t, nodeInfo.Devices, "vendor-B")
+	require.Contains(t, nodeInfo.Devices, "vendor-C")
+	require.NotContains(t, nodeInfo.Devices, "vendor-D")
+
+	atomic.StoreUint32(&s.started, 1)
+
+	// Execute register cycle:
+	// - For node-1: vendor-B (0 devices) is removed from cache (exercises ok == true branch);
+	//   vendor-D (0 devices) is not in cache (exercises ok == false branch).
+	// - For node-absent: node is absent from scheduler cache (exercises GetNode error branch).
+	s.register(labels.Everything(), map[string]bool{})
+
+	// Expect vendor-B to be removed from node-1 cache, while vendor-A and vendor-C remain
+	nodeInfo, err = s.GetNode("node-1")
+	require.NoError(t, err)
+	_, hasVendorA := nodeInfo.Devices["vendor-A"]
+	_, hasVendorB := nodeInfo.Devices["vendor-B"]
+	_, hasVendorC := nodeInfo.Devices["vendor-C"]
+	assert.Equal(t, hasVendorA, true, "vendor-A should remain in node cache")
+	assert.Equal(t, hasVendorB, false, "stale vendor-B should be removed from node cache")
+	assert.Equal(t, hasVendorC, true, "vendor-C should remain in node cache")
+
+	// Confirm node-absent was never added to scheduler cache
+	_, err = s.GetNode("node-absent")
+	require.Error(t, err)
 }
 
 func Test_ResourceQuota(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

During the scheduler's periodic registration/sync cycle, each registered device vendor reports its current devices for a node.

When a vendor reports zero devices for a node, the previous implementation passed an empty device update to `nodeManager.addNode()`. Since `addNode()` does not modify the cached device map when no devices are present, the previously cached vendor entry remained in the scheduler's node state.

This could leave stale device-vendor information in `s.nodes[nodeID].Devices` even after the vendor stopped reporting devices for that node.

This PR updates the registration flow to remove the cached vendor when `GetNodeDevices()` reports zero devices, while preserving the device state of other vendors on the same node.

**Which issue(s) this PR fixes**:

Fixes #2548 

**Special notes for your reviewer**:

The reconciliation is intentionally handled in `s.register()` rather than changing `nodeManager.addNode()` to replace the complete device map.

HAMi handles device updates vendor-by-vendor, so replacing the entire device map in `addNode()` could incorrectly remove valid devices belonging to other vendors on a heterogeneous node.

A regression test, `Test_register_StaleDeviceVendorRemoval`, was added to verify that:

* a vendor reporting zero devices is removed from the cached node state
* other active vendors on the same node remain unchanged

The following checks were run successfully:

* `go test ./pkg/scheduler/...`
* `go test ./pkg/device/...`
* `go test -race ./pkg/scheduler/...`
* `go vet ./pkg/scheduler/...`
* GolangCI-Lint
* `git diff --check`

**Does this PR introduce a user-facing change?**:

No.

**AI disclosure**:
Claude Assistance was used during investigation of the codebase, root-cause analysis, implementation of the fix and regression test, and verification of the changes. The resulting code and tests were reviewed and validated against the existing HAMi codebase and test suite by the contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale cached device entries when healthy vendors report no available devices.
  * Prevented obsolete device capacity from remaining available after scheduler registration.
  * Preserved current device availability for vendors that continue reporting devices.
  * Avoided adding devices for vendors or nodes not tracked by the scheduler.

* **Tests**
  * Added coverage for stale-entry removal, active vendor preservation, untracked vendors, and uncached nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->