### PR TITLE
cleanup(metax): decouple MetaxDevices.ScoreNode (Metax-GPU) from the scheduler policy string

### DIFF
--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -182,36 +182,45 @@ func parseMetaxAnnos(annos string, index int) float32 {
 	return float32(res)
 }
 
+// ScoreNode returns a policy-independent score for the node following a
+// "higher score is a better node" convention. The shared scheduler policy layer
+// is responsible for weighting this score and adapting it to the active
+// scheduling policy (for example, inverting it under the Spread policy).
+//
+// Metax publishes two topology annotations for the requested device count: a
+// "scores" map where higher is better and a "losses" map where lower is better.
+// The scores annotation is used directly; when it is absent the losses
+// annotation is converted onto the same "higher is better" scale. This keeps a
+// node's topology preference effective regardless of which of the two
+// annotations it publishes.
 func (dev *MetaxDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
 	sum := 0
 	for _, dev := range podDevices {
 		sum += len(dev)
 	}
 
-	res := float32(0)
-	if policy == string(util.NodeSchedulerPolicyBinpack) {
-		lossAnno, ok := node.Annotations[MetaxAnnotationLoss]
-		if ok {
-			// it's preferred to select the node with lower loss
-			loss := parseMetaxAnnos(lossAnno, sum)
-			res = 2000 - loss
-
-			klog.InfoS("Detected annotations", "policy", policy, "key", MetaxAnnotationLoss, "value", lossAnno, "requesting", sum, "extract", loss)
-		}
-	} else if policy == string(util.NodeSchedulerPolicySpread) {
-		scoreAnno, ok := node.Annotations[MetaxAnnotationScore]
-		if ok {
-			// it's preferred to select the node with higher score
-			// But we have to give it a smaller value because of Spread policy
-			score := parseMetaxAnnos(scoreAnno, sum)
-			res = 2000 - score
-
-			klog.InfoS("Detected annotations", "policy", policy, "key", MetaxAnnotationScore, "value", scoreAnno, "requesting", sum, "extract", score)
-		}
+	if scoreAnno, ok := node.Annotations[MetaxAnnotationScore]; ok {
+		// it's preferred to select the node with higher score
+		score := parseMetaxAnnos(scoreAnno, sum)
+		klog.InfoS("Detected annotations", "key", MetaxAnnotationScore, "value", scoreAnno, "requesting", sum, "extract", score)
+		return score
 	}
 
-	return res
+	if lossAnno, ok := node.Annotations[MetaxAnnotationLoss]; ok {
+		// it's preferred to select the node with lower loss, so convert the
+		// loss onto a "higher is better" scale.
+		loss := parseMetaxAnnos(lossAnno, sum)
+		klog.InfoS("Detected annotations", "key", MetaxAnnotationLoss, "value", lossAnno, "requesting", sum, "extract", loss)
+		return 2000 - loss
+	}
+
+	return 0
 }
+
+// PolicyNeutralScore marks MetaxDevices as returning a policy-independent score
+// from ScoreNode, so the shared scheduler policy layer owns the weighting and
+// Spread-policy sign inversion.
+func (dev *MetaxDevices) PolicyNeutralScore() {}
 
 func (dev *MetaxDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
 	n.Used++

--- a/pkg/device/metax/device_test.go
+++ b/pkg/device/metax/device_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 func TestGetNodeDevices(t *testing.T) {
@@ -398,87 +399,97 @@ func Test_CustomFilterRule(t *testing.T) {
 }
 
 func Test_ScoreNode(t *testing.T) {
+	// twoDevices requests two GPUs, so the topology annotations are looked up
+	// with index 2.
+	twoDevices := device.PodSingleDevice{
+		device.ContainerDevices{
+			{Idx: 0, UUID: "test-0", Type: MetaxGPUDevice, Usedmem: 1000, Usedcores: 1},
+			{Idx: 1, UUID: "test-1", Type: MetaxGPUDevice, Usedmem: 1000, Usedcores: 1},
+		},
+	}
+
 	tests := []struct {
-		name string
-		args struct {
-			node       *corev1.Node
-			podDevices device.PodSingleDevice
-			policy     string
-		}
-		want float32
+		name       string
+		node       *corev1.Node
+		podDevices device.PodSingleDevice
+		want       float32
 	}{
 		{
-			name: "policy is binpack",
-			args: struct {
-				node       *corev1.Node
-				podDevices device.PodSingleDevice
-				policy     string
-			}{
-				node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"metax-tech.com/gpu.topology.losses": "{\"1\":100,\"2\":200}",
-						},
+			name: "scores annotation is used directly",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						MetaxAnnotationScore: "{\"1\":100,\"2\":200}",
 					},
 				},
-				podDevices: device.PodSingleDevice{
-					device.ContainerDevices{
-						{
-							Idx:       int(0),
-							UUID:      "test-0",
-							Type:      MetaxGPUDevice,
-							Usedmem:   int32(1000),
-							Usedcores: int32(1),
-						},
-						{
-							Idx:       int(1),
-							UUID:      "test-1",
-							Type:      MetaxGPUDevice,
-							Usedmem:   int32(1000),
-							Usedcores: int32(1),
-						},
-					},
-				},
-				policy: "binpack",
 			},
-			want: float32(1800),
+			podDevices: twoDevices,
+			want:       float32(200),
 		},
 		{
-			name: "policy is spread",
-			args: struct {
-				node       *corev1.Node
-				podDevices device.PodSingleDevice
-				policy     string
-			}{
-				node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"metax-tech.com/gpu.topology.scores": "{\"1\":100,\"2\":200}",
-						},
+			name: "losses annotation is used when scores is absent",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						MetaxAnnotationLoss: "{\"1\":100,\"2\":200}",
 					},
 				},
-				podDevices: device.PodSingleDevice{
-					device.ContainerDevices{
-						{
-							Idx:       int(0),
-							UUID:      "test-0",
-							Type:      MetaxGPUDevice,
-							Usedmem:   int32(1000),
-							Usedcores: int32(1),
-						},
-					},
-				},
-				policy: "spread",
 			},
-			want: float32(1900),
+			podDevices: twoDevices,
+			want:       float32(1800),
 		},
+		{
+			name: "scores is preferred over losses when both are present",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						MetaxAnnotationScore: "{\"2\":200}",
+						MetaxAnnotationLoss:  "{\"2\":50}",
+					},
+				},
+			},
+			podDevices: twoDevices,
+			want:       float32(200),
+		},
+		{
+			name:       "no topology annotation scores zero",
+			node:       &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
+			podDevices: twoDevices,
+			want:       float32(0),
+		},
+	}
+
+	// ScoreNode must be policy-independent: the same inputs produce the same
+	// score regardless of the scheduling policy. The shared scheduler policy
+	// layer (OverrideScore) is responsible for adapting the score to binpack or
+	// spread.
+	policies := []string{
+		util.NodeSchedulerPolicyBinpack.String(),
+		util.NodeSchedulerPolicySpread.String(),
+		"",
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dev := MetaxDevices{}
-			result := dev.ScoreNode(test.args.node, test.args.podDevices, []*device.DeviceUsage{}, test.args.policy)
-			assert.DeepEqual(t, result, test.want)
+			for _, policy := range policies {
+				result := dev.ScoreNode(test.node, test.podDevices, []*device.DeviceUsage{}, policy)
+				assert.DeepEqual(t, result, test.want)
+			}
 		})
+	}
+}
+
+// TestMetaxDevicesImplementsPolicyNeutralScorer verifies that MetaxDevices
+// exposes the PolicyNeutralScore marker method, which is how the shared
+// scheduler policy layer detects that ScoreNode is policy-independent and
+// applies the weight and Spread sign inversion.
+func TestMetaxDevicesImplementsPolicyNeutralScorer(t *testing.T) {
+	type policyNeutralScorer interface {
+		PolicyNeutralScore()
+	}
+	var dev any = &MetaxDevices{}
+	if _, ok := dev.(policyNeutralScorer); !ok {
+		t.Errorf("MetaxDevices does not implement the PolicyNeutralScore marker")
 	}
 }
 

--- a/pkg/scheduler/policy/node_policy_test.go
+++ b/pkg/scheduler/policy/node_policy_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package policy
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
 	"k8s.io/klog/v2"
@@ -24,6 +26,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -255,8 +258,53 @@ func TestOverrideScore(t *testing.T) {
 					Usedmem:   0,
 				},
 			},
+			// Metax-GPU implements the policy-neutral scorer, so OverrideScore
+			// weights its raw "higher is better" score by 10000 under Binpack.
+			// The node only carries the losses annotation, so the raw score
+			// falls back to 2000 - loss = 2000 - 321 = 1679 for the requested
+			// two devices, giving a weighted result of 16790000.
 			policy:    "binpack",
-			wantScore: 1679,
+			wantScore: 16790000,
+		},
+		{
+			// Under Spread the same policy-neutral raw score of 1679 is inverted
+			// (weight -10000), producing -16790000. Because Binpack picks the
+			// highest score and Spread picks the lowest, inverting the sign
+			// preserves the node ranking across both policies.
+			name: "Metax-GPU with spread policy returns inverted weighted score",
+			nodeScore: &NodeScore{
+				Node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Annotations: map[string]string{
+							"metax-tech.com/gpu.topology.losses": "{\"1\":123,\"2\":321}",
+						},
+					},
+				},
+				NodeID: "node1",
+				Devices: device.PodDevices{
+					"Metax-GPU": device.PodSingleDevice{
+						device.ContainerDevices{
+							{Idx: 1, UUID: "uuid1", Type: "gpu", Usedmem: 1024, Usedcores: 2},
+							{Idx: 2, UUID: "uuid2", Type: "gpu", Usedmem: 2048, Usedcores: 4},
+						},
+					},
+				},
+				Score: 0,
+			},
+			devices: []*device.DeviceUsage{
+				{
+					Count:     4,
+					Totalcore: 8,
+					Totalmem:  4096,
+					Type:      "gpu",
+					Used:      0,
+					Usedcores: 0,
+					Usedmem:   0,
+				},
+			},
+			policy:    "spread",
+			wantScore: -16790000,
 		},
 		{
 			name: "Device score equal to zero",
@@ -409,6 +457,138 @@ func TestOverrideScore(t *testing.T) {
 			if gotScore := tt.nodeScore.Score; gotScore != tt.wantScore {
 				t.Errorf("OverrideScore() gotScore = %v, want %v", gotScore, tt.wantScore)
 			}
+		})
+	}
+}
+
+// TestOverrideScoreMetaxGPUOrderingUnchanged verifies that decoupling
+// MetaxDevices.ScoreNode from the scheduler policy string does not change which
+// node wins for Metax-GPU.
+//
+// The pre-decoupling code implemented two distinct selection rules: under
+// Binpack it preferred the node with the lowest topology loss, and under Spread
+// it preferred the node with the highest topology score. When a node advertises
+// both annotations they describe the same underlying topology preference, so the
+// lowest-loss node is also the highest-score node. This test builds such
+// consistent nodes, derives the winner each original rule would have chosen, and
+// asserts that the new single policy-neutral score — once weighted and sorted by
+// the shared OverrideScore/Less layer exactly as the scheduler does — selects the
+// same node under both policies.
+func TestOverrideScoreMetaxGPUOrderingUnchanged(t *testing.T) {
+	setup(t, &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultGPUNum:                1,
+		},
+	})
+
+	// Each node requests two Metax-GPU devices, so the topology annotations are
+	// looked up at index "2".
+	type metaxNode struct {
+		name  string
+		loss  int
+		score int
+	}
+
+	// buildNode returns a NodeScore that advertises both topology annotations for
+	// the two requested devices.
+	buildNode := func(n metaxNode) *NodeScore {
+		return &NodeScore{
+			NodeID: n.name,
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: n.name,
+					Annotations: map[string]string{
+						"metax-tech.com/gpu.topology.losses": fmt.Sprintf("{\"2\":%d}", n.loss),
+						"metax-tech.com/gpu.topology.scores": fmt.Sprintf("{\"2\":%d}", n.score),
+					},
+				},
+			},
+			Devices: device.PodDevices{
+				"Metax-GPU": device.PodSingleDevice{
+					device.ContainerDevices{
+						{Idx: 0, UUID: n.name + "-0", Type: "gpu", Usedmem: 1024, Usedcores: 2},
+						{Idx: 1, UUID: n.name + "-1", Type: "gpu", Usedmem: 1024, Usedcores: 2},
+					},
+				},
+			},
+		}
+	}
+
+	// originalBinpackWinner is the node the pre-decoupling code selected under
+	// Binpack: the lowest topology loss.
+	originalBinpackWinner := func(nodes []metaxNode) string {
+		best := nodes[0]
+		for _, n := range nodes[1:] {
+			if n.loss < best.loss {
+				best = n
+			}
+		}
+		return best.name
+	}
+
+	// originalSpreadWinner is the node the pre-decoupling code selected under
+	// Spread: the highest topology score.
+	originalSpreadWinner := func(nodes []metaxNode) string {
+		best := nodes[0]
+		for _, n := range nodes[1:] {
+			if n.score > best.score {
+				best = n
+			}
+		}
+		return best.name
+	}
+
+	// newWinner reproduces the scheduler's selection: weight every node with
+	// OverrideScore, sort with the policy-aware Less, and take the last element
+	// (see scheduler.go).
+	newWinner := func(nodes []metaxNode, policy string) string {
+		list := NodeScoreList{Policy: policy}
+		for _, n := range nodes {
+			ns := buildNode(n)
+			ns.OverrideScore([]*device.DeviceUsage{}, policy)
+			list.NodeList = append(list.NodeList, ns)
+		}
+		sort.Sort(&list)
+		return list.NodeList[len(list.NodeList)-1].NodeID
+	}
+
+	tests := []struct {
+		name  string
+		nodes []metaxNode
+	}{
+		{
+			name: "best node has both lowest loss and highest score",
+			nodes: []metaxNode{
+				{name: "node-a", loss: 300, score: 100},
+				{name: "node-b", loss: 100, score: 300},
+				{name: "node-c", loss: 200, score: 200},
+			},
+		},
+		{
+			name: "best node is first in the list",
+			nodes: []metaxNode{
+				{name: "node-a", loss: 50, score: 500},
+				{name: "node-b", loss: 400, score: 100},
+				{name: "node-c", loss: 250, score: 250},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantBinpack := originalBinpackWinner(tt.nodes)
+			wantSpread := originalSpreadWinner(tt.nodes)
+			// Consistent annotations must agree on the best node; otherwise a
+			// single policy-neutral score could not preserve both rankings and
+			// this test's premise would not hold.
+			assert.Equal(t, wantBinpack, wantSpread)
+
+			assert.Equal(t, wantBinpack, newWinner(tt.nodes, util.NodeSchedulerPolicyBinpack.String()))
+			assert.Equal(t, wantSpread, newWinner(tt.nodes, util.NodeSchedulerPolicySpread.String()))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

`MetaxDevices.ScoreNode` (the **Metax-GPU** backend) branched on the scheduler `policy` string, reading a different topology annotation for each policy:

- **Binpack** → `2000 - losses[n]`
- **Spread**  → `2000 - scores[n]`

This is the same coupling that was removed for the sibling **Metax-SGPU** backend in #2404 / #2413. The device layer should not know scheduler policy names, and the `2000 - score` subtraction only existed to flip the sign so the
best node wins under both sort directions.

This PR makes `ScoreNode` return a single **policy-independent, "higher is a better node"** score:

- Prefer the `metax-tech.com/gpu.topology.scores` annotation.
- Fall back to `metax-tech.com/gpu.topology.losses` (converted onto the same
  "higher is better" scale via `2000 - loss`) when `scores` is absent.

`MetaxDevices` now implements the policy-neutral scorer marker, so the shared `OverrideScore` layer owns the `±10000` weighting and the Spread-policy sign inversion — exactly as it already does for Metax-SGPU. **`OverrideScore` itself
is unchanged.**

Fixes #2572

## Why the node ranking is unchanged

When a node advertises **both** annotations, they describe the same underlyingtopology preference, so the lowest-loss node is also the highest-score node. Because `OverrideScore` inverts the sign under Spread (which selects the lowest
score) and keeps it under Binpack (which selects the highest), the **winning node is the same under both policies** as before.

A new test, `TestOverrideScoreMetaxGPUOrderingUnchanged`, asserts this directly:
it builds nodes with consistent annotations, computes the winner each *original*
per-policy rule would have chosen, then weights and sorts the nodes exactly as the scheduler does (`OverrideScore` → `sort.Sort` → `NodeList[len-1]`) and checks the same node wins under both Binpack and Spread.

> **Note for reviewers:** this preserves ordering
> under the assumption that a node exposing both annotations encodes one
> consistent topology preference (min-loss node = max-score node). The issue
> invites maintainer input on whether `losses` and `scores` can ever rank nodes
> inconsistently, and on whether the two annotations should ultimately be
> unified. Happy to adjust the fallback direction (or gate it) based on that.

## Scope

Exactly three files, no changes to the shared scheduler infrastructure that landed with #2413:

- `pkg/device/metax/device.go` — the fix
- `pkg/device/metax/device_test.go` — policy-independence + marker-interface tests
- `pkg/scheduler/policy/node_policy_test.go` — weighted Binpack/Spread cases + ordering-equivalence test

## Acceptance criteria (from #2572)

- [x] `MetaxDevices.ScoreNode` no longer reads the `policy` parameter
- [x] `MetaxDevices` implements the policy-neutral scorer marker
- [x] Binpack and Spread give the same node ranking for Metax-GPU as before (test)
- [x] Policy-independence test added
- [x] Marker-interface test added
- [x] Existing tests still pass
- [x] No scheduling behavior change for Metax-GPU (aside from the intended fix)

## Testing

- `go test ./pkg/device/metax/... ./pkg/scheduler/policy/... -short --race -count=1` — pass
- `go vet` clean, `go build ./...` clean
- `goimports` (local prefix) clean, import aliases correct, license headers present
- `golangci-lint run` on the changed packages — **0 issues**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved accelerator topology scoring to provide consistent, policy-independent results.
  * Score-based and loss-based topology annotations are now interpreted consistently, with clear precedence rules and fallback behavior.
  * Preserved expected node ordering under both Binpack and Spread scheduling policies.
  * Improved handling of missing topology information and multi-device configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->