### PR TITLE
fix: Handle HTTP response write errors in scheduler routes

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -40,6 +40,14 @@ func checkBody(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
+func writeResponse(w http.ResponseWriter, code int, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if _, err := w.Write(body); err != nil {
+		klog.ErrorS(err, "Failed to write response")
+	}
+}
+
 func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 	klog.Infoln("Initializing Predicate Route")
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -83,21 +91,15 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 
 		if resultBody, err := json.Marshal(extenderFilterResult); err != nil {
 			klog.ErrorS(err, "Failed to marshal extender filter result", "result", extenderFilterResult)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
 			extenderFilterResult = &extenderv1.ExtenderFilterResult{
 				Error: fmt.Sprintf("Failed to marshal extender filter result: %s", err.Error()),
 			}
 			resultBody, _ = json.Marshal(extenderFilterResult)
-			if _, err := w.Write(resultBody); err != nil {
-				klog.ErrorS(err, "Failed to write response")
-			}
+			// Note: write error in this fallback path is not explicitly tested
+			// as it requires both a marshal failure and a write failure.
+			writeResponse(w, http.StatusInternalServerError, resultBody)
 		} else {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			if _, err := w.Write(resultBody); err != nil {
-				klog.ErrorS(err, "Failed to write response")
-			}
+			writeResponse(w, http.StatusOK, resultBody)
 		}
 	}
 }
@@ -132,22 +134,16 @@ func Bind(s *scheduler.Scheduler) httprouter.Handle {
 
 		if response, err := json.Marshal(extenderBindingResult); err != nil {
 			klog.ErrorS(err, "Failed to marshal binding result", "result", extenderBindingResult)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
 			extenderBindingResult = &extenderv1.ExtenderBindingResult{
 				Error: fmt.Sprintf("Failed to marshal binding result: %s", err.Error()),
 			}
 			response, _ := json.Marshal(extenderBindingResult)
-			if _, err := w.Write(response); err != nil {
-				klog.ErrorS(err, "Failed to write response")
-			}
+			// Note: write error in this fallback path is not explicitly tested
+			// as it requires both a marshal failure and a write failure.
+			writeResponse(w, http.StatusInternalServerError, response)
 		} else {
 			klog.V(5).InfoS("Returning bind response", "result", extenderBindingResult)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			if _, err := w.Write(response); err != nil {
-				klog.ErrorS(err, "Failed to write response")
-			}
+			writeResponse(w, http.StatusOK, response)
 		}
 	}
 }

--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -89,11 +89,15 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 				Error: fmt.Sprintf("Failed to marshal extender filter result: %s", err.Error()),
 			}
 			resultBody, _ = json.Marshal(extenderFilterResult)
-			w.Write(resultBody)
+			if _, err := w.Write(resultBody); err != nil {
+				klog.ErrorS(err, "Failed to write response")
+			}
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write(resultBody)
+			if _, err := w.Write(resultBody); err != nil {
+				klog.ErrorS(err, "Failed to write response")
+			}
 		}
 	}
 }
@@ -134,12 +138,16 @@ func Bind(s *scheduler.Scheduler) httprouter.Handle {
 				Error: fmt.Sprintf("Failed to marshal binding result: %s", err.Error()),
 			}
 			response, _ := json.Marshal(extenderBindingResult)
-			w.Write(response)
+			if _, err := w.Write(response); err != nil {
+				klog.ErrorS(err, "Failed to write response")
+			}
 		} else {
 			klog.V(5).InfoS("Returning bind response", "result", extenderBindingResult)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write(response)
+			if _, err := w.Write(response); err != nil {
+				klog.ErrorS(err, "Failed to write response")
+			}
 		}
 	}
 }

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -20,11 +20,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/scheduler"
@@ -256,5 +260,51 @@ func TestBind_DecodeError(t *testing.T) {
 	}
 	if result.Error == "" {
 		t.Error("expected a decode error to be reported in the bind result")
+	}
+}
+
+type errorResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w *errorResponseWriter) Write(b []byte) (int, error) {
+	return 0, errors.New("mock write error")
+}
+func TestPredicateRoute_WriteError(t *testing.T) {
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	klog.LogToStderr(false)
+	defer func() {
+		klog.SetOutput(os.Stderr)
+		klog.LogToStderr(true)
+	}()
+	req := httptest.NewRequest("POST", "/predicate", strings.NewReader("{not-json"))
+	w := httptest.NewRecorder()
+	ew := &errorResponseWriter{ResponseWriter: w}
+	s := &scheduler.Scheduler{}
+	handler := PredicateRoute(s)
+	handler(ew, req, nil)
+	klog.Flush()
+	if !strings.Contains(buf.String(), "Failed to write response") {
+		t.Errorf("Expected 'Failed to write response' in log output, but got: %s", buf.String())
+	}
+}
+func TestBind_WriteError(t *testing.T) {
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	klog.LogToStderr(false)
+	defer func() {
+		klog.SetOutput(os.Stderr)
+		klog.LogToStderr(true)
+	}()
+	req := httptest.NewRequest("POST", "/bind", strings.NewReader("{not-json"))
+	w := httptest.NewRecorder()
+	ew := &errorResponseWriter{ResponseWriter: w}
+	s := &scheduler.Scheduler{}
+	handler := Bind(s)
+	handler(ew, req, nil)
+	klog.Flush()
+	if !strings.Contains(buf.String(), "Failed to write response") {
+		t.Errorf("Expected 'Failed to write response' in log output, but got: %s", buf.String())
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR error handling for HTTP `w.Write()` calls. Previously, if `w.Write()` failed when returning the scheduler binding or filter results, the error was silently ignored without any visibility. 

Changes Made:

- `pkg/scheduler/routes/route.go`: Added error handling for `w.Write()` in both PredicateRoute and Bind handlers to log write failures.
- `pkg/scheduler/routes/route_test.go`: Added dedicated regression tests (`TestPredicateRoute_WriteError` and `TestBind_WriteError`) for this exact failure path.

The new tests mock an `http.ResponseWriter` that forcibly returns an error when `Write()` is called. The test captures the internal klog output and asserts that the Failed to write response error is successfully recorded. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a followup to the earlier broader PR #2279 . It introduces a minimal change along with the regression test.

AI assistance disclosure:
I manually ran `errcheck` to catch the unhandled cases. The changes was made using assistance from Gemini 3.1 Pro. I have manually verified the changes and the new regressions tests.

**Does this PR introduce a user-facing change?**:
No, this PR is for error handling. If the server fails to write an HTTP response back to a client, the error is logged to the scheduler's internal logs rather than failing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failures when sending Predicate and Bind responses.
  * Added diagnostic logging when response delivery fails, while preserving existing response behavior.
* **Tests**
  * Added coverage to verify response-write failures are correctly detected and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->