### PR TITLE
fix(scheduler): check if pod is actually bound before releasing locks on api error

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1006,7 +1006,7 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 
 	if err = s.kubeClient.CoreV1().Pods(args.PodNamespace).Bind(context.Background(), binding, metav1.CreateOptions{}); err != nil {
 		klog.ErrorS(err, "Failed to bind pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
-		
+
 		// Verify if the pod was actually bound despite the API error (e.g., due to a network timeout)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1008,14 +1008,23 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 		klog.ErrorS(err, "Failed to bind pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
 
 		// Verify if the pod was actually bound despite the API error (e.g., due to a network timeout)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if actualPod, getErr := s.kubeClient.CoreV1().Pods(args.PodNamespace).Get(ctx, args.PodName, metav1.GetOptions{}); getErr == nil {
-			if actualPod.Spec.NodeName == args.Node {
-				klog.InfoS("Pod successfully bound despite API error, retaining node locks", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
-				s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
-				return &extenderv1.ExtenderBindingResult{Error: ""}, nil
+		// We use a retry loop because a single immediate Get might read a stale cache or pre-bind state.
+		errPoll := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			actualPod, getErr := s.kubeClient.CoreV1().Pods(args.PodNamespace).Get(ctx, args.PodName, metav1.GetOptions{})
+			if getErr != nil {
+				return false, nil // Ignore and retry
 			}
+			// Require UID match to avoid keeping locks for a replacement pod with the same name.
+			if actualPod.UID == args.PodUID && actualPod.Spec.NodeName == args.Node {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if errPoll == nil {
+			klog.InfoS("Pod successfully bound despite API error, retaining node locks", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
+			s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
+			return &extenderv1.ExtenderBindingResult{Error: ""}, nil
 		}
 
 		return fail(err)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1006,6 +1006,18 @@ func (s *Scheduler) Bind(args extenderv1.ExtenderBindingArgs) (*extenderv1.Exten
 
 	if err = s.kubeClient.CoreV1().Pods(args.PodNamespace).Bind(context.Background(), binding, metav1.CreateOptions{}); err != nil {
 		klog.ErrorS(err, "Failed to bind pod", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
+		
+		// Verify if the pod was actually bound despite the API error (e.g., due to a network timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if actualPod, getErr := s.kubeClient.CoreV1().Pods(args.PodNamespace).Get(ctx, args.PodName, metav1.GetOptions{}); getErr == nil {
+			if actualPod.Spec.NodeName == args.Node {
+				klog.InfoS("Pod successfully bound despite API error, retaining node locks", "pod", args.PodName, "namespace", args.PodNamespace, "node", args.Node)
+				s.recordScheduleBindingResultEvent(current, EventReasonBindingSucceed, []string{args.Node}, nil)
+				return &extenderv1.ExtenderBindingResult{Error: ""}, nil
+			}
+		}
+
 		return fail(err)
 	}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -37,11 +37,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
-	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/common"
@@ -2301,7 +2301,8 @@ func TestBind_TimeoutStateRecovery(t *testing.T) {
 	defer cleanup()
 
 	// Intercept bindings to simulate a network timeout returning from the Bind API call
-	fakeClient := s.kubeClient.(*fake.Clientset)
+	fakeClient, ok := s.kubeClient.(*fake.Clientset)
+	require.True(t, ok, "kubeClient should be of type *fake.Clientset")
 	fakeClient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() == "binding" {
 			return true, nil, fmt.Errorf("simulated network timeout")

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2303,6 +2303,21 @@ func TestBind_TimeoutStateRecovery(t *testing.T) {
 	// Intercept bindings to simulate a network timeout returning from the Bind API call
 	fakeClient, ok := s.kubeClient.(*fake.Clientset)
 	require.True(t, ok, "kubeClient should be of type *fake.Clientset")
+
+	// Track get requests to simulate delayed visibility
+	getCalls := int32(0)
+	fakeClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		calls := atomic.AddInt32(&getCalls, 1)
+		// On the first read, simulate the pod being unbound
+		if calls == 1 {
+			unboundPod := pod.DeepCopy()
+			unboundPod.Spec.NodeName = ""
+			return true, unboundPod, nil
+		}
+		// On subsequent reads, simulate the binding becoming visible
+		return true, pod, nil
+	})
+
 	fakeClient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() == "binding" {
 			return true, nil, fmt.Errorf("simulated network timeout")
@@ -2314,4 +2329,5 @@ func TestBind_TimeoutStateRecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, res.Error, "Bind should recover and return success when pod is actually bound")
 	require.Equal(t, int32(0), mock.releaseCalls.Load(), "ReleaseNodeLock should NOT be called because pod is actually bound")
+	require.GreaterOrEqual(t, getCalls, int32(2), "Expected at least 2 Get calls (one unbound, then bound) due to retry mechanism")
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2304,17 +2304,21 @@ func TestBind_TimeoutStateRecovery(t *testing.T) {
 	fakeClient, ok := s.kubeClient.(*fake.Clientset)
 	require.True(t, ok, "kubeClient should be of type *fake.Clientset")
 
-	// Track get requests to simulate delayed visibility
+	// Track get requests to simulate delayed visibility and intermittent errors
 	getCalls := int32(0)
 	fakeClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		calls := atomic.AddInt32(&getCalls, 1)
-		// On the first read, simulate the pod being unbound
+		// On the first read, simulate a network error reading the pod to hit the getErr != nil branch
 		if calls == 1 {
+			return true, nil, fmt.Errorf("simulated get error")
+		}
+		// On the second read, simulate the pod being unbound to hit the return false branch
+		if calls == 2 {
 			unboundPod := pod.DeepCopy()
 			unboundPod.Spec.NodeName = ""
 			return true, unboundPod, nil
 		}
-		// On subsequent reads, simulate the binding becoming visible
+		// On subsequent reads, simulate the binding becoming visible to hit the true branch
 		return true, pod, nil
 	})
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/common"
@@ -2284,4 +2285,32 @@ func Test_Bind_PodGroupPodNonContentionErrorDoesNotRetry(t *testing.T) {
 	require.Contains(t, res.Error, "apiserver 500")
 	require.Equal(t, int32(1), mock.lockCalls.Load(),
 		"non-contention error must not trigger retry")
+}
+
+func TestBind_TimeoutStateRecovery(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-timeout-test", Namespace: "default", UID: types.UID("uid-timeout"),
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1", // simulate that it was actually bound by API server despite timeout
+		},
+	}
+	mock := &bindLockMockDevice{}
+	s, args, cleanup := setupBindLockRetryTest(t, 5*time.Second, pod, mock)
+	defer cleanup()
+
+	// Intercept bindings to simulate a network timeout returning from the Bind API call
+	fakeClient := s.kubeClient.(*fake.Clientset)
+	fakeClient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		if action.GetSubresource() == "binding" {
+			return true, nil, fmt.Errorf("simulated network timeout")
+		}
+		return false, nil, nil
+	})
+
+	res, err := s.Bind(args)
+	require.NoError(t, err)
+	require.Empty(t, res.Error, "Bind should recover and return success when pod is actually bound")
+	require.Equal(t, int32(0), mock.releaseCalls.Load(), "ReleaseNodeLock should NOT be called because pod is actually bound")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a silent state-corruption bug in the scheduler's `Bind` phase. 
Previously, if the `kubeClient.CoreV1().Pods(args.PodNamespace).Bind(...)` API call returned a network error (e.g., a timeout), the scheduler assumed a complete failure and immediately called `releaseAllDevices`. However, if the API server had successfully committed the bind right before the connection dropped, the Pod would start running on the kubelet, but the scheduler had already prematurely released its device locks. This race condition leads to dangerous hardware oversubscription.

The fix adds a safety check: before releasing node locks on a `Bind` error, we do a quick `Get` on the Pod. If the Pod's `NodeName` confirms it was actually bound, we retain the device locks and recover gracefully. I've also added a comprehensive unit test (`TestBind_TimeoutStateRecovery`) using a mock `k8stesting.Reactor` to explicitly simulate this exact timeout edge case.

**Which issue(s) this PR fixes**:
Fixes #2645 

**Special notes for reviewer**:
* **AI Disclosure:** I consulted AI to understand the codebase and help debug this race condition, but the final logic and tests were authored and verified manually by myself.
* **Testing:** As per the Contribution Gates, because this fix is scoped entirely to the scheduler extender's state machine and not device allocation/isolation, it has been verified purely through unit testing (`make verify` and `go test -v ./pkg/scheduler/...`) and does not require physical GPU hardware validation logs. 

**Does this PR introduce a user-facing change?**:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod binding reliability when the API reports an error or times out.
  * Binding now succeeds when the pod is confirmed on the intended node, while preserving the node lock.
  * Failed bindings continue to follow the existing cleanup behavior.
  * Reduced the risk of incorrectly treating successfully assigned pods as failed during temporary API communication issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->