### PR TITLE
fix(scheduler): avoid false positives in AllInitContainersSucceeded

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -160,7 +160,14 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	return err
 }
 func AllInitContainersSucceeded(pod *corev1.Pod) bool {
-	if len(pod.Status.InitContainerStatuses) == 0 {
+	if pod == nil {
+		return false
+	}
+	initContainers := len(pod.Spec.InitContainers)
+	if initContainers == 0 {
+		return false
+	}
+	if len(pod.Status.InitContainerStatuses) != initContainers {
 		return false
 	}
 	for _, s := range pod.Status.InitContainerStatuses {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -538,6 +538,72 @@ func Test_AllContainersCreated(t *testing.T) {
 	}
 }
 
+func Test_AllInitContainersSucceeded(t *testing.T) {
+	tests := []struct {
+		name string
+		args *corev1.Pod
+		want bool
+	}{
+		{
+			name: "missing init container statuses",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a"},
+						{Name: "init-b"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-a",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all init containers terminated successfully",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a"},
+						{Name: "init-b"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-a",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+						{
+							Name: "init-b",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := AllInitContainersSucceeded(test.args)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestIsPodGroupMember(t *testing.T) {
 	podGroupName := "my-training-job"
 	emptyPodGroupName := ""


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes a scheduler correctness bug in `AllInitContainersSucceeded`.

Previously, the function could return `true` even when not all init containers had reported status entries (for example, 2 init containers in spec, but only 1 in status).
That can cause HAMi to treat init containers as completed too early and may trigger early resource-usage shrink decisions in scheduler flow.

This PR makes the check strict:
- pod must have init containers
- `len(Status.InitContainerStatuses)` must equal `len(Spec.InitContainers)`
- each init container status must be terminated with `exit code 0`

It also adds focused regression coverage in `Test_AllInitContainersSucceeded` for:
- missing init-container statuses (bug case)
- all init containers succeeded (valid case)

**Which issue(s) this PR fixes**:
Fixes #2642 

**Special notes for your reviewer**:

Scope is intentionally minimal and focused.
Changed files only:
- `pkg/util/util.go`
- `pkg/util/util_test.go`

Validation run:
- go test ./pkg/util -run Test_AllInitContainersSucceeded -count=1
- go test ./pkg/util -count=1

**Does this PR introduce a user-facing change?**:
No,
This is an internal scheduler correctness fix and test update only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved init-container completion checks to correctly handle missing pods, absent init containers, incomplete status reporting, and unsuccessful termination states.
  * Ensured workloads are recognized as complete only when every declared init container finishes successfully.

* **Tests**
  * Added coverage for incomplete status reporting and successful completion of all init containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->