### PR TITLE
fix(device-plugin): make MigInstanceManager own its NVML init/shutdown

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
@@ -97,6 +97,10 @@ func profileSliceKey(profile string) string {
 // have MIG mode enabled and all existing GI/CI instances destroyed.
 func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct{}) ([]int, error) {
 	reset := []int{}
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return reset, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	defer nvml.Shutdown()
 	for gpuIndex := 0; gpuIndex < deviceCount; gpuIndex++ {
 		if _, busy := inUse[gpuIndex]; busy {
 			continue
@@ -284,6 +288,10 @@ func (m *MigInstanceManager) Release(migUUID string) error {
 	lk := m.gpuLock(key.GPUIndex)
 	lk.Lock()
 	defer lk.Unlock()
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	defer nvml.Shutdown()
 	m.mu.Lock()
 	inst := m.byAllocation[key]
 	m.mu.Unlock()
@@ -321,6 +329,11 @@ func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, plac
 		return uuid, false, nil
 	}
 	m.mu.Unlock()
+
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return "", false, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	defer nvml.Shutdown()
 
 	if err := ensureMigModeEnabled(gpuIndex); err != nil {
 		return "", false, err
@@ -417,6 +430,10 @@ func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID stri
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
 	defer lk.Unlock()
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	defer nvml.Shutdown()
 	dev, err := deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
@@ -476,6 +493,13 @@ func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocation
 		keys = append(keys, key)
 	}
 	m.mu.Unlock()
+	if len(keys) == 0 {
+		return nil
+	}
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	defer nvml.Shutdown()
 	for _, key := range keys {
 		if _, ok := active[key]; ok {
 			continue

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
@@ -59,6 +59,9 @@ type migInstance struct {
 
 // MigInstanceManager is the single authority over live MIG GI+CI state on a
 // node. Keys are the scheduler-reserved profile and physical placement.
+//
+// Callers must invoke Init once before using other methods, and Shutdown
+// once when done; NVML is not re-initialized per call.
 type MigInstanceManager struct {
 	mu                  sync.Mutex
 	gpuLocks            map[int]*sync.Mutex
@@ -71,6 +74,24 @@ func NewMigInstanceManager() *MigInstanceManager {
 		gpuLocks:            make(map[int]*sync.Mutex),
 		byAllocation:        make(map[migAllocationKey]*migInstance),
 		byAllocationMigUUID: make(map[string]migAllocationKey),
+	}
+}
+
+// Init initializes NVML for this manager. It must be called exactly once,
+// before any other MigInstanceManager method, and paired with a single
+// later call to Shutdown.
+func (m *MigInstanceManager) Init() error {
+	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	}
+	return nil
+}
+
+// Shutdown releases the NVML session acquired by Init. Safe to call once,
+// when the manager is no longer needed.
+func (m *MigInstanceManager) Shutdown() {
+	if nvret := nvml.Shutdown(); nvret != nvml.SUCCESS {
+		klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(nvret)), "nvml Shutdown failed")
 	}
 }
 
@@ -95,12 +116,10 @@ func profileSliceKey(profile string) string {
 // ResetIdleGPUs prepares idle MIG-capable GPUs for on-demand instance creation
 // through NVML. Busy GPUs are left untouched; idle GPUs
 // have MIG mode enabled and all existing GI/CI instances destroyed.
+//
+// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct{}) ([]int, error) {
 	reset := []int{}
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return reset, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
-	}
-	defer nvml.Shutdown()
 	for gpuIndex := 0; gpuIndex < deviceCount; gpuIndex++ {
 		if _, busy := inUse[gpuIndex]; busy {
 			continue
@@ -277,6 +296,8 @@ func destroyAllMigInstances(dev nvml.Device) error {
 }
 
 // Release destroys the GI+CI bound to the given MIG UUID.
+//
+// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) Release(migUUID string) error {
 	m.mu.Lock()
 	key, ok := m.byAllocationMigUUID[migUUID]
@@ -288,10 +309,6 @@ func (m *MigInstanceManager) Release(migUUID string) error {
 	lk := m.gpuLock(key.GPUIndex)
 	lk.Lock()
 	defer lk.Unlock()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
-	}
-	defer nvml.Shutdown()
 	m.mu.Lock()
 	inst := m.byAllocation[key]
 	m.mu.Unlock()
@@ -316,6 +333,8 @@ func allocationKey(gpuIndex int, profile string, placement nvml.GpuInstancePlace
 // placement. It returns whether this call created the instance, allowing the
 // caller to roll back only its own partial allocation. It never retries
 // another placement.
+//
+// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) (string, bool, error) {
 	key := allocationKey(gpuIndex, profile, placement)
 	lk := m.gpuLock(gpuIndex)
@@ -329,11 +348,6 @@ func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, plac
 		return uuid, false, nil
 	}
 	m.mu.Unlock()
-
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return "", false, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
-	}
-	defer nvml.Shutdown()
 
 	if err := ensureMigModeEnabled(gpuIndex); err != nil {
 		return "", false, err
@@ -426,14 +440,11 @@ func (m *MigInstanceManager) AllocationRuntimeInfo(gpuIndex int, profile string,
 	}, true
 }
 
+// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID string, placement nvml.GpuInstancePlacement, gpuInstanceID, computeInstanceID uint32) error {
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
 	defer lk.Unlock()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
-	}
-	defer nvml.Shutdown()
 	dev, err := deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
@@ -486,6 +497,7 @@ func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID stri
 	return fmt.Errorf("annotated MIG allocation %s profile=%s placement=%+v is not live", migUUID, profile, placement)
 }
 
+// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocationKey]struct{}) error {
 	m.mu.Lock()
 	keys := make([]migAllocationKey, 0, len(m.byAllocation))
@@ -496,10 +508,6 @@ func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocation
 	if len(keys) == 0 {
 		return nil
 	}
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
-	}
-	defer nvml.Shutdown()
 	for _, key := range keys {
 		if _, ok := active[key]; ok {
 			continue

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
@@ -116,8 +116,6 @@ func profileSliceKey(profile string) string {
 // ResetIdleGPUs prepares idle MIG-capable GPUs for on-demand instance creation
 // through NVML. Busy GPUs are left untouched; idle GPUs
 // have MIG mode enabled and all existing GI/CI instances destroyed.
-//
-// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct{}) ([]int, error) {
 	reset := []int{}
 	for gpuIndex := 0; gpuIndex < deviceCount; gpuIndex++ {
@@ -296,8 +294,6 @@ func destroyAllMigInstances(dev nvml.Device) error {
 }
 
 // Release destroys the GI+CI bound to the given MIG UUID.
-//
-// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) Release(migUUID string) error {
 	m.mu.Lock()
 	key, ok := m.byAllocationMigUUID[migUUID]
@@ -333,8 +329,6 @@ func allocationKey(gpuIndex int, profile string, placement nvml.GpuInstancePlace
 // placement. It returns whether this call created the instance, allowing the
 // caller to roll back only its own partial allocation. It never retries
 // another placement.
-//
-// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) (string, bool, error) {
 	key := allocationKey(gpuIndex, profile, placement)
 	lk := m.gpuLock(gpuIndex)
@@ -440,7 +434,6 @@ func (m *MigInstanceManager) AllocationRuntimeInfo(gpuIndex int, profile string,
 	}, true
 }
 
-// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID string, placement nvml.GpuInstancePlacement, gpuInstanceID, computeInstanceID uint32) error {
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
@@ -497,7 +490,6 @@ func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID stri
 	return fmt.Errorf("annotated MIG allocation %s profile=%s placement=%+v is not live", migUUID, profile, placement)
 }
 
-// Requires NVML already initialized via Init.
 func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocationKey]struct{}) error {
 	m.mu.Lock()
 	keys := make([]migAllocationKey, 0, len(m.byAllocation))
@@ -505,9 +497,6 @@ func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocation
 		keys = append(keys, key)
 	}
 	m.mu.Unlock()
-	if len(keys) == 0 {
-		return nil
-	}
 	for _, key := range keys {
 		if _, ok := active[key]; ok {
 			continue

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -193,6 +193,9 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 	var migMgr *MigInstanceManager
 	if mode == "mig" {
 		migMgr = NewMigInstanceManager()
+		if err := migMgr.Init(); err != nil {
+			return nil, fmt.Errorf("init MIG instance manager: %w", err)
+		}
 	}
 	return &NvidiaDevicePlugin{
 		ctx:                        ctx,
@@ -340,6 +343,13 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		// reconcile the manager with live Pods so completed or deleted Pods
 		// release their exact profile+placement allocation.
 		go plugin.runMigAnnotationReconciler(5 * time.Second)
+		// The manager's NVML session is owned by the plugin's lifetime, not
+		// by individual Start/Stop cycles (Stop only restarts the gRPC
+		// server); release it once when the plugin is finally torn down.
+		go func() {
+			<-plugin.ctx.Done()
+			plugin.migMgr.Shutdown()
+		}()
 	}
 
 	return nil


### PR DESCRIPTION
## What this does

`MigInstanceManager` (migmgr.go) makes raw NVML calls in several of its methods but never calls `nvml.Init()` itself. It only works today because `nvmlBusyGPUs()` (mig_startup.go) happens to leave NVML initialized at startup and never shuts it down an implicit, undocumented dependency on that leak.

This PR makes `MigInstanceManager` self-contained: each public entry point that touches NVML (`ResetIdleGPUs`, `Release`, `EnsureAllocation`, `AdoptAllocation`, `ReconcileActiveAllocations`) now brackets its own `nvml.Init()` / `defer nvml.Shutdown()`, matching the self-contained convention used everywhere else in this package (e.g. `util.go`).

NVML's `Init`/`Shutdown` pair is reference-counted per-process, so this is safe to call independently alongside other NVML users in the same process without tearing down a session another caller still needs.

## Why

Found while reviewing the MIG refactor (#2378). Once the companion leak in `mig_startup.go`'s `gpuUUIDToIndex` / `nvmlBusyGPUs` is fixed to properly call `nvml.Shutdown()`, `MigInstanceManager` would start failing with "NVML not initialized" since it never initializes NVML on its own. This PR removes that hidden coupling first.
Discussed in #2246.

## Testing

- `go build ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/...`
- `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -short --race -count=1`

AI disclosure: AI was used for exploring possible approaches to identify an appropriate solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved reliability of GPU partition (MIG) allocation and cleanup operations.
- Improved handling of GPU resource adoption, release, reset, and recovery workflows.
- Reconciliation now skips unnecessary processing when no active allocations are present.
- Systems report GPU management initialization failures more clearly.
- Improved resource management across service restarts and final shutdown.
- GPU management sessions now remain available across service restarts and are released cleanly during final shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->