### PR TITLE
feat: add hami_gpu_device_health metric to scheduler

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -144,6 +144,11 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		"Realized MIG instance identity and scheduler placement",
 		[]string{"node", "device_uuid", "device_index", "mig_uuid", "profile", "gpu_instance_id", "compute_instance_id", "placement_start", "placement_size"}, nil,
 	)
+	nodeGPUDeviceHealthDesc := prometheus.NewDesc(
+		"hami_gpu_device_health",
+		"GPU device health status (1=healthy, 0=unhealthy)",
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+	)
 
 	// Legacy metric descriptors (only created when legacy mode is enabled)
 	var (
@@ -264,6 +269,16 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index)); err != nil {
 					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
 				}
+			}
+
+			healthVal := float64(0)
+			if devs.Device.Health {
+				healthVal = 1
+			}
+			if err := sendMetric(ch, nodeGPUDeviceHealthDesc, prometheus.GaugeValue,
+				healthVal, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+			); err != nil {
+				klog.V(4).Infof("Failed to send nodeGPUDeviceHealthDesc metric: %v", err)
 			}
 
 			if legacy {

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -477,3 +477,57 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 		}
 	})
 }
+
+func TestCollectNodeMetricsDeviceHealth(t *testing.T) {
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-healthy-0",
+							Index:     0,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    true,
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-unhealthy-1",
+							Index:     1,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{LegacyMetrics: false},
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: device.NewQuotaManager(),
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_gpu_device_health GPU device health status (1=healthy, 0=unhealthy)
+# TYPE hami_gpu_device_health gauge
+hami_gpu_device_health{device_index="0",device_type="NVIDIA",device_uuid="GPU-healthy-0",node="node-1"} 1
+hami_gpu_device_health{device_index="1",device_type="NVIDIA",device_uuid="GPU-unhealthy-1",node="node-1"} 0
+`
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_gpu_device_health",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
Used Claude to help identify the gap and draft the patch. 
I went through the code myself and understand it.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
DeviceUsage.Health is set by the device plugin via CheckHealth() and 
the scheduler already uses it internally to skip unhealthy devices 
during scoring. but it was never exposed as a Prometheus metric — if 
a gpu goes unhealthy the only way to catch it is checking node 
annotations manually. this adds hami_gpu_device_health as a gauge 
(1=healthy, 0=unhealthy) inside collectNodeMetrics, same label set 
as hami_gpu_memory_limit_bytes.

**Which issue(s) this PR fixes**:
Fixes #2612

**Special notes for your reviewer**:
same 0/1 gauge pattern hami_mig_device_info already uses. 
nodeGPUDev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a node-level GPU device health metric for monitoring.
  - Reports each GPU as healthy (`1`) or unhealthy (`0`) with node, device, and GPU type details.

- **Tests**
  - Added coverage confirming health values and associated device and node information are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->