### PR TITLE
fix(nvidia): preserve devreq order in selectPreferredDeviceIDsFromAnnotatedDevices

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -664,16 +664,14 @@ func (plugin *NvidiaDevicePlugin) selectPreferredDeviceIDsFromAnnotatedDevices(a
 	}
 
 	requiredSet := make(map[string]bool, len(required))
-	requiredByPhysical := make(map[string]int, len(required))
-	availableByPhysical := make(map[string][]string)
-	selected := make([]string, 0, allocationSize)
-
+	requiredByPhysical := make(map[string][]string, len(required))
 	for _, id := range required {
 		requiredSet[id] = true
-		requiredByPhysical[physicalDeviceID(id)]++
-		selected = append(selected, id)
+		physicalID := physicalDeviceID(id)
+		requiredByPhysical[physicalID] = append(requiredByPhysical[physicalID], id)
 	}
 
+	availableByPhysical := make(map[string][]string)
 	for _, id := range available {
 		if requiredSet[id] {
 			continue
@@ -681,10 +679,16 @@ func (plugin *NvidiaDevicePlugin) selectPreferredDeviceIDsFromAnnotatedDevices(a
 		availableByPhysical[physicalDeviceID(id)] = append(availableByPhysical[physicalDeviceID(id)], id)
 	}
 
+	// Build the result in desired's order. Allocate() later zips this
+	// response positionally against the scheduler's per-device memory/core
+	// plan (see alignContainerDevicesWithAllocatedIDs); putting required IDs
+	// first here would desync position i's UUID from position i's limits.
+	selected := make([]string, 0, allocationSize)
 	for _, dev := range desired[:allocationSize] {
 		physicalID := physicalDeviceID(dev.UUID)
-		if requiredByPhysical[physicalID] > 0 {
-			requiredByPhysical[physicalID]--
+		if queue := requiredByPhysical[physicalID]; len(queue) > 0 {
+			selected = append(selected, queue[0])
+			requiredByPhysical[physicalID] = queue[1:]
 			continue
 		}
 		candidates := availableByPhysical[physicalID]

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -232,9 +232,10 @@ func TestSelectPreferredDeviceIDsFromAnnotatedDevices(t *testing.T) {
 
 	got, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, required, desired, len(desired))
 	require.NoError(t, err)
-	require.Len(t, got, len(desired))
-	require.Contains(t, got, "GPU-03f69c50-207a-2038-9b45-23cac89cb67d-1")
-	require.ElementsMatch(t, []string{
+	// Order must match desired's order position-for-position — required's
+	// device (67d) sits at desired[3], not desired[0] — so a correct
+	// implementation must not float it to the front of the result.
+	require.Equal(t, []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
@@ -260,6 +261,59 @@ func TestSelectPreferredDeviceIDsFromAnnotatedDevicesErrorsWhenAnnotatedUUIDMiss
 	_, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, nil, desired, len(desired))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "GPU-03f69c50-207a-2038-9b45-23cac89cb67c")
+}
+
+func TestSelectPreferredDeviceIDsFromAnnotatedDevicesRequiredNotAtFrontOfDesired(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{}
+	available := []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
+	}
+	// Kubelet requires the LAST GPU in the scheduler's plan to stay put —
+	// the case that would previously float to selected[0].
+	required := []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0"}
+	desired := device.ContainerDevices{
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c"},
+	}
+
+	got, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, required, desired, len(desired))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
+	}, got)
+}
+
+func TestSelectPreferredDeviceIDsFromAnnotatedDevicesMultipleRequiredSlicesSamePhysicalGPU(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{}
+	available := []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0", "GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+	}
+	// Two required slices come from the same physical GPU (67a); each must
+	// land at the desired position matching that physical GPU, in required's
+	// own relative order, without being confused for one another.
+	required := []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+	}
+	desired := device.ContainerDevices{
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a"},
+		{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b"},
+	}
+
+	got, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(available, required, desired, len(desired))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-1",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+	}, got)
 }
 
 func TestGetDevicePluginOptionsEnablesPreferredAllocation(t *testing.T) {
@@ -332,7 +386,9 @@ func TestGetPreferredAllocationAlignsWithAnnotatedDevices(t *testing.T) {
 	response, err := plugin.GetPreferredAllocation(context.Background(), request)
 	require.NoError(t, err)
 	require.Len(t, response.ContainerResponses, 1)
-	require.ElementsMatch(t, []string{
+	// Order must match the annotated devreq order, since Allocate() later
+	// reads per-position memory/core limits from that same order.
+	require.Equal(t, []string{
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
 		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
@@ -847,6 +903,127 @@ func TestAllocatePreservesContainerOrderWhenOneContainerFallsBack(t *testing.T) 
 	require.Equal(t, "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", response.ContainerResponses[1].Envs[deviceListEnvVar])
 	require.Equal(t, "3000m", response.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
 	require.Equal(t, "4000m", response.ContainerResponses[1].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+}
+
+// TestAllocateAppliesCorrectMemoryLimitAfterPreferredAllocationReorder drives
+// GetPreferredAllocation followed by Allocate end to end, the way kubelet
+// actually calls the plugin: kubelet asks for a preferred device order, then
+// echoes that exact order back as DevicesIds on the following Allocate call.
+// It guards against selectPreferredDeviceIDsFromAnnotatedDevices reordering
+// its response relative to the scheduler's per-device memory/core plan,
+// which would attach one GPU's memory/core limit to a different physical
+// GPU's env vars.
+func TestAllocateAppliesCorrectMemoryLimitAfterPreferredAllocationReorder(t *testing.T) {
+	deviceListStrategies, _ := v1.NewDeviceListStrategies([]string{"envvar"})
+	deviceIDStrategy := v1.DeviceIDStrategyUUID
+	memScale := 1.0
+	logLevel := nvidia.Error
+
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							DeviceIDStrategy: &deviceIDStrategy,
+						},
+					},
+				},
+			},
+		},
+		deviceListStrategies: deviceListStrategies,
+		schedulerConfig: nvidia.NvidiaConfig{
+			NodeDefaultConfig: nvidia.NodeDefaultConfig{
+				DeviceMemoryScaling: &memScale,
+				LogLevel:            &logLevel,
+			},
+		},
+		operatingMode: "default",
+	}
+
+	previousEnable := enableGetPreferredAllocation
+	enableGetPreferredAllocation = true
+	defer func() { enableGetPreferredAllocation = previousEnable }()
+
+	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	// The scheduler's plan for this container, in this exact order:
+	// position 0 -> GPU a (1000MiB), position 1 -> GPU b (2000MiB),
+	// position 2 -> GPU c (3000MiB).
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
+					{
+						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67a", Type: nvidia.NvidiaGPUDevice, Usedmem: 1000, Usedcores: 10},
+						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67b", Type: nvidia.NvidiaGPUDevice, Usedmem: 2000, Usedcores: 20},
+						{UUID: "GPU-03f69c50-207a-2038-9b45-23cac89cb67c", Type: nvidia.NvidiaGPUDevice, Usedmem: 3000, Usedcores: 30},
+					},
+				}),
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+	}
+
+	t.Setenv(util.NodeNameEnvName, "node-a")
+	previousGetPendingPod := getPendingPod
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	defer func() { getPendingPod = previousGetPendingPod }()
+
+	previousPodAllocationFailed := podAllocationFailed
+	podAllocationFailed = func(string, *corev1.Pod, string) {}
+	defer func() { podAllocationFailed = previousPodAllocationFailed }()
+
+	previousPodAllocationTrySuccess := podAllocationTrySuccess
+	podAllocationTrySuccess = func(string, string, string, *corev1.Pod) {}
+	defer func() { podAllocationTrySuccess = previousPodAllocationTrySuccess }()
+
+	previousKubeClient := client.KubeClient
+	client.KubeClient = fake.NewSimpleClientset(pod.DeepCopy())
+	defer func() { client.KubeClient = previousKubeClient }()
+
+	// Kubelet asks for a preferred order first, pinning a slice of GPU c —
+	// the last entry in the scheduler's plan, not the first.
+	prefRequest := &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{
+			{
+				AvailableDeviceIDs: []string{
+					"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+					"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+					"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
+				},
+				MustIncludeDeviceIDs: []string{"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0"},
+				AllocationSize:       3,
+			},
+		},
+	}
+	prefResponse, err := plugin.GetPreferredAllocation(context.Background(), prefRequest)
+	require.NoError(t, err)
+	require.Len(t, prefResponse.ContainerResponses, 1)
+	require.Equal(t, []string{
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67a-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67b-0",
+		"GPU-03f69c50-207a-2038-9b45-23cac89cb67c-0",
+	}, prefResponse.ContainerResponses[0].DeviceIDs)
+
+	// Kubelet echoes GetPreferredAllocation's response back as DevicesIds.
+	allocRequest := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: prefResponse.ContainerResponses[0].DeviceIDs},
+		},
+	}
+	allocResponse, err := plugin.Allocate(context.Background(), allocRequest)
+	require.NoError(t, err)
+	// Each position's memory/core limit must match the GPU actually visible
+	// at that position, not the position it originally occupied pre-reorder.
+	require.Equal(t, "1000m", allocResponse.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+	require.Equal(t, "2000m", allocResponse.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_1"])
+	require.Equal(t, "3000m", allocResponse.ContainerResponses[0].Envs["CUDA_DEVICE_MEMORY_LIMIT_2"])
 }
 
 type mockListAndWatchServer struct {


### PR DESCRIPTION
## Summary

`selectPreferredDeviceIDsFromAnnotatedDevices` builds its `GetPreferredAllocation`
response by placing all of kubelet's required (`MustIncludeDeviceIDs`) devices
first, then filling the rest from the scheduler's per-device memory/core plan
(`devreq`/`desired`) in order. Whenever `required` wasn't already `desired`'s
first entry, the returned device order diverged from `devreq`'s order.

`Allocate()` later zips its (possibly kubelet-reordered) `DevicesIds` against
`devreq` **positionally** in `alignContainerDevicesWithAllocatedIDs`, updating
only the UUID at each index and leaving that index's `Usedmem`/`Usedcores`
untouched. With the order divergence above, position `i`'s UUID could end up
pointing at a different physical GPU than the one `devreq[i]` was computed
for — so `CUDA_DEVICE_MEMORY_LIMIT_<i>` would carry the memory ceiling
intended for one GPU while actually applying to another, letting a container
exceed what the scheduler reserved on that GPU.

Triggers with `EnableGetPreferredAllocation: true`, non-MIG mode, a single
container requesting multiple GPUs with heterogeneous per-device memory
(e.g. via `nvidia.com/gpumem-percentage` across differently-sized GPUs), and
a kubelet-supplied `MustIncludeDeviceIDs` that isn't a prefix of the
scheduler's order (realistic on kubelet-driven container restarts).

## Fix

Rebuild the result in `desired`'s order instead of required-first: at each
position, pull from a per-physical-GPU queue of required IDs if one is
pending for that GPU, otherwise from the available pool. This keeps every
position's UUID and its memory/core limit describing the same physical
device, while still satisfying kubelet's `MustIncludeDeviceIDs` constraint.

## Tests

- Tightened the two existing tests that only checked set equality
  (`ElementsMatch`) to assert exact order.
- Added two unit tests: required device at a non-leading `desired` position,
  and multiple required slices from the same physical GPU.
- Added an end-to-end test that drives `GetPreferredAllocation` followed by
  `Allocate`, the way kubelet actually calls the plugin, asserting each
  container's `CUDA_DEVICE_MEMORY_LIMIT_<i>` matches the GPU visible at that
  position.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/device-plugin/nvidiadevice/nvinternal/plugin/... -race -short -count=1 -v` — all pass
- [x] `make test` (full suite, race detector) — all packages pass
- [x] `make lint` (golangci-lint) — 0 issues

## AI Assistance Disclosure

This PR was written primarily using AI coding assistance, following the
project's CONTRIBUTING.md disclosure requirement. The bug was found via an
independent audit of the NVIDIA device-plugin allocation path, reproduced
against this repo's own existing test fixtures before being fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preferred device allocation now preserves the scheduler’s requested device order.
  * Required devices are matched to the correct physical GPU, including multiple slices from one GPU.
  * Memory limits remain associated with the correct GPU after preferred allocation reordering.

* **Tests**
  * Added coverage for required devices appearing in different positions and for multiple slices on the same GPU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->