### PR TITLE
docs: add AI disclosure to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,7 @@ Fixes #
 **Special notes for your reviewer**:
 
 **Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**:
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**
/kind documenation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Adds AI disclosure section to PR template at the very end.
We need this as it removes redundant and repetitive conversation in almost all PRs of maintainers and contributors about adding AI Disclosure, hope this helps out our Maintainers Team

My earlier PR #2483 got closed since it was duplicate of this PR https://github.com/Project-HAMi/HAMi/pull/2261, but eventually this PR also the did not merge, hence creating a new PR to resolve the same.


**Which issue(s) this PR fixes**:
Fixes #2482 

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
Next time, when contributor raises a PR, they will see a **AI Disclosure**:  as well, which well ensure that do not forget to add the disclosure.

**AI Disclosure:**
There is no AI usage for this one and all the Issue and PR content is typed by myself along with the fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template to include AI assistance disclosure guidance.
  * Clarified that AI co-author or assistance commit trailers should not be added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->