### PR TITLE
fix(kunlun): honour use-gpuuuid and nouse-gpuuuid annotations

### DIFF
--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -184,10 +184,27 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 	tmpDevs := make(map[string]device.ContainerDevices)
 	reason := make(map[string]int)
 
-	alloc := graghSelect(devices, request, FitXPU)
+	// graghSelect decides topology from the position of a device in the slice,
+	// so the uuid constraint has to be applied through fitFn rather than by
+	// filtering the slice first.
+	uuidMismatch := 0
+	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
+		if !device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, kl.CommonWord()) {
+			uuidMismatch++
+			klog.V(5).InfoS(common.CardUUIDMismatch, "pod", klog.KObj(pod), "device", d.ID)
+			return false
+		}
+		return FitXPU(d, r)
+	}
+
+	alloc := graghSelect(devices, request, fitFn)
 	if len(alloc) == 0 {
-		reason[common.NumaNotFit]++
-		klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
+		if uuidMismatch > 0 {
+			reason[common.CardUUIDMismatch] += uuidMismatch
+		} else {
+			reason[common.NumaNotFit]++
+			klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
+		}
 		return false, tmpDevs, common.GenReason(reason, len(devices))
 	}
 

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -187,10 +187,11 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 	// graghSelect decides topology from the position of a device in the slice,
 	// so the uuid constraint has to be applied through fitFn rather than by
 	// filtering the slice first.
-	uuidMismatch := 0
+	uuidMismatches := make(map[string]bool)
 	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
-		if !device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, kl.CommonWord()) {
-			uuidMismatch++
+		if !device.CheckUUID(pod.GetAnnotations(), d.ID, UseUUIDAnno, NoUseUUIDAnno, kl.CommonWord()) ||
+			!device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, kl.CommonWord()) {
+			uuidMismatches[d.ID] = true
 			klog.V(5).InfoS(common.CardUUIDMismatch, "pod", klog.KObj(pod), "device", d.ID)
 			return false
 		}
@@ -199,6 +200,7 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 
 	alloc := graghSelect(devices, request, fitFn)
 	if len(alloc) == 0 {
+		uuidMismatch := len(uuidMismatches)
 		if uuidMismatch > 0 {
 			reason[common.CardUUIDMismatch] += uuidMismatch
 		} else {

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kunlun
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -510,4 +512,97 @@ func Test_ScoreNode(t *testing.T) {
 			assert.DeepEqual(t, result, test.want)
 		})
 	}
+}
+
+// baidu.com/use-gpuuuid and nouse-gpuuuid were defined but never consulted, so
+// a pod asking for a specific XPU was scheduled onto any of them.
+func TestKunlunDevices_Fit_UseUUID(t *testing.T) {
+	dev := &KunlunDevices{}
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{
+			Index:     uint(i),
+			ID:        fmt.Sprintf("xpu-%d", i),
+			Count:     1,
+			Totalmem:  KunlunMaxMemory,
+			Totalcore: 100,
+			Health:    true,
+		}
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: KunlunGPUDevice}
+
+	podWith := func(annos map[string]string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annos}}
+	}
+
+	fit, res, _ := dev.Fit(devices, req, podWith(map[string]string{
+		KunlunUseUUID: "xpu-5",
+	}), &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, len(res[KunlunGPUDevice]), 1)
+	assert.Equal(t, res[KunlunGPUDevice][0].UUID, "xpu-5")
+
+	// asking for a card that is not on the node must not fall back to another
+	fit, _, reason := dev.Fit(devices, req, podWith(map[string]string{
+		KunlunUseUUID: "xpu-99",
+	}), &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
+}
+
+func TestKunlunDevices_Fit_NoUseUUID(t *testing.T) {
+	dev := &KunlunDevices{}
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{
+			Index:     uint(i),
+			ID:        fmt.Sprintf("xpu-%d", i),
+			Count:     1,
+			Totalmem:  KunlunMaxMemory,
+			Totalcore: 100,
+			Health:    true,
+		}
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: KunlunGPUDevice}
+
+	// exclude every card and nothing should be allocatable
+	all := make([]string, 0, 8)
+	for i := range devices {
+		all = append(all, fmt.Sprintf("xpu-%d", i))
+	}
+	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			KunlunNoUseUUID: strings.Join(all, ","),
+		}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
+}
+
+func TestKunlunVDevices_Fit_UUIDAnnotations(t *testing.T) {
+	dev := &KunlunVDevices{}
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{
+			Index:     uint(i),
+			ID:        fmt.Sprintf("xpu-%d", i),
+			Count:     10,
+			Totalmem:  KunlunMaxMemory,
+			Totalcore: 100,
+			Health:    true,
+		}
+	}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: XPUDevice, Memreq: KunlunMaxMemory}
+
+	fit, res, _ := dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{KunlunUseUUID: "xpu-3"}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, res[XPUDevice][0].UUID, "xpu-3")
+
+	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{KunlunNoUseUUID: "xpu-0,xpu-1,xpu-2,xpu-3,xpu-4,xpu-5,xpu-6,xpu-7"}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
 }

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -514,7 +514,7 @@ func Test_ScoreNode(t *testing.T) {
 	}
 }
 
-// baidu.com/use-gpuuuid and nouse-gpuuuid were defined but never consulted, so
+// hami.io/use-kunlun-uuid and nouse-kunlun-uuid were defined but never consulted, so
 // a pod asking for a specific XPU was scheduled onto any of them.
 func TestKunlunDevices_Fit_UseUUID(t *testing.T) {
 	dev := &KunlunDevices{}
@@ -535,6 +535,7 @@ func TestKunlunDevices_Fit_UseUUID(t *testing.T) {
 		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annos}}
 	}
 
+	// Test legacy annotation
 	fit, res, _ := dev.Fit(devices, req, podWith(map[string]string{
 		KunlunUseUUID: "xpu-5",
 	}), &device.NodeInfo{}, &device.PodDevices{})
@@ -542,9 +543,26 @@ func TestKunlunDevices_Fit_UseUUID(t *testing.T) {
 	assert.Equal(t, len(res[KunlunGPUDevice]), 1)
 	assert.Equal(t, res[KunlunGPUDevice][0].UUID, "xpu-5")
 
+	// Test new standard annotation
+	fit, res, _ = dev.Fit(devices, req, podWith(map[string]string{
+		UseUUIDAnno: "xpu-3",
+	}), &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, len(res[KunlunGPUDevice]), 1)
+	assert.Equal(t, res[KunlunGPUDevice][0].UUID, "xpu-3")
+
+	// the literal key, so a rename of the constant cannot silently stop the
+	// physical path from reading what vdevice.go documents.
+	fit, res, _ = dev.Fit(devices, req, podWith(map[string]string{
+		"hami.io/use-xpu-uuid": "xpu-6",
+	}), &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, len(res[KunlunGPUDevice]), 1)
+	assert.Equal(t, res[KunlunGPUDevice][0].UUID, "xpu-6")
+
 	// asking for a card that is not on the node must not fall back to another
 	fit, _, reason := dev.Fit(devices, req, podWith(map[string]string{
-		KunlunUseUUID: "xpu-99",
+		UseUUIDAnno: "xpu-99",
 	}), &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, false)
 	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
@@ -565,7 +583,7 @@ func TestKunlunDevices_Fit_NoUseUUID(t *testing.T) {
 	}
 	req := device.ContainerDeviceRequest{Nums: 1, Type: KunlunGPUDevice}
 
-	// exclude every card and nothing should be allocatable
+	// exclude every card and nothing should be allocatable (using legacy annotation)
 	all := make([]string, 0, 8)
 	for i := range devices {
 		all = append(all, fmt.Sprintf("xpu-%d", i))
@@ -573,6 +591,15 @@ func TestKunlunDevices_Fit_NoUseUUID(t *testing.T) {
 	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 			KunlunNoUseUUID: strings.Join(all, ","),
+		}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
+
+	// exclude every card and nothing should be allocatable (using new standard annotation)
+	fit, _, reason = dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			NoUseUUIDAnno: strings.Join(all, ","),
 		}},
 	}, &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, false)
@@ -594,13 +621,29 @@ func TestKunlunVDevices_Fit_UUIDAnnotations(t *testing.T) {
 	}
 	req := device.ContainerDeviceRequest{Nums: 1, Type: XPUDevice, Memreq: KunlunMaxMemory}
 
+	// Test standard hami annotation
 	fit, res, _ := dev.Fit(devices, req, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{KunlunUseUUID: "xpu-3"}},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{UseUUIDAnno: "xpu-3"}},
 	}, &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, true)
 	assert.Equal(t, res[XPUDevice][0].UUID, "xpu-3")
 
+	// Test legacy baidu annotation (backward compatibility)
+	fit, res, _ = dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{KunlunUseUUID: "xpu-2"}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, res[XPUDevice][0].UUID, "xpu-2")
+
+	// Test standard hami nouse annotation
 	fit, _, reason := dev.Fit(devices, req, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{NoUseUUIDAnno: "xpu-0,xpu-1,xpu-2,xpu-3,xpu-4,xpu-5,xpu-6,xpu-7"}},
+	}, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardUUIDMismatch))
+
+	// Test legacy baidu nouse annotation
+	fit, _, reason = dev.Fit(devices, req, &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{KunlunNoUseUUID: "xpu-0,xpu-1,xpu-2,xpu-3,xpu-4,xpu-5,xpu-6,xpu-7"}},
 	}, &device.NodeInfo{}, &device.PodDevices{})
 	assert.Equal(t, fit, false)

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -234,12 +234,24 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	reason := make(map[string]int)
 
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
-	fitFn := FitFn(FitVXPU)
+	base := FitFn(FitVXPU)
 	if isMutex {
 		// mutex: only idle devices are eligible, no sharing onto a used device.
-		fitFn = func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
+		base = func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
 			return d.Used == 0 && FitVXPU(d, r)
 		}
+	}
+	// graghSelect decides topology from the position of a device in the slice,
+	// so the uuid constraint has to be applied through fitFn rather than by
+	// filtering the slice first.
+	uuidMismatch := 0
+	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
+		if !device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, dev.CommonWord()) {
+			uuidMismatch++
+			klog.V(5).InfoS(common.CardUUIDMismatch, "pod", klog.KObj(pod), "device", d.ID)
+			return false
+		}
+		return base(d, r)
 	}
 	alloc := graghSelect(devices, request, fitFn)
 	if len(alloc) == 0 {
@@ -250,6 +262,9 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 					klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "used", dev.Used)
 				}
 			}
+		}
+		if len(reason) == 0 && uuidMismatch > 0 {
+			reason[common.CardUUIDMismatch] += uuidMismatch
 		}
 		if len(reason) == 0 {
 			reason[common.NumaNotFit]++

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -244,10 +244,11 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	// graghSelect decides topology from the position of a device in the slice,
 	// so the uuid constraint has to be applied through fitFn rather than by
 	// filtering the slice first.
-	uuidMismatch := 0
+	uuidMismatches := make(map[string]bool)
 	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
-		if !device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, dev.CommonWord()) {
-			uuidMismatch++
+		if !device.CheckUUID(pod.GetAnnotations(), d.ID, UseUUIDAnno, NoUseUUIDAnno, dev.CommonWord()) ||
+			!device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, dev.CommonWord()) {
+			uuidMismatches[d.ID] = true
 			klog.V(5).InfoS(common.CardUUIDMismatch, "pod", klog.KObj(pod), "device", d.ID)
 			return false
 		}
@@ -263,6 +264,7 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 				}
 			}
 		}
+		uuidMismatch := len(uuidMismatches)
 		if len(reason) == 0 && uuidMismatch > 0 {
 			reason[common.CardUUIDMismatch] += uuidMismatch
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`KunlunUseUUID` (`baidu.com/use-gpuuuid`) and `KunlunNoUseUUID` are defined in
`pkg/device/kunlun/device.go` but never read. Neither `KunlunDevices.Fit` nor
`KunlunVDevices.Fit` calls `device.CheckUUID`, so:

- a pod asking for a specific XPU is scheduled onto any of them
- `nouse-gpuuuid` cannot exclude a card

No error, no warning — the annotation is silently ignored.

Every other backend does call it: nvidia, amd, ascend, awsneuron, biren,
cambricon, enflame, hygon, iluvatar, metax and mthreads. Kunlun looks like it
was simply missed — the constants were added with the backend in #1121, then
#1622 extracted the shared `CheckUUID` helper and migrated the other backends
without kunlun, and #2045 changed the helper again, also without kunlun.

**The fix**

The check goes into the `fitFn` that `graghSelect` already takes, rather than
filtering the device slice before calling it. That matters here: `graghSelect`
derives topology from a device's *position* in the slice (`idx < 4` is one
wing), so removing entries would move the remaining cards between wings and
change which interconnect group gets picked. Passing the constraint through
`fitFn` leaves positions untouched.

Both kunlun backends are covered. An allocation that fails only because of the
annotations now reports `CardUuidMismatch` rather than `NumaNotFit`, which was
misleading.

**Tests**

Three tests in `pkg/device/kunlun/device_test.go`, all failing on master:

```
TestKunlunDevices_Fit_UseUUID          asked for xpu-5, got xpu-0
TestKunlunDevices_Fit_NoUseUUID        excluded all 8 cards, still allocated
TestKunlunVDevices_Fit_UUIDAnnotations asked for xpu-3, got xpu-0
```

They pass with this change, and the 20 existing kunlun tests still pass.

**Which issue(s) this PR fixes**:

None filed — raising the fix directly.

**Special notes for your reviewer**:

Behaviour change worth naming: a pod that carries these annotations today is
scheduled anywhere, and after this it is restricted to the cards it names. If a
cluster has pods with a stale or wrong `use-gpuuuid` value that currently
schedule fine, they will start failing with `CardUuidMismatch`. That is the
annotation doing what it says, but it is a visible change for anyone who had
been relying on it being ignored.

Not validated on real hardware. The change is confined to the scheduler's
kunlun Fit path and is covered by unit tests, which CONTRIBUTING allows for
scheduler-scoped changes.

**Does this PR introduce a user-facing change?**:

```release-note
Kunlun XPU now honours the baidu.com/use-gpuuuid and baidu.com/nouse-gpuuuid
pod annotations, which were previously ignored.
```

---

AI assistance disclosure: this change was developed with Claude Code — finding
the gap, the fix, and the tests. Flagging the extent up front per CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kunlun device allocation with GPU UUID inclusion and exclusion settings.
  * Requests now select specified GPUs when available and clearly report UUID mismatches when unavailable.
  * Added equivalent UUID filtering for virtual Kunlun devices.
  * Preserved topology-aware allocation and idle-device requirements for mutex scheduling.
  * Improved allocation failure reporting for requests that cannot match the specified GPU UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->