### PR TITLE
fix(device-plugin): prevent mutex pass-by-value in device replication

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -169,7 +169,7 @@ func TestCDIAllocateResponse(t *testing.T) {
 	}
 
 	for i := range testCases {
-		tc := testCases[i]
+		tc := &testCases[i]
 		t.Run(tc.description, func(t *testing.T) {
 			deviceListStrategies, _ := v1.NewDeviceListStrategies(tc.deviceListStrategies)
 			plugin := NvidiaDevicePlugin{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/device_map.go
@@ -38,6 +38,7 @@ import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/klog/v2"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
@@ -340,9 +341,19 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 		for _, id := range ids {
 			for i := 0; i < r.Replicas; i++ {
 				annotatedID := string(NewAnnotatedID(id, i))
-				replicatedDevice := *(oDevices[r.Name][id])
-				replicatedDevice.ID = annotatedID
-				replicatedDevice.Replicas = r.Replicas
+				orig := oDevices[r.Name][id]
+				replicatedDevice := Device{
+					Device: kubeletdevicepluginv1beta1.Device{
+						ID:       annotatedID,
+						Health:   orig.Health,
+						Topology: orig.Topology,
+					},
+					Paths:             orig.Paths,
+					Index:             orig.Index,
+					TotalMemory:       orig.TotalMemory,
+					ComputeCapability: orig.ComputeCapability,
+					Replicas:          r.Replicas,
+				}
 				devices.insert(name, &replicatedDevice)
 			}
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
@@ -253,7 +253,7 @@ func (ds Devices) AlignedAllocationSupported() bool {
 }
 
 // AlignedAllocationSupported checks whether the device supports an aligned allocation
-func (d Device) AlignedAllocationSupported() bool {
+func (d *Device) AlignedAllocationSupported() bool {
 	if d.IsMigDevice() {
 		return false
 	}
@@ -268,12 +268,12 @@ func (d Device) AlignedAllocationSupported() bool {
 }
 
 // IsMigDevice returns checks whether d is a MIG device or not.
-func (d Device) IsMigDevice() bool {
+func (d *Device) IsMigDevice() bool {
 	return strings.Contains(d.Index, ":")
 }
 
 // GetUUID returns the UUID for the device from the annotated ID.
-func (d Device) GetUUID() string {
+func (d *Device) GetUUID() string {
 	return AnnotatedID(d.ID).GetID()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes the `go vet` warnings regarding Mutex lock copying in the `nvidiadevice` RM package. By passing `Device` by pointer instead of value, we ensure the embedded mutex is not silently cloned, which would otherwise defeat synchronization. 

*AI Disclosure: I manually authored and reviewed this code, but I used an AI assistant to help me run `go vet` across the repository and draft the initial fix. The final implementation and understanding of the code is my own work.*

**Which issue(s) this PR fixes**:
Fixes #2651

**Special notes for your reviewer**:
Note: `make verify` currently fails on the `master` branch due to a pre-existing syntax error in `.golangci.yaml` (`Error: can't load config: the format is required`), but standard `go vet` passes cleanly on these changes.

**Does this PR introduce a user-facing change?**:
```release-note
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of replicated GPU devices by preserving device metadata and configuration.
  * Enhanced reliability when identifying devices, retrieving device identifiers, and determining supported allocation modes.
  * Fixed test-case handling to ensure allocation scenarios are evaluated against the correct data.

* **Tests**
  * Updated allocation coverage to better validate device-plugin responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->