### PR TITLE
fix(webhook): process InitContainers during admission and quota checks

### DIFF
--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -70,6 +70,17 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false
+	for idx := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[idx]
+		for _, val := range device.GetDevices() {
+			found, err := val.MutateAdmission(c, pod)
+			if err != nil {
+				klog.Errorf("validating pod failed:%s", err.Error())
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			hasResource = hasResource || found
+		}
+	}
 	for idx := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[idx]
 		for _, val := range device.GetDevices() {
@@ -139,6 +150,22 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 		// container spec here. It applies its own memory factor, defaults and
 		// template rounding, which is what the scheduler later records as used,
 		// so this keeps admission and the scheduler on the same numbers.
+		var initMemoryReq, initCoresReq int64
+		for i := range pod.Spec.InitContainers {
+			req := dev.GenerateResourceRequests(&pod.Spec.InitContainers[i])
+			if req.Nums == 0 {
+				continue
+			}
+			reqMem := int64(req.Memreq) * int64(req.Nums)
+			reqCores := int64(req.Coresreq) * int64(req.Nums)
+			if reqMem > initMemoryReq {
+				initMemoryReq = reqMem
+			}
+			if reqCores > initCoresReq {
+				initCoresReq = reqCores
+			}
+		}
+
 		var memoryReq, coresReq int64
 		for i := range pod.Spec.Containers {
 			req := dev.GenerateResourceRequests(&pod.Spec.Containers[i])
@@ -148,6 +175,14 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 			memoryReq += int64(req.Memreq) * int64(req.Nums)
 			coresReq += int64(req.Coresreq) * int64(req.Nums)
 		}
+
+		if initMemoryReq > memoryReq {
+			memoryReq = initMemoryReq
+		}
+		if initCoresReq > coresReq {
+			coresReq = initCoresReq
+		}
+
 		if memoryReq == 0 && coresReq == 0 {
 			continue
 		}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -1070,3 +1070,91 @@ func TestPrivilegedContainerDenied(t *testing.T) {
 		})
 	}
 }
+
+func TestInitContainersWebhook(t *testing.T) {
+	config.SchedulerName = "hami-scheduler"
+	config.ForceOverwriteDefaultScheduler = true
+
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("Failed to initialize devices with config: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init-container1",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hami.io/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "regular-container",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+	podBytes, err := runtime.Encode(codec, pod)
+	if err != nil {
+		t.Fatalf("Error encoding pod: %v", err)
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:       "test-uid",
+			Namespace: "default",
+			Name:      "test-pod",
+			Object: runtime.RawExtension{
+				Raw: podBytes,
+			},
+		},
+	}
+
+	wh, err := NewWebHook()
+	if err != nil {
+		t.Fatalf("Error creating WebHook: %v", err)
+	}
+
+	resp := wh.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Errorf("Expected allowed response, but got denied: %v", resp)
+	}
+
+	// Verify that the scheduler name was patched (meaning hasResource was true)
+	if len(resp.Patches) == 0 {
+		t.Errorf("Expected patches for the scheduler name, but got none")
+	}
+
+	hasSchedulerPatch := false
+	for _, p := range resp.Patches {
+		if p.Operation == "add" && p.Path == "/spec/schedulerName" && p.Value == "hami-scheduler" {
+			hasSchedulerPatch = true
+		}
+	}
+	if !hasSchedulerPatch {
+		t.Errorf("Expected scheduler name patch for init containers, got patches: %+v", resp.Patches)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR fixes a critical bug where the mutating admission webhook (`pkg/scheduler/webhook.go`) completely ignored `InitContainers`, leading to GPU quota bypasses and pod scheduling failures.

### The Problem
Previously, the `Handle()` function and the `fitResourceQuota()` function in the webhook only iterated through `pod.Spec.Containers`. This caused two major issues:
1. **Scheduling Failures (Bypassing HAMi)**: If a pod requested HAMi GPUs exclusively inside an `InitContainer`, the webhook's `hasResource` flag remained `false`. As a result, the webhook did not mutate `pod.Spec.SchedulerName` to `hami-scheduler`, causing the pod to be scheduled by the default Kubernetes scheduler without proper GPU allocation.
2. **Quota Bypass**: The `fitResourceQuota` function never parsed the requests of `InitContainers`. A malicious or unaware user could request GPUs inside an `InitContainer` and bypass the configured HAMi cluster resource quotas entirely.

*Note: This was strictly an admission webhook issue; the scheduler backend (`pkg/device/devices.go`) was already correctly parsing and allocating resources for `InitContainers`.*

### The Solution
1. **Admission Mutation**: Updated the `Handle()` loop to iterate over `pod.Spec.InitContainers` in addition to `pod.Spec.Containers`. This ensures that the webhook executes `MutateAdmission` for each `InitContainer`, correctly setting `hasResource = true`, and mutating the `SchedulerName` to use HAMi.
2. **Quota Validation**: Updated `fitResourceQuota()` to calculate resource quotas for `InitContainers`. Since `InitContainers` run sequentially and complete before regular containers start, the effective resource limit for a Pod is `MAX(max(initContainers), sum(regularContainers))`. 
   - The webhook now calculates the maximum GPU memory/core requirement across all `InitContainers`.
   - It then calculates the sum of the GPU memory/core requirements across all `Containers`.
   - It enforces quota limits using the maximum of these two values, perfectly matching standard Kubernetes resource allocation logic.
3. **Tests**: Added `TestInitContainersWebhook` to `webhook_test.go` to explicitly verify that pods requesting resources only in an `InitContainer` are properly mutated, have their scheduler changed, and are verified against quotas.

**Which issue(s) this PR fixes**:
Fixes #2558 

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Fix: Mutating admission webhook now correctly parses InitContainers, preventing GPU resource quota bypasses and ensuring proper scheduler routing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validated configuration schema for scheduler, device, topology, service, scaling, and feature settings.
  * Added support for detecting and mutating device resources requested by init containers.
  * Improved resource quota calculations to follow Kubernetes init-container resource semantics.

* **Bug Fixes**
  * Pods requesting GPU resources in init containers are now admitted and scheduled correctly.

* **Tests**
  * Added coverage for init-container GPU scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->