### PR TITLE
fix(ascend): guard int32 narrowing in GenerateResourceRequests

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -312,6 +313,10 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 		klog.V(3).Infof("Counting %s devices", dev.config.CommonWord)
 		if n, ok := v.AsInt64(); ok {
 			klog.Info("Found AscendDevices devices")
+			if n <= 0 || n > math.MaxInt32 {
+				klog.ErrorS(nil, "ascend device count request is out of range", "container", ctr.Name, "request", n)
+				return device.ContainerDeviceRequest{}
+			}
 			memnum := 0
 			mem, ok := ctr.Resources.Limits[ascendResourceMem]
 			if !ok {
@@ -320,9 +325,24 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 			if ok {
 				memnums, ok := mem.AsInt64()
 				if ok {
+					// Ascend memory is expressed in MB, so a byte-suffixed quantity such as
+					// 16Gi is several orders of magnitude past the int32 request field and is
+					// almost always a wrong-unit mistake rather than a real request.
+					if memnums < 0 || memnums > math.MaxInt32 {
+						klog.ErrorS(nil, "ascend device memory request is out of range; memory unit is treated as MB not Byte, so a quantity such as 16Gi is invalid, request 16384 for 16GB instead",
+							"container", ctr.Name, "request", mem.String(), "device", dev.config.CommonWord)
+						return device.ContainerDeviceRequest{}
+					}
 					if dev.config.MemoryFactor > 1 {
 						rawMemnums := memnums
+						// memnums is already bounded by math.MaxInt32 and MemoryFactor is an
+						// int32, so this product cannot overflow int64 before it is checked.
 						memnums = memnums * int64(dev.config.MemoryFactor)
+						if memnums > math.MaxInt32 {
+							klog.ErrorS(nil, "ascend device memory request overflows int32 after applying memory factor; memory unit is treated as MB not Byte",
+								"container", ctr.Name, "raw", rawMemnums, "scaled", memnums, "factor", dev.config.MemoryFactor)
+							return device.ContainerDeviceRequest{}
+						}
 						klog.V(4).Infof("Update Ascend memory request. before %d, after %d, factor %d", rawMemnums, memnums, dev.config.MemoryFactor)
 					}
 					// If "core" is requested, it explicitly indicates the use of soft-partitioning.
@@ -347,10 +367,17 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 			// Process Core Resources
 			corenum := int32(0)
 			if ascendResourceCore != "" {
-				if cv, ok := ctr.Resources.Limits[ascendResourceCore]; ok {
-					corenum = int32(cv.Value())
-				} else if cv, ok := ctr.Resources.Requests[ascendResourceCore]; ok {
-					corenum = int32(cv.Value())
+				cv, ok := ctr.Resources.Limits[ascendResourceCore]
+				if !ok {
+					cv, ok = ctr.Resources.Requests[ascendResourceCore]
+				}
+				if ok {
+					corenums := cv.Value()
+					if corenums < 0 || corenums > math.MaxInt32 {
+						klog.ErrorS(nil, "ascend device core request is out of range", "container", ctr.Name, "request", cv.String())
+						return device.ContainerDeviceRequest{}
+					}
+					corenum = int32(corenums)
 				}
 			}
 

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -323,20 +323,22 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 				mem, ok = ctr.Resources.Requests[ascendResourceMem]
 			}
 			if ok {
+				// Negative quantities such as -1m return ok=false from AsInt64, so reject by sign first.
+				if mem.Sign() < 0 {
+					klog.ErrorS(nil, "ascend device memory request is negative", "container", ctr.Name, "request", mem.String(), "device", dev.config.CommonWord)
+					return device.ContainerDeviceRequest{}
+				}
 				memnums, ok := mem.AsInt64()
 				if ok {
-					// Ascend memory is expressed in MB, so a byte-suffixed quantity such as
-					// 16Gi is several orders of magnitude past the int32 request field and is
-					// almost always a wrong-unit mistake rather than a real request.
-					if memnums < 0 || memnums > math.MaxInt32 {
+					// Ascend memory is in MB, so an over-int32 value such as a byte quantity 16Gi is a wrong-unit mistake.
+					if memnums > math.MaxInt32 {
 						klog.ErrorS(nil, "ascend device memory request is out of range; memory unit is treated as MB not Byte, so a quantity such as 16Gi is invalid, request 16384 for 16GB instead",
 							"container", ctr.Name, "request", mem.String(), "device", dev.config.CommonWord)
 						return device.ContainerDeviceRequest{}
 					}
 					if dev.config.MemoryFactor > 1 {
 						rawMemnums := memnums
-						// memnums is already bounded by math.MaxInt32 and MemoryFactor is an
-						// int32, so this product cannot overflow int64 before it is checked.
+						// memnums is bounded by math.MaxInt32 and MemoryFactor is int32, so this product cannot overflow int64.
 						memnums = memnums * int64(dev.config.MemoryFactor)
 						if memnums > math.MaxInt32 {
 							klog.ErrorS(nil, "ascend device memory request overflows int32 after applying memory factor; memory unit is treated as MB not Byte",

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1439,13 +1439,8 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 	}
 }
 
-// Test_GenerateResourceRequests_OutOfRangeValues covers requests whose values do
-// not fit the int32 fields of ContainerDeviceRequest. Before the range guards
-// these narrowed silently: a byte-suffixed memory quantity such as 16Gi wrapped
-// to 0 on the soft-partitioning path, which made the scheduler's memory fit
-// check pass against any device.
+// Test_GenerateResourceRequests_OutOfRangeValues checks that out-of-range values are rejected, not silently wrapped.
 func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
-	// Soft-partitioning (a core request) uses the raw memory value instead of trimming, which is where the int32 wrap happened.
 	coreModeConfig := VNPUConfig{
 		CommonWord:         "Ascend910B3",
 		ResourceName:       "huawei.com/Ascend910B3",
@@ -1462,8 +1457,7 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 		want device.ContainerDeviceRequest
 	}{
 		{
-			// 16Gi is 17179869184, which wrapped to 0 when narrowed to int32.
-			// Ascend memory is denominated in MB, so this is a wrong-unit request.
+			// 16Gi in bytes wraps to 0 when narrowed to int32; Ascend memory is counted in MB.
 			name: "memory requested in bytes exceeds int32 range on soft-partitioning path",
 			dev:  Devices{config: coreModeConfig},
 			args: corev1.Container{
@@ -1491,7 +1485,7 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 			want: device.ContainerDeviceRequest{},
 		},
 		{
-			// -1m returns ok=false from AsInt64, so it must be rejected by sign before defaulting to a 100% request.
+			// -1m makes AsInt64 return ok=false, so it must be rejected by sign, not defaulted to 100%.
 			name: "negative fractional memory request",
 			dev:  Devices{config: coreModeConfig},
 			args: corev1.Container{
@@ -1551,8 +1545,7 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 	}
 }
 
-// Test_GenerateResourceRequests_MemoryFactorOverflow covers a raw memory value that
-// fits in int32 but overflows once MemoryFactor is applied (300000000 * 10 > math.MaxInt32).
+// Test_GenerateResourceRequests_MemoryFactorOverflow covers a value that fits int32 but overflows after MemoryFactor.
 func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1560,8 +1553,6 @@ func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
 		args corev1.Container
 	}{
 		{
-			// Soft-partitioning keeps the scaled value, so this narrowed to a
-			// negative Memreq before the guard.
 			name: "scaled memory overflows int32 on soft-partitioning path",
 			dev: Devices{
 				config: VNPUConfig{

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1499,6 +1499,20 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 			want: device.ContainerDeviceRequest{},
 		},
 		{
+			// A plain whole -100 passes AsInt64 (ok=true), so it must be rejected by sign before the int32 narrowing.
+			name: "negative whole memory request",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("-100"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
 			name: "oversized device count exceeds int32 range",
 			dev:  Devices{config: coreModeConfig},
 			args: corev1.Container{

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1439,6 +1439,170 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 	}
 }
 
+// Test_GenerateResourceRequests_OutOfRangeValues covers requests whose values do
+// not fit the int32 fields of ContainerDeviceRequest. Before the range guards
+// these narrowed silently: a byte-suffixed memory quantity such as 16Gi wrapped
+// to 0 on the soft-partitioning path, which made the scheduler's memory fit
+// check pass against any device.
+func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
+	// Soft-partitioning layout: requesting a core count makes
+	// GenerateResourceRequests use the raw memory value instead of trimming it
+	// to a template, which is where the int32 wrap used to happen.
+	coreModeConfig := VNPUConfig{
+		CommonWord:         "Ascend910B3",
+		ResourceName:       "huawei.com/Ascend910B3",
+		ResourceCoreName:   "huawei.com/Ascend910B3-core",
+		ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+		MemoryAllocatable:  int64(65536),
+		MemoryCapacity:     int64(65536),
+	}
+
+	tests := []struct {
+		name string
+		dev  Devices
+		args corev1.Container
+		want device.ContainerDeviceRequest
+	}{
+		{
+			// 16Gi is 17179869184, which wrapped to 0 when narrowed to int32.
+			// Ascend memory is denominated in MB, so this is a wrong-unit request.
+			name: "memory requested in bytes exceeds int32 range on soft-partitioning path",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core":   resource.MustParse("10"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "memory requested in bytes exceeds int32 range on trim path",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized device count exceeds int32 range",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3": resource.MustParse("2200000000"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "negative core request",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":      resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core": resource.MustParse("-1"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized core request exceeds int32 range",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":      resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core": resource.MustParse("2200000000"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.dev.GenerateResourceRequests(&test.args)
+			assert.Equal(t, result, test.want)
+		})
+	}
+}
+
+// Test_GenerateResourceRequests_MemoryFactorOverflow covers a raw memory request
+// that fits in int32 on its own but overflows once MemoryFactor is applied.
+// 300000000 fits in int32, but 300000000 * 10 exceeds math.MaxInt32.
+func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
+	tests := []struct {
+		name string
+		dev  Devices
+		args corev1.Container
+	}{
+		{
+			// Soft-partitioning keeps the scaled value, so this narrowed to a
+			// negative Memreq before the guard.
+			name: "scaled memory overflows int32 on soft-partitioning path",
+			dev: Devices{
+				config: VNPUConfig{
+					CommonWord:         "Ascend910B3",
+					ResourceName:       "huawei.com/Ascend910B3",
+					ResourceCoreName:   "huawei.com/Ascend910B3-core",
+					ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+					MemoryAllocatable:  int64(65536),
+					MemoryCapacity:     int64(65536),
+					MemoryFactor:       int32(10),
+				},
+			},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-core":   resource.MustParse("10"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("300000000"),
+					},
+				},
+			},
+		},
+		{
+			name: "scaled memory overflows int32 on trim path",
+			dev: Devices{
+				config: VNPUConfig{
+					CommonWord:         "Ascend910A",
+					ResourceName:       "huawei.com/Ascend910A",
+					ResourceMemoryName: "huawei.com/Ascend910A-memory",
+					MemoryAllocatable:  int64(32768),
+					MemoryCapacity:     int64(32768),
+					MemoryFactor:       int32(10),
+				},
+			},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910A":        resource.MustParse("1"),
+						"huawei.com/Ascend910A-memory": resource.MustParse("300000000"),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.dev.GenerateResourceRequests(&test.args)
+			assert.Equal(t, result, device.ContainerDeviceRequest{})
+		})
+	}
+}
+
 func TestDevices_LockNode(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1445,9 +1445,7 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 // to 0 on the soft-partitioning path, which made the scheduler's memory fit
 // check pass against any device.
 func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
-	// Soft-partitioning layout: requesting a core count makes
-	// GenerateResourceRequests use the raw memory value instead of trimming it
-	// to a template, which is where the int32 wrap used to happen.
+	// Soft-partitioning (a core request) uses the raw memory value instead of trimming, which is where the int32 wrap happened.
 	coreModeConfig := VNPUConfig{
 		CommonWord:         "Ascend910B3",
 		ResourceName:       "huawei.com/Ascend910B3",
@@ -1487,6 +1485,20 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 					Limits: corev1.ResourceList{
 						"huawei.com/Ascend910B3":        resource.MustParse("1"),
 						"huawei.com/Ascend910B3-memory": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			// -1m returns ok=false from AsInt64, so it must be rejected by sign before defaulting to a 100% request.
+			name: "negative fractional memory request",
+			dev:  Devices{config: coreModeConfig},
+			args: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"huawei.com/Ascend910B3":        resource.MustParse("1"),
+						"huawei.com/Ascend910B3-memory": resource.MustParse("-1m"),
 					},
 				},
 			},
@@ -1539,9 +1551,8 @@ func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
 	}
 }
 
-// Test_GenerateResourceRequests_MemoryFactorOverflow covers a raw memory request
-// that fits in int32 on its own but overflows once MemoryFactor is applied.
-// 300000000 fits in int32, but 300000000 * 10 exceeds math.MaxInt32.
+// Test_GenerateResourceRequests_MemoryFactorOverflow covers a raw memory value that
+// fits in int32 but overflows once MemoryFactor is applied (300000000 * 10 > math.MaxInt32).
 func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`GenerateResourceRequests` in the ascend backend converts user-controlled `int64` resource limits (device count, memory, cores) into the `int32` fields of `ContainerDeviceRequest` (`Nums`, `Memreq`, `Coresreq`) without bounds checking. A value exceeding `math.MaxInt32` silently wraps to a small or negative number that flows into `Fit()`. A memory request that wraps to 0 makes the `Fit()` check (`Totalmem - Usedmem < memreq`) always pass, so the scheduler can place a pod onto an already-full NPU, causing oversubscription and OOM for other workloads on the same card.

This PR adds range guards that return the existing empty `ContainerDeviceRequest{}` rejection sentinel before every `int32()` narrowing, matching the pattern from #2388 (hygon, metax-sgpu). Memory is guarded both before and after the `MemoryFactor` multiplication, covering the soft-partitioning path (raw value) and the `trimMemory` path.

**Which issue(s) this PR fixes**:
Fixes #2600

**Special notes for your reviewer**:

- Guards four conversion points: device count, memory pre-factor, memory post-factor (after `MemoryFactor` scaling), and cores.
- After studying #2285, I followed the maintainer's suggestion there that an over-int32 memory value on ascend is almost always a wrong-unit mistake (for example `16Gi` instead of an integer number of MB). The memory error messages state that Ascend memory is treated as MB not Byte, and that `16384` should be requested for 16 GB.
- Scope is the int32 overflow case only, matching #2388. It does not address #2532 (an over-capacity-but-within-int32 case where `trimMemory` returns 0), which is below `math.MaxInt32` and out of scope here.
- Tests cover pre-factor overflow (`16Gi` on both the soft-partitioning and trim paths), post-factor overflow after `MemoryFactor`, oversized device count, and negative and oversized core requests. Each was confirmed to fail before the guard and pass after.
- Change is scoped to the scheduler extender, so unit tests are used rather than on-hardware validation, consistent with #2388.

**Does this PR introduce a user-facing change?**:

```
Oversized or invalid Ascend device resource requests (for example an ascend memory request such as 16Gi, or values exceeding the int32 range) are now rejected instead of silently wrapping to an incorrect value.
```

AI assistance disclosure: I used AI assistance (Claude Code) to help audit the backends, implement the guards, and draft the regression tests. I reviewed the change and verified the new tests fail without the guards and pass with them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of device, memory, and core resource requests.
  * Invalid, negative, or oversized values are now rejected safely.
  * Prevented errors caused by memory scaling exceeding supported limits.

* **Tests**
  * Added coverage for invalid resource values and overflow scenarios across supported request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->