### PR TITLE
fix(kunlun): prevent panic on invalid or empty connection strings

### DIFF
--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -34,6 +34,9 @@ const (
 	KunlunDeviceSelection = "BAIDU_COM_DEVICE_IDX"
 	KunlunUseUUID         = "baidu.com/use-gpuuuid"
 	KunlunNoUseUUID       = "baidu.com/nouse-gpuuuid"
+)
+
+var (
 	InterGroupConnection  = "0-4,1-5,2-6,3-7"
 	InterGroupConnection2 = "0-1-4-5,2-3-6-7,0-2-4-6,1-3-5-7,0-3-4-7,1-2-5-6"
 	GroupConnection       = "0-1,0-2,0-3,1-2,1-3,2-3,4-5,4-6,4-7,5-6,5-7,6-7"

--- a/pkg/device/kunlun/topo.go
+++ b/pkg/device/kunlun/topo.go
@@ -100,14 +100,22 @@ func parseInterconnection() [][]int {
 	var interconnection [][]int
 	pairs := strings.Split(InterGroupConnection, ",")
 	for _, pair := range pairs {
-		lw, _ := strconv.Atoi(strings.Split(pair, "-")[0])
-		rw, _ := strconv.Atoi(strings.Split(pair, "-")[1])
+		parts := strings.Split(pair, "-")
+		if len(parts) != 2 {
+			continue
+		}
+		lw, _ := strconv.Atoi(parts[0])
+		rw, _ := strconv.Atoi(parts[1])
 		interconnection = append(interconnection, []int{lw, rw})
 	}
 	pairs = strings.Split(GroupConnection, ",")
 	for _, pair := range pairs {
-		lw, _ := strconv.Atoi(strings.Split(pair, "-")[0])
-		rw, _ := strconv.Atoi(strings.Split(pair, "-")[1])
+		parts := strings.Split(pair, "-")
+		if len(parts) != 2 {
+			continue
+		}
+		lw, _ := strconv.Atoi(parts[0])
+		rw, _ := strconv.Atoi(parts[1])
 		interconnection = append(interconnection, []int{lw, rw})
 	}
 	return interconnection
@@ -139,8 +147,12 @@ func interconnect(devices []*device.DeviceUsage, request device.ContainerDeviceR
 					continue
 				}
 				for p := range strings.SplitSeq(InterGroupConnection, ",") {
-					lw, _ := strconv.Atoi(strings.Split(p, "-")[0])
-					rw, _ := strconv.Atoi(strings.Split(p, "-")[1])
+					parts := strings.Split(p, "-")
+					if len(parts) != 2 {
+						continue
+					}
+					lw, _ := strconv.Atoi(parts[0])
+					rw, _ := strconv.Atoi(parts[1])
 					klog.V(5).InfoS("interconnect", "lw", lw, "rw", rw, "left device", val.Index, "right device", val2.Index)
 					if lw == int(val.Index) && rw == int(val2.Index) || lw == int(val2.Index) && rw == int(val.Index) {
 						return []int{int(val.Index), int(val2.Index)}

--- a/pkg/device/kunlun/topo_test.go
+++ b/pkg/device/kunlun/topo_test.go
@@ -399,3 +399,22 @@ func TestParseInterconnection2_Structure(t *testing.T) {
 		}
 	}
 }
+
+func TestParseInterconnection_InvalidString(t *testing.T) {
+	origInter := InterGroupConnection
+	origGroup := GroupConnection
+	defer func() {
+		InterGroupConnection = origInter
+		GroupConnection = origGroup
+	}()
+
+	InterGroupConnection = "0-4,invalid,1-5,"
+	GroupConnection = "0-1,invalid,2-3,"
+
+	// Should not panic, should skip invalid pairs
+	got := parseInterconnection()
+
+	if len(got) != 4 {
+		t.Errorf("Expected 4 valid pairs, got %d", len(got))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes a bug in `pkg/device/kunlun/topo.go` where parsing `InterGroupConnection` and `GroupConnection` strings could result in a runtime panic.

Previously, the code assumed that `strings.Split(pair, "-")` would always return at least two elements. If the connection string contained an empty or malformed pair, such as a trailing comma or a pair without `-`, accessing index `[1]` would cause an `index out of range` panic and crash the application during Kunlun topology initialization.

This change validates the result of the split before accessing its elements, allowing invalid pairs to be safely skipped instead of causing a fatal panic.

**Which issue(s) this PR fixes**:

Fixes #2556 

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
Fixes a scheduler panic when starting with invalid or malformed Kunlun topology connection strings.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of device interconnection configuration entries.
  * Malformed entries are now safely rejected instead of being incorrectly processed or indexed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->