### PR TITLE
docs: fix typo in Helm chart README (#2585)

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -176,7 +176,7 @@ This document provides detailed descriptions of all configurable values paramete
 | `devicePlugin.passDeviceSpecsEnabled` | Whether to enable passing device specs | `false` |
 | `devicePlugin.extraArgs` | Device plugin extra arguments | `["-v=4"]` |
 | `devicePlugin.nodeConfiguration.config` | Node configuration for device plugin by json | An example of default configuration. |
-| `devicePlugin.nodeConfiguration.externalConfigName` | Node configuration for device plugin by external congimap | `""` |
+| `devicePlugin.nodeConfiguration.externalConfigName` | Node configuration for device plugin by external configmap | `""` |
 | `devicePlugin.extraEnvs` | Device plugin extra environments | `{}` |
 
 ### Device Plugin Service Configuration


### PR DESCRIPTION
### Summary
This PR fixes a typo in `charts/hami/README.md` under the **Device Plugin Other Configuration** table on line 179:
- `congimap` -> `configmap`

Fixes #2585

### AI Assistance Disclosure
I used an AI coding assistant to help locate and verify documentation typos across the repository.
<img width="871" height="217" alt="Screenshot 2026-08-11 190745" src="https://github.com/user-attachments/assets/5c03511d-da84-4741-937b-0ba95761ef8d" />
@rootsongjc kindly review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the description of the external configuration map setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->