### PR TITLE
fix(monitor): prevent fatal data race during feedback observation

### DIFF
--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -72,6 +72,9 @@ func CheckPriority(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 }
 
 func Observe(lister *nvidia.ContainerLister) {
+	lister.Lock()
+	defer lister.UnLock()
+
 	utSwitchOn := map[string]UtilizationPerDevice{}
 	containers := lister.ListContainers()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a critical data race in the `HAMi-vGPUmonitor` that causes the monitor to crash with a fatal `concurrent map iteration and map write` runtime panic.

In `cmd/vGPUmonitor/feedback.go`, the `Observe()` function fetches the `containers` map via `lister.ListContainers()` and iterates over it in a background ticker loop. However, it was missing a lock acquisition before doing so. At the same time, the Kubernetes Pod informer events (handled by `podInformer.AddEventHandler` in `pkg/monitor/nvidia/cudevshr.go`) concurrently trigger `lister.Update()`, which explicitly locks the mutex and modifies the exact same map. 

Iterating over a map without a lock while another goroutine modifies it triggers a fatal runtime panic in Go. This PR adds the missing `lister.Lock()` and `defer lister.UnLock()` to `Observe()`, safely synchronizing it with the informer events. This strictly mirrors the correct locking behavior already implemented for the exact same map in `cmd/vGPUmonitor/metrics.go`.

**Which issue(s) this PR fixes**:
Fixes #2573

**Special notes for your reviewer**:
This is a standard Go concurrency bug fix. The lock is only held during the fast in-memory map iteration inside `Observe()`, so there is no risk of deadlock or blocking the informer goroutines for a significant amount of time.

**Does this PR introduce a user-facing change?**:
```release-note
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container state monitoring reliability by preventing concurrent updates during observation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->