### PR TITLE
fix(monitor): avoid uint64 underflow when deriving the legacy device-memory offset label

### DIFF
--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -38,6 +38,7 @@ type stubInfo struct {
 	ctxSize    []uint64
 	modSize    []uint64
 	bufSize    []uint64
+	offset     []uint64
 	smUtil     []uint64
 	lastKernel int64
 }
@@ -60,7 +61,7 @@ func (s *stubInfo) DeviceUUID(i int) string {
 func (s *stubInfo) DeviceMemoryContextSize(i int) uint64 { return slot(s.ctxSize, i) }
 func (s *stubInfo) DeviceMemoryModuleSize(i int) uint64  { return slot(s.modSize, i) }
 func (s *stubInfo) DeviceMemoryBufferSize(i int) uint64  { return slot(s.bufSize, i) }
-func (s *stubInfo) DeviceMemoryOffset(int) uint64        { return 0 }
+func (s *stubInfo) DeviceMemoryOffset(i int) uint64      { return slot(s.offset, i) }
 func (s *stubInfo) DeviceMemoryTotal(i int) uint64       { return slot(s.total, i) }
 func (s *stubInfo) DeviceSmUtil(i int) uint64            { return slot(s.smUtil, i) }
 func (s *stubInfo) SetDeviceSmLimit(uint64)              {}

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -463,7 +463,8 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			klog.Errorf("Failed to send device memory desc: %v", err)
 			return err
 		}
-		memoryOffset := memoryTotal - memoryContextSize - memoryModuleSize - memoryBufferSize
+		// Send legacy metric with additional memory details
+		memoryOffset := c.Info.DeviceMemoryOffset(i) // Get the memory offset for the device
 		memoryLabels := append(labels, fmt.Sprint(memoryContextSize), fmt.Sprint(memoryModuleSize), fmt.Sprint(memoryBufferSize), fmt.Sprint(memoryOffset))
 		sendLegacyMetric(ch, legacyCtrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), memoryLabels...)
 

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -155,8 +155,8 @@ func TestCollectContainerMetricsSkipsInvalidUTF8UUID(t *testing.T) {
 	}
 }
 
-// TestCheckBlocking_MultiDevice tests CheckBlocking() with multiple devices, some
-// of which are contended, some of which are clear, and some of which are missing from the switch
+// TestCollectContainerMetricsLegacyOffsetNoUnderflow verifies that the legacy
+// device-memory offset label uses the recorded value without uint64 underflow.
 func TestCollectContainerMetricsLegacyOffsetNoUnderflow(t *testing.T) {
 	// This test ensures that the legacy metric for device memory offset is emitted correctly, even when the total memory is smaller than the sum of context, module, and buffer sizes. It checks that the offset label reflects the actual recorded offset without wrapping or underflowing.
 	prev := legacyCtrDeviceMemorydesc

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -154,3 +154,49 @@ func TestCollectContainerMetricsSkipsInvalidUTF8UUID(t *testing.T) {
 		t.Errorf("got %d metrics for an invalid UUID, want 0", len(metrics))
 	}
 }
+
+// TestCheckBlocking_MultiDevice tests CheckBlocking() with multiple devices, some
+// of which are contended, some of which are clear, and some of which are missing from the switch
+func TestCollectContainerMetricsLegacyOffsetNoUnderflow(t *testing.T) {
+	// This test ensures that the legacy metric for device memory offset is emitted correctly, even when the total memory is smaller than the sum of context, module, and buffer sizes. It checks that the offset label reflects the actual recorded offset without wrapping or underflowing.
+	prev := legacyCtrDeviceMemorydesc
+	legacyCtrDeviceMemorydesc = prometheus.NewDesc(
+		"Device_memory_desc_of_container",
+		"Container device memory description",
+		[]string{"podnamespace", "podname", "ctrname", "vdeviceid", "deviceuuid", "context", "module", "data", "offset"}, nil,
+	)
+	t.Cleanup(func() { legacyCtrDeviceMemorydesc = prev })
+
+	cu := &nvidia.ContainerUsage{Info: &stubInfo{
+		uuids:   []string{testUUID},
+		total:   []uint64{100},
+		ctxSize: []uint64{1000},
+		modSize: []uint64{500},
+		bufSize: []uint64{300},
+		offset:  []uint64{7},
+	}}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "trainer-0"}}
+	ctr := corev1.Container{Name: "worker"}
+	cc := ClusterManagerCollector{ClusterManager: &ClusterManager{LegacyMetrics: true}}
+	ch := make(chan prometheus.Metric, 64)
+	if err := cc.collectContainerMetrics(ch, pod, ctr, cu, 0); err != nil {
+		t.Fatal(err)
+	}
+	close(ch)
+
+	found := false
+	for m := range ch {
+		if m.Desc() != legacyCtrDeviceMemorydesc {
+			continue
+		}
+		found = true
+		_, labels := gaugeValue(t, m)
+		if labels["offset"] != "7" {
+			t.Errorf("offset label = %q, want %q (got a wrapped/underflowed value instead of the recorded offset)", labels["offset"], "7")
+		}
+	}
+	if !found {
+		t.Fatal("legacy device memory metric was not emitted")
+	}
+}

--- a/cmd/vGPUmonitor/metrics_container_test.go
+++ b/cmd/vGPUmonitor/metrics_container_test.go
@@ -158,8 +158,6 @@ func TestCollectContainerMetricsSkipsInvalidUTF8UUID(t *testing.T) {
 // TestCollectContainerMetricsLegacyOffsetNoUnderflow verifies that the legacy
 // device-memory offset label uses the recorded value without uint64 underflow.
 func TestCollectContainerMetricsLegacyOffsetNoUnderflow(t *testing.T) {
-	// This test ensures that the legacy metric for device memory offset is emitted correctly, even when the total memory is smaller than the sum of context, module, and buffer sizes. It checks that the offset label reflects the actual recorded offset without wrapping or underflowing.
-	prev := legacyCtrDeviceMemorydesc
 	legacyCtrDeviceMemorydesc = prometheus.NewDesc(
 		"Device_memory_desc_of_container",
 		"Container device memory description",


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This fixes a possible uint64 underflow when collectContainerMetrics calculates the legacy Device_memory_desc_of_container metric's offset label

The values used for the calculation come from separate reads of shared memory, so they can become inconsistent if hami-core updates the memory information between reads. In that case, the subtraction can wrap around to a value close to math.MaxUint64

Instead of calculating the offset from those four values, this change uses the existing DeviceMemoryOffset() method, which returns the recorded offset directly and avoids the underflow

A regression test was also added to cover the torn-read scenario

**Which issue(s) this PR fixes**:
Fixes #2551 

**Special notes**:

The full test suite could not be run locally because the environment could not access the Go module proxy required by the repository's Go toolchain version. gofmt was run on all touched files

The new test also avoids calling initLegacyDescriptors() because it modifies package-level Prometheus descriptors and could affect other tests

**Does this PR introduce a user-facing change?**:

No. This does not change the intended metric behavior. It prevents an invalid, wrapped offset value from being exposed when shared-memory values are read inconsistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected legacy device-memory metrics to report accurate per-device memory offsets.
  * Prevented invalid offset values when total memory is smaller than component sizes.
  * Improved metric collection reliability for legacy configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->