### PR TITLE
fix(monitor): add missing lock in Observe to prevent data race

### DIFF
--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -71,7 +71,12 @@ func CheckPriority(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 	return false
 }
 
+var observeTestHook func()
+
 func Observe(lister *nvidia.ContainerLister) {
+	if observeTestHook != nil {
+		observeTestHook()
+	}
 	lister.Lock()
 	defer lister.UnLock()
 

--- a/cmd/vGPUmonitor/feedback.go
+++ b/cmd/vGPUmonitor/feedback.go
@@ -72,6 +72,9 @@ func CheckPriority(utSwitchOn map[string]UtilizationPerDevice, p int, c *nvidia.
 }
 
 func Observe(lister *nvidia.ContainerLister) {
+	lister.Lock()
+	defer lister.UnLock()
+
 	utSwitchOn := map[string]UtilizationPerDevice{}
 	containers := lister.ListContainers()
 

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -169,22 +169,22 @@ func TestObserve(t *testing.T) {
 
 	// Test that Observe actually acquires the lock deterministically.
 	lister.Lock()
-	
+
 	reachedLock := make(chan struct{})
 	observeTestHook = func() {
 		close(reachedLock)
 	}
 	defer func() { observeTestHook = nil }()
-	
+
 	done := make(chan struct{})
 	go func() {
 		Observe(lister)
 		close(done)
 	}()
-	
+
 	// Wait until Observe reaches the lock boundary
 	<-reachedLock
-	
+
 	// Ensure Observe is now blocked on the lock
 	select {
 	case <-done:
@@ -192,10 +192,10 @@ func TestObserve(t *testing.T) {
 	default:
 		// Expected: Observe is blocked
 	}
-	
+
 	// Release the lock
 	lister.UnLock()
-	
+
 	// Now Observe should complete
 	select {
 	case <-done:

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -167,8 +167,14 @@ func TestObserve(t *testing.T) {
 	// and to ensure no panics occur with locking/unlocking.
 	lister := &nvidia.ContainerLister{}
 
-	// Test that Observe actually acquires the lock.
+	// Test that Observe actually acquires the lock deterministically.
 	lister.Lock()
+	
+	reachedLock := make(chan struct{})
+	observeTestHook = func() {
+		close(reachedLock)
+	}
+	defer func() { observeTestHook = nil }()
 	
 	done := make(chan struct{})
 	go func() {
@@ -176,12 +182,14 @@ func TestObserve(t *testing.T) {
 		close(done)
 	}()
 	
-	// Observe should be blocked waiting for the lock, so it shouldn't complete yet.
+	// Wait until Observe reaches the lock boundary
+	<-reachedLock
+	
+	// Ensure Observe is now blocked on the lock
 	select {
 	case <-done:
 		t.Fatal("Observe completed while lock was held by another goroutine, indicating it did not acquire the lock!")
-	// A small delay to ensure the goroutine has time to schedule and block
-	case <-time.After(50 * time.Millisecond):
+	default:
 		// Expected: Observe is blocked
 	}
 	

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
 )
@@ -165,5 +166,33 @@ func TestObserve(t *testing.T) {
 	// Call Observe with an empty lister to cover the missing lines for codecov
 	// and to ensure no panics occur with locking/unlocking.
 	lister := &nvidia.ContainerLister{}
-	Observe(lister)
+
+	// Test that Observe actually acquires the lock.
+	lister.Lock()
+	
+	done := make(chan struct{})
+	go func() {
+		Observe(lister)
+		close(done)
+	}()
+	
+	// Observe should be blocked waiting for the lock, so it shouldn't complete yet.
+	select {
+	case <-done:
+		t.Fatal("Observe completed while lock was held by another goroutine, indicating it did not acquire the lock!")
+	// A small delay to ensure the goroutine has time to schedule and block
+	case <-time.After(50 * time.Millisecond):
+		// Expected: Observe is blocked
+	}
+	
+	// Release the lock
+	lister.UnLock()
+	
+	// Now Observe should complete
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Observe did not complete after lock was released")
+	}
 }

--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -160,3 +160,10 @@ func TestCheckBlocking_MultiDevice(t *testing.T) {
 		})
 	}
 }
+
+func TestObserve(t *testing.T) {
+	// Call Observe with an empty lister to cover the missing lines for codecov
+	// and to ensure no panics occur with locking/unlocking.
+	lister := &nvidia.ContainerLister{}
+	Observe(lister)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
> Disclosure: I used AI to help me track down where the lock was missing, but I wrote and tested the fix myself.

I noticed a data race in `vGPUmonitor` that causes a panic. `Observe()` in `cmd/vGPUmonitor/feedback.go` reads `lister.ListContainers()` without grabbing the lock, but `Update()` in `cudevshr.go` mutates that exact same map via the pod informer. 

This just adds `lister.Lock()` and `defer lister.UnLock()` to `Observe()` to fix it, matching how `metrics.go` safely reads it. I also added a quick test in `feedback_test.go` to cover the new lines.

**Which issue(s) this PR fixes**:
Fixes #2573

**Special notes for your reviewer**:
Nothing special, just a straightforward concurrency fix.

**Does this PR introduce a user-facing change?**:
```release-note
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring reliability by coordinating container-list access during observation and feedback processing.
  * Prevented conflicting updates while monitoring is in progress.
  * Ensured observation completes safely once container-list access becomes available.

* **Tests**
  * Added coverage for container-list locking, blocking behavior, and successful completion after access is released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->