### PR TITLE
feat: add hami_gpu_device_health metric to scheduler

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -144,6 +144,11 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		"Realized MIG instance identity and scheduler placement",
 		[]string{"node", "device_uuid", "device_index", "mig_uuid", "profile", "gpu_instance_id", "compute_instance_id", "placement_start", "placement_size"}, nil,
 	)
+	nodeGPUDeviceHealthDesc := prometheus.NewDesc(
+		"hami_gpu_device_health",
+		"GPU device health status (1=healthy, 0=unhealthy)",
+		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
+	)
 
 	// Legacy metric descriptors (only created when legacy mode is enabled)
 	var (
@@ -264,6 +269,16 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index)); err != nil {
 					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
 				}
+			}
+
+			healthVal := float64(0)
+			if devs.Device.Health {
+				healthVal = 1
+			}
+			if err := sendMetric(ch, nodeGPUDeviceHealthDesc, prometheus.GaugeValue,
+				healthVal, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type,
+			); err != nil {
+				klog.V(4).Infof("Failed to send nodeGPUDeviceHealthDesc metric: %v", err)
 			}
 
 			if legacy {

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -477,3 +477,57 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 		}
 	})
 }
+
+func TestCollectNodeMetricsDeviceHealth(t *testing.T) {
+	nodeUsage := map[string]*schedulerpkg.NodeUsage{
+		"node-1": {
+			Devices: policy.DeviceUsageList{
+				DeviceLists: []*policy.DeviceListsScore{
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-healthy-0",
+							Index:     0,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    true,
+						},
+					},
+					{
+						Device: &device.DeviceUsage{
+							ID:        "GPU-unhealthy-1",
+							Index:     1,
+							Totalmem:  8192,
+							Totalcore: 100,
+							Type:      "NVIDIA",
+							Health:    false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := ClusterManagerCollector{
+		ClusterManager: &ClusterManager{LegacyMetrics: false},
+		metricsProvider: &fakeMetricsProvider{
+			nodeUsage:    nodeUsage,
+			quotaManager: device.NewQuotaManager(),
+			podManager:   device.NewPodManager(),
+		},
+	}
+
+	want := `
+# HELP hami_gpu_device_health GPU device health status (1=healthy, 0=unhealthy)
+# TYPE hami_gpu_device_health gauge
+hami_gpu_device_health{device_index="0",device_type="NVIDIA",device_uuid="GPU-healthy-0",node="node-1"} 1
+hami_gpu_device_health{device_index="1",device_type="NVIDIA",device_uuid="GPU-unhealthy-1",node="node-1"} 0
+`
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_gpu_device_health",
+	); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
scheduler was silently skipping unhealthy GPUs during scoring using 
DeviceUsage.Health but nothing ever made it to Prometheus. only way 
to know a device was unhealthy was manually checking node annotations. 
added hami_gpu_device_health gauge (1=healthy, 0=unhealthy) so you 
can actually alert on it.

**Which issue(s) this PR fixes**:
Fixes #2612

**Special notes for your reviewer**:
same 0/1 pattern as hami_mig_device_info. descriptor kept local to 
the function like everything else in there.

**Does this PR introduce a user-facing change?**:
yes — hami_gpu_device_health gauge

I used Claude to help identify this gap. I reviewed the code and 
understand the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus metric reporting the health status of each GPU device.
  * Healthy devices report `1`; unhealthy devices report `0`.
  * Metrics include node, device UUID, index, and device type details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->