### PR TITLE
fix(client): use mockable function variables in loadKubeConfig

### DIFF
--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -35,8 +35,10 @@ type Client struct {
 }
 
 var (
-	KubeClient kubernetes.Interface
-	once       sync.Once
+	KubeClient           kubernetes.Interface
+	once                 sync.Once
+	buildConfigFromFlags = clientcmd.BuildConfigFromFlags
+	inClusterConfig      = rest.InClusterConfig
 )
 
 func init() {
@@ -92,10 +94,10 @@ func loadKubeConfig() (*rest.Config, error) {
 		kubeConfigPath = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	config, err := buildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
 		klog.Infof("BuildConfigFromFlags failed for file %s: %v. Using in-cluster config.", kubeConfigPath, err)
-		return rest.InClusterConfig()
+		return inClusterConfig()
 	}
 	return config, nil
 }

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -29,18 +29,10 @@ import (
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-// Mock functions for testing.
-var (
-	buildConfigFromFlags = clientcmd.BuildConfigFromFlags
-	inClusterConfig      = rest.InClusterConfig
 )
 
 // TestGetClient tests the GetClient function.
 func TestGetClient(t *testing.T) {
-	InitGlobalClient()
 	tests := []struct {
 		name           string
 		kubeConfig     string
@@ -72,14 +64,17 @@ func TestGetClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock the clientcmd.BuildConfigFromFlags function.
+			once = sync.Once{}
+			KubeClient = nil
+
+			// Mock the buildConfigFromFlags function.
 			oldBuildConfigFromFlags := buildConfigFromFlags
 			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return tt.buildConfig, tt.buildConfigErr
 			}
 			defer func() { buildConfigFromFlags = oldBuildConfigFromFlags }()
 
-			// Mock the rest.InClusterConfig function.
+			// Mock the inClusterConfig function.
 			oldInClusterConfig := inClusterConfig
 			inClusterConfig = func() (*rest.Config, error) {
 				return tt.inCluster, tt.inClusterErr
@@ -87,9 +82,10 @@ func TestGetClient(t *testing.T) {
 			defer func() { inClusterConfig = oldInClusterConfig }()
 
 			// Set the KUBECONFIG environment variable.
-			oldKubeConfig := os.Getenv("KUBECONFIG")
-			os.Setenv("KUBECONFIG", tt.kubeConfig)
-			defer os.Setenv("KUBECONFIG", oldKubeConfig)
+			t.Setenv("KUBECONFIG", tt.kubeConfig)
+
+			// Initialize global client with mock.
+			InitGlobalClient()
 
 			// Call GetClient and check the result.
 			client := GetClient()
@@ -108,6 +104,7 @@ func TestGetClient(t *testing.T) {
 
 // TestClientWithOptions tests client initialization with options.
 func TestClientWithOptions(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join("testdata", "kubeconfig.yaml"))
 	KubeClient = nil
 	once = sync.Once{}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR updates `pkg/util/client/client.go` to use package-level variables (`buildConfigFromFlags` and `inClusterConfig`) in `loadKubeConfig()`. Previously, `loadKubeConfig()` called `clientcmd.BuildConfigFromFlags` directly, which prevented `go test ./pkg/util/client/...` from mocking kubeconfig loading when running in environments without an active cluster or local `.kube/config`.

Also updates `client_test.go` to reset global state per subtest and set `KUBECONFIG` env variables for `TestClientWithOptions`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Ran `go test ./pkg/... -short` locally and all unit tests pass cleanly.

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**AI assistance disclosure**:
AI assistance was used to inspect function calls and run local test suites.

**Checklist**:
- [x] Scoped to `pkg/util/client/`
- [x] Commit is signed off (DCO)
- [x] Followed CONTRIBUTING.md guidelines
- [x] AI assistance disclosed above