### PR TITLE
feat: add hami_host_gpu_memory_controller_utilization_ratio metric

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -67,6 +67,12 @@ var (
 		[]string{"node", "device_index", "device_uuid", "device_type"}, nil,
 	)
 
+	hostGPUMemoryUtilizationdesc = prometheus.NewDesc(
+		"hami_host_gpu_memory_controller_utilization_ratio",
+		"GPU memory controller utilization ratio (0-100)",
+		[]string{"device_index", "device_uuid", "device_type"}, nil,
+	)
+
 	ctrvGPUdesc = prometheus.NewDesc(
 		"hami_vgpu_memory_used_bytes",
 		"vGPU device memory usage in bytes",
@@ -188,6 +194,7 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ctrvGPUdesc
 	ch <- ctrvGPUlimitdesc
 	ch <- hostGPUUtilizationdesc
+	ch <- hostGPUMemoryUtilizationdesc
 	ch <- ctrDeviceMemorydesc
 	ch <- ctrDeviceUtilizationdesc
 	ch <- ctrDeviceLastKernelDesc
@@ -362,6 +369,13 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu),
 		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
+
+	if err := sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
+		float64(util.Memory),
+		fmt.Sprint(index), uuid, deviceName,
+	); err != nil {
+		return fmt.Errorf("nvml send memory controller utilization: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -371,7 +371,7 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	)
 
 	if err := sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
-		float64(util.Memory),
+		float64(utilRates.Memory),
 		fmt.Sprint(index), uuid, deviceName,
 	); err != nil {
 		return fmt.Errorf("nvml send memory controller utilization: %w", err)

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -32,12 +33,10 @@ import (
 
 func TestDescribeCollectSync(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-
 	t.Setenv(util.NodeNameEnvName, "test-node")
 	client := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	podLister := informerFactory.Core().V1().Pods().Lister()
-
 	c := &ClusterManager{
 		Zone:            "test-zone",
 		LegacyMetrics:   false,
@@ -45,15 +44,12 @@ func TestDescribeCollectSync(t *testing.T) {
 		containerLister: &nvidia.ContainerLister{},
 	}
 	cc := ClusterManagerCollector{ClusterManager: c}
-
 	if err := reg.Register(cc); err != nil {
 		t.Fatalf("Failed to register ClusterManagerCollector (non-legacy): %v", err)
 	}
-
 	if _, err := reg.Gather(); err != nil {
 		t.Errorf("Gather failed (non-legacy): %v", err)
 	}
-
 	regLegacy := prometheus.NewPedanticRegistry()
 	cLegacy := &ClusterManager{
 		Zone:            "test-zone-legacy",
@@ -63,7 +59,6 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 	initLegacyDescriptors()
 	ccLegacy := ClusterManagerCollector{ClusterManager: cLegacy}
-
 	if err := regLegacy.Register(ccLegacy); err != nil {
 		t.Fatalf("Failed to register ClusterManagerCollector (legacy): %v", err)
 	}
@@ -72,11 +67,9 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
 	initLegacyDescriptors()
 
-	// Verify standard host GPU descriptors include "node" label
 	hostGPUString := hostGPUdesc.String()
 	if !strings.Contains(hostGPUString, `"node"`) && !strings.Contains(hostGPUString, `node`) {
 		t.Errorf("hostGPUdesc does not contain 'node' label: %s", hostGPUString)
@@ -87,7 +80,6 @@ func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
 		t.Errorf("hostGPUUtilizationdesc does not contain 'node' label: %s", hostGPUUtilString)
 	}
 
-	// Verify legacy host GPU descriptors include "nodeid" label
 	legacyHostGPUString := legacyHostGPUdesc.String()
 	if !strings.Contains(legacyHostGPUString, `"nodeid"`) && !strings.Contains(legacyHostGPUString, `nodeid`) {
 		t.Errorf("legacyHostGPUdesc does not contain 'nodeid' label: %s", legacyHostGPUString)
@@ -104,13 +96,11 @@ func TestHostGPUMetricsMissingNodeName(t *testing.T) {
 
 	cc := ClusterManagerCollector{}
 
-	// Test collectGPUUtilizationMetrics with missing NODE_NAME
 	err := cc.collectGPUUtilizationMetrics(nil, nil, 0)
 	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
 		t.Errorf("expected missing node name error from collectGPUUtilizationMetrics, got: %v", err)
 	}
 
-	// Test collectGPUMemoryMetrics with missing NODE_NAME
 	mockDev := &nvmlmock.Device{
 		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
 			return nvml.Memory{Used: 100}, nvml.SUCCESS
@@ -169,34 +159,42 @@ func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
 	}
 	if count < 4 {
 		t.Errorf("expected at least 4 metrics, got %d", count)
-=======
-func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
-	t.Setenv(util.NodeNameEnvName, "test-node")
-	client := fake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podLister := informerFactory.Core().V1().Pods().Lister()
-
-	c := &ClusterManager{
-		Zone:            "test-zone",
-		LegacyMetrics:   false,
-		PodLister:       podLister,
-		containerLister: &nvidia.ContainerLister{},
 	}
-	cc := ClusterManagerCollector{ClusterManager: c}
+}
 
+func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
+	c := &ClusterManager{Zone: "test-zone", LegacyMetrics: false}
+	cc := ClusterManagerCollector{ClusterManager: c}
 	descCh := make(chan *prometheus.Desc, 32)
 	cc.Describe(descCh)
 	close(descCh)
-
-	found := false
-	for desc := range descCh {
-		if desc == hostGPUMemoryUtilizationdesc {
-			found = true
-			break
+	for d := range descCh {
+		if strings.Contains(d.String(), "hami_host_gpu_memory_controller_utilization_ratio") {
+			return
 		}
 	}
-	if !found {
-		t.Error("Describe did not emit hostGPUMemoryUtilizationdesc; hami_host_gpu_memory_controller_utilization_ratio will be missing from scrape output")
->>>>>>> a861173 (feat: add hami_host_gpu_memory_controller_utilization_ratio metric)
+	t.Error("hami_host_gpu_memory_controller_utilization_ratio not found in Describe output")
+}
+
+func TestCollectMemoryControllerUtilizationValue(t *testing.T) {
+	const wantVal = float64(73)
+	m, err := prometheus.NewConstMetric(
+		hostGPUMemoryUtilizationdesc,
+		prometheus.GaugeValue,
+		wantVal,
+		"0", "GPU-abc123", "NVIDIA-A100",
+	)
+	if err != nil {
+		t.Fatalf("NewConstMetric: %v", err)
+	}
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if dm.Gauge == nil {
+		t.Fatal("expected gauge metric, got nil")
+	}
+	if *dm.Gauge.Value != wantVal {
+		t.Fatalf("want %v, got %v", wantVal, *dm.Gauge.Value)
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -72,6 +72,7 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
 	initLegacyDescriptors()
 
@@ -168,5 +169,34 @@ func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
 	}
 	if count < 4 {
 		t.Errorf("expected at least 4 metrics, got %d", count)
+=======
+func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podLister := informerFactory.Core().V1().Pods().Lister()
+
+	c := &ClusterManager{
+		Zone:            "test-zone",
+		LegacyMetrics:   false,
+		PodLister:       podLister,
+		containerLister: &nvidia.ContainerLister{},
+	}
+	cc := ClusterManagerCollector{ClusterManager: c}
+
+	descCh := make(chan *prometheus.Desc, 32)
+	cc.Describe(descCh)
+	close(descCh)
+
+	found := false
+	for desc := range descCh {
+		if desc == hostGPUMemoryUtilizationdesc {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Describe did not emit hostGPUMemoryUtilizationdesc; hami_host_gpu_memory_controller_utilization_ratio will be missing from scrape output")
+>>>>>>> a861173 (feat: add hami_host_gpu_memory_controller_utilization_ratio metric)
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -177,24 +177,40 @@ func TestDescribeRegistersMemoryControllerUtilization(t *testing.T) {
 }
 
 func TestCollectMemoryControllerUtilizationValue(t *testing.T) {
-	const wantVal = float64(73)
-	m, err := prometheus.NewConstMetric(
-		hostGPUMemoryUtilizationdesc,
-		prometheus.GaugeValue,
-		wantVal,
-		"0", "GPU-abc123", "NVIDIA-A100",
-	)
-	if err != nil {
-		t.Fatalf("NewConstMetric: %v", err)
+	t.Setenv(util.NodeNameEnvName, "test-node")
+	const wantMemory = uint32(73)
+	mockDev := &nvmlmock.Device{
+		GetUtilizationRatesFunc: func() (nvml.Utilization, nvml.Return) {
+			return nvml.Utilization{Gpu: 10, Memory: wantMemory}, nvml.SUCCESS
+		},
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return "GPU-abc123", nvml.SUCCESS
+		},
+		GetNameFunc: func() (string, nvml.Return) {
+			return "A100", nvml.SUCCESS
+		},
 	}
-	var dm dto.Metric
-	if err := m.Write(&dm); err != nil {
-		t.Fatalf("Write: %v", err)
+	ch := make(chan prometheus.Metric, 10)
+	c := &ClusterManager{Zone: "test-zone", LegacyMetrics: false}
+	cc := ClusterManagerCollector{ClusterManager: c}
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUUtilizationMetrics: %v", err)
 	}
-	if dm.Gauge == nil {
-		t.Fatal("expected gauge metric, got nil")
+	close(ch)
+	var found bool
+	for m := range ch {
+		var dm dto.Metric
+		if err := m.Write(&dm); err != nil {
+			continue
+		}
+		if dm.Gauge == nil {
+			continue
+		}
+		if *dm.Gauge.Value == float64(wantMemory) {
+			found = true
+		}
 	}
-	if *dm.Gauge.Value != wantVal {
-		t.Fatalf("want %v, got %v", wantVal, *dm.Gauge.Value)
+	if !found {
+		t.Fatalf("expected memory controller utilization metric with value %v", wantMemory)
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
was looking at collectGPUUtilizationMetrics and noticed we call 
GetUtilizationRates() which returns both Gpu and Memory but Memory 
just gets ignored after the call. wired it up as 
hami_host_gpu_memory_controller_utilization_ratio. no extra NVML 
calls, data was already there. matters on inference workloads where 
memory bandwidth fills up way before SM does.

**Which issue(s) this PR fixes**:
Fixes #2613

**Special notes for your reviewer**:
three line change essentially. one descriptor, one Describe entry, 
one sendMetric.

**Does this PR introduce a user-facing change?**:
yes — hami_host_gpu_memory_controller_utilization_ratio gauge

I used Claude to help identify this gap. I reviewed the code and 
understand the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus metric for host GPU memory-controller utilization.
  * Added node labels to host memory and core metrics.
  * Expanded MIG metrics with GPU, profile, instance, and MIG UUID labels.
  * Improved container and GPU identification validation, including clearer collection errors.

* **Tests**
  * Added coverage for metric registration, labels, successful collection, validation errors, and reported utilization values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->