### PR TITLE
fix(deviceplugin): add error handling and symlink guard in Allocate

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -838,10 +838,55 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				cacheFileHostDirectory := fmt.Sprintf("%s/vgpu/containers/%s_%s", hostHookPath, current.UID, currentCtr.Name)
 				os.RemoveAll(cacheFileHostDirectory)
 
-				os.MkdirAll(cacheFileHostDirectory, 0777)
-				os.Chmod(cacheFileHostDirectory, 0777)
-				os.MkdirAll("/tmp/vgpulock", 0777)
-				os.Chmod("/tmp/vgpulock", 0777)
+				// WHY: We must check the error from MkdirAll. If the directory
+				// cannot be created (e.g., permissions on the parent, full disk),
+				// the volume mount that follows will silently fail inside the
+				// container. By returning the error here we surface the problem
+				// immediately and abort the allocation cleanly.
+				if err := os.MkdirAll(cacheFileHostDirectory, 0777); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("create vgpu cache directory %s: %w", cacheFileHostDirectory, err)
+				}
+				// WHY: Before calling Chmod we verify the path is a real
+				// directory (not a symlink). The plugin runs as root and /tmp is
+				// world-writable, so a malicious local user could race to replace
+				// this path with a symlink pointing at a sensitive file (e.g.
+				// /etc/shadow). os.Chmod follows symlinks, so without this check
+				// we would silently chmod the symlink target to 0777, giving
+				// every user on the node read/write access — a textbook Local
+				// Privilege Escalation. os.Lstat does NOT follow symlinks, so it
+				// lets us inspect what actually sits at the path.
+				if fi, err := os.Lstat(cacheFileHostDirectory); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("stat vgpu cache directory %s: %w", cacheFileHostDirectory, err)
+				} else if fi.Mode()&os.ModeSymlink != 0 {
+					// The path is a symlink — something is wrong. Refuse to
+					// proceed; changing permissions through a symlink is unsafe.
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("vgpu cache path %s is a symlink; refusing to chmod", cacheFileHostDirectory)
+				} else if err := os.Chmod(cacheFileHostDirectory, 0777); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("chmod vgpu cache directory %s: %w", cacheFileHostDirectory, err)
+				}
+
+				// WHY: Same pattern for the vgpulock directory. /tmp is
+				// world-writable, so the symlink attack surface here is even
+				// larger. We apply the identical Lstat guard before Chmod.
+				const vgpuLockDir = "/tmp/vgpulock"
+				if err := os.MkdirAll(vgpuLockDir, 0777); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("create vgpulock directory: %w", err)
+				}
+				if fi, err := os.Lstat(vgpuLockDir); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("stat vgpulock directory: %w", err)
+				} else if fi.Mode()&os.ModeSymlink != 0 {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("vgpulock path %s is a symlink; refusing to chmod", vgpuLockDir)
+				} else if err := os.Chmod(vgpuLockDir, 0777); err != nil {
+					PodAllocationFailed(nodename, current, NodeLockNvidia)
+					return nil, fmt.Errorf("chmod vgpulock directory: %w", err)
+				}
 				response.Mounts = append(response.Mounts,
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath),
 						HostPath: GetLibPath(),


### PR DESCRIPTION
The Allocate function in the NVIDIA device plugin created two host directories (per-container vGPU cache and /tmp/vgpulock) with four bare os.MkdirAll / os.Chmod calls whose return values were silently discarded.

This caused two problems:

1. Missing error handling: if MkdirAll failed (disk full, permission denied on the parent, read-only filesystem), the plugin continued to append volume mounts that would silently fail inside the container. The allocation appeared to succeed but the pod runtime was broken.

2. Local Privilege Escalation via symlink: the plugin runs as root. /tmp is world-writable. A malicious local user could race to place a symlink at /tmp/vgpulock pointing at a sensitive file such as /etc/shadow. os.Chmod follows symlinks, so the plugin would silently change /etc/shadow to mode 0777, allowing any user on the node to read or write it.

Fix: wrap every MkdirAll and Chmod call with an error check that calls PodAllocationFailed and returns the error immediately. Before each Chmod, use os.Lstat (which does NOT follow symlinks) to verify the path is a real directory; refuse to chmod if a symlink is found.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device allocation reliability by detecting failures when preparing required cache and lock directories.
  * Prevented unsafe permission changes when directory paths are symbolic links.
  * Allocation now fails cleanly when directory creation, inspection, or permission updates cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->