### PR TITLE
fix(cambricon): use shared nodelock package for node-level locking

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -92,31 +92,6 @@ func (dev *CambriconDevices) CommonWord() string {
 	return CambriconMLUCommonWord
 }
 
-func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {
-	ctx := context.Background()
-	patchedAnnotation, err := json.Marshal(
-		map[string]any{
-			"metadata": map[string]map[string]string{"annotations": {
-				DsmluLockTime: time.Now().Format(time.RFC3339),
-			}}})
-	if err != nil {
-		klog.ErrorS(err, "Failed to marshal node annotation", "node", node.Name)
-		return fmt.Errorf("marshal node annotation: %w", err)
-	}
-
-	_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchedAnnotation, metav1.PatchOptions{})
-	for i := 0; i < retry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to patch node annotation", "node", node.Name, "retry", i)
-		time.Sleep(time.Duration(rand.Intn(i+1)) * 10 * time.Millisecond)
-		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchedAnnotation, metav1.PatchOptions{})
-	}
-	if err != nil {
-		return fmt.Errorf("setNodeLock exceeds retry count %d", retry)
-	}
-	klog.InfoS("Node lock set", "node", node.Name)
-	return nil
-}
-
 func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 	found := false
 	for _, val := range p.Spec.Containers {
@@ -132,49 +107,17 @@ func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 }
 
 func (dev *CambriconDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	ctx := context.Background()
-	nodeName := n.Name
-
-	current, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get node for lock release: %w", err)
+	found := false
+	for _, val := range p.Spec.Containers {
+		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
+			found = true
+			break
+		}
 	}
-	if current.Annotations == nil {
+	if !found {
 		return nil
 	}
-	if _, ok := current.Annotations[DsmluLockTime]; !ok {
-		klog.InfoS("Node lock not set", "node", nodeName)
-		return nil
-	}
-
-	patchData, err := json.Marshal(
-		map[string]any{
-			"metadata": map[string]map[string]any{"annotations": {
-				DsmluLockTime: nil,
-			}}})
-	if err != nil {
-		return fmt.Errorf("marshal patch for lock release: %w", err)
-	}
-
-	_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
-	for i := 0; i < retry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to release node lock", "node", nodeName, "retry", i)
-		time.Sleep(time.Duration(rand.Intn(i+1)) * 10 * time.Millisecond)
-
-		current, err = client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to re-get node during release retry: %w", err)
-		}
-		if current.Annotations == nil || current.Annotations[DsmluLockTime] == "" {
-			return nil
-		}
-		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
-	}
-	if err != nil {
-		return fmt.Errorf("releaseNodeLock exceeds retry count %d", retry)
-	}
-	klog.InfoS("Node lock released", "node", nodeName)
-	return nil
+	return nodelock.ReleaseNodeLock(n.Name, NodeLockCambricon, p, false)
 }
 
 func (dev *CambriconDevices) NodeCleanUp(nn string) error {

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -17,24 +17,18 @@ limitations under the License.
 package cambricon
 
 import (
-	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"math/rand"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/common"
 	"github.com/Project-HAMi/HAMi/pkg/util"
-	"github.com/Project-HAMi/HAMi/pkg/util/client"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 )
 
@@ -50,10 +44,12 @@ const (
 	MLUUseUUID = "cambricon.com/use-gpuuuid"
 	// MLUNoUseUUID annotation specifies a comma-separated list of MLU UUIDs to exclude.
 	MLUNoUseUUID          = "cambricon.com/nouse-gpuuuid"
-	DsmluLockTime         = "cambricon.com/dsmlu.lock"
 	DsmluProfile          = "CAMBRICON_DSMLU_PROFILE"
 	DsmluResourceAssigned = "CAMBRICON_DSMLU_ASSIGNED"
-	retry                 = 5
+	// NodeLockCambricon should be the same as the node lock name used by the
+	// device plugin; nodelock hard-codes the annotation key regardless of the
+	// name passed in, so this only needs to be distinct for readability.
+	NodeLockCambricon = "hami.io/mutex.lock"
 	// MemoryFactor converts the vmemory unit used in the pod spec into the MiB
 	// HAMi accounts internally. One cambricon.com/mlu.smlu.vmemory is 256 MiB.
 	MemoryFactor = 256
@@ -96,35 +92,6 @@ func (dev *CambriconDevices) CommonWord() string {
 	return CambriconMLUCommonWord
 }
 
-func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {
-	ctx := context.Background()
-	if _, ok := node.Annotations[DsmluLockTime]; ok {
-		return fmt.Errorf("node %s is locked", node.Name)
-	}
-
-	patchedAnnotation, err := json.Marshal(
-		map[string]any{
-			"metadata": map[string]map[string]string{"annotations": {
-				DsmluLockTime: time.Now().Format(time.RFC3339),
-			}}})
-	if err != nil {
-		klog.ErrorS(err, "Failed to patch node annotation", "node", node.Name)
-		return fmt.Errorf("patch node annotation %v", err)
-	}
-
-	_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patchedAnnotation, metav1.PatchOptions{})
-	for i := 0; i < retry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to patch node annotation", "node", node.Name, "retry", i)
-		time.Sleep(time.Duration(rand.Intn(i+1)) * 10 * time.Millisecond)
-		_, err = client.GetClient().CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patchedAnnotation, metav1.PatchOptions{})
-	}
-	if err != nil {
-		return fmt.Errorf("setNodeLock exceeds retry count %d", retry)
-	}
-	klog.InfoS("Node lock set", "node", node.Name)
-	return nil
-}
-
 func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 	found := false
 	for _, val := range p.Spec.Containers {
@@ -136,48 +103,21 @@ func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 	if !found {
 		return nil
 	}
-	if _, ok := n.Annotations[DsmluLockTime]; !ok {
-		return dev.setNodeLock(n)
-	}
-	lockTime, err := time.Parse(time.RFC3339, n.Annotations[DsmluLockTime])
-	if err != nil {
-		return err
-	}
-	if time.Since(lockTime) > time.Minute*2 {
-		klog.InfoS("Node lock expired", "node", n.Name, "lockTime", lockTime)
-		err = dev.ReleaseNodeLock(n, p)
-		if err != nil {
-			klog.ErrorS(err, "Failed to release node lock", "node", n.Name)
-			return err
-		}
-		return dev.setNodeLock(n)
-	}
-	return fmt.Errorf("node %s has been locked within 2 minutes", n.Name)
+	return nodelock.LockNode(n.Name, NodeLockCambricon, p)
 }
 
 func (dev *CambriconDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	if n.Annotations == nil {
+	found := false
+	for _, val := range p.Spec.Containers {
+		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
 		return nil
 	}
-	if _, ok := n.Annotations[DsmluLockTime]; !ok {
-		klog.InfoS("Node lock not set", "node", n.Name)
-		return nil
-	}
-
-	newNode := n.DeepCopy()
-	delete(newNode.Annotations, DsmluLockTime)
-	_, err := client.GetClient().CoreV1().Nodes().Update(context.Background(), newNode, metav1.UpdateOptions{})
-	for i := 0; i < retry && err != nil; i++ {
-		klog.ErrorS(err, "Failed to patch node annotation", "node", n.Name, "retry", i)
-		time.Sleep(time.Duration(rand.Intn(i+1)) * 10 * time.Millisecond)
-		_, err = client.GetClient().CoreV1().Nodes().Update(context.Background(), newNode, metav1.UpdateOptions{})
-	}
-	if err != nil {
-		return fmt.Errorf("releaseNodeLock exceeds retry count %d", retry)
-	}
-	delete(n.Annotations, DsmluLockTime)
-	klog.InfoS("Node lock released", "node", n.Name)
-	return nil
+	return nodelock.ReleaseNodeLock(n.Name, NodeLockCambricon, p, false)
 }
 
 func (dev *CambriconDevices) NodeCleanUp(nn string) error {

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -19,7 +19,6 @@ package cambricon
 import (
 	"context"
 	"flag"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 )
 
 func Test_GetNodeDevices(t *testing.T) {
@@ -394,80 +394,6 @@ func Test_PatchAnnotations(t *testing.T) {
 	}
 }
 
-func Test_setNodeLock(t *testing.T) {
-	tests := []struct {
-		name      string
-		node      corev1.Node
-		expectErr bool
-		expectMsg string
-	}{
-		{
-			name: "node is locked",
-			node: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "node-01",
-					Annotations: map[string]string{
-						"cambricon.com/dsmlu.lock": "test123",
-					},
-				},
-			},
-			expectErr: true,
-			expectMsg: "node node-01 is locked",
-		},
-		{
-			name: "set node lock",
-			node: corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node-02",
-					Annotations: map[string]string{},
-				},
-			},
-			expectErr: false,
-		},
-	}
-
-	client.KubeClient = fake.NewClientset()
-	k8sClient := client.GetClient()
-	if k8sClient != nil {
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				ctx := context.Background()
-
-				defer func() {
-					if tt.node.Name != "" {
-						// Delete the node to clean up
-						err := k8sClient.CoreV1().Nodes().Delete(ctx, tt.node.Name, metav1.DeleteOptions{})
-						if err != nil {
-							t.Errorf("failed to delete node %s: %v", tt.node.Name, err)
-						}
-					}
-				}()
-
-				_, err := k8sClient.CoreV1().Nodes().Create(ctx, &tt.node, metav1.CreateOptions{})
-				if err != nil {
-					t.Fatalf("failed to create node %s: %v", tt.node.Name, err)
-				}
-
-				dev := CambriconDevices{}
-				err = dev.setNodeLock(&tt.node)
-
-				if tt.expectErr {
-					if err == nil {
-						t.Errorf("expected error but got none")
-					} else if !strings.Contains(err.Error(), tt.expectMsg) {
-						t.Errorf("expected error to contain '%s' but got '%s'", tt.expectMsg, err.Error())
-					}
-				} else {
-					if err != nil {
-						t.Errorf("did not expect error but got %v", err)
-					}
-				}
-			})
-		}
-	}
-}
-
 // Setup function to initialize resources for each test case.
 func setupTest(t *testing.T) (*corev1.Node, *corev1.Pod, func(), *fake.Clientset) {
 	ctx := context.Background()
@@ -524,9 +450,17 @@ func setupTest(t *testing.T) (*corev1.Node, *corev1.Pod, func(), *fake.Clientset
 }
 
 func Test_LockNode(t *testing.T) {
+	otherPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-pod",
+			Namespace: "default",
+		},
+	}
+
 	tests := []struct {
 		name        string
 		annotations map[string]string
+		existingPod *corev1.Pod
 		wantErr     bool
 	}{
 		{
@@ -535,23 +469,24 @@ func Test_LockNode(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "node is already locked within 2 minutes",
+			name: "node is locked by another live pod within the timeout",
 			annotations: map[string]string{
-				DsmluLockTime: time.Now().Add(-time.Minute).Format(time.RFC3339),
+				nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(otherPod),
 			},
-			wantErr: true,
+			existingPod: otherPod,
+			wantErr:     true,
 		},
 		{
-			name: "lock time expired (more than 2 minutes)",
+			name: "lock time expired",
 			annotations: map[string]string{
-				DsmluLockTime: time.Now().Add(-time.Hour).Format(time.RFC3339),
+				nodelock.NodeLockKey: time.Now().Add(-2*nodelock.NodeLockTimeout).Format(time.RFC3339) + nodelock.NodeLockSep + "default" + nodelock.NodeLockSep + "other-pod",
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid lock time format",
 			annotations: map[string]string{
-				DsmluLockTime: "invalid-format",
+				nodelock.NodeLockKey: "invalid-format",
 			},
 			wantErr: true,
 		},
@@ -565,6 +500,16 @@ func Test_LockNode(t *testing.T) {
 
 			// Set up the node with the specified annotations.
 			node.Annotations = tt.annotations
+			_, err := clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to update node annotations: %v", err)
+			}
+
+			if tt.existingPod != nil {
+				if _, err := clientset.CoreV1().Pods(tt.existingPod.Namespace).Create(context.TODO(), tt.existingPod, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create existing pod: %v", err)
+				}
+			}
 
 			dev := InitMLUDevice(CambriconConfig{
 				ResourceCountName:  MLUResourceCount,
@@ -572,7 +517,7 @@ func Test_LockNode(t *testing.T) {
 				ResourceCoreName:   MLUResourceCores,
 			})
 
-			err := dev.LockNode(node, pod)
+			err = dev.LockNode(node, pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LockNode() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -580,7 +525,7 @@ func Test_LockNode(t *testing.T) {
 			// Optionally check if the node was correctly patched with the lock annotation.
 			if !tt.wantErr {
 				fetchedNode, _ := clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-				if _, ok := fetchedNode.Annotations[DsmluLockTime]; !ok && !tt.wantErr {
+				if _, ok := fetchedNode.Annotations[nodelock.NodeLockKey]; !ok {
 					t.Error("Expected node to be locked but it wasn't")
 				}
 			}
@@ -633,11 +578,56 @@ func Test_ReleaseNodeLock(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			client.KubeClient = fake.NewClientset(&test.args.node)
 			dev := CambriconDevices{}
 			result := dev.ReleaseNodeLock(&test.args.node, &test.args.pod)
 			assert.Equal(t, test.err, result)
 		})
 	}
+}
+
+// Test_ReleaseNodeLock_ReleasesOwnedLock verifies that ReleaseNodeLock
+// delegates to the shared nodelock package and actually clears the lock
+// annotation held by the requesting pod.
+func Test_ReleaseNodeLock_ReleasesOwnedLock(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceName(MLUResourceCount): resource.MustParse("1"),
+					},
+				},
+			}},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-03",
+			Annotations: map[string]string{
+				nodelock.NodeLockKey: nodelock.GenerateNodeLockKeyByPod(pod),
+			},
+		},
+	}
+	client.KubeClient = fake.NewClientset(node)
+
+	dev := InitMLUDevice(CambriconConfig{
+		ResourceCountName:  MLUResourceCount,
+		ResourceMemoryName: MLUResourceMemory,
+		ResourceCoreName:   MLUResourceCores,
+	})
+
+	err := dev.ReleaseNodeLock(node, pod)
+	assert.NoError(t, err)
+
+	fetchedNode, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	_, ok := fetchedNode.Annotations[nodelock.NodeLockKey]
+	assert.False(t, ok, "expected lock annotation to be removed")
 }
 
 func TestDevices_Fit(t *testing.T) {

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -19,19 +19,14 @@ package cambricon
 import (
 	"context"
 	"flag"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
@@ -399,43 +394,6 @@ func Test_PatchAnnotations(t *testing.T) {
 	}
 }
 
-func Test_setNodeLock(t *testing.T) {
-	client.KubeClient = fake.NewClientset()
-	k8sClient := client.GetClient()
-	if k8sClient == nil {
-		t.Skip("no k8s client available")
-	}
-
-	node := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-set-lock",
-			Annotations: map[string]string{},
-		},
-	}
-
-	ctx := context.Background()
-	_, err := k8sClient.CoreV1().Nodes().Create(ctx, &node, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("failed to create node: %v", err)
-	}
-	defer k8sClient.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{})
-
-	dev := CambriconDevices{}
-	err = dev.setNodeLock(&node)
-	if err != nil {
-		t.Errorf("did not expect error but got %v", err)
-	}
-
-	// Verify the annotation was set on the apiserver.
-	fetchedNode, err := k8sClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to fetch node: %v", err)
-	}
-	if _, ok := fetchedNode.Annotations[DsmluLockTime]; !ok {
-		t.Error("Expected node to be locked but it wasn't")
-	}
-}
-
 // Setup function to initialize resources for each test case.
 func setupTest(t *testing.T) (*corev1.Node, *corev1.Pod, func(), *fake.Clientset) {
 	ctx := context.Background()
@@ -576,226 +534,56 @@ func Test_LockNode(t *testing.T) {
 }
 
 func Test_ReleaseNodeLock(t *testing.T) {
-	clientset := fake.NewClientset()
-	client.KubeClient = clientset
-	ctx := context.Background()
-
 	tests := []struct {
-		name              string
-		nodeName          string
-		annotations       map[string]string
-		callerAnnotations map[string]string
-		skipCreate        bool
-		wantErr           bool
+		name string
+		args struct {
+			node corev1.Node
+			pod  corev1.Pod
+		}
+		err error
 	}{
 		{
-			name:        "no annotation — lock not present",
-			nodeName:    "node-rel-01",
-			annotations: nil,
-			wantErr:     false,
-		},
-		{
-			name:     "annotation without lock key",
-			nodeName: "node-rel-02",
-			annotations: map[string]string{
-				"test": "test123",
+			name: "no annation",
+			args: struct {
+				node corev1.Node
+				pod  corev1.Pod
+			}{
+				node: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-01",
+					},
+				},
+				pod: corev1.Pod{},
 			},
-			wantErr: false,
+			err: nil,
 		},
 		{
-			name:     "lock present — successfully released",
-			nodeName: "node-rel-03",
-			annotations: map[string]string{
-				DsmluLockTime: time.Now().Format(time.RFC3339),
+			name: "annation no lock value",
+			args: struct {
+				node corev1.Node
+				pod  corev1.Pod
+			}{
+				node: corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-02",
+						Annotations: map[string]string{
+							"test": "test123",
+						},
+					},
+				},
+				pod: corev1.Pod{},
 			},
-			wantErr: false,
-		},
-		{
-			name:     "stale caller — lock on server but not on caller node",
-			nodeName: "node-rel-04",
-			annotations: map[string]string{
-				DsmluLockTime: time.Now().Format(time.RFC3339),
-			},
-			callerAnnotations: map[string]string{},
-			wantErr:           false,
-		},
-		{
-			name:       "node not found",
-			nodeName:   "node-rel-nonexistent",
-			skipCreate: true,
-			wantErr:    true,
+			err: nil,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if !tt.skipCreate {
-				node := &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        tt.nodeName,
-						Annotations: tt.annotations,
-					},
-				}
-				_, err := clientset.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-				if err != nil {
-					t.Fatalf("failed to create node %s: %v", tt.nodeName, err)
-				}
-				defer clientset.CoreV1().Nodes().Delete(ctx, tt.nodeName, metav1.DeleteOptions{})
-			}
-
-			callerNode := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tt.nodeName,
-				},
-			}
-			if tt.callerAnnotations != nil {
-				callerNode.Annotations = tt.callerAnnotations
-			} else if tt.annotations != nil {
-				callerNode.Annotations = tt.annotations
-			}
-
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client.KubeClient = fake.NewClientset(&test.args.node)
 			dev := CambriconDevices{}
-			err := dev.ReleaseNodeLock(callerNode, &corev1.Pod{})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ReleaseNodeLock() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !tt.wantErr && !tt.skipCreate && tt.annotations != nil {
-				if _, ok := tt.annotations[DsmluLockTime]; ok {
-					fetched, ferr := clientset.CoreV1().Nodes().Get(ctx, tt.nodeName, metav1.GetOptions{})
-					if ferr != nil {
-						t.Fatalf("failed to fetch node: %v", ferr)
-					}
-					if _, ok := fetched.Annotations[DsmluLockTime]; ok {
-						t.Error("Expected lock annotation to be removed but it's still present")
-					}
-				}
-			}
+			result := dev.ReleaseNodeLock(&test.args.node, &test.args.pod)
+			assert.Equal(t, test.err, result)
 		})
 	}
-
-	// Retry/conflict tests using PrependReactor.
-	t.Run("patch error — retry succeeds", func(t *testing.T) {
-		cs := fake.NewClientset()
-		client.KubeClient = cs
-
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-retry-01",
-				Annotations: map[string]string{
-					DsmluLockTime: time.Now().Format(time.RFC3339),
-				},
-			},
-		}
-		_, err := cs.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("failed to create node: %v", err)
-		}
-		defer cs.CoreV1().Nodes().Delete(ctx, "node-retry-01", metav1.DeleteOptions{})
-
-		patchFailCount := 0
-		cs.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			patchFailCount++
-			if patchFailCount <= 2 {
-				return true, nil, apierrors.NewInternalError(fmt.Errorf("patch error"))
-			}
-			return false, nil, nil
-		})
-
-		dev := CambriconDevices{}
-		err = dev.ReleaseNodeLock(node, &corev1.Pod{})
-		if err != nil {
-			t.Errorf("ReleaseNodeLock() unexpected error: %v", err)
-		}
-		if patchFailCount < 2 {
-			t.Errorf("expected at least 2 patch errors before success, got %d", patchFailCount)
-		}
-
-		fetched, _ := cs.CoreV1().Nodes().Get(ctx, "node-retry-01", metav1.GetOptions{})
-		if _, ok := fetched.Annotations[DsmluLockTime]; ok {
-			t.Error("Expected lock annotation to be removed after retries")
-		}
-	})
-
-	t.Run("lock already removed during retry", func(t *testing.T) {
-		cs := fake.NewClientset()
-		client.KubeClient = cs
-
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-retry-02",
-				Annotations: map[string]string{
-					DsmluLockTime: time.Now().Format(time.RFC3339),
-				},
-			},
-		}
-		_, err := cs.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("failed to create node: %v", err)
-		}
-		defer cs.CoreV1().Nodes().Delete(ctx, "node-retry-02", metav1.DeleteOptions{})
-
-		cs.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			return true, nil, apierrors.NewInternalError(fmt.Errorf("patch error"))
-		})
-
-		getCount := 0
-		cs.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			getCount++
-			if getCount == 2 {
-				return true, &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "node-retry-02",
-						Annotations: map[string]string{},
-					},
-				}, nil
-			}
-			return false, nil, nil
-		})
-
-		dev := CambriconDevices{}
-		err = dev.ReleaseNodeLock(node, &corev1.Pod{})
-		if err != nil {
-			t.Errorf("ReleaseNodeLock() unexpected error: %v", err)
-		}
-	})
-
-	t.Run("re-get fails during retry", func(t *testing.T) {
-		cs := fake.NewClientset()
-		client.KubeClient = cs
-
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-retry-03",
-				Annotations: map[string]string{
-					DsmluLockTime: time.Now().Format(time.RFC3339),
-				},
-			},
-		}
-		_, err := cs.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("failed to create node: %v", err)
-		}
-		defer cs.CoreV1().Nodes().Delete(ctx, "node-retry-03", metav1.DeleteOptions{})
-
-		cs.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			return true, nil, apierrors.NewInternalError(fmt.Errorf("patch error"))
-		})
-		getCount := 0
-		cs.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			getCount++
-			if getCount == 2 {
-				return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "node-retry-03")
-			}
-			return false, nil, nil
-		})
-
-		dev := CambriconDevices{}
-		err = dev.ReleaseNodeLock(node, &corev1.Pod{})
-		if err == nil {
-			t.Error("ReleaseNodeLock() expected error but got nil")
-		}
-	})
 }
 
 // Test_ReleaseNodeLock_ReleasesOwnedLock verifies that ReleaseNodeLock


### PR DESCRIPTION
## Summary

Cambricon's device backend implemented its own node-lock annotation
(`cambricon.com/dsmlu.lock`) instead of using the shared `pkg/util/nodelock`
package that every other backend (nvidia, hygon, amd, biren, vastai,
iluvatar, kunlun, metax) relies on for serializing device allocation on a
node.

The bespoke implementation had no real concurrency protection:

- `LockNode`/`setNodeLock` checked the lock annotation on the `*corev1.Node`
  object handed to it by the caller (from an informer cache), never
  re-fetching a live copy.
- `setNodeLock` then issued a `Patch` containing only the annotation field,
  with no `resourceVersion` precondition anywhere in the request.

Since Kubernetes `Patch` does not enforce optimistic concurrency unless a
precondition is supplied, two pods being bound to the same node concurrently
could both read the same "unlocked" node snapshot, both pass the check, and
both successfully `Patch` — nothing rejected the second writer. Both pods
would then proceed to mutate MLU device usage/annotations on the same node
with no mutual exclusion, which is exactly the over-allocation / corrupted
device-state scenario the lock exists to prevent.

## Fix

`LockNode`/`ReleaseNodeLock` now delegate to `nodelock.LockNode` /
`nodelock.ReleaseNodeLock`, the same shared package used by every other
backend. That package re-fetches the node on each attempt and patches with
a `resourceVersion` precondition plus retry-on-conflict, so concurrent lock
attempts on the same node are properly serialized. The bespoke
`setNodeLock` method and the `cambricon.com/dsmlu.lock` annotation constant
are removed as dead code.

One intentional behavior change: the stale-lock recovery window moves from
Cambricon's hardcoded 2 minutes to the shared default of 5 minutes
(overridable via `HAMI_NODELOCK_EXPIRE`), matching every other backend
instead of being a Cambricon-specific special case.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/device/cambricon/... -race -short -count=1 -v` — all
      pass, including new/updated lock tests exercising contention, expiry,
      and successful release
- [x] `make test` (full suite, race detector) — all packages pass
- [x] `make lint` (golangci-lint) on changed files — 0 issues
- [x] `hack/verify-license.sh`, `hack/verify-import-aliases.sh` — pass

## AI Assistance Disclosure

This PR was written primarily by  Geminy, following the project's
CONTRIBUTING.md disclosure requirement. The bug was found via an
independent code audit of the scheduler's node-locking paths across all
device backends; the fix mirrors the pattern already used by the
nvidia/hygon/amd backends in this codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved Cambricon device node locking for more consistent acquisition and release behavior.
- Locking continues to apply only to workloads requesting MLU resources.
- Improved handling of active, expired, and malformed locks.
- Locks owned by the requesting workload are now released correctly.
- Improved validation of lock persistence, ownership, and release scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->