### PR TITLE
fix(device-plugin): auto-set CUDA_DISABLE_CONTROL for whole-GPU allocations

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -470,6 +470,44 @@ func TestAllocate_MultiContainer_CUDA_DISABLE_CONTROL_FirstContainer(t *testing.
 		"container 1 should have ld.so.preload mounted")
 }
 
+func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"}, // No explicit CUDA_DISABLE_CONTROL
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+
+	require.Equal(t, "true", response.ContainerResponses[0].Envs["CUDA_DISABLE_CONTROL"],
+		"CUDA_DISABLE_CONTROL should be auto-set to true for whole-GPU allocation")
+	require.False(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"ld.so.preload should NOT be mounted for whole-GPU allocation")
+}
+
 func TestAllocate_DeviceNumberMismatch(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -508,6 +508,46 @@ func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
 		"ld.so.preload should NOT be mounted for whole-GPU allocation")
 }
 
+func TestAllocate_WholeGPU_Explicit_False_Preserves_Mount(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0", Env: []corev1.EnvVar{
+					{Name: "CUDA_DISABLE_CONTROL", Value: "false"},
+				}},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+
+	_, hasControl := response.ContainerResponses[0].Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, hasControl, "CUDA_DISABLE_CONTROL should not be auto-set if explicitly false")
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"ld.so.preload should be mounted since CUDA_DISABLE_CONTROL is explicitly false")
+}
+
 func TestAllocate_DeviceNumberMismatch(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -860,25 +860,21 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						HostPath: "/tmp/vgpulock",
 						ReadOnly: false},
 				)
-				found := false
+				hasControlSetting := false
+				controlDisabled := false
 				for _, val := range currentCtr.Env {
 					if strings.Compare(val.Name, "CUDA_DISABLE_CONTROL") == 0 {
-						// if env existed but is set to false or can not be parsed, ignore
-						t, _ := strconv.ParseBool(val.Value)
-						if !t {
-							continue
-						}
-						// only env existed and set to true, we mark it "found"
-						found = true
+						hasControlSetting = true
+						controlDisabled, _ = strconv.ParseBool(val.Value)
 						break
 					}
 				}
-				if isWholeGPU && !found {
+				if isWholeGPU && !hasControlSetting {
 					klog.Infof("Whole GPU allocation detected without explicit CUDA_DISABLE_CONTROL, auto-setting to true")
-					found = true
+					controlDisabled = true
 					response.Envs["CUDA_DISABLE_CONTROL"] = "true"
 				}
-				if !found {
+				if !controlDisabled {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",
 						HostPath: hostHookPath + "/vgpu/ld.so.preload",
 						ReadOnly: true},

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -820,11 +820,18 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 
 			if plugin.operatingMode != "mig" {
+				isWholeGPU := true
 				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
+					if dev.Usedmem != 0 {
+						isWholeGPU = false
+					}
 				}
 				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
+				if devreq[0].Usedcores != 0 {
+					isWholeGPU = false
+				}
 				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
 				if *plugin.schedulerConfig.DeviceMemoryScaling > 1 {
 					response.Envs["CUDA_OVERSUBSCRIBE"] = "true"
@@ -865,6 +872,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						found = true
 						break
 					}
+				}
+				if isWholeGPU && !found {
+					klog.Infof("Whole GPU allocation detected without explicit CUDA_DISABLE_CONTROL, auto-setting to true")
+					found = true
+					response.Envs["CUDA_DISABLE_CONTROL"] = "true"
 				}
 				if !found {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -67,28 +68,59 @@ func UpdateNode(clientSet *kubernetes.Clientset, node *v1.Node) (*v1.Node, error
 }
 
 func AddNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey, labelValue string) (*v1.Node, error) {
-	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	var updatedNode *v1.Node
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		
+		if val, ok := node.Labels[labelKey]; ok && val == labelValue {
+			updatedNode = node
+			return nil // Label already set to the desired value
+		}
+		
+		node.Labels[labelKey] = labelValue
+
+		updatedNode, err = UpdateNode(clientSet, node)
+		return err
+	})
+
 	if err != nil {
 		return nil, err
 	}
-
-	if node.Labels == nil {
-		node.Labels = make(map[string]string)
-	}
-	node.Labels[labelKey] = labelValue
-
-	return UpdateNode(clientSet, node)
+	return updatedNode, nil
 }
 
 func RemoveNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey string) (*v1.Node, error) {
-	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	var updatedNode *v1.Node
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if node.Labels != nil {
+			if _, ok := node.Labels[labelKey]; !ok {
+				updatedNode = node
+				return nil // Label already removed
+			}
+			delete(node.Labels, labelKey)
+		} else {
+			updatedNode = node
+			return nil
+		}
+
+		updatedNode, err = UpdateNode(clientSet, node)
+		return err
+	})
+	
 	if err != nil {
 		return nil, err
 	}
-
-	if node.Labels != nil {
-		delete(node.Labels, labelKey)
-	}
-
-	return UpdateNode(clientSet, node)
+	return updatedNode, nil
 }

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -78,12 +78,12 @@ func AddNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey, labelValu
 		if node.Labels == nil {
 			node.Labels = make(map[string]string)
 		}
-		
+
 		if val, ok := node.Labels[labelKey]; ok && val == labelValue {
 			updatedNode = node
 			return nil // Label already set to the desired value
 		}
-		
+
 		node.Labels[labelKey] = labelValue
 
 		updatedNode, err = UpdateNode(clientSet, node)
@@ -118,7 +118,7 @@ func RemoveNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey string)
 		updatedNode, err = UpdateNode(clientSet, node)
 		return err
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR auto-sets `CUDA_DISABLE_CONTROL=true` and skips mounting `ld.so.preload` when a pod is allocated a whole GPU (meaning `Usedmem == 0` and `Usedcores == 0`). In whole-GPU mode, there are no limits for `libvgpu.so` to enforce, so the interception adds no value and causes deadlocks in vLLM's pynccl during `ncclCommInitRank`. By bypassing it automatically, vLLM works out of the box for whole-GPU allocations without requiring users to manually configure their pod environment.

**Which issue(s) this PR fixes**:
Fixes #2641

**Special notes for your reviewer**:
The device plugin now checks if the allocation has no memory or core limits. If so, and if `CUDA_DISABLE_CONTROL` isn't explicitly set by the user, we auto-inject it into the environment. Unit tests have been updated/added in `alloc_refactor_test.go` to ensure this behavior is covered.

**Does this PR introduce a user-facing change?**:
```release-note
Fix: Auto-set CUDA_DISABLE_CONTROL=true for whole-GPU allocations to prevent vLLM pynccl deadlocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Whole-GPU allocations now automatically set `CUDA_DISABLE_CONTROL=true` when no explicit value is provided.
  - Explicit `CUDA_DISABLE_CONTROL` settings continue to be honored, including associated library mount behavior.

- **Bug Fixes**
  - Improved reliability when adding or removing node labels by safely handling concurrent Kubernetes updates and avoiding unnecessary changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->