### PR TITLE
fix(scheduler): rollback partial device locks

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -902,16 +903,38 @@ func (s *Scheduler) cleanupStalePodAllocation(pod *corev1.Pod) {
 }
 
 func (s *Scheduler) lockAllDevices(node *corev1.Node, pod *corev1.Pod) error {
-	for _, val := range device.GetDevices() {
+	devs := device.GetDevices()
+	keys := make([]string, 0, len(devs))
+	for k := range devs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	acquired := make([]device.Devices, 0, len(keys))
+	for _, k := range keys {
+		val := devs[k]
 		if err := val.LockNode(node, pod); err != nil {
+			for _, locked := range slices.Backward(acquired) {
+				if relErr := locked.ReleaseNodeLock(node, pod); relErr != nil {
+					klog.ErrorS(relErr, "Failed to release node lock during rollback", "node", node.Name, "pod", klog.KObj(pod))
+				}
+			}
 			return err
 		}
+		acquired = append(acquired, val)
 	}
 	return nil
 }
 
 func (s *Scheduler) releaseAllDevices(node *corev1.Node, pod *corev1.Pod) {
-	for _, val := range device.GetDevices() {
+	devs := device.GetDevices()
+	keys := make([]string, 0, len(devs))
+	for k := range devs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		val := devs[k]
 		if err := val.ReleaseNodeLock(node, pod); err != nil {
 			klog.ErrorS(err, "Failed to release node lock", "node", node.Name, "pod", klog.KObj(pod))
 		}
@@ -929,7 +952,6 @@ func (s *Scheduler) acquireNodeLocks(node *corev1.Node, pod *corev1.Pod) error {
 		if err == nil {
 			return nil
 		}
-		s.releaseAllDevices(node, pod)
 		if !nodelockutil.IsNodeLockContention(err) {
 			return err
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2458,35 +2458,52 @@ func Test_lockAllDevices_Transactional(t *testing.T) {
 		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
 	})
 
-	// RollbackReleaseError: backend1 acquires its lock, backend2's LockNode fails triggering
-	// rollback, but backend1's ReleaseNodeLock itself returns an error.
+	// RollbackReleaseError: backend1 and backend2 acquire locks, backend3's LockNode fails.
+	// During rollback, backend2's ReleaseNodeLock returns an error, but rollback continues
+	// and backend1's ReleaseNodeLock is still executed.
 	// Verifies:
-	//   - the original LockNode error from backend2 is returned (not swallowed by relErr).
-	//   - ReleaseNodeLock is still called on backend1 exactly once (release is attempted).
-	//   - the release error does not prevent returning the original lock error.
+	//   - backend1: LockNode succeeds (1), ReleaseNodeLock succeeds (1).
+	//   - backend2: LockNode succeeds (1), ReleaseNodeLock returns a release error (1).
+	//   - backend3: LockNode fails with errMockFailed (1), ReleaseNodeLock is NOT called (0).
+	//   - Rollback continues despite backend2's release error.
+	//   - The original LockNode error from backend3 is returned (not overwritten by backend2's release error).
 	t.Run("RollbackReleaseError", func(t *testing.T) {
 		oldDevicesMap := device.DevicesMap
 		defer func() { device.DevicesMap = oldDevicesMap }()
 
 		errRelease := fmt.Errorf("mock release failed")
-		dev1 := &transactionMockDevice{name: "backend1", releaseErr: errRelease}
-		dev2 := &transactionMockDevice{name: "backend2", lockErr: errMockFailed}
+		events := &[]string{}
+		dev1 := &transactionMockDevice{name: "backend1", events: events}
+		dev2 := &transactionMockDevice{name: "backend2", releaseErr: errRelease, events: events}
+		dev3 := &transactionMockDevice{name: "backend3", lockErr: errMockFailed, events: events}
 		device.DevicesMap = map[string]device.Devices{
 			"backend1": dev1,
 			"backend2": dev2,
+			"backend3": dev3,
 		}
 
 		s := Scheduler{}
 		err := s.lockAllDevices(node, pod)
 
-		// Original LockNode error must be returned, not the release error.
+		// Original LockNode error from backend3 must be returned, not backend2's release error.
 		assert.ErrorIs(t, err, errMockFailed)
-		// backend1 was locked and release was attempted exactly once.
+
+		// Call count assertions:
 		assert.Equal(t, dev1.lockCalls.Load(), int32(1))
 		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
-		// backend2 was attempted but failed; no release on it.
 		assert.Equal(t, dev2.lockCalls.Load(), int32(1))
-		assert.Equal(t, dev2.releaseCalls.Load(), int32(0))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev3.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+
+		// Verify event sequence: lock1, lock2, lock3(fail), release2(err), release1
+		assert.DeepEqual(t, *events, []string{
+			"lock:backend1",
+			"lock:backend2",
+			"lock:backend3",
+			"release:backend2",
+			"release:backend1",
+		})
 	})
 
 	// AcquireNodeLocks_RetryLoop_ReleaseCount: exercises the REAL acquireNodeLocks() retry loop

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2284,4 +2285,279 @@ func Test_Bind_PodGroupPodNonContentionErrorDoesNotRetry(t *testing.T) {
 	require.Contains(t, res.Error, "apiserver 500")
 	require.Equal(t, int32(1), mock.lockCalls.Load(),
 		"non-contention error must not trigger retry")
+}
+
+type transactionMockDevice struct {
+	registerMockDevice
+	name         string
+	lockErr      error
+	lockErrFunc  func(attempt int32) error // optional dynamic lock error generator
+	releaseErr   error                     // returned by ReleaseNodeLock; exercises rollback error branch
+	lockCalls    atomic.Int32
+	releaseCalls atomic.Int32
+
+	// events records the sequence of "lock:<name>" and "release:<name>" calls.
+	// The pointer is shared across all devices in a test so ordering is global.
+	events *[]string
+	mu     sync.Mutex
+}
+
+func (m *transactionMockDevice) CommonWord() string { return m.name }
+func (m *transactionMockDevice) LockNode(_ *corev1.Node, _ *corev1.Pod) error {
+	attempt := m.lockCalls.Add(1)
+	if m.events != nil {
+		m.mu.Lock()
+		*m.events = append(*m.events, "lock:"+m.name)
+		m.mu.Unlock()
+	}
+	if m.lockErrFunc != nil {
+		return m.lockErrFunc(attempt)
+	}
+	return m.lockErr
+}
+func (m *transactionMockDevice) ReleaseNodeLock(_ *corev1.Node, _ *corev1.Pod) error {
+	m.releaseCalls.Add(1)
+	if m.events != nil {
+		m.mu.Lock()
+		*m.events = append(*m.events, "release:"+m.name)
+		m.mu.Unlock()
+	}
+	return m.releaseErr
+}
+
+func Test_lockAllDevices_Transactional(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}}
+	errMockFailed := fmt.Errorf("mock lock failed")
+
+	t.Run("AllLocksSucceed", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		dev1 := &transactionMockDevice{name: "backend1"}
+		dev2 := &transactionMockDevice{name: "backend2"}
+		dev3 := &transactionMockDevice{name: "backend3"}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+			"backend3": dev3,
+		}
+
+		s := Scheduler{}
+		err := s.lockAllDevices(node, pod)
+		assert.NilError(t, err)
+		assert.Equal(t, dev1.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev2.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev3.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(0))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(0))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+	})
+
+	t.Run("FirstBackendFails", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		dev1 := &transactionMockDevice{name: "backend1", lockErr: errMockFailed}
+		dev2 := &transactionMockDevice{name: "backend2"}
+		dev3 := &transactionMockDevice{name: "backend3"}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+			"backend3": dev3,
+		}
+
+		s := Scheduler{}
+		err := s.lockAllDevices(node, pod)
+		assert.ErrorIs(t, err, errMockFailed)
+		assert.Equal(t, dev1.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev2.lockCalls.Load(), int32(0))
+		assert.Equal(t, dev3.lockCalls.Load(), int32(0))
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(0))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(0))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+	})
+
+	// LastBackendFails: backend1 and backend2 both acquire locks, backend3 fails.
+	// This verifies:
+	//   - backend1 and backend2 are each released exactly once.
+	//   - backend3 is NOT released.
+	//   - rollback is in reverse acquisition order: release:backend2 before release:backend1.
+	t.Run("LastBackendFails", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		events := &[]string{}
+		dev1 := &transactionMockDevice{name: "backend1", events: events}
+		dev2 := &transactionMockDevice{name: "backend2", events: events}
+		dev3 := &transactionMockDevice{name: "backend3", lockErr: errMockFailed, events: events}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+			"backend3": dev3,
+		}
+
+		s := Scheduler{}
+		err := s.lockAllDevices(node, pod)
+		assert.ErrorIs(t, err, errMockFailed)
+
+		// Call counts
+		assert.Equal(t, dev1.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev2.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev3.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+
+		// Verify event order: lock1, lock2, lock3(fail), release2, release1
+		assert.DeepEqual(t, *events, []string{
+			"lock:backend1",
+			"lock:backend2",
+			"lock:backend3",
+			"release:backend2",
+			"release:backend1",
+		})
+	})
+
+	// SubsequentAttemptSucceedsAfterRollback: confirms that after a failed+rollback attempt,
+	// a subsequent lockAllDevices() call with the failure cleared succeeds cleanly.
+	t.Run("SubsequentAttemptSucceedsAfterRollback", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		dev1 := &transactionMockDevice{name: "backend1"}
+		dev2 := &transactionMockDevice{name: "backend2"}
+		dev3 := &transactionMockDevice{name: "backend3", lockErr: errMockFailed}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+			"backend3": dev3,
+		}
+
+		s := Scheduler{}
+
+		// First attempt: backend3 fails → rollback
+		err := s.lockAllDevices(node, pod)
+		assert.ErrorIs(t, err, errMockFailed)
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+
+		// Clear the failure for backend3
+		dev3.lockErr = nil
+
+		// Second attempt: all succeed
+		err = s.lockAllDevices(node, pod)
+		assert.NilError(t, err)
+		assert.Equal(t, dev1.lockCalls.Load(), int32(2))
+		assert.Equal(t, dev2.lockCalls.Load(), int32(2))
+		assert.Equal(t, dev3.lockCalls.Load(), int32(2))
+		// No additional releases
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev3.releaseCalls.Load(), int32(0))
+	})
+
+	// RollbackReleaseError: backend1 acquires its lock, backend2's LockNode fails triggering
+	// rollback, but backend1's ReleaseNodeLock itself returns an error.
+	// Verifies:
+	//   - the original LockNode error from backend2 is returned (not swallowed by relErr).
+	//   - ReleaseNodeLock is still called on backend1 exactly once (release is attempted).
+	//   - the release error does not prevent returning the original lock error.
+	t.Run("RollbackReleaseError", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		errRelease := fmt.Errorf("mock release failed")
+		dev1 := &transactionMockDevice{name: "backend1", releaseErr: errRelease}
+		dev2 := &transactionMockDevice{name: "backend2", lockErr: errMockFailed}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+		}
+
+		s := Scheduler{}
+		err := s.lockAllDevices(node, pod)
+
+		// Original LockNode error must be returned, not the release error.
+		assert.ErrorIs(t, err, errMockFailed)
+		// backend1 was locked and release was attempted exactly once.
+		assert.Equal(t, dev1.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
+		// backend2 was attempted but failed; no release on it.
+		assert.Equal(t, dev2.lockCalls.Load(), int32(1))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(0))
+	})
+
+	// AcquireNodeLocks_RetryLoop_ReleaseCount: exercises the REAL acquireNodeLocks() retry loop
+	// when a podgroup member encounters node-lock contention on attempt 1 and succeeds on attempt 2.
+	// Verifies:
+	//   - backend1 is locked on attempt 1, then backend2 returns nodelockutil.ErrNodeLockContention.
+	//   - rollback in lockAllDevices() releases backend1 exactly once for attempt 1 (release:backend1).
+	//   - acquireNodeLocks() catches contention error and enters retry loop.
+	//   - on attempt 2, backend1 and backend2 both lock successfully.
+	//   - acquireNodeLocks() returns nil.
+	//   - total release count for backend1 is 1 (no duplicate releases from acquireNodeLocks).
+	//   - total release count for backend2 is 0.
+	t.Run("AcquireNodeLocks_RetryLoop_ReleaseCount", func(t *testing.T) {
+		oldDevicesMap := device.DevicesMap
+		defer func() { device.DevicesMap = oldDevicesMap }()
+
+		oldTimeout := config.NodeLockRetryTimeout
+		config.NodeLockRetryTimeout = 5 * time.Second
+		defer func() { config.NodeLockRetryTimeout = oldTimeout }()
+
+		pgPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "default",
+				Labels:    map[string]string{util.PodGroupLabel: "pg1"},
+			},
+		}
+
+		events := &[]string{}
+		dev1 := &transactionMockDevice{name: "backend1", events: events}
+		dev2 := &transactionMockDevice{
+			name:   "backend2",
+			events: events,
+			lockErrFunc: func(attempt int32) error {
+				if attempt == 1 {
+					return nodelockutil.ErrNodeLockContention
+				}
+				return nil
+			},
+		}
+		device.DevicesMap = map[string]device.Devices{
+			"backend1": dev1,
+			"backend2": dev2,
+		}
+
+		s := Scheduler{}
+		err := s.acquireNodeLocks(node, pgPod)
+
+		// Verification:
+		// 1. acquireNodeLocks() returns nil (second attempt succeeded)
+		assert.NilError(t, err)
+
+		// 2. Call counts: both backends locked twice (attempt 1 & attempt 2)
+		assert.Equal(t, dev1.lockCalls.Load(), int32(2))
+		assert.Equal(t, dev2.lockCalls.Load(), int32(2))
+
+		// 3. Release counts: backend1 released EXACTLY ONCE (during attempt 1 rollback).
+		//    backend2 NEVER released (failed attempt 1 before lock was acquired, succeeded attempt 2).
+		//    NO duplicate release was issued by acquireNodeLocks().
+		assert.Equal(t, dev1.releaseCalls.Load(), int32(1))
+		assert.Equal(t, dev2.releaseCalls.Load(), int32(0))
+
+		// 4. Exact sequence of events across the real retry loop:
+		//    Attempt 1: lock1, lock2(fail -> contention) -> release1 (rollback)
+		//    Attempt 2: lock1, lock2(succeed)
+		assert.DeepEqual(t, *events, []string{
+			"lock:backend1",
+			"lock:backend2",
+			"release:backend1",
+			"lock:backend1",
+			"lock:backend2",
+		})
+	})
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When the scheduler acquires node locks across multiple registered device backends, `lockAllDevices()` acquires the locks sequentially.

Previously, if an earlier backend successfully acquired its lock but a later backend failed, the function returned immediately without rolling back the locks that had already been acquired.

This could leave partially acquired node locks behind even though the scheduling attempt itself failed, potentially causing stale lock state or unnecessary lock contention for subsequent scheduling attempts on heterogeneous nodes.

This PR makes device lock acquisition transactional:

- Successfully acquired locks are tracked during the current attempt.
- If a later backend fails to acquire its lock, previously acquired locks are released.
- Rollback happens in reverse acquisition order.
- The original `LockNode()` error is preserved.
- The failed backend and backends that were never attempted are not released.
- Existing successful lock acquisition behavior remains unchanged.
- Existing pod-group retry behavior is preserved without duplicate rollback.

## Which issue(s) this PR fixes

Fixes #2625

## Special notes for your reviewer

The fix is intentionally limited to the scheduler's device-lock acquisition path.

The existing `releaseAllDevices()` mechanism is reused for rollback rather than introducing a separate locking mechanism.

Regression tests cover:

- all device locks succeeding
- failure on the first backend
- failure after earlier backends have successfully acquired locks
- exact rollback of previously acquired locks
- no release for the failed or unattempted backends
- preservation of the original lock acquisition error

## Validation

The following checks were run successfully:

- `go test ./pkg/scheduler/...`
- `go test -race ./pkg/scheduler/...`
- `go vet ./pkg/scheduler/...`
- GolangCI-Lint
- `gofmt`
- `git diff --check`

## Does this PR introduce a user-facing change?

No.

This is an internal scheduler correctness fix that ensures failed multi-backend lock acquisition does not leave previously acquired locks behind.

## AI Assistance Disclosure

AI assistance was used during investigation of the HAMi codebase, root-cause analysis, implementation, regression-test development, and validation of this change.

The resulting changes were reviewed against the existing HAMi scheduler and device-locking architecture, with the implementation and tests validated by the contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-locking reliability with a consistent acquisition and release order.
  * Automatically rolls back previously acquired locks when a later lock cannot be obtained.
  * Prevented redundant lock-release operations after failed acquisition attempts.
  * Preserved the original locking error when rollback encounters an additional failure.
  * Enabled reliable retries after failed locking attempts.

* **Tests**
  * Added coverage for successful locking, failures, rollback scenarios, retries, and operation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->