### PR TITLE
feat(chart): add values.schema.json for Helm values validation

### DIFF
--- a/charts/hami/values.schema.json
+++ b/charts/hami/values.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metaxsGPUTopologyAware": {
+      "type": "string",
+      "enum": ["true", "false"]
+    },
+    "device-config": {
+      "type": "object"
+    },
+    "scheduler": {
+      "type": "object",
+      "properties": {
+        "forceOverwriteDefaultScheduler": {
+          "type": "boolean"
+        },
+        "livenessProbe": {
+          "type": "boolean"
+        },
+        "leaderElect": {
+          "type": "boolean"
+        },
+        "kubeScheduler": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "overwriteEnv": {
+          "type": "string",
+          "enum": ["true", "false"]
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "admissionWebhook": {
+          "type": "object",
+          "properties": {
+            "customURL": {
+              "type": "object",
+              "properties": {
+                "port": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "httpPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "schedulerPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "monitorPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "monitorTargetPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "httpTargetPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            }
+          }
+        }
+      }
+    },
+    "devicePlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "hostPID": {
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "type": "boolean"
+        },
+        "gpuOperatorToolkitReady": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "deviceSplitCount": {
+          "type": "integer"
+        },
+        "deviceMemoryScaling": {
+          "anyOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" }
+          ]
+        },
+        "deviceCoreScaling": {
+          "anyOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" }
+          ]
+        },
+        "preConfiguredDeviceMemory": {
+          "type": "integer"
+        },
+        "disablecorelimit": {
+          "type": "string",
+          "enum": ["true", "false"]
+        },
+        "nvidiaHookPath": {
+          "type": ["string", "null"]
+        },
+        "nvidiaDriverRoot": {
+          "type": ["string", "null"]
+        },
+        "gdrcopyEnabled": {
+          "type": ["boolean", "null"]
+        },
+        "gdsEnabled": {
+          "type": ["boolean", "null"]
+        },
+        "mofedEnabled": {
+          "type": ["boolean", "null"]
+        },
+        "pluginPort": {
+          "type": "object",
+          "properties": {
+            "httpPort": {
+              "type": "integer"
+            }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "httpPort": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "devices": {
+      "type": "object",
+      "properties": {
+        "amd": { "type": "object" },
+        "awsneuron": { "type": "object" },
+        "nvidia": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "kunlun": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "enflame": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "mthreads": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "vastai": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "biren": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "ascend": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+        "iluvatar": { "type": "object", "properties": { "enabled": { "type": "boolean" } } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind feature

**What this PR does / why we need it**:
Adds `charts/hami/values.schema.json` — a JSON Schema (draft-07) that Helm 3.x automatically validates the coalesced chart values against during `helm lint`, `helm template`, and `helm install/upgrade`. Today the chart ships no schema, so type errors in user-supplied values (a quoted integer, a bool where a string is expected, a non-null value on a null-guarded field) surface only as a broken render or a malformed generated config at install time.

**Which issue(s) this PR fixes**:
Fixes #2419

**Special notes for your reviewer**:

### Design
The schema is deliberately **permissive**. It constrains only load-bearing types, each traced to how the templates actually consume the value:

* **String-typed booleans** (`scheduler.overwriteEnv`, `metaxsGPUTopologyAware`, `devicePlugin.disablecorelimit`) — rendered as raw YAML scalars / CLI flags, so typed `string`, not `boolean`.
* **Null-unions** — `nvidiaHookPath` / `nvidiaDriverRoot` → `["null","string"]`; `gdrcopyEnabled` / `gdsEnabled` / `mofedEnabled` → `["null","boolean"]`, matching the `typeIs` guards in `daemonsetnvidia.yaml`.
* **Strict integers** — `deviceSplitCount`, `preConfiguredDeviceMemory`, `scheduler.replicas`, `ports` — quoted strings are correctly rejected.
* **Float scaling factors** — `deviceMemoryScaling` / `deviceCoreScaling` accept a number or a numeric string (`^[0-9]+(\.[0-9]+)?$`). They are Go `*float64`, so fractional values are first-class; the string branch preserves `--set devicePlugin.deviceMemoryScaling=1.5` (Helm renders `--set` floats as strings) while still rejecting non-numeric input.
* **Open policy strings** — `nodeSchedulerPolicy` / `gpuSchedulerPolicy` are not enum-constrained (`topology-aware` is valid).
* `devices.amd` / `devices.awsneuron` carry no `enabled` key (their customresources are ranged unconditionally); other vendors keep `enabled`.

No `additionalProperties: false` and an empty top-level `required`, so undocumented and forward-compatible keys and every documented install path keep working.

### Testing
Validated with the CI-pinned Helm v3.7.1:
* `helm lint charts/hami` → 0 failures; `helm template` renders all manifests.
* **Positive**: fractional `--set` scaling (`1.5`/`0.8`/`2`), genuine floats via a values file, and every `--set` override used by `hack/deploy-helm.sh` (empty registries, `leaderElect=false`) all pass.
* **Negative**: non-numeric scaling, quoted integer fields (`deviceSplitCount`, `replicas`) all correctly rejected.

No Go files changed; build/lint/test are unaffected.

**Does this PR introduce a user-facing change?**:
```release-note
Add values.schema.json for Helm install-time values validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive validation for Helm configuration values.
  * Documented supported topology, scheduler, admission webhook, service, device-plugin, scaling, integration, and device settings.
  * Clarified accepted numeric and numeric-string scaling values, optional integration settings, and boolean enablement options.
  * Invalid or unsupported configuration values can now be identified earlier during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->