### PR TITLE
fix(device): return deep copied pods in GetScheduledPods to prevent data race

### DIFF
--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -238,6 +238,8 @@ func (m *PodManager) GetScheduledPods() (map[k8stypes.UID]*PodInfo, error) {
 	// Return a shallow copy of the pods map to avoid race conditions.
 	// This prevents a "concurrent map iteration and map write" fatal error.
 	podsCopy := make(map[k8stypes.UID]*PodInfo, podCount)
-	maps.Copy(podsCopy, m.pods)
+	for k, v := range m.pods {
+		podsCopy[k] = v.DeepCopy()
+	}
 	return podsCopy, nil
 }


### PR DESCRIPTION
Fixes #2471

Re-opening after #2501 was closed due to an unrelated commit accidentally pushed to the branch (a benchmark graph file, now removed).

---

Currently, `GetScheduledPods()` returns a shallow copy of the pods map via `maps.Copy`. While this prevents concurrent map iteration/write panics on the map itself, the map values are `*PodInfo` pointers — the underlying structs are still shared across goroutines.

This causes a data race between the metrics scraping goroutine (which reads `PodInfo` fields) and the scheduler goroutine (which writes to the same `PodInfo` structs).

Fix: call `v.DeepCopy()` on each value so callers receive fully independent copies.

Signed-off-by: Aryan Srivastava <aryansriva05@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled pod data handling to prevent unintended changes from propagating between copied results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->