### PR TITLE
fix: remove redundant fmt.Sprintf in NVIDIA device plugin startup logging

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -136,7 +136,7 @@ func readFromConfigFile(sConfig *nvidia.NvidiaConfig, path string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	klog.Infof("Device Plugin Configs: %v", fmt.Sprintf("%v", deviceConfigs))
+	klog.Infof("Device Plugin Configs: %v", deviceConfigs)
 	for _, val := range deviceConfigs.Nodeconfig {
 		if os.Getenv(util.NodeNameEnvName) == val.Name {
 			klog.Infof("Reading config from file %s", val.Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind fix

**What this PR does / why we need it**:
Removes a redundant `fmt.Sprintf` wrapper during the initialization of the NVIDIA device plugin (`pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go`). 

The startup configuration was previously logged as:
`klog.Infof("Device Plugin Configs: %v", fmt.Sprintf("%v", deviceConfigs))`

This creates an unnecessary string allocation because `klog.Infof` natively handles the `%v` format verb. This commit simplifies the statement to `klog.Infof("Device Plugin Configs: %v", deviceConfigs)` to prevent the redundant allocation and satisfy Go linters.

**Which issue(s) this PR fixes**:
Fixes #2631 

**Special notes for reviewer**:
*AI Disclosure: An AI coding assistant helped me edit the code, while I identified the code quality issue and guided the changes..*

**Does this PR introduce a user-facing change?**:
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the formatting of device configuration information in diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->