### PR TITLE
fix(vGPUmonitor): add missing node label to host GPU metrics

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -58,13 +58,13 @@ var (
 	hostGPUdesc = prometheus.NewDesc(
 		"hami_host_gpu_memory_used_bytes",
 		"GPU device memory usage in bytes",
-		[]string{"device_index", "device_uuid", "device_type"}, nil,
+		[]string{"node", "device_index", "device_uuid", "device_type"}, nil,
 	)
 
 	hostGPUUtilizationdesc = prometheus.NewDesc(
 		"hami_host_gpu_utilization_ratio",
 		"GPU core utilization ratio (0-100)",
-		[]string{"device_index", "device_uuid", "device_type"}, nil,
+		[]string{"node", "device_index", "device_uuid", "device_type"}, nil,
 	)
 
 	ctrvGPUdesc = prometheus.NewDesc(
@@ -133,12 +133,12 @@ func initLegacyDescriptors() {
 	legacyHostGPUdesc = prometheus.NewDesc(
 		"HostGPUMemoryUsage",
 		"GPU device memory usage",
-		[]string{"deviceidx", "deviceuuid", "devicetype"}, nil,
+		[]string{"nodeid", "deviceidx", "deviceuuid", "devicetype"}, nil,
 	)
 	legacyHostGPUUtilizationdesc = prometheus.NewDesc(
 		"HostCoreUtilization",
 		"GPU core utilization",
-		[]string{"deviceidx", "deviceuuid", "devicetype"}, nil,
+		[]string{"nodeid", "deviceidx", "deviceuuid", "devicetype"}, nil,
 	)
 	legacyCtrvGPUdesc = prometheus.NewDesc(
 		"vGPU_device_memory_usage_in_bytes",
@@ -310,22 +310,26 @@ func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.M
 
 	deviceName = "NVIDIA-" + deviceName
 
+	nodeName := os.Getenv(util.NodeNameEnvName)
+
 	ch <- prometheus.MustNewConstMetric(
 		hostGPUdesc,
 		prometheus.GaugeValue,
 		float64(memory.Used),
-		fmt.Sprint(index), uuid, deviceName,
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
 	sendLegacyMetric(ch, legacyHostGPUdesc, prometheus.GaugeValue, float64(memory.Used),
-		fmt.Sprint(index), uuid, deviceName,
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
 	return nil
 }
 
 func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
-	util, nvret := hdev.GetUtilizationRates()
+	nodeName := os.Getenv(util.NodeNameEnvName)
+
+	utilRates, nvret := hdev.GetUtilizationRates()
 	if nvret != nvml.SUCCESS {
 		return fmt.Errorf("nvml GetUtilizationRates err: %s", nvml.ErrorString(nvret))
 	}
@@ -345,12 +349,12 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	ch <- prometheus.MustNewConstMetric(
 		hostGPUUtilizationdesc,
 		prometheus.GaugeValue,
-		float64(util.Gpu),
-		fmt.Sprint(index), uuid, deviceName,
+		float64(utilRates.Gpu),
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
-	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(util.Gpu),
-		fmt.Sprint(index), uuid, deviceName,
+	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu),
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
 	return nil

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -311,6 +311,9 @@ func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.M
 	deviceName = "NVIDIA-" + deviceName
 
 	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
 
 	ch <- prometheus.MustNewConstMetric(
 		hostGPUdesc,
@@ -328,6 +331,9 @@ func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.M
 
 func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
 	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
 
 	utilRates, nvret := hdev.GetUtilizationRates()
 	if nvret != nvml.SUCCESS {

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -126,3 +126,47 @@ func TestHostGPUMetricsMissingNodeName(t *testing.T) {
 		t.Errorf("expected missing node name error from collectGPUMemoryMetrics, got: %v", err)
 	}
 }
+
+func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+
+	mockDev := &nvmlmock.Device{
+		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+			return nvml.Memory{Used: 1024}, nvml.SUCCESS
+		},
+		GetUtilizationRatesFunc: func() (nvml.Utilization, nvml.Return) {
+			return nvml.Utilization{Gpu: 50, Memory: 20}, nvml.SUCCESS
+		},
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return "GPU-12345678-1234-1234-1234-123456789012", nvml.SUCCESS
+		},
+		GetNameFunc: func() (string, nvml.Return) {
+			return "Tesla T4", nvml.SUCCESS
+		},
+	}
+
+	initLegacyDescriptors()
+	cc := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{LegacyMetrics: true},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+
+	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUMemoryMetrics failed: %v", err)
+	}
+
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUUtilizationMetrics failed: %v", err)
+	}
+
+	close(ch)
+
+	count := 0
+	for range ch {
+		count++
+	}
+	if count < 4 {
+		t.Errorf("expected at least 4 metrics, got %d", count)
+	}
+}

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -66,5 +67,31 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 	if _, err := regLegacy.Gather(); err != nil {
 		t.Errorf("Gather failed (legacy): %v", err)
+	}
+}
+
+func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
+	initLegacyDescriptors()
+
+	// Verify standard host GPU descriptors include "node" label
+	hostGPUString := hostGPUdesc.String()
+	if !strings.Contains(hostGPUString, `"node"`) && !strings.Contains(hostGPUString, `node`) {
+		t.Errorf("hostGPUdesc does not contain 'node' label: %s", hostGPUString)
+	}
+
+	hostGPUUtilString := hostGPUUtilizationdesc.String()
+	if !strings.Contains(hostGPUUtilString, `"node"`) && !strings.Contains(hostGPUUtilString, `node`) {
+		t.Errorf("hostGPUUtilizationdesc does not contain 'node' label: %s", hostGPUUtilString)
+	}
+
+	// Verify legacy host GPU descriptors include "nodeid" label
+	legacyHostGPUString := legacyHostGPUdesc.String()
+	if !strings.Contains(legacyHostGPUString, `"nodeid"`) && !strings.Contains(legacyHostGPUString, `nodeid`) {
+		t.Errorf("legacyHostGPUdesc does not contain 'nodeid' label: %s", legacyHostGPUString)
+	}
+
+	legacyHostGPUUtilString := legacyHostGPUUtilizationdesc.String()
+	if !strings.Contains(legacyHostGPUUtilString, `"nodeid"`) && !strings.Contains(legacyHostGPUUtilString, `nodeid`) {
+		t.Errorf("legacyHostGPUUtilizationdesc does not contain 'nodeid' label: %s", legacyHostGPUUtilString)
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -93,5 +95,34 @@ func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
 	legacyHostGPUUtilString := legacyHostGPUUtilizationdesc.String()
 	if !strings.Contains(legacyHostGPUUtilString, `"nodeid"`) && !strings.Contains(legacyHostGPUUtilString, `nodeid`) {
 		t.Errorf("legacyHostGPUUtilizationdesc does not contain 'nodeid' label: %s", legacyHostGPUUtilString)
+	}
+}
+
+func TestHostGPUMetricsMissingNodeName(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "")
+
+	cc := ClusterManagerCollector{}
+
+	// Test collectGPUUtilizationMetrics with missing NODE_NAME
+	err := cc.collectGPUUtilizationMetrics(nil, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from collectGPUUtilizationMetrics, got: %v", err)
+	}
+
+	// Test collectGPUMemoryMetrics with missing NODE_NAME
+	mockDev := &nvmlmock.Device{
+		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+			return nvml.Memory{Used: 100}, nvml.SUCCESS
+		},
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return "GPU-1234", nvml.SUCCESS
+		},
+		GetNameFunc: func() (string, nvml.Return) {
+			return "Tesla T4", nvml.SUCCESS
+		},
+	}
+	err = cc.collectGPUMemoryMetrics(nil, mockDev, 0)
+	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from collectGPUMemoryMetrics, got: %v", err)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**: In cmd/vGPUmonitor/metrics.go, the metric descriptors for host-level GPU memory and utilization (hostGPUdesc and hostGPUUtilizationdesc) do not include the node label ([]string{"device_index", "device_uuid", "device_type"}).

Without node label, Prometheus metrics scraped across nodes cannot be grouped/filtered by node in Grafana. And PromQL joins between scheduler and monitor host metrics fail due to mismatched label keys.

I guess host GPU metrics in vGPUmonitor should include the node label to align with the scheduler metrics.

**Which issue(s) this PR fixes**:
Fixes #2578 

**Special notes for your reviewer**: Nope

<img width="1110" height="408" alt="image" src="https://github.com/user-attachments/assets/395dcfab-cd9b-4fd9-ae14-0395f79c442a" />

disclosure: Antigravity was used to audit.

**Does this PR introduce a user-facing change?**:
```release-note
fix(vGPUmonitor): add missing node label to host GPU metrics (hami_host_gpu_memory_used_bytes, hami_host_gpu_utilization_ratio)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host GPU memory and utilization metrics now include the node name for improved identification.
  * Legacy GPU metrics now include the corresponding node identifier.
  * GPU utilization reporting now uses utilization-rate data for more accurate metrics.

* **Bug Fixes**
  * GPU metric collection now reports an error when the node name is unavailable, preventing incomplete metric data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->