### PR TITLE
fix(vGPUmonitor): report recorded memory offset instead of derived value

### DIFF
--- a/cmd/vGPUmonitor/feedback_test.go
+++ b/cmd/vGPUmonitor/feedback_test.go
@@ -38,6 +38,7 @@ type stubInfo struct {
 	ctxSize    []uint64
 	modSize    []uint64
 	bufSize    []uint64
+	offset     []uint64
 	smUtil     []uint64
 	lastKernel int64
 }
@@ -60,7 +61,7 @@ func (s *stubInfo) DeviceUUID(i int) string {
 func (s *stubInfo) DeviceMemoryContextSize(i int) uint64 { return slot(s.ctxSize, i) }
 func (s *stubInfo) DeviceMemoryModuleSize(i int) uint64  { return slot(s.modSize, i) }
 func (s *stubInfo) DeviceMemoryBufferSize(i int) uint64  { return slot(s.bufSize, i) }
-func (s *stubInfo) DeviceMemoryOffset(int) uint64        { return 0 }
+func (s *stubInfo) DeviceMemoryOffset(i int) uint64      { return slot(s.offset, i) }
 func (s *stubInfo) DeviceMemoryTotal(i int) uint64       { return slot(s.total, i) }
 func (s *stubInfo) DeviceSmUtil(i int) uint64            { return slot(s.smUtil, i) }
 func (s *stubInfo) SetDeviceSmLimit(uint64)              {}

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -462,7 +462,12 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			klog.Errorf("Failed to send device memory desc: %v", err)
 			return err
 		}
-		memoryOffset := memoryTotal - memoryContextSize - memoryModuleSize - memoryBufferSize
+		// Read the offset recorded by the CUDA hook directly rather than deriving
+		// it from total - context - module - buffer. Those four values are summed
+		// independently across active processes in the shared region and are not an
+		// atomic snapshot, so context+module+buffer can momentarily exceed total,
+		// which underflows the unsigned subtraction to a value near MaxUint64.
+		memoryOffset := c.Info.DeviceMemoryOffset(i)
 		memoryLabels := append(labels, fmt.Sprint(memoryContextSize), fmt.Sprint(memoryModuleSize), fmt.Sprint(memoryBufferSize), fmt.Sprint(memoryOffset))
 		sendLegacyMetric(ch, legacyCtrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), memoryLabels...)
 

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -66,5 +69,65 @@ func TestDescribeCollectSync(t *testing.T) {
 	}
 	if _, err := regLegacy.Gather(); err != nil {
 		t.Errorf("Gather failed (legacy): %v", err)
+	}
+}
+
+// TestCollectContainerMetricsOffsetNoUnderflow guards the offset label of the
+// Device_memory_desc_of_container legacy metric. The offset used to be derived as
+// total - context - module - buffer, an unsigned subtraction that underflows to a
+// value near MaxUint64 whenever context+module+buffer momentarily exceeds total
+// (the four sizes are summed independently over the shared region and are not an
+// atomic snapshot). The collector now reports the offset recorded by the CUDA hook
+// directly, so the label must equal that recorded value regardless of how the
+// other sizes relate to total.
+func TestCollectContainerMetricsOffsetNoUnderflow(t *testing.T) {
+	initLegacyDescriptors()
+
+	const recordedOffset = 4096
+	// context+module+buffer (150) deliberately exceeds total (100); the old
+	// derivation would underflow here.
+	info := &stubInfo{
+		uuids:   []string{"GPU-00000000-1111-2222-3333-444444444444"},
+		total:   []uint64{100},
+		limit:   []uint64{100},
+		ctxSize: []uint64{60},
+		modSize: []uint64{50},
+		bufSize: []uint64{40},
+		offset:  []uint64{recordedOffset},
+	}
+	c := &nvidia.ContainerUsage{PodUID: "uid", ContainerName: "ctr", Info: info}
+	pod := &corev1.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "pod"
+
+	ch := make(chan prometheus.Metric, 64)
+	cc := ClusterManagerCollector{}
+	if err := cc.collectContainerMetrics(ch, pod, corev1.Container{Name: "ctr"}, c, 0); err != nil {
+		t.Fatalf("collectContainerMetrics returned error: %v", err)
+	}
+	close(ch)
+
+	var got string
+	found := false
+	for m := range ch {
+		if !strings.Contains(m.Desc().String(), "Device_memory_desc_of_container") {
+			continue
+		}
+		var dm dto.Metric
+		if err := m.Write(&dm); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+		for _, l := range dm.GetLabel() {
+			if l.GetName() == "offset" {
+				got = l.GetValue()
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("Device_memory_desc_of_container metric with an offset label was not emitted")
+	}
+	if got != "4096" {
+		t.Errorf("offset label = %q, want %q (recorded offset must be reported verbatim, not derived and underflowed)", got, "4096")
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
The `Device_memory_desc_of_container` legacy metric computes its `offset` label as `total - context - module - buffer`. `DeviceMemoryContextSize`, `DeviceMemoryModuleSize`, `DeviceMemoryBufferSize` and `DeviceMemoryTotal` each sum their field independently across the active processes in the mmap'd shared region and are not read as one atomic snapshot, so `context + module + buffer` can momentarily exceed `total`. The unsigned subtraction then underflows and the metric exports an `offset` near `MaxUint64`.

The shared region already records the offset as a first-class field, exposed through `UsageInfo.DeviceMemoryOffset(idx)` (implemented in both v0 and v1 Spec). This reports that recorded value directly — semantically correct and free of underflow.

### Which issue(s) this PR fixes
Fixes #2551

### Test
Adds `TestCollectContainerMetricsOffsetNoUnderflow`, which drives `collectContainerMetrics` with `context+module+buffer > total` and asserts the emitted `offset` label equals the recorded offset. The test fails on the old subtraction (label `18446744073709551566`) and passes with the fix.

### AI assistance disclosure
This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container device-memory metrics that could report incorrect values when sampled memory components temporarily exceeded total memory.
  * Metrics now accurately reflect the recorded device-memory offset, preventing underflow-related inaccuracies.

* **Tests**
  * Added regression coverage for accurate offset reporting under inconsistent memory samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->