### PR TITLE
feat(deviceplugin): persist container GPU config to file for child an…

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
@@ -127,6 +127,13 @@ func WriteConfig(directory string, cfg ContainerConfig) error {
 		return fmt.Errorf("write container config temp file: %w", err)
 	}
 
+	// Explicitly chmod 0644 so the file mode is not restricted by a process umask (e.g. 0077),
+	// guaranteeing that non-root container users (like SSH sessions) can always read the config.
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod container config temp file: %w", err)
+	}
+
 	finalPath := filepath.Join(directory, Filename)
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		_ = os.Remove(tmpPath) // best-effort cleanup of the orphaned temp file

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
@@ -64,6 +64,29 @@ type DeviceLimitConfig struct {
 // Backward compatibility: all env-var injection in Allocate is kept unchanged.
 // This file is additive — it provides a second, env-independent path to the
 // same information.
+//
+// # Consumer authority contract (for libvgpu.so implementers)
+//
+// The intended lookup order when libvgpu.so resolves a limit value is:
+//
+//  1. Environment variable present and non-empty → use the env value.
+//     (Highest priority; preserves backward compatibility with all existing
+//     deployments that do not use config.json.)
+//
+//  2. Environment variable absent or empty → read the corresponding field
+//     from config.json mounted at {hostHookPath}/vgpu/config.json.
+//     (Fallback for SSH/su/sudo sessions where the env has been scrubbed.)
+//
+//  3. Both absent → apply no limit.
+//     (Identical to current behaviour before this mechanism was introduced.)
+//
+// If config.json is missing, unreadable, or unparseable, the consumer MUST
+// fall back silently to case (3) and MUST NOT fail the process. The file is
+// written on a best-effort basis; its absence is not an error condition.
+//
+// If an env variable and config.json disagree on the same limit, the env
+// variable wins (case 1 above). config.json is never authoritative over a
+// present, non-empty environment variable.
 type ContainerConfig struct {
 	// Version is the schema version (currently 1).
 	// libvgpu.so should reject or warn on versions it does not understand.

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config.go
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The HAMi Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+// Package containerconfig defines the per-container GPU allocation config that
+// the NVIDIA device plugin writes to disk during Allocate so that libvgpu.so
+// can recover GPU limits even when process environment variables have been
+// scrubbed by SSH, su, sudo, or login shells (issue #2125).
+package containerconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Version is the schema version written into every config.json.
+// Increment when making backward-incompatible changes to the struct layout
+// so that libvgpu.so can detect and handle old vs new files correctly.
+const Version = 1
+
+// Filename is the name of the per-container config file written into the
+// container's cache directory. It is a deliberately short, fixed name so that
+// libvgpu.so can locate it without any additional coordination.
+const Filename = "config.json"
+
+// DeviceLimitConfig holds the resource constraints for a single GPU device
+// allocated to a container.
+//
+// WHY a struct per device: a container can request multiple physical GPUs.
+// Each GPU gets its own memory and core limits, so they must be stored
+// individually rather than as a single aggregate.
+type DeviceLimitConfig struct {
+	// Index is the 0-based device slot index within this container's allocation
+	// (matches the suffix of CUDA_DEVICE_MEMORY_LIMIT_<index>).
+	Index int `json:"index"`
+
+	// UUID is the physical GPU UUID string (e.g. "GPU-xxxxxxxx-...").
+	// libvgpu.so can cross-check this against the device it detects at runtime
+	// to ensure it is applying limits to the correct GPU.
+	UUID string `json:"uuid"`
+
+	// MemoryLimitMB is the GPU memory quota for this device in mebibytes
+	// (matches the numeric part of CUDA_DEVICE_MEMORY_LIMIT_<index>=NNNm).
+	MemoryLimitMB int32 `json:"memory_limit_mb"`
+
+	// SMLimit is the GPU compute utilisation limit, expressed as a percentage
+	// of streaming-multiprocessor throughput (0 = unlimited).
+	// Matches CUDA_DEVICE_SM_LIMIT.
+	SMLimit int32 `json:"sm_limit_percent"`
+}
+
+// ContainerConfig is the complete allocation record written to config.json.
+// It mirrors every environment variable that the device plugin injects so that
+// processes with a clean environment (SSH logins, su/sudo shells, child
+// processes started with an explicit empty env) can still recover the full
+// isolation policy directly from the filesystem.
+//
+// Backward compatibility: all env-var injection in Allocate is kept unchanged.
+// This file is additive — it provides a second, env-independent path to the
+// same information.
+type ContainerConfig struct {
+	// Version is the schema version (currently 1).
+	// libvgpu.so should reject or warn on versions it does not understand.
+	Version int `json:"version"`
+
+	// PodUID is the Kubernetes pod UID for operator diagnostics.
+	PodUID string `json:"pod_uid"`
+
+	// ContainerName is the Kubernetes container name within the pod.
+	ContainerName string `json:"container_name"`
+
+	// Devices lists the per-GPU constraints in ascending index order.
+	Devices []DeviceLimitConfig `json:"devices"`
+
+	// SharedCachePath is the path of the shared-memory tracker file
+	// (the value of CUDA_DEVICE_MEMORY_SHARED_CACHE).
+	// All processes within the container must attach to the same cache file so
+	// that their aggregate allocations are correctly accounted.
+	SharedCachePath string `json:"shared_cache_path"`
+
+	// Oversubscribe indicates whether memory over-subscription is enabled
+	// (true when DeviceMemoryScaling > 1; matches CUDA_OVERSUBSCRIBE=true).
+	Oversubscribe bool `json:"oversubscribe"`
+
+	// DisableCoreLimit, when true, means compute-utilisation enforcement is
+	// intentionally disabled (GPU_CORE_UTILIZATION_POLICY=disable).
+	DisableCoreLimit bool `json:"disable_core_limit"`
+
+	// LogLevel is the optional logging verbosity forwarded from the scheduler
+	// config (LIBCUDA_LOG_LEVEL). Empty string means default.
+	LogLevel string `json:"log_level,omitempty"`
+}
+
+// WriteConfig serialises cfg as JSON and writes it atomically to
+// directory/config.json with permissions 0644.
+//
+// WHY 0644 and not 0600 or 0777:
+//   - 0644 allows any UID inside the container (including non-root users and
+//     SSH-spawned shells) to read the file.
+//   - The file contains no secrets — only resource limits that the container
+//     is already entitled to know (they are also in its environment).
+//   - Write permission is root-only (the device plugin runs as root) to
+//     prevent container processes from tampering with their own limits.
+//
+// WHY atomic write (temp file + rename):
+//   - libvgpu.so may open this file at any point after container start.
+//   - A direct os.WriteFile leaves the file half-written during the syscall.
+//   - A rename from a temp file on the same filesystem is atomic on Linux,
+//     so the reader always sees either the complete old file or the complete
+//     new file, never a partial write.
+func WriteConfig(directory string, cfg ContainerConfig) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal container config: %w", err)
+	}
+
+	// Write to a sibling temp file first so the rename is intra-directory
+	// (same filesystem mount) and therefore atomic on Linux.
+	tmpPath := filepath.Join(directory, ".config.json.tmp")
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("write container config temp file: %w", err)
+	}
+
+	finalPath := filepath.Join(directory, Filename)
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath) // best-effort cleanup of the orphaned temp file
+		return fmt.Errorf("rename container config into place: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_posix_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_posix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build unix
 
 /*
  * SPDX-License-Identifier: Apache-2.0

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_posix_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_posix_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The HAMi Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package containerconfig
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestWriteConfig_RestrictiveUmask verifies that WriteConfig explicitly applies
+// mode 0644 so config.json remains world-readable even when the process has a
+// restrictive umask (e.g. 0077 or 0027).
+func TestWriteConfig_RestrictiveUmask(t *testing.T) {
+	// Set a very restrictive umask (0077 -> removes group and other permissions).
+	oldMask := syscall.Umask(0077)
+	defer syscall.Umask(oldMask)
+
+	dir := t.TempDir()
+	cfg := ContainerConfig{
+		Version:       Version,
+		PodUID:        "uid-umask-test",
+		ContainerName: "ctr",
+		Devices:       []DeviceLimitConfig{{Index: 0, UUID: "GPU-UMASK", MemoryLimitMB: 1000, SMLimit: 100}},
+		SharedCachePath: "/tmp/u.cache",
+	}
+
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, Filename))
+	if err != nil {
+		t.Fatalf("stat config.json: %v", err)
+	}
+
+	// Because of explicit os.Chmod(..., 0644), the file must be 0644 despite umask 0077.
+	const wantMode = 0644
+	if got := info.Mode().Perm(); got != wantMode {
+		t.Errorf("file permissions with restrictive umask (0077): got %o, want %o", got, wantMode)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig/config_test.go
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The HAMi Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package containerconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteConfig_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := ContainerConfig{
+		Version:       Version,
+		PodUID:        "pod-uid-abc",
+		ContainerName: "my-container",
+		Devices: []DeviceLimitConfig{
+			{Index: 0, UUID: "GPU-1234", MemoryLimitMB: 3000, SMLimit: 50},
+			{Index: 1, UUID: "GPU-5678", MemoryLimitMB: 4000, SMLimit: 80},
+		},
+		SharedCachePath:  "/usr/local/vgpu/abc.cache",
+		Oversubscribe:    false,
+		DisableCoreLimit: false,
+		LogLevel:         "info",
+	}
+
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig returned unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, Filename))
+	if err != nil {
+		t.Fatalf("config.json not found after write: %v", err)
+	}
+
+	var got ContainerConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("config.json is not valid JSON: %v", err)
+	}
+
+	if got.Version != Version {
+		t.Errorf("version: got %d, want %d", got.Version, Version)
+	}
+	if got.PodUID != cfg.PodUID {
+		t.Errorf("pod_uid: got %q, want %q", got.PodUID, cfg.PodUID)
+	}
+	if got.ContainerName != cfg.ContainerName {
+		t.Errorf("container_name: got %q, want %q", got.ContainerName, cfg.ContainerName)
+	}
+	if len(got.Devices) != 2 {
+		t.Fatalf("devices length: got %d, want 2", len(got.Devices))
+	}
+	if got.Devices[0].MemoryLimitMB != 3000 {
+		t.Errorf("devices[0].memory_limit_mb: got %d, want 3000", got.Devices[0].MemoryLimitMB)
+	}
+	if got.Devices[1].MemoryLimitMB != 4000 {
+		t.Errorf("devices[1].memory_limit_mb: got %d, want 4000", got.Devices[1].MemoryLimitMB)
+	}
+	if got.SharedCachePath != cfg.SharedCachePath {
+		t.Errorf("shared_cache_path: got %q, want %q", got.SharedCachePath, cfg.SharedCachePath)
+	}
+}
+
+// TestWriteConfig_FilePermissions verifies config.json is written 0644 so
+// non-root users (SSH logins) can read it.
+func TestWriteConfig_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := ContainerConfig{
+		Version:       Version,
+		PodUID:        "uid-perm-test",
+		ContainerName: "ctr",
+		Devices:       []DeviceLimitConfig{{Index: 0, UUID: "GPU-PERM", MemoryLimitMB: 1000, SMLimit: 100}},
+		SharedCachePath: "/tmp/x.cache",
+	}
+
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, Filename))
+	if err != nil {
+		t.Fatalf("stat config.json: %v", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping POSIX file permission bit check on Windows")
+	}
+
+	// 0644: world-readable so SSH-spawned non-root shells can open the file.
+	const wantMode = 0644
+	if got := info.Mode().Perm(); got != wantMode {
+		t.Errorf("file permissions: got %o, want %o", got, wantMode)
+	}
+}
+
+// TestWriteConfig_Idempotent verifies that calling WriteConfig twice overwrites
+// the first file cleanly (no stale partial state).
+func TestWriteConfig_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(mem int32) {
+		cfg := ContainerConfig{
+			Version:       Version,
+			PodUID:        "uid-idem",
+			ContainerName: "ctr",
+			Devices:       []DeviceLimitConfig{{Index: 0, UUID: "GPU-X", MemoryLimitMB: mem, SMLimit: 50}},
+			SharedCachePath: "/tmp/y.cache",
+		}
+		if err := WriteConfig(dir, cfg); err != nil {
+			t.Fatalf("WriteConfig(%d): %v", mem, err)
+		}
+	}
+
+	write(1000)
+	write(2000)
+
+	data, _ := os.ReadFile(filepath.Join(dir, Filename))
+	var got ContainerConfig
+	_ = json.Unmarshal(data, &got)
+	if got.Devices[0].MemoryLimitMB != 2000 {
+		t.Errorf("expected second write (2000m) to win; got %dm", got.Devices[0].MemoryLimitMB)
+	}
+}
+
+// TestWriteConfig_NonExistentDir verifies WriteConfig returns an error for a
+// missing directory rather than panicking.
+func TestWriteConfig_NonExistentDir(t *testing.T) {
+	if err := WriteConfig("/this/path/does/not/exist", ContainerConfig{}); err == nil {
+		t.Error("expected error for non-existent directory, got nil")
+	}
+}
+
+// TestWriteConfig_OversubscribeFlag verifies the oversubscribe field is
+// faithfully preserved (controls libvgpu.so behaviour when scaling > 1).
+func TestWriteConfig_OversubscribeFlag(t *testing.T) {
+	dir := t.TempDir()
+	cfg := ContainerConfig{
+		Version:         Version,
+		PodUID:          "uid-over",
+		ContainerName:   "ctr-over",
+		Devices:         []DeviceLimitConfig{{Index: 0, UUID: "GPU-O", MemoryLimitMB: 5000, SMLimit: 100}},
+		SharedCachePath: "/tmp/o.cache",
+		Oversubscribe:   true,
+	}
+	if err := WriteConfig(dir, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, Filename))
+	var got ContainerConfig
+	_ = json.Unmarshal(data, &got)
+	if !got.Oversubscribe {
+		t.Error("oversubscribe: expected true, got false")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -62,6 +62,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/cdi"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/imex"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
@@ -820,14 +821,33 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 
 			if plugin.operatingMode != "mig" {
+				// --- Build per-device limit records ----------------------------------
+				// WHY collect into a slice first: we need both the env-var loop (below,
+				// for backward compatibility) and the config-file writer to see the same
+				// data without duplicating the loop body.
+				deviceLimits := make([]containerconfig.DeviceLimitConfig, len(devreq))
 				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
+					deviceLimits[i] = containerconfig.DeviceLimitConfig{
+						Index:         i,
+						UUID:          dev.UUID,
+						MemoryLimitMB: dev.Usedmem,
+						SMLimit:       devreq[0].Usedcores,
+					}
 				}
+
+				// Capture the shared-cache path in a variable so we can include it in
+				// both the env-var response AND the config file without generating two
+				// different UUIDs (which would break the shared-memory tracker).
+				sharedCachePath := fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
 				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
-				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
+				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = sharedCachePath
+
+				oversubscribe := false
 				if *plugin.schedulerConfig.DeviceMemoryScaling > 1 {
 					response.Envs["CUDA_OVERSUBSCRIBE"] = "true"
+					oversubscribe = true
 				}
 				if *plugin.schedulerConfig.LogLevel != "" {
 					response.Envs["LIBCUDA_LOG_LEVEL"] = string(*plugin.schedulerConfig.LogLevel)
@@ -842,6 +862,41 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				os.Chmod(cacheFileHostDirectory, 0777)
 				os.MkdirAll("/tmp/vgpulock", 0777)
 				os.Chmod("/tmp/vgpulock", 0777)
+
+				// --- Write persistent config.json for issue #2125 -------------------
+				// WHY: Environment variables injected above are the primary mechanism
+				// for conveying GPU limits to libvgpu.so. However, when a user SSHes
+				// into the container, or when a process is spawned via su/sudo/login,
+				// the shell runtime scrubs the environment. libvgpu.so is still
+				// preloaded via ld.so.preload in those sessions, but it sees no
+				// CUDA_DEVICE_MEMORY_LIMIT_* variables and falls back to "no limit",
+				// allowing the process to exhaust the full GPU.
+				//
+				// Writing all limits to config.json inside cacheFileHostDirectory gives
+				// libvgpu.so a filesystem-based fallback. Because cacheFileHostDirectory
+				// is already bind-mounted into the container at {hostHookPath}/vgpu/,
+				// the file appears inside the container at {hostHookPath}/vgpu/config.json
+				// and is readable by any UID (mode 0644), including non-root SSH users.
+				//
+				// The env-var injection above is kept fully intact for backward
+				// compatibility with libvgpu.so builds that do not yet read this file.
+				containerCfg := containerconfig.ContainerConfig{
+					Version:          containerconfig.Version,
+					PodUID:           string(current.UID),
+					ContainerName:    currentCtr.Name,
+					Devices:          deviceLimits,
+					SharedCachePath:  sharedCachePath,
+					Oversubscribe:    oversubscribe,
+					DisableCoreLimit: plugin.schedulerConfig.DisableCoreLimit,
+					LogLevel:         string(*plugin.schedulerConfig.LogLevel),
+				}
+				if err := containerconfig.WriteConfig(cacheFileHostDirectory, containerCfg); err != nil {
+					// Non-fatal: the env-var path still enforces limits for normal
+					// (non-SSH, non-su) processes. Log the failure so operators can
+					// investigate, but do not abort the allocation.
+					klog.Warningf("containerconfig.WriteConfig for pod %s/%s container %s: %v",
+						current.Namespace, current.Name, currentCtr.Name, err)
+				}
 				response.Mounts = append(response.Mounts,
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath),
 						HostPath: GetLibPath(),

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -864,49 +864,62 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				os.Chmod("/tmp/vgpulock", 0777)
 
 				// --- Write persistent config.json for issue #2125 -------------------
-				// WHY: Environment variables injected above are the primary mechanism
-				// for conveying GPU limits to libvgpu.so. However, when a user SSHes
-				// into the container, or when a process is spawned via su/sudo/login,
-				// the shell runtime scrubs the environment. libvgpu.so is still
-				// preloaded via ld.so.preload in those sessions, but it sees no
-				// CUDA_DEVICE_MEMORY_LIMIT_* variables and falls back to "no limit",
-				// allowing the process to exhaust the full GPU.
+				// WHY a SEPARATE directory: cacheFileHostDirectory is mode 0777 and is
+				// bind-mounted read-write into the container so libvgpu.so can create its
+				// shared-memory cache files. If config.json lived there, a container
+				// process running as root could remove or replace it (e.g. symlink to
+				// /dev/null) and silently defeat its own GPU memory limits.
 				//
-				// Writing all limits to config.json inside cacheFileHostDirectory gives
-				// libvgpu.so a filesystem-based fallback. Because cacheFileHostDirectory
-				// is already bind-mounted into the container at {hostHookPath}/vgpu/,
-				// the file appears inside the container at {hostHookPath}/vgpu/config.json
-				// and is readable by any UID (mode 0644), including non-root SSH users.
+				// Instead, config.json is written to a root-owned 0755 host directory
+				// that is bind-mounted into the container as a READ-ONLY individual file
+				// at {hostHookPath}/vgpu/config.json. The directory is readable by all
+				// UIDs (including SSH non-root users) but cannot be modified from inside
+				// the container because the mount is ReadOnly.
 				//
 				// The env-var injection above is kept fully intact for backward
 				// compatibility with libvgpu.so builds that do not yet read this file.
-				containerCfg := containerconfig.ContainerConfig{
-					Version:          containerconfig.Version,
-					PodUID:           string(current.UID),
-					ContainerName:    currentCtr.Name,
-					Devices:          deviceLimits,
-					SharedCachePath:  sharedCachePath,
-					Oversubscribe:    oversubscribe,
-					DisableCoreLimit: plugin.schedulerConfig.DisableCoreLimit,
-					LogLevel:         string(*plugin.schedulerConfig.LogLevel),
-				}
-				if err := containerconfig.WriteConfig(cacheFileHostDirectory, containerCfg); err != nil {
-					// Non-fatal: the env-var path still enforces limits for normal
-					// (non-SSH, non-su) processes. Log the failure so operators can
-					// investigate, but do not abort the allocation.
-					klog.Warningf("containerconfig.WriteConfig for pod %s/%s container %s: %v",
-						current.Namespace, current.Name, currentCtr.Name, err)
+				configHostDir := fmt.Sprintf("%s/vgpu/configs/%s_%s", hostHookPath, current.UID, currentCtr.Name)
+				os.RemoveAll(configHostDir)
+				if err := os.MkdirAll(configHostDir, 0755); err != nil {
+					// Non-fatal: log and continue — the env-var path still enforces
+					// limits for normal (non-SSH, non-su) processes.
+					klog.Warningf("containerconfig: MkdirAll(%s): %v", configHostDir, err)
+				} else {
+					containerCfg := containerconfig.ContainerConfig{
+						Version:          containerconfig.Version,
+						PodUID:           string(current.UID),
+						ContainerName:    currentCtr.Name,
+						Devices:          deviceLimits,
+						SharedCachePath:  sharedCachePath,
+						Oversubscribe:    oversubscribe,
+						DisableCoreLimit: plugin.schedulerConfig.DisableCoreLimit,
+						LogLevel:         string(*plugin.schedulerConfig.LogLevel),
+					}
+					if err := containerconfig.WriteConfig(configHostDir, containerCfg); err != nil {
+						klog.Warningf("containerconfig.WriteConfig for pod %s/%s container %s: %v",
+							current.Namespace, current.Name, currentCtr.Name, err)
+					}
 				}
 				response.Mounts = append(response.Mounts,
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath),
 						HostPath: GetLibPath(),
 						ReadOnly: true},
+					// Read-write mount for shared-memory cache files. config.json is NOT
+					// placed here; see the separate read-only config mount below.
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: fmt.Sprintf("%s/vgpu", hostHookPath),
-						HostPath: cacheFileHostDirectory,
-						ReadOnly: false},
+						HostPath:  cacheFileHostDirectory,
+						ReadOnly:  false},
 					&kubeletdevicepluginv1beta1.Mount{ContainerPath: "/tmp/vgpulock",
 						HostPath: "/tmp/vgpulock",
 						ReadOnly: false},
+					// Read-only config file mount. Lives outside the 0777 read-write
+					// cacheFileHostDirectory so container processes cannot tamper with
+					// their own GPU limits.
+					&kubeletdevicepluginv1beta1.Mount{
+						ContainerPath: fmt.Sprintf("%s/vgpu/%s", hostHookPath, containerconfig.Filename),
+						HostPath:      fmt.Sprintf("%s/%s", configHostDir, containerconfig.Filename),
+						ReadOnly:      true,
+					},
 				)
 				found := false
 				for _, val := range currentCtr.Env {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

In HAMi, GPU memory and compute isolation are currently configured via environment variables (`CUDA_DEVICE_MEMORY_LIMIT_*`, `CUDA_DEVICE_SM_LIMIT`, and `CUDA_DEVICE_MEMORY_SHARED_CACHE`) injected by the device plugin during `Allocate`.

However, when child processes, `su`/`sudo` sessions, or SSH login shells start within a container, PAM and shell runtimes scrub process environment variables. Consequently, `libvgpu.so` (preloaded via `/etc/ld.so.preload`) cannot find the memory limits via `getenv()` and falls back to unconstrained GPU access.

This PR introduces a file-based configuration mechanism to persist container allocation limits to disk:
1. **New Package**: Adds `pkg/device-plugin/nvidiadevice/nvinternal/plugin/containerconfig` defining `ContainerConfig`, `DeviceLimitConfig`, and an atomic `WriteConfig` helper (using temp-file + intra-directory rename with mode `0644`).
2. **Device Plugin Integration**: Updates `Allocate` in `server.go` to write `config.json` into the container's cache directory (`cacheFileHostDirectory`), which is already bind-mounted to `{hostHookPath}/vgpu/` inside the container.
3. **Backward Compatibility**: Preserves all existing environment variable injection so existing `libvgpu.so` binaries continue to work unchanged.
4. **Unit Tests**: Adds unit test suite in `config_test.go` covering JSON serialization, file permissions, idempotency, and error handling.

**Which issue(s) this PR fixes**:
Fixes #2125

**Special notes for your reviewer**:
- Writing to `cacheFileHostDirectory` makes `config.json` available inside the container at `{hostHookPath}/vgpu/config.json` via the existing container volume mount (no new mounts required).
- The file is written with mode `0644` so both root and non-root users (e.g., unprivileged SSH logins) can read the configuration file without `EACCES` errors.
- The corresponding reader logic in `libvgpu.so` (`HAMi-core`) can now fall back to reading `{hostHookPath}/vgpu/config.json` when `getenv("CUDA_DEVICE_MEMORY_LIMIT_...")` returns empty.

**Does this PR introduce a user-facing change?**:
```release-note
Persist container GPU allocation limits to config.json in the container vGPU directory to support GPU memory isolation for SSH and child processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GPU allocations now provide persistent per-container configuration with device limits and runtime settings.
  - Configuration includes memory, compute, oversubscription, caching, and logging options.
  - Persistent configuration is exposed through a read-only mount while shared caching remains available.
  - Environment-based and persistent settings remain consistent.

- **Reliability Improvements**
  - Configuration updates are written safely to prevent incomplete files.
  - File permissions are applied consistently for dependable access.
  - Allocation continues with existing enforcement if persistent configuration cannot be created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->