### PR TITLE
fix(scheduler): exponential backoff for acquireNodeLocks retries

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -941,10 +941,7 @@ func (s *Scheduler) acquireNodeLocks(node *corev1.Node, pod *corev1.Pod) error {
 			return fmt.Errorf("timed out after %v waiting for node %s to be unlocked: %w",
 				config.NodeLockRetryTimeout, node.Name, nodelockutil.ErrNodeLockContention)
 		}
-		delay := backoff.Step()
-		if delay > remaining {
-			delay = remaining
-		}
+		delay := min(backoff.Step(), remaining)
 		if delay <= 0 {
 			return fmt.Errorf("timed out after %v waiting for node %s to be unlocked: %w",
 				config.NodeLockRetryTimeout, node.Name, nodelockutil.ErrNodeLockContention)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -936,13 +936,18 @@ func (s *Scheduler) acquireNodeLocks(node *corev1.Node, pod *corev1.Pod) error {
 		if !nodelockutil.IsNodeLockContention(err) {
 			return err
 		}
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return fmt.Errorf("timed out after %v waiting for node %s to be unlocked: %w",
 				config.NodeLockRetryTimeout, node.Name, nodelockutil.ErrNodeLockContention)
 		}
 		delay := backoff.Step()
-		if remaining := time.Until(deadline); delay > remaining {
+		if delay > remaining {
 			delay = remaining
+		}
+		if delay <= 0 {
+			return fmt.Errorf("timed out after %v waiting for node %s to be unlocked: %w",
+				config.NodeLockRetryTimeout, node.Name, nodelockutil.ErrNodeLockContention)
 		}
 		step++
 		klog.V(4).InfoS("Node lock contended, backing off",

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -910,12 +911,22 @@ func (s *Scheduler) releaseAllDevices(node *corev1.Node, pod *corev1.Pod) {
 	}
 }
 
+var nodeLockRetryBackoff = wait.Backoff{
+	Duration: 100 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.5,
+	Steps:    math.MaxInt32,
+	Cap:      1 * time.Second,
+}
+
 func (s *Scheduler) acquireNodeLocks(node *corev1.Node, pod *corev1.Pod) error {
 	if !util.IsPodGroupMember(pod) || config.NodeLockRetryTimeout <= 0 {
 		return s.lockAllDevices(node, pod)
 	}
 
 	deadline := time.Now().Add(config.NodeLockRetryTimeout)
+	backoff := nodeLockRetryBackoff
+	step := 0
 	for {
 		err := s.lockAllDevices(node, pod)
 		if err == nil {
@@ -929,10 +940,17 @@ func (s *Scheduler) acquireNodeLocks(node *corev1.Node, pod *corev1.Pod) error {
 			return fmt.Errorf("timed out after %v waiting for node %s to be unlocked: %w",
 				config.NodeLockRetryTimeout, node.Name, nodelockutil.ErrNodeLockContention)
 		}
+		delay := backoff.Step()
+		if remaining := time.Until(deadline); delay > remaining {
+			delay = remaining
+		}
+		step++
+		klog.V(4).InfoS("Node lock contended, backing off",
+			"node", node.Name, "pod", klog.KObj(pod), "attempt", step, "delay", delay)
 		select {
 		case <-s.stopCh:
 			return fmt.Errorf("scheduler shutting down while waiting for node lock: %w", nodelockutil.ErrNodeLockContention)
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(delay):
 		}
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2285,3 +2285,224 @@ func Test_Bind_PodGroupPodNonContentionErrorDoesNotRetry(t *testing.T) {
 	require.Equal(t, int32(1), mock.lockCalls.Load(),
 		"non-contention error must not trigger retry")
 }
+
+// --- acquireNodeLocks backoff tests ---
+
+// backoffTimingMockDevice records the time of each LockNode call for analysis.
+type backoffTimingMockDevice struct {
+	registerMockDevice
+	lockTimes    []time.Time
+	releaseCalls atomic.Int32
+	succeedAfter int32
+	callCount    atomic.Int32
+}
+
+func (m *backoffTimingMockDevice) CommonWord() string { return "backoff-timing-mock" }
+func (m *backoffTimingMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error {
+	n := m.callCount.Add(1)
+	m.lockTimes = append(m.lockTimes, time.Now())
+	if m.succeedAfter > 0 && n >= m.succeedAfter {
+		return nil
+	}
+	return fmt.Errorf("busy: %w", nodelockutil.ErrNodeLockContention)
+}
+func (m *backoffTimingMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error {
+	m.releaseCalls.Add(1)
+	return nil
+}
+
+func setupAcquireNodeLocksTest(t *testing.T, retryTimeout time.Duration, mock *backoffTimingMockDevice) (*Scheduler, *corev1.Node, *corev1.Pod, func()) {
+	t.Helper()
+
+	oldRetry := config.NodeLockRetryTimeout
+	config.NodeLockRetryTimeout = retryTimeout
+	oldDevicesMap := device.DevicesMap
+	device.DevicesMap = map[string]device.Devices{"backoff-timing-mock": mock}
+
+	s := NewScheduler()
+	cleanup := func() {
+		config.NodeLockRetryTimeout = oldRetry
+		device.DevicesMap = oldDevicesMap
+		close(s.stopCh)
+	}
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-gang", Namespace: "default", UID: types.UID("uid-gang"),
+			Labels: map[string]string{util.PodGroupLabel: "my-training-job"},
+		},
+	}
+	return s, node, pod, cleanup
+}
+
+func TestAcquireNodeLocks_BackoffCap(t *testing.T) {
+	mock := &backoffTimingMockDevice{succeedAfter: 0} // never succeeds
+	s, node, pod, cleanup := setupAcquireNodeLocksTest(t, 5*time.Second, mock)
+	defer cleanup()
+
+	_ = s.acquireNodeLocks(node, pod)
+
+	// Verify no inter-retry gap exceeds the 1s cap + a generous margin for scheduling jitter.
+	// The cap is 1s, jitter adds up to 50% of the computed duration, so max theoretical
+	// sleep is 1.5s. We use 1.8s to account for OS scheduling delays.
+	const maxAllowedGap = 1800 * time.Millisecond
+	for i := 1; i < len(mock.lockTimes); i++ {
+		gap := mock.lockTimes[i].Sub(mock.lockTimes[i-1])
+		require.LessOrEqual(t, gap, maxAllowedGap,
+			"gap between attempt %d and %d was %v, exceeds cap", i-1, i, gap)
+	}
+}
+
+func TestAcquireNodeLocks_BackoffBudget(t *testing.T) {
+	mock := &backoffTimingMockDevice{succeedAfter: 0} // never succeeds
+	s, node, pod, cleanup := setupAcquireNodeLocksTest(t, 3*time.Second, mock)
+	defer cleanup()
+
+	start := time.Now()
+	err := s.acquireNodeLocks(node, pod)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.True(t, nodelockutil.IsNodeLockContention(err))
+
+	// With exponential backoff (100, 200, 400, 800, 1000, 1000, ...) the number of
+	// attempts in 3s should be significantly less than 30 (which fixed 100ms would give).
+	// Exponential: ~100+200+400+800+1000+1000 = ~3.5s worth of sleep in ~6 steps.
+	// Accounting for jitter, expect roughly 5-12 attempts.
+	calls := int(mock.callCount.Load())
+	require.Less(t, calls, 20,
+		"expected fewer than 20 attempts with exponential backoff in 3s, got %d", calls)
+	require.Greater(t, calls, 2,
+		"expected more than 2 attempts, got %d", calls)
+
+	// Elapsed time should be close to the 3s deadline.
+	require.InDelta(t, 3.0, elapsed.Seconds(), 0.5,
+		"elapsed time should be close to the 3s timeout")
+}
+
+func TestAcquireNodeLocks_BackoffDesync(t *testing.T) {
+	// Run multiple acquireNodeLocks calls sequentially and verify that the jitter
+	// produces meaningfully different inter-retry intervals across runs.
+	// This confirms that concurrent pods would desynchronize in practice.
+	const numRuns = 6
+	const retryTimeout = 1500 * time.Millisecond
+
+	type runResult struct {
+		gaps []time.Duration
+	}
+	results := make([]runResult, numRuns)
+
+	for i := range numRuns {
+		mock := &backoffTimingMockDevice{succeedAfter: 0}
+		s, node, pod, cleanup := setupAcquireNodeLocksTest(t, retryTimeout, mock)
+		pod.Name = fmt.Sprintf("pod-%d", i)
+		pod.UID = types.UID(fmt.Sprintf("uid-desync-%d", i))
+
+		_ = s.acquireNodeLocks(node, pod)
+		cleanup()
+
+		var gaps []time.Duration
+		for j := 1; j < len(mock.lockTimes); j++ {
+			gaps = append(gaps, mock.lockTimes[j].Sub(mock.lockTimes[j-1]))
+		}
+		results[i] = runResult{gaps: gaps}
+	}
+
+	// Check that at gap index 2 (the 3rd retry interval, where backoff has grown to ~400ms
+	// base with ±50% jitter), the intervals differ across runs.
+	const checkIdx = 2
+	var intervals []time.Duration
+	for _, r := range results {
+		if len(r.gaps) > checkIdx {
+			intervals = append(intervals, r.gaps[checkIdx])
+		}
+	}
+	if len(intervals) < 3 {
+		t.Skip("not enough data points for desync check")
+	}
+
+	minD, maxD := intervals[0], intervals[0]
+	for _, d := range intervals[1:] {
+		if d < minD {
+			minD = d
+		}
+		if d > maxD {
+			maxD = d
+		}
+	}
+	spread := maxD - minD
+
+	// With 50% jitter on a ~400ms base, the spread across 6 runs should be > 50ms.
+	require.Greater(t, spread, 50*time.Millisecond,
+		"retry intervals at gap %d should vary due to jitter, but spread was only %v (intervals: %v)",
+		checkIdx, spread, intervals)
+}
+
+func BenchmarkAcquireNodeLocksContention(b *testing.B) {
+	for _, numPods := range []int{2, 4, 8, 16} {
+		b.Run(fmt.Sprintf("pods=%d", numPods), func(b *testing.B) {
+			for range b.N {
+				benchAcquireContention(b, numPods)
+			}
+		})
+	}
+}
+
+func benchAcquireContention(b *testing.B, numPods int) {
+	b.Helper()
+
+	oldRetry := config.NodeLockRetryTimeout
+	config.NodeLockRetryTimeout = 10 * time.Second
+	oldDevicesMap := device.DevicesMap
+	defer func() {
+		config.NodeLockRetryTimeout = oldRetry
+		device.DevicesMap = oldDevicesMap
+	}()
+
+	// Simulate a shared node lock: only one pod can hold it at a time.
+	var lockHolder atomic.Int32
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bench-node"}}
+
+	mock := &sharedLockMockDevice{lockHolder: &lockHolder}
+	device.DevicesMap = map[string]device.Devices{"shared-lock-mock": mock}
+
+	done := make(chan struct{})
+	for i := range numPods {
+		go func() {
+			s := NewScheduler()
+			defer close(s.stopCh)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("pod-%d", i), Namespace: "default",
+					UID:    types.UID(fmt.Sprintf("uid-bench-%d", i)),
+					Labels: map[string]string{util.PodGroupLabel: "bench-gang"},
+				},
+			}
+			_ = s.acquireNodeLocks(node, pod)
+			done <- struct{}{}
+		}()
+	}
+	for range numPods {
+		<-done
+	}
+}
+
+// sharedLockMockDevice simulates a real shared lock: only one caller at a time succeeds.
+type sharedLockMockDevice struct {
+	registerMockDevice
+	lockHolder *atomic.Int32
+}
+
+func (m *sharedLockMockDevice) CommonWord() string { return "shared-lock-mock" }
+func (m *sharedLockMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error {
+	if m.lockHolder.CompareAndSwap(0, 1) {
+		return nil
+	}
+	return fmt.Errorf("busy: %w", nodelockutil.ErrNodeLockContention)
+}
+func (m *sharedLockMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error {
+	m.lockHolder.Store(0)
+	return nil
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2461,10 +2462,9 @@ func benchAcquireContention(b *testing.B, numPods int) {
 	}()
 
 	// Simulate a shared node lock: only one pod can hold it at a time.
-	var lockHolder atomic.Int32
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bench-node"}}
 
-	mock := &sharedLockMockDevice{lockHolder: &lockHolder}
+	mock := &sharedLockMockDevice{}
 	device.DevicesMap = map[string]device.Devices{"shared-lock-mock": mock}
 
 	done := make(chan struct{})
@@ -2480,7 +2480,10 @@ func benchAcquireContention(b *testing.B, numPods int) {
 					Labels: map[string]string{util.PodGroupLabel: "bench-gang"},
 				},
 			}
-			_ = s.acquireNodeLocks(node, pod)
+			if err := s.acquireNodeLocks(node, pod); err == nil {
+				time.Sleep(5 * time.Millisecond)
+				s.releaseAllDevices(node, pod)
+			}
 			done <- struct{}{}
 		}()
 	}
@@ -2490,19 +2493,28 @@ func benchAcquireContention(b *testing.B, numPods int) {
 }
 
 // sharedLockMockDevice simulates a real shared lock: only one caller at a time succeeds.
+// Tracks the holder by pod UID so that only the holder can release.
 type sharedLockMockDevice struct {
 	registerMockDevice
-	lockHolder *atomic.Int32
+	mu     sync.Mutex
+	holder types.UID
 }
 
 func (m *sharedLockMockDevice) CommonWord() string { return "shared-lock-mock" }
-func (m *sharedLockMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error {
-	if m.lockHolder.CompareAndSwap(0, 1) {
+func (m *sharedLockMockDevice) LockNode(_ *corev1.Node, pod *corev1.Pod) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.holder == "" || m.holder == pod.UID {
+		m.holder = pod.UID
 		return nil
 	}
 	return fmt.Errorf("busy: %w", nodelockutil.ErrNodeLockContention)
 }
-func (m *sharedLockMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error {
-	m.lockHolder.Store(0)
+func (m *sharedLockMockDevice) ReleaseNodeLock(_ *corev1.Node, pod *corev1.Pod) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.holder == pod.UID {
+		m.holder = ""
+	}
 	return nil
 }


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>This PR changes the pod allocation lock retry strategy from a fixed 100ms delay to an exponential backoff with jitter.</p><p>Under contention, a fixed retry interval causes multiple pods to retry at the same time, increasing API-server load and creating unnecessary contention. Exponential backoff spreads retries over time, reducing synchronized retries and improving allocation latency as the number of contending pods increases.</p><h2>Changes</h2><ul><li><p>Replace the fixed 100ms lock retry interval with exponential backoff.</p></li><li><p>Add jitter to retry delays to reduce synchronized retry behavior.</p></li><li><p>Preserve the existing lock ownership semantics and retry behavior.</p></li><li><p>Update the benchmark to accurately model lock acquisition and release under contention.</p></li></ul><h2>Benchmark Results</h2><p><strong>Update (post-review):</strong> An earlier version of the benchmark had a mock bug where losing pods could clear the winning pod's lock — this was caught by CodeRabbit. After fixing the lock-ownership semantics in the test mock, the corrected results confirm that this is a genuine latency improvement under realistic contention, rather than simply an API-load tradeoff.</p>
Contending pods | Fixed 100ms (before) | Exp backoff (after) | Δ
-- | -- | -- | --
2 | 105.6 ms | 132.5 ms | +25%
4 | 306.5 ms | 255.0 ms | -17%
8 | 708.2 ms | 535.5 ms | -24%
16 | 1,511 ms | 1,163 ms | -23%

<p>The results show that while exponential backoff introduces a small overhead at very low contention (2 pods), it provides a significant latency reduction once contention becomes realistic (4+ pods), with improvements of approximately 17–24%.</p><h2>Why</h2><p>With a fixed retry interval, contending pods tend to retry simultaneously:</p><pre><code class="language-text">Pod A ──retry──retry──retry──retry──&gt;
Pod B ──retry──retry──retry──retry──&gt;
Pod C ──retry──retry──retry──retry──&gt;
</code></pre><p>This creates synchronized bursts of lock requests.</p><p>With exponential backoff and jitter, retries become more distributed:</p><pre><code class="language-text">Pod A ──retry──────retry────────retry──&gt;
Pod B ─────retry────────retry──────────&gt;
Pod C ─────────retry──────retry────────&gt;
</code></pre><p>This reduces contention on the lock/API server and allows the winning pod to make progress with less interference.</p><h2>Testing</h2><ul><li><p>Updated and validated the lock contention benchmark.</p></li><li><p>Fixed the benchmark mock to ensure only the lock owner can release the lock.</p></li><li><p>Verified behavior across multiple contention levels.</p></li><li><p>Confirmed the latency improvement is reproducible under 4+ contending pods.</p></li></ul><p>Fixes #2589</p></body></html>