### PR TITLE
fix(device-plugin): auto-set CUDA_DISABLE_CONTROL for whole-GPU allocations

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -470,6 +470,44 @@ func TestAllocate_MultiContainer_CUDA_DISABLE_CONTROL_FirstContainer(t *testing.
 		"container 1 should have ld.so.preload mounted")
 }
 
+func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"}, // No explicit CUDA_DISABLE_CONTROL
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+
+	require.Equal(t, "true", response.ContainerResponses[0].Envs["CUDA_DISABLE_CONTROL"],
+		"CUDA_DISABLE_CONTROL should be auto-set to true for whole-GPU allocation")
+	require.False(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"ld.so.preload should NOT be mounted for whole-GPU allocation")
+}
+
 func TestAllocate_DeviceNumberMismatch(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -508,6 +508,46 @@ func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
 		"ld.so.preload should NOT be mounted for whole-GPU allocation")
 }
 
+func TestAllocate_WholeGPU_Explicit_False_Preserves_Mount(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0", Env: []corev1.EnvVar{
+					{Name: "CUDA_DISABLE_CONTROL", Value: "false"},
+				}},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+
+	_, hasControl := response.ContainerResponses[0].Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, hasControl, "CUDA_DISABLE_CONTROL should not be auto-set if explicitly false")
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"ld.so.preload should be mounted since CUDA_DISABLE_CONTROL is explicitly false")
+}
+
 func TestAllocate_DeviceNumberMismatch(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -470,6 +470,7 @@ func TestAllocate_MultiContainer_CUDA_DISABLE_CONTROL_FirstContainer(t *testing.
 		"container 1 should have ld.so.preload mounted")
 }
 
+
 func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)
@@ -480,7 +481,7 @@ func TestAllocate_WholeGPU_AutoSets_CUDA_DISABLE_CONTROL(t *testing.T) {
 			Namespace: "default",
 			UID:       "pod-uid",
 			Annotations: map[string]string{
-				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,100:;",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -518,7 +519,7 @@ func TestAllocate_WholeGPU_Explicit_False_Preserves_Mount(t *testing.T) {
 			Namespace: "default",
 			UID:       "pod-uid",
 			Annotations: map[string]string{
-				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:;",
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,100:;",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -558,7 +559,7 @@ func TestAllocate_WholeGPU_MultiDevice_NonZeroSMOnSecondDevice(t *testing.T) {
 			Namespace: "default",
 			UID:       "pod-uid",
 			Annotations: map[string]string{
-				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:GPU-bbb,NVIDIA,0,50:;",
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,100:GPU-bbb,NVIDIA,0,50:;",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -548,6 +548,44 @@ func TestAllocate_WholeGPU_Explicit_False_Preserves_Mount(t *testing.T) {
 		"ld.so.preload should be mounted since CUDA_DISABLE_CONTROL is explicitly false")
 }
 
+func TestAllocate_WholeGPU_MultiDevice_NonZeroSMOnSecondDevice(t *testing.T) {
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,0,0:GPU-bbb,NVIDIA,0,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c0"},
+			},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0", "GPU-bbb-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+
+	_, hasControl := response.ContainerResponses[0].Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, hasControl, "CUDA_DISABLE_CONTROL should not be auto-set if any device is not whole-GPU")
+	require.True(t, hasLdSoPreloadMount(response.ContainerResponses[0].Mounts),
+		"ld.so.preload should be mounted if any device is not whole-GPU")
+}
+
 func TestAllocate_DeviceNumberMismatch(t *testing.T) {
 	setupInRequestDevices(t)
 	plugin := newTestPlugin(t)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -824,7 +824,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
-					if dev.Usedmem != 0 || dev.Usedcores != 0 {
+					if dev.Usedcores != 100 {
 						isWholeGPU = false
 					}
 				}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -860,25 +860,21 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						HostPath: "/tmp/vgpulock",
 						ReadOnly: false},
 				)
-				found := false
+				hasControlSetting := false
+				controlDisabled := false
 				for _, val := range currentCtr.Env {
 					if strings.Compare(val.Name, "CUDA_DISABLE_CONTROL") == 0 {
-						// if env existed but is set to false or can not be parsed, ignore
-						t, _ := strconv.ParseBool(val.Value)
-						if !t {
-							continue
-						}
-						// only env existed and set to true, we mark it "found"
-						found = true
+						hasControlSetting = true
+						controlDisabled, _ = strconv.ParseBool(val.Value)
 						break
 					}
 				}
-				if isWholeGPU && !found {
+				if isWholeGPU && !hasControlSetting {
 					klog.Infof("Whole GPU allocation detected without explicit CUDA_DISABLE_CONTROL, auto-setting to true")
-					found = true
+					controlDisabled = true
 					response.Envs["CUDA_DISABLE_CONTROL"] = "true"
 				}
-				if !found {
+				if !controlDisabled {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",
 						HostPath: hostHookPath + "/vgpu/ld.so.preload",
 						ReadOnly: true},

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -824,14 +824,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
-					if dev.Usedmem != 0 {
+					if dev.Usedmem != 0 || dev.Usedcores != 0 {
 						isWholeGPU = false
 					}
 				}
 				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
-				if devreq[0].Usedcores != 0 {
-					isWholeGPU = false
-				}
 				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
 				if *plugin.schedulerConfig.DeviceMemoryScaling > 1 {
 					response.Envs["CUDA_OVERSUBSCRIBE"] = "true"

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -820,11 +820,18 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 			}
 
 			if plugin.operatingMode != "mig" {
+				isWholeGPU := true
 				for i, dev := range devreq {
 					limitKey := fmt.Sprintf("CUDA_DEVICE_MEMORY_LIMIT_%v", i)
 					response.Envs[limitKey] = fmt.Sprintf("%vm", dev.Usedmem)
+					if dev.Usedmem != 0 {
+						isWholeGPU = false
+					}
 				}
 				response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
+				if devreq[0].Usedcores != 0 {
+					isWholeGPU = false
+				}
 				response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("%s/vgpu/%v.cache", hostHookPath, uuid.New().String())
 				if *plugin.schedulerConfig.DeviceMemoryScaling > 1 {
 					response.Envs["CUDA_OVERSUBSCRIBE"] = "true"
@@ -865,6 +872,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						found = true
 						break
 					}
+				}
+				if isWholeGPU && !found {
+					klog.Infof("Whole GPU allocation detected without explicit CUDA_DISABLE_CONTROL, auto-setting to true")
+					found = true
+					response.Envs["CUDA_DISABLE_CONTROL"] = "true"
 				}
 				if !found {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

HAMi allows multiple pods to share a single GPU by enforcing memory limits. It enforces these limits by pushing a file called `ld.so.preload` that intercepts GPU commands. However, when a user requests a whole GPU, HAMi was still pushing that interception file. That interception was causing a major issue: it was making vLLM (a popular AI model runner) freeze up in a deadlock when it tried to initialize its networking (NCCL).

My PR changes the code in `server.go`  to detect when a pod is asking for a whole GPU. Because a whole GPU doesn't need memory limits, we can safely bypass the interception. To do this, our code automatically injects an environment variable called `CUDA_DISABLE_CONTROL=true` into the pod. When this variable is set to true, HAMi skips the `ld.so.preload` interception, which allows vLLM to start up perfectly without freezing or stuck.

We had to be careful: what if a user explicitly wants the interception and manually sets `CUDA_DISABLE_CONTROL=false` in their pod configuration? Our code includes a check for this. It looks at the pod's environment variables first, and if the user explicitly set a value, we never overwrite it.

To prove our code works, we added two new unit tests in `alloc_refactor_test.go`. One test proves that we auto-set the variable when a whole GPU is requested, and the second test proves that we preserve the user's manual choice if they explicitly set it to false.

**Which issue(s) this PR fixes**:
Fixes #2641

**Special notes for your reviewer**:
**Hardware Validation:**
- **Device Type**: 4x NVIDIA RTX PRO 6000 Blackwell
- **Driver Version**: Validated by the original reporter (@ok-claven) on their deployment, who confirmed: *"With `CUDA_DISABLE_CONTROL=true` set, the deployment is live and verified: pod 1/1 Running, health checks passing, serving inference."*

**AI Assistance Notice:**
I used an chatgpt to help me understand the vLLM deadlock and write the `CUDA_DISABLE_CONTROL` injection logic, but I fully understand the code produced and have explicitly verified it via the new unit tests.

**Does this PR introduce a user-facing change?**:
```release-note
Fix: Auto-set CUDA_DISABLE_CONTROL=true for whole-GPU allocations to prevent vLLM pynccl deadlocks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Whole-GPU allocations now automatically disable CUDA control when no explicit setting is provided.
  * Explicit CUDA control settings are respected during GPU allocation.
  * Mixed-device allocations preserve CUDA control behavior for devices that are not allocated as whole GPUs.

* **Bug Fixes**
  * Preload mounts are now omitted when CUDA control is disabled and retained when it remains enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->