### PR TITLE
fix(server): preserve per-container device index in Kunlun/Mthreads P…

### DIFF
--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -91,15 +91,21 @@ func (dev *KunlunDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[strin
 	devlist, ok := pd[KunlunGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[KunlunGPUDevice]] = device.EncodePodSingleDevice(devlist)
+		annoKey := KunlunDeviceSelection
+		var values []string
 		for _, dp := range devlist {
-			annoKey := KunlunDeviceSelection
 			value := ""
 			for _, val := range dp {
 				value = value + fmt.Sprint(val.Idx) + ","
 			}
 			if len(value) > 0 {
-				(*annoinput)[annoKey] = strings.TrimRight(value, ",")
+				values = append(values, strings.TrimRight(value, ","))
+			} else {
+				values = append(values, "")
 			}
+		}
+		if len(values) > 0 {
+			(*annoinput)[annoKey] = strings.Join(values, device.OnePodMultiContainerSplitSymbol)
 		}
 	}
 	return *annoinput

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -516,7 +516,7 @@ func TestKunlunDevices_PatchAnnotations(t *testing.T) {
 	dev := &KunlunDevices{}
 	pod := &corev1.Pod{}
 	anno := map[string]string{}
-	
+
 	// Test multi-container encoding
 	pd := device.PodDevices{
 		KunlunGPUDevice: {
@@ -525,14 +525,14 @@ func TestKunlunDevices_PatchAnnotations(t *testing.T) {
 			{},         // Container 3 (empty)
 		},
 	}
-	
+
 	dev.PatchAnnotations(pod, &anno, pd)
-	
+
 	val, ok := anno[KunlunDeviceSelection]
 	if !ok {
 		t.Fatalf("expected annotation %s to be set", KunlunDeviceSelection)
 	}
-	
+
 	expected := "0;1;"
 	if val != expected {
 		t.Errorf("expected %s, got %s", expected, val)

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -511,3 +511,30 @@ func Test_ScoreNode(t *testing.T) {
 		})
 	}
 }
+
+func TestKunlunDevices_PatchAnnotations(t *testing.T) {
+	dev := &KunlunDevices{}
+	pod := &corev1.Pod{}
+	anno := map[string]string{}
+	
+	// Test multi-container encoding
+	pd := device.PodDevices{
+		KunlunGPUDevice: {
+			{{Idx: 0}}, // Container 1
+			{{Idx: 1}}, // Container 2
+			{},         // Container 3 (empty)
+		},
+	}
+	
+	dev.PatchAnnotations(pod, &anno, pd)
+	
+	val, ok := anno[KunlunDeviceSelection]
+	if !ok {
+		t.Fatalf("expected annotation %s to be set", KunlunDeviceSelection)
+	}
+	
+	expected := "0;1;"
+	if val != expected {
+		t.Errorf("expected %s, got %s", expected, val)
+	}
+}

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -512,6 +512,8 @@ func Test_ScoreNode(t *testing.T) {
 	}
 }
 
+// TestKunlunDevices_PatchAnnotations tests the PatchAnnotations function for Kunlun devices
+// to ensure that it correctly encodes multi-container device indices.
 func TestKunlunDevices_PatchAnnotations(t *testing.T) {
 	dev := &KunlunDevices{}
 	pod := &corev1.Pod{}

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -156,20 +156,24 @@ func (dev *MthreadsDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[str
 	devlist, ok := pd[MthreadsGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[MthreadsGPUDevice]] = device.EncodePodSingleDevice(devlist)
+		var values []string
 		for _, dp := range devlist {
-			if len(dp) > 0 {
-				value := ""
-				for _, val := range dp {
-					value = value + fmt.Sprint(val.Idx) + ","
-				}
-				if len(value) > 0 {
-					(*annoinput)[MthreadsAssignedGPUIndex] = strings.TrimRight(value, ",")
-					//(*annoinput)[MthreadsAssignedNode]=
-					tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
-					(*annoinput)[MthreadsPredicateTime] = tmp
-					(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
-				}
+			value := ""
+			for _, val := range dp {
+				value = value + fmt.Sprint(val.Idx) + ","
 			}
+			if len(value) > 0 {
+				values = append(values, strings.TrimRight(value, ","))
+			} else {
+				values = append(values, "")
+			}
+		}
+		if len(values) > 0 {
+			(*annoinput)[MthreadsAssignedGPUIndex] = strings.Join(values, device.OnePodMultiContainerSplitSymbol)
+			//(*annoinput)[MthreadsAssignedNode]=
+			tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
+			(*annoinput)[MthreadsPredicateTime] = tmp
+			(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
 		}
 	}
 	klog.Infoln("annoinput", (*annoinput))

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -1207,5 +1208,42 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMthreadsDevices_PatchAnnotations(t *testing.T) {
+	dev := &MthreadsDevices{}
+	pod := &corev1.Pod{}
+	anno := map[string]string{
+		util.AssignedNodeAnnotations: "test-node",
+	}
+	
+	// Test multi-container encoding with middle-empty and trailing-empty container groups
+	pd := device.PodDevices{
+		MthreadsGPUDevice: {
+			{{Idx: 0}}, // Container 1
+			{{Idx: 1}}, // Container 2
+			{},         // Container 3 (empty)
+		},
+	}
+	
+	dev.PatchAnnotations(pod, &anno, pd)
+	
+	val, ok := anno[MthreadsAssignedGPUIndex]
+	if !ok {
+		t.Fatalf("expected annotation %s to be set", MthreadsAssignedGPUIndex)
+	}
+	
+	expected := "0;1;"
+	if val != expected {
+		t.Errorf("expected %s, got %s", expected, val)
+	}
+	
+	if anno[MthreadsPredicateTime] == "" {
+		t.Errorf("expected %s to be non-empty", MthreadsPredicateTime)
+	}
+	
+	if anno[MthreadsAssignedNode] != "test-node" {
+		t.Errorf("expected %s to be propagated, got %s", MthreadsAssignedNode, anno[MthreadsAssignedNode])
 	}
 }

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -1217,7 +1217,7 @@ func TestMthreadsDevices_PatchAnnotations(t *testing.T) {
 	anno := map[string]string{
 		util.AssignedNodeAnnotations: "test-node",
 	}
-	
+
 	// Test multi-container encoding with middle-empty and trailing-empty container groups
 	pd := device.PodDevices{
 		MthreadsGPUDevice: {
@@ -1226,23 +1226,23 @@ func TestMthreadsDevices_PatchAnnotations(t *testing.T) {
 			{},         // Container 3 (empty)
 		},
 	}
-	
+
 	dev.PatchAnnotations(pod, &anno, pd)
-	
+
 	val, ok := anno[MthreadsAssignedGPUIndex]
 	if !ok {
 		t.Fatalf("expected annotation %s to be set", MthreadsAssignedGPUIndex)
 	}
-	
+
 	expected := "0;1;"
 	if val != expected {
 		t.Errorf("expected %s, got %s", expected, val)
 	}
-	
+
 	if anno[MthreadsPredicateTime] == "" {
 		t.Errorf("expected %s to be non-empty", MthreadsPredicateTime)
 	}
-	
+
 	if anno[MthreadsAssignedNode] != "test-node" {
 		t.Errorf("expected %s to be propagated, got %s", MthreadsAssignedNode, anno[MthreadsAssignedNode])
 	}

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -1211,6 +1211,8 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 	}
 }
 
+// TestMthreadsDevices_PatchAnnotations tests the PatchAnnotations function for Mthreads devices
+// to ensure that it correctly encodes multi-container device indices and propagates annotations.
 func TestMthreadsDevices_PatchAnnotations(t *testing.T) {
 	dev := &MthreadsDevices{}
 	pod := &corev1.Pod{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a pod has multiple containers requesting Kunlun or Mthreads GPUs, the `PatchAnnotations` function was mistakenly resetting the device index string inside the container loop. Because of this, the pod's annotation was being overwritten on every iteration, leaving only the GPUs assigned to the very last container.
This patch simply moves the string initialization outside the loop so it correctly collects and joins the indices across all the containers in the pod instead of overwriting them.

**Which issue(s) this PR fixes**:
Fixes #2463

**Special notes for your reviewer**:
I saw the previous PR for this was closed due to missing the DCO sign-off and bot reply rules, so I picked it up and made sure my commits are signed properly. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device assignment metadata for Kunlun devices when multiple device groups are used.
  * Fixed GPU assignment metadata for MThreads devices so allocations from all groups are retained.
  * Preserved empty device groups correctly while preventing incomplete or overwritten assignment information.
  * Ensured related assignment details continue to be recorded consistently when devices are assigned across multiple containers.
  * Improved reliability of multi-device allocation tracking and scheduling metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->