### PR TITLE
fix(ci): fix invalid golangci-lint version tag v2.12.2 to v1.64.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v1.64.6
           install-mode: goinstall
       - name: import alias
         run: hack/verify-import-aliases.sh

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v2.12.2"
+GOLANGCI_LINT_VER="v1.64.6"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"


### PR DESCRIPTION
### Summary
This PR fixes the invalid `golangci-lint` release version tag `v2.12.2` in both the static check script and CI workflow.

`golangci-lint` uses `v1.x` release version tags (e.g. `v1.64.6`). The tag `v2.12.2` does not exist as a release version for `golangci-lint` (likely confused with the config schema version `"2"` in `.golangci.yaml`), causing installation failures when running static check verification scripts.

### Changes
- Updated `GOLANGCI_LINT_VER="v1.64.6"` in `hack/verify-staticcheck.sh`
- Updated `version: v1.64.6` in `.github/workflows/ci.yaml`

Fixes #2595

Signed-off-by: Kanika0306 

@rootsongjc kindly review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated code quality checks to use a compatible linter version.
  - Synchronized linter verification across continuous integration and local validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->