### PR TITLE
docs: fix helm repository URL formatting in multi-language READMEs and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ kubectl label nodes <node-name> gpu=on
 Add the HAMi Helm repository:
 
 ```bash
-helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo add hami-charts https://project-hami.github.io/HAMi
 helm repo update
 ```
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -113,7 +113,7 @@ kubectl label nodes <node-name> gpu=on
 添加 HAMi Helm 仓库：
 
 ```bash
-helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo add hami-charts https://project-hami.github.io/HAMi
 helm repo update
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -113,7 +113,7 @@ kubectl label nodes <node-name> gpu=on
 HAMi Helm リポジトリを追加します：
 
 ```bash
-helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo add hami-charts https://project-hami.github.io/HAMi
 helm repo update
 ```
 

--- a/docs/general-technical-review.md
+++ b/docs/general-technical-review.md
@@ -163,7 +163,7 @@ Semantic versioning, tagged releases, release branches, automated image/chart/re
 kubectl label nodes <gpu-node-name> gpu=on
 
 # 2) Add HAMi Helm repository
-helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo add hami-charts https://project-hami.github.io/HAMi
 helm repo update
 
 # 3) Install HAMi into kube-system


### PR DESCRIPTION
Standardizes and fixes the helm repo add hami-charts URL references across README.md, README_cn.md, README_ja.md, and docs/general-technical-review.md to remove trailing slash discrepancies and improve doc consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Helm repository URL in the installation instructions.
  * Updated the URL consistently across English, Chinese, and Japanese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->