### PR TITLE
test(device): fuzz container codec round trip

### DIFF
--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -1719,6 +1720,28 @@ func FuzzDecodeContainerDevices(f *testing.F) {
 	f.Fuzz(func(t *testing.T, str string) {
 		// Must never panic on arbitrary pod-annotation input.
 		_, _ = DecodeContainerDevices(str)
+	})
+}
+
+func FuzzEncodeDecodeContainerDevices(f *testing.F) {
+	f.Add("GPU-uuid", "NVIDIA", int32(1024), int32(10))
+	f.Add("", "", int32(0), int32(0))
+	f.Add("GPU-boundary", "NVIDIA", int32(-2147483648), int32(2147483647))
+	f.Fuzz(func(t *testing.T, uuid, deviceType string, usedmem, usedcores int32) {
+		if strings.ContainsAny(uuid, ",:;") || strings.ContainsAny(deviceType, ",:;") {
+			t.Skip()
+		}
+
+		want := ContainerDevices{{
+			UUID:      uuid,
+			Type:      deviceType,
+			Usedmem:   usedmem,
+			Usedcores: usedcores,
+		}}
+		encoded := EncodeContainerDevices(want)
+		got, err := DecodeContainerDevices(encoded)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, want, got)
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

Adds a structure-aware fuzz test for the internal container-device annotation codec.

The existing `FuzzDecodeContainerDevices` verifies that arbitrary input does not panic, but it discards both the decoded result and error. Therefore, it cannot detect semantic regressions where an annotation is accepted but its serialized allocation fields are changed or lost.

The new `FuzzEncodeDecodeContainerDevices`:

- Generates UUID, device type, memory, and core values.
- Restricts UUID and type inputs to the delimiter-safe wire-format domain.
- Encodes the generated allocation with `EncodeContainerDevices`.
- Decodes it with `DecodeContainerDevices`.
- Verifies that decoding succeeds and preserves every serialized field.
- Covers empty, zero, negative, and `int32` boundary values.

The existing arbitrary-input/no-panic fuzzer remains unchanged. This PR is test-only and does not change annotation parsing behavior.


**Which issue(s) this PR fixes**:
Fixes #2582 

**Special notes for your reviewer**:

This follows the internal-API testing direction discussed after #2507 and #2508. It tests annotations generated by HAMi itself without reopening the malformed external-input parsing contract.

Validation performed on macOS:

- Focused fuzz corpus test passed.
- 30-second fuzz run passed with 268,803 executions.
- `go test ./pkg/device/...` passed.
- `make verify` passed in a clean checkout.
- `git diff --check` passed.

No GPU hardware or Kubernetes cluster is required.

**Does this PR introduce a user-facing change?**:
Nope, this is a test-only change.

AI Disclosure:
I used OpenAI Codex to inspect the related annotation-codec history, check for duplicate issues and pull requests, and assist with implementing and validating this focused fuzz test. I reviewed the complete change, understand the tested round-trip property, and ran all verification commands myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added fuzz testing to verify reliable round-trip encoding and decoding of container-device data.
  * Added coverage for preserving valid input values without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->