### PR TITLE
fix(nvidia): clean up node health bookkeeping on deletion

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -208,7 +208,19 @@ func FilterDeviceToRegister(uuid, indexStr string) bool {
 	return false
 }
 
+// NodeDeleted removes the per-node health bookkeeping entries for nn from
+// ReportedGPUNum and ReportedRegisterAnnos. It must be called whenever a
+// node is permanently removed (deletion or unrecoverable health failure) so
+// that the maps do not retain stale entries and node-name reuse starts clean.
+func (dev *NvidiaGPUDevices) NodeDeleted(nn string) {
+	dev.mu.Lock()
+	defer dev.mu.Unlock()
+	delete(dev.ReportedGPUNum, nn)
+	delete(dev.ReportedRegisterAnnos, nn)
+}
+
 func (dev *NvidiaGPUDevices) NodeCleanUp(nn string) error {
+	dev.NodeDeleted(nn)
 	return util.MarkAnnotationsToDelete(HandshakeAnnos, nn)
 }
 

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2751,3 +2751,82 @@ func TestFit_TopologyNegativeScores(t *testing.T) {
 		assert.Assert(t, uuids["dev-2"])
 	})
 }
+
+// TestNodeDeleted_ClearsBookkeepingForDeletedNode verifies that NodeDeleted
+// removes both ReportedGPUNum and ReportedRegisterAnnos entries for the
+// named node while leaving other nodes' entries intact.
+func TestNodeDeleted_ClearsBookkeepingForDeletedNode(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{ResourceCountName: "nvidia.com/gpu"})
+
+	// Populate bookkeeping for two nodes.
+	dev.mu.Lock()
+	dev.ReportedGPUNum["node-a"] = 4
+	dev.ReportedGPUNum["node-b"] = 2
+	dev.ReportedRegisterAnnos["node-a"] = "anno-a"
+	dev.ReportedRegisterAnnos["node-b"] = "anno-b"
+	dev.mu.Unlock()
+
+	// Delete node-a.
+	dev.NodeDeleted("node-a")
+
+	dev.mu.Lock()
+	defer dev.mu.Unlock()
+
+	// node-a entries must be gone.
+	_, gpuPresent := dev.ReportedGPUNum["node-a"]
+	assert.Assert(t, !gpuPresent, "expected ReportedGPUNum entry for node-a to be removed")
+	_, annoPresent := dev.ReportedRegisterAnnos["node-a"]
+	assert.Assert(t, !annoPresent, "expected ReportedRegisterAnnos entry for node-a to be removed")
+
+	// node-b must be untouched.
+	assert.Equal(t, dev.ReportedGPUNum["node-b"], int64(2), "ReportedGPUNum for node-b must be unchanged")
+	assert.Equal(t, dev.ReportedRegisterAnnos["node-b"], "anno-b", "ReportedRegisterAnnos for node-b must be unchanged")
+}
+
+// TestNodeDeleted_IdempotentOnUnknownNode verifies that calling NodeDeleted
+// for a node that was never registered does not panic or error.
+func TestNodeDeleted_IdempotentOnUnknownNode(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{ResourceCountName: "nvidia.com/gpu"})
+	// Should not panic.
+	dev.NodeDeleted("node-never-registered")
+	dev.mu.Lock()
+	defer dev.mu.Unlock()
+	assert.Equal(t, len(dev.ReportedGPUNum), 0)
+	assert.Equal(t, len(dev.ReportedRegisterAnnos), 0)
+}
+
+// TestNodeDeleted_ReuseAfterDeletion verifies that after a node is deleted its
+// bookkeeping is cleared so that a subsequent CheckHealth call for a node with
+// the same name (i.e. re-created node) is not hampered by stale state.
+func TestNodeDeleted_ReuseAfterDeletion(t *testing.T) {
+	config := NvidiaConfig{ResourceCountName: "nvidia.com/gpu"}
+	dev := InitNvidiaDevice(config)
+
+	allocatable := corev1.ResourceList{
+		corev1.ResourceName(config.ResourceCountName): *resource.NewQuantity(4, resource.DecimalSI),
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "reused-node",
+			Annotations: map[string]string{
+				util.HandshakeAnnos[NvidiaGPUDevice]: "Heartbeat_2099-01-01T00:00:00Z",
+			},
+		},
+		Status: corev1.NodeStatus{Allocatable: allocatable},
+	}
+
+	// Simulate a prior registration cycle: CheckHealth establishes bookkeeping.
+	dev.mu.Lock()
+	dev.ReportedGPUNum["reused-node"] = 4
+	dev.ReportedRegisterAnnos["reused-node"] = "old-anno"
+	dev.mu.Unlock()
+
+	// Node deleted — bookkeeping must be wiped.
+	dev.NodeDeleted("reused-node")
+
+	// After re-creation the new CheckHealth must detect a change (needUpdate=true)
+	// because reported=0 (after deletion) != current=4.
+	healthy, needUpdate := dev.CheckHealth("NVIDIA", node)
+	assert.Equal(t, healthy, true, "re-created node should be healthy")
+	assert.Equal(t, needUpdate, true, "re-created node must trigger an update (stale bookkeeping was cleared)")
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -252,8 +252,8 @@ func (s *Scheduler) onDelPod(obj any) {
 }
 
 // onDelNode handles node delete events. It removes any in-memory per-node
-// lock bookkeeping to avoid unbounded growth when nodes are removed by
-// autoscalers or administratively.
+// lock bookkeeping and per-device health bookkeeping to avoid unbounded growth
+// when nodes are removed by autoscalers or administratively.
 func (s *Scheduler) onDelNode(obj any) {
 	// Ensure downstream consumers are notified regardless of decoding success
 	defer s.doNodeNotify()
@@ -279,6 +279,14 @@ func (s *Scheduler) onDelNode(obj any) {
 	nodelockutil.CleanupNodeLock(nodeName)
 	s.rmNode(nodeName)
 	s.cleanupNodeUsage(nodeName)
+	// Clear per-device health bookkeeping for the deleted node.
+	// Devices that track per-node state (e.g. NvidiaGPUDevices) implement
+	// NodeDeleted to prune their internal maps; others are a no-op.
+	for _, devInstance := range device.GetDevices() {
+		if nd, ok := devInstance.(*nvidia.NvidiaGPUDevices); ok {
+			nd.NodeDeleted(nodeName)
+		}
+	}
 }
 
 // cleanupNodeUsage removes the node from overviewstatus maps


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When a Kubernetes node is deleted, the scheduler's `onDelNode` cleanup currently removes scheduler-side node state such as locks and overview information, but the NVIDIA device plugin's internal per-node health bookkeeping is not cleared.

`NvidiaGPUDevices` maintains node-specific state in `ReportedGPUNum` and `ReportedRegisterAnnos`. If a node is deleted, these entries can remain indefinitely because the device cleanup lifecycle is not invoked.

This can result in stale NVIDIA device state being retained for nodes that no longer exist. If a node name is later reused, the stale bookkeeping can also interfere with the newly created node's device state.

This PR:

* Adds a node deletion cleanup hook for NVIDIA device bookkeeping.
* Clears `ReportedGPUNum` and `ReportedRegisterAnnos` when a node is removed.
* Integrates the cleanup into the scheduler's existing `onDelNode` lifecycle.
* Keeps the cleanup idempotent for nodes with no existing bookkeeping.
* Ensures node reuse starts with clean NVIDIA device state.
* Adds regression tests covering deletion, unknown-node deletion, and node-name reuse.

## Which issue(s) does this PR fix?

Fixes #2586 

## Special notes for your reviewer

The cleanup is intentionally performed as part of the existing node deletion lifecycle rather than relying on future device registration to overwrite stale state.

The change is limited to NVIDIA device bookkeeping and does not alter the scheduler's node deletion semantics.

The cleanup is safe when a node has no corresponding NVIDIA bookkeeping and is idempotent for repeated or unknown-node deletion events.

Regression coverage verifies:

* NVIDIA bookkeeping is removed when a node is deleted.
* Deleting an unknown node does not cause failures.
* Reusing a previously deleted node name does not inherit stale bookkeeping.

Validation performed:

* `gofmt`
* `git diff --check`
* GolangCI-Lint
* Unit tests were added for the affected behavior.

Due to the Windows development environment, NVIDIA package tests requiring CGO/NVML could not be executed locally because of the local GCC/CGO toolchain limitation. These tests should run in the Linux CI environment.

## Does this PR introduce a user-facing change?

No.

## AI Assistance Disclosure

AI assistance from Claude and Antigravity was used during codebase investigation, root-cause analysis, implementation, regression-test development, and validation of this change. The resulting changes were reviewed against the existing HAMi architecture, scheduler/device lifecycle, and relevant test behavior by the contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when nodes are removed, including cached GPU availability and device health information.
  * Prevented stale device state from affecting recreated nodes.
  * Ensured cleanup is safe and repeatable for unknown or previously removed nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->