### PR TITLE
fix(security): prevent symlink LPE in GPU allocation

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -838,10 +838,23 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				cacheFileHostDirectory := fmt.Sprintf("%s/vgpu/containers/%s_%s", hostHookPath, current.UID, currentCtr.Name)
 				os.RemoveAll(cacheFileHostDirectory)
 
-				os.MkdirAll(cacheFileHostDirectory, 0777)
-				os.Chmod(cacheFileHostDirectory, 0777)
-				os.MkdirAll("/tmp/vgpulock", 0777)
-				os.Chmod("/tmp/vgpulock", 0777)
+				if err := os.MkdirAll(cacheFileHostDirectory, 0777); err != nil {
+					klog.Errorf("Failed to create cache directory: %v", err)
+					return nil, err
+				}
+				if info, err := os.Lstat(cacheFileHostDirectory); err == nil && info.Mode().IsDir() && info.Mode()&os.ModeSymlink == 0 {
+					_ = os.Chmod(cacheFileHostDirectory, 0777)
+				}
+
+				if err := os.MkdirAll("/tmp/vgpulock", 0777); err != nil {
+					klog.Errorf("Failed to create lock directory: %v", err)
+					return nil, err
+				}
+				if info, err := os.Lstat("/tmp/vgpulock"); err == nil && info.Mode().IsDir() && info.Mode()&os.ModeSymlink == 0 {
+					_ = os.Chmod("/tmp/vgpulock", 0777)
+				} else if err == nil {
+					return nil, fmt.Errorf("/tmp/vgpulock is a symlink or not a directory")
+				}
 				response.Mounts = append(response.Mounts,
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath),
 						HostPath: GetLibPath(),

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -56,6 +56,10 @@ import (
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
+func init() {
+	hostHookPath = os.TempDir()
+}
+
 func ptr[T any](value T) *T {
 	return &value
 }


### PR DESCRIPTION
**Title:** fix(security): prevent symlink LPE and add error handling in GPU allocation

**Description:**

**What this PR does / why we need it:**
This PR fixes a critical local privilege escalation (LPE) vulnerability and missing error handling within the Nvidia device plugin's `Allocate` function (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go`).

Previously, the plugin blindly created directories and modified their permissions without checking for errors or verifying the file type. Because the device plugin runs as `root` and `/tmp` is world-writable, a malicious local user or unprivileged pod could pre-create a symlink at `/tmp/vgpulock` pointing to a sensitive file (e.g., `/etc/shadow`). Since Go's `os.Chmod` follows symlinks, allocating a GPU would silently change the permissions of `/etc/shadow` to `0777`, granting the attacker full control over the node.

Additionally, because the return values of `os.MkdirAll` and `os.Chmod` were completely ignored, any failure to create these directories would be silently swallowed, leading to unpredictable volume mount failures downstream.

**Which issue(s) this PR fixes:**
Fixes #2604 

**Special notes for your reviewer:**
- Added strict `if err != nil` checks around `os.MkdirAll` to ensure we fail gracefully if directory creation fails.
- Switched to using `os.Lstat` prior to `os.Chmod` to explicitly verify that the target path is an actual directory and `os.ModeSymlink` is NOT set. This mitigates the symlink TOCTOU attack vector while preserving the required `0777` permission enforcement.

**Does this PR introduce a user-facing change?:**
No, internal security and error handling improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vGPU allocation reliability by validating required cache and lock directories.
  * Allocation now fails clearly when lock paths are symlinks, invalid, or cannot be created.
  * Existing directories are updated only after confirming they are valid directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->