### PR TITLE
docs: document the node-lock mechanism and device accounting in protocol.md

### DIFF
--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -71,3 +71,12 @@ hami.io/vgpu-node: node67-4v100
 hami.io/vgpu-time: 1705054796
 ```
 
+## Node Lock Mechanism
+
+To prevent race conditions during concurrent pod scheduling, HAMi employs an annotation-based node locking mechanism (`hami.io/node-lock`).
+
+During the `Bind` phase, the scheduler acquires this lock on the target node before proceeding with device allocation. It is critical to understand the separation of concerns:
+- **Annotation Lock:** The `hami.io/node-lock` annotation acts strictly as a concurrency mutex.
+- **Device Accounting:** The actual accounting of GPU resources (memory, cores) is tracked independently.
+
+If a binding fails, releasing the lock (e.g., via a `fail()` fallback mechanism) **only removes the annotation lock**. It does not automatically revert or touch the underlying device accounting. Therefore, a prematurely released lock during an API error does not inherently cause hardware oversubscription, as the accounting state remains untouched. The device plugin is responsible for consuming this lock during pod creation to safely instantiate the required environment variables and mounts.

--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -75,8 +75,10 @@ hami.io/vgpu-time: 1705054796
 
 To prevent race conditions during concurrent pod scheduling, HAMi employs an annotation-based node locking mechanism (`hami.io/mutex.lock`).
 
-During the `Bind` phase, the scheduler acquires this lock on the target node before proceeding with device allocation. It is critical to understand the separation of concerns:
-- **Annotation Lock:** The `hami.io/mutex.lock` annotation acts strictly as a concurrency mutex.
+Note that device allocation is actually decided in the `Filter` phase, not `Bind`. The lock is used to cover the critical window between the `Bind` phase and the device plugin's allocate phase. 
+
+It is critical to understand the separation of concerns:
+- **Annotation Lock:** The `hami.io/mutex.lock` annotation acts strictly as a concurrency mutex. The lock value is formatted as `<time.RFC3339>,<podNamespace>,<podName>` (e.g., `2024-01-23T04:30:00Z,default,my-pod`). By default, it expires after 5 minutes, though this can be overridden via the `HAMI_NODELOCK_EXPIRE` environment variable. The lock is released by the device plugin upon successful allocation, or by the scheduler if binding fails.
 - **Device Accounting:** The actual accounting of GPU resources (memory, cores) is tracked independently.
 
-If a binding fails, releasing the lock (e.g., via a `fail()` fallback mechanism) **only removes the annotation lock**. It does not automatically revert or touch the underlying device accounting. Therefore, a prematurely released lock during an API error does not inherently cause hardware oversubscription, as the accounting state remains untouched. The device plugin is responsible for consuming this lock during pod creation to safely instantiate the required environment variables and mounts.
+If a binding fails, releasing the lock **only removes the annotation lock**. It does not automatically revert or touch the underlying device accounting state. The device plugin is responsible for consuming this lock during pod creation to safely instantiate the required environment variables and mounts.

--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -73,10 +73,10 @@ hami.io/vgpu-time: 1705054796
 
 ## Node Lock Mechanism
 
-To prevent race conditions during concurrent pod scheduling, HAMi employs an annotation-based node locking mechanism (`hami.io/node-lock`).
+To prevent race conditions during concurrent pod scheduling, HAMi employs an annotation-based node locking mechanism (`hami.io/mutex.lock`).
 
 During the `Bind` phase, the scheduler acquires this lock on the target node before proceeding with device allocation. It is critical to understand the separation of concerns:
-- **Annotation Lock:** The `hami.io/node-lock` annotation acts strictly as a concurrency mutex.
+- **Annotation Lock:** The `hami.io/mutex.lock` annotation acts strictly as a concurrency mutex.
 - **Device Accounting:** The actual accounting of GPU resources (memory, cores) is tracked independently.
 
 If a binding fails, releasing the lock (e.g., via a `fail()` fallback mechanism) **only removes the annotation lock**. It does not automatically revert or touch the underlying device accounting. Therefore, a prematurely released lock during an API error does not inherently cause hardware oversubscription, as the accounting state remains untouched. The device plugin is responsible for consuming this lock during pod creation to safely instantiate the required environment variables and mounts.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds a new section to `docs/develop/protocol.md` to formally document the `hami.io/node-lock` mechanism.

Currently, the concurrency controls used during the scheduler's `Bind` phase are entirely undocumented. This PR clarifies two critical architectural points for future contributors:
1. The `hami.io/node-lock` acts strictly as an annotation mutex to prevent race conditions during concurrent pod scheduling.
2. Device accounting is tracked independently. Releasing the node-lock (e.g., via a bind failure fallback) only removes the annotation and does not automatically revert the underlying device accounting.

This significantly improves the architectural documentation and prevents future contributors from making incorrect assumptions about hardware oversubscription during the Bind phase.

**Which issue(s) this PR fixes**:
Fixes #2662 

**Special notes for reviewer**:
* **AI Disclosure:** I consulted AI to help draft this documentation based on recent maintainer feedback regarding the strict separation of annotation locks and device accounting. The final documentation was manually verified and authored by myself.

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the node lock mechanism during pod binding.
  * Clarified lock expiration, release behavior, separation from device accounting, and cleanup after binding failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->