### PR TITLE
fix kunlun and mthreads device index tracking for multi-container pods

### DIFF
--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -91,15 +91,21 @@ func (dev *KunlunDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[strin
 	devlist, ok := pd[KunlunGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[KunlunGPUDevice]] = device.EncodePodSingleDevice(devlist)
+		annoKey := KunlunDeviceSelection
+		var values []string
 		for _, dp := range devlist {
-			annoKey := KunlunDeviceSelection
 			value := ""
 			for _, val := range dp {
 				value = value + fmt.Sprint(val.Idx) + ","
 			}
 			if len(value) > 0 {
-				(*annoinput)[annoKey] = strings.TrimRight(value, ",")
+				values = append(values, strings.TrimRight(value, ","))
+			} else {
+				values = append(values, "")
 			}
+		}
+		if len(values) > 0 {
+			(*annoinput)[annoKey] = strings.Join(values, device.OnePodMultiContainerSplitSymbol)
 		}
 	}
 	return *annoinput

--- a/pkg/device/kunlun/device_test.go
+++ b/pkg/device/kunlun/device_test.go
@@ -511,3 +511,32 @@ func Test_ScoreNode(t *testing.T) {
 		})
 	}
 }
+
+// TestKunlunDevices_PatchAnnotations tests the PatchAnnotations function for Kunlun devices
+// to ensure that it correctly encodes multi-container device indices.
+func TestKunlunDevices_PatchAnnotations(t *testing.T) {
+	dev := &KunlunDevices{}
+	pod := &corev1.Pod{}
+	anno := map[string]string{}
+
+	// Test multi-container encoding
+	pd := device.PodDevices{
+		KunlunGPUDevice: {
+			{{Idx: 0}}, // Container 1
+			{{Idx: 1}}, // Container 2
+			{},         // Container 3 (empty)
+		},
+	}
+
+	dev.PatchAnnotations(pod, &anno, pd)
+
+	val, ok := anno[KunlunDeviceSelection]
+	if !ok {
+		t.Fatalf("expected annotation %s to be set", KunlunDeviceSelection)
+	}
+
+	expected := "0;1;"
+	if val != expected {
+		t.Errorf("expected %s, got %s", expected, val)
+	}
+}

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -156,20 +156,24 @@ func (dev *MthreadsDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[str
 	devlist, ok := pd[MthreadsGPUDevice]
 	if ok && len(devlist) > 0 {
 		(*annoinput)[device.SupportDevices[MthreadsGPUDevice]] = device.EncodePodSingleDevice(devlist)
+		var values []string
 		for _, dp := range devlist {
-			if len(dp) > 0 {
-				value := ""
-				for _, val := range dp {
-					value = value + fmt.Sprint(val.Idx) + ","
-				}
-				if len(value) > 0 {
-					(*annoinput)[MthreadsAssignedGPUIndex] = strings.TrimRight(value, ",")
-					//(*annoinput)[MthreadsAssignedNode]=
-					tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
-					(*annoinput)[MthreadsPredicateTime] = tmp
-					(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
-				}
+			value := ""
+			for _, val := range dp {
+				value = value + fmt.Sprint(val.Idx) + ","
 			}
+			if len(value) > 0 {
+				values = append(values, strings.TrimRight(value, ","))
+			} else {
+				values = append(values, "")
+			}
+		}
+		if len(values) > 0 {
+			(*annoinput)[MthreadsAssignedGPUIndex] = strings.Join(values, device.OnePodMultiContainerSplitSymbol)
+			//(*annoinput)[MthreadsAssignedNode]=
+			tmp := strconv.FormatInt(time.Now().UnixNano(), 10)
+			(*annoinput)[MthreadsPredicateTime] = tmp
+			(*annoinput)[MthreadsAssignedNode] = (*annoinput)[util.AssignedNodeAnnotations]
 		}
 	}
 	klog.Infoln("annoinput", (*annoinput))

--- a/pkg/device/mthreads/device_test.go
+++ b/pkg/device/mthreads/device_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -1207,5 +1208,44 @@ func TestDevices_AddResourceUsage(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestMthreadsDevices_PatchAnnotations tests the PatchAnnotations function for Mthreads devices
+// to ensure that it correctly encodes multi-container device indices and propagates annotations.
+func TestMthreadsDevices_PatchAnnotations(t *testing.T) {
+	dev := &MthreadsDevices{}
+	pod := &corev1.Pod{}
+	anno := map[string]string{
+		util.AssignedNodeAnnotations: "test-node",
+	}
+
+	// Test multi-container encoding with middle-empty and trailing-empty container groups
+	pd := device.PodDevices{
+		MthreadsGPUDevice: {
+			{{Idx: 0}}, // Container 1
+			{{Idx: 1}}, // Container 2
+			{},         // Container 3 (empty)
+		},
+	}
+
+	dev.PatchAnnotations(pod, &anno, pd)
+
+	val, ok := anno[MthreadsAssignedGPUIndex]
+	if !ok {
+		t.Fatalf("expected annotation %s to be set", MthreadsAssignedGPUIndex)
+	}
+
+	expected := "0;1;"
+	if val != expected {
+		t.Errorf("expected %s, got %s", expected, val)
+	}
+
+	if anno[MthreadsPredicateTime] == "" {
+		t.Errorf("expected %s to be non-empty", MthreadsPredicateTime)
+	}
+
+	if anno[MthreadsAssignedNode] != "test-node" {
+		t.Errorf("expected %s to be propagated, got %s", MthreadsAssignedNode, anno[MthreadsAssignedNode])
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When a pod has multiple containers requesting Kunlun or Mthreads GPUs, `PatchAnnotations` was resetting the device index string inside the container loop. Because of this, the annotation was overwritten for each container and ended up containing only the GPU indices from the last container.

This change moves the string initialization outside the loop, so the indices from all containers are collected correctly and joined into the pod annotation.

Added regression tests to cover the multi-container case as well.

**Which issue(s) does this PR fix?**:

Fixes #2463

**Special notes for your reviewer**:

This PR replaces #2606. The changes have been squashed into a single commit, and the required AI disclosure has been added.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected device and GPU assignment annotations when workloads contain multiple containers.
  * Preserved empty container entries and combined all container selections consistently.
  * Ensured assigned-node and predicate-time annotations are recorded when applicable.

* **Tests**
  * Added coverage for multi-container assignments, empty entries, and related annotation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->