### PR TITLE
fix(metrics): add device_type label to node memory ratio metrics (#2370)

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -190,7 +190,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		legacyMemoryPercentage = prometheus.NewDesc(
 			"nodeGPUMemoryPercentage",
 			"GPU Memory Allocated Percentage on a certain GPU",
-			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx"}, nil,
 		)
 		legacyMigInstance = prometheus.NewDesc(
 			"nodeGPUMigInstance",
@@ -274,7 +274,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				sendLegacyMetric(ch, legacyCoreAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedcores), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
 				sendLegacyMetric(ch, legacyOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type)
 				if devs.Device.Totalmem > 0 {
-					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index))
 				}
 			}
 		}

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -137,7 +137,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 	nodeGPUMemoryPercentage := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
 		"GPU Memory Allocated Percentage on a certain GPU",
-		[]string{"node", "device_uuid", "device_index"}, nil,
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodeGPUMigInstance := prometheus.NewDesc(
 		"hami_node_gpu_mig_instance_info",
@@ -190,7 +190,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		legacyMemoryPercentage = prometheus.NewDesc(
 			"nodeGPUMemoryPercentage",
 			"GPU Memory Allocated Percentage on a certain GPU",
-			[]string{"nodeid", "deviceuuid", "deviceidx"}, nil,
+			[]string{"nodeid", "deviceuuid", "deviceidx", "devicetype"}, nil,
 		)
 		legacyMigInstance = prometheus.NewDesc(
 			"nodeGPUMigInstance",
@@ -261,7 +261,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 			}
 
 			if devs.Device.Totalmem > 0 {
-				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index)); err != nil {
+				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
 				}
 			}
@@ -274,7 +274,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				sendLegacyMetric(ch, legacyCoreAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedcores), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
 				sendLegacyMetric(ch, legacyOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type)
 				if devs.Device.Totalmem > 0 {
-					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index))
+					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
 				}
 			}
 		}

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -364,7 +364,7 @@ hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="nor
 hami_node_gpu_memory_allocated_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 0.25
 # HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU
 # TYPE nodeGPUMemoryPercentage gauge
-nodeGPUMemoryPercentage{deviceidx="2",devicetype="NVIDIA",deviceuuid="normal-memory",nodeid="node-1"} 0.25
+nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"} 0.25
 `
 
 	if err := promtestutil.CollectAndCompare(

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -361,10 +361,10 @@ hami_gpu_core_limit_ratio{device_index="1",device_type="test-device",device_uuid
 hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 2
 # HELP hami_node_gpu_memory_allocated_ratio GPU Memory Allocated Percentage on a certain GPU
 # TYPE hami_node_gpu_memory_allocated_ratio gauge
-hami_node_gpu_memory_allocated_ratio{device_index="2",device_uuid="normal-memory",node="node-1"} 0.25
+hami_node_gpu_memory_allocated_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 0.25
 # HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU
 # TYPE nodeGPUMemoryPercentage gauge
-nodeGPUMemoryPercentage{deviceidx="2",deviceuuid="normal-memory",nodeid="node-1"} 0.25
+nodeGPUMemoryPercentage{deviceidx="2",devicetype="NVIDIA",deviceuuid="normal-memory",nodeid="node-1"} 0.25
 `
 
 	if err := promtestutil.CollectAndCompare(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
In the scheduler's Prometheus metrics in cmd/scheduler/metrics.go, hami_node_gpu_memory_allocated_ratio did not have the device_type label that every other device metric in the file carries....On running the scheduler on a node with different devices(lets say NVIDIA and Ascend) sharing the same device_index...scraping /metrics produced metric series for hami_node_gpu_memory_allocated_ratio where we cannot tell the NVIDIA and Ascend apart without already knowing which device_uuid belonged to which one.

Added device_type to nodeGPUMemoryPercentage in cmd/scheduler/metrics to be consistent with all other sibling metrics....also updated the corresponding tests in cmd/scheduler/metrics_test.go

**Which issue(s) this PR fixes**:
Fixes #2370 

**Special notes for your reviewer**:
- Verified with unit tests passing
- AI Disclosure : Used Claude for assistance

**Does this PR introduce a user-facing change?**:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added a `device_type` label to node-level and legacy GPU memory utilization metrics.
  * Prometheus metric samples now identify the type of device associated with reported memory usage.
  * This provides clearer visibility into GPU memory allocation across different device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->