### PR TITLE
test(common): add unit test coverage for GenReason and ParseReason

### DIFF
--- a/pkg/device/common/common_test.go
+++ b/pkg/device/common/common_test.go
@@ -21,30 +21,104 @@ import (
 	"testing"
 )
 
-func TestParseReason(t *testing.T) {
-	for _, ts := range []struct {
-		name   string
-		reason string
+func TestGenReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		reasons  map[string]int
+		cards    int
+		expected string
+	}{
+		{
+			name:     "empty reasons",
+			reasons:  map[string]int{},
+			cards:    8,
+			expected: "",
+		},
+		{
+			name: "single reason",
+			reasons: map[string]int{
+				CardInsufficientMemory: 3,
+			},
+			cards:    8,
+			expected: "3/8 CardInsufficientMemory",
+		},
+		{
+			name: "multiple reasons sorted alphabetically",
+			reasons: map[string]int{
+				CardInsufficientMemory: 3,
+				CardInsufficientCore:   2,
+				CardNotHealth:          3,
+			},
+			cards:    8,
+			expected: "2/8 CardInsufficientCore, 3/8 CardInsufficientMemory, 3/8 CardNotHealth",
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenReason(tt.reasons, tt.cards)
+			if result != tt.expected {
+				t.Errorf("GenReason() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseReason(t *testing.T) {
+	tests := []struct {
+		name              string
+		reason            string
 		expectedReasonMap map[string]int
 	}{
 		{
 			name:   "base test",
 			reason: "3/8 CardInsufficientMemory, 2/8 CardInsufficientCore, 3/8 CardNotHealth",
-
 			expectedReasonMap: map[string]int{
 				"CardInsufficientMemory": 3,
 				"CardInsufficientCore":   2,
 				"CardNotHealth":          3,
 			},
 		},
-	} {
-		t.Run(ts.name, func(t *testing.T) {
-			result := ParseReason(ts.reason)
-			if !reflect.DeepEqual(result, ts.expectedReasonMap) {
-				t.Errorf("ParseReason failed: result %v, expected %v",
-					result, ts.expectedReasonMap)
+		{
+			name:              "empty reason string",
+			reason:            "",
+			expectedReasonMap: map[string]int{},
+		},
+		{
+			name:              "malformed reason string",
+			reason:            "invalid_reason_format",
+			expectedReasonMap: map[string]int{},
+		},
+		{
+			name:   "single reason format",
+			reason: "4/4 CardTypeMismatch",
+			expectedReasonMap: map[string]int{
+				CardTypeMismatch: 4,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseReason(tt.reason)
+			if !reflect.DeepEqual(result, tt.expectedReasonMap) {
+				t.Errorf("ParseReason() = %v, expected %v", result, tt.expectedReasonMap)
 			}
 		})
+	}
+}
+
+func TestGenAndParseReasonRoundTrip(t *testing.T) {
+	originalReasons := map[string]int{
+		CardInsufficientMemory: 5,
+		CardInsufficientCore:   2,
+	}
+	cards := 8
+
+	formatted := GenReason(originalReasons, cards)
+	parsed := ParseReason(formatted)
+
+	if !reflect.DeepEqual(parsed, originalReasons) {
+		t.Errorf("Round-trip failed: original %v, parsed %v", originalReasons, parsed)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Adds comprehensive unit test coverage for `GenReason` and `ParseReason` in `pkg/device/common/common_test.go`.

Tests added:
- `TestGenReason`: empty reasons map, single reason, and multiple reasons with alphabetical sorting.
- `TestParseReason`: base case, empty string, malformed string, and single reason format.
- `TestGenAndParseReasonRoundTrip`: verifies round-trip symmetry between `GenReason` and `ParseReason`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested with `go test ./pkg/device/common/... -v`. No logic changes to `common.go`.

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**AI assistance disclosure**:
AI assistance was used to draft test cases and verify test execution.

**Checklist**:
- [x] Scoped to `pkg/device/common/common_test.go`
- [x] Commit is signed off (DCO)
- [x] Followed CONTRIBUTING.md guidelines
- [x] AI assistance disclosed above