### PR TITLE
docs: make the bug-report template accelerator-neutral

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,11 +16,11 @@ labels: kind/bug
 
 **Anything else we need to know?**:
 
-Please include the following information when it is relevant:
+Please include the following information:
 
 - The Pod manifest, or at least its accelerator resource requests and limits
 - Pod events and relevant accelerator-related node annotations
-- Output from the vendor's diagnostic tool (for example, `nvidia-smi -a` for NVIDIA devices)
+- Output from the vendor's diagnostic tool, when available (for example, `nvidia-smi -a` for NVIDIA devices)
 - Your container runtime configuration (for example, `/etc/docker/daemon.json` or the relevant containerd configuration)
 - Logs from the device plugin for the affected accelerator
 - The hami-scheduler logs
@@ -36,6 +36,6 @@ Please include the following information when it is relevant:
 - HAMi device backend and requested resource names (for example, `nvidia.com/gpu`):
 - Accelerator driver and runtime version:
 - Container runtime and version:
-- Workload image and tag:
+- Workload image and tag (redact private image names and state when redacted):
 - Operating system and kernel version (for example, the output of `uname -a`):
 - Others:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,18 +16,26 @@ labels: kind/bug
 
 **Anything else we need to know?**:
 
-- The output of `nvidia-smi -a` on your host
-- Your docker or containerd configuration file (e.g: `/etc/docker/daemon.json`)
-- The hami-device-plugin container logs
-- The hami-scheduler container logs
-- The kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
-- Any relevant kernel output lines from `dmesg`
+Please include the following information when it is relevant:
+
+- The Pod manifest, or at least its accelerator resource requests and limits
+- Pod events and relevant accelerator-related node annotations
+- Output from the vendor's diagnostic tool (for example, `nvidia-smi -a` for NVIDIA devices)
+- Your container runtime configuration (for example, `/etc/docker/daemon.json` or the relevant containerd configuration)
+- Logs from the device plugin for the affected accelerator
+- The hami-scheduler logs
+- The kubelet logs from the affected node (for example, `sudo journalctl -r -u kubelet`)
+- Relevant kernel output from `dmesg`
+
+> **Security note:** Remove credentials, tokens, registry secrets, private image names, and other sensitive information before posting manifests, configuration files, or logs.
 
 **Environment**:
 - HAMi version:
-- nvidia driver or other AI device driver version:
-- Docker version from `docker version`
-- Docker command, image and tag used
-- Kernel version from `uname -a`
+- Kubernetes version:
+- Accelerator vendor and model:
+- HAMi device backend and requested resource names (for example, `nvidia.com/gpu`):
+- Accelerator driver and runtime version:
+- Container runtime and version:
+- Workload image and tag:
+- Operating system and kernel version (for example, the output of `uname -a`):
 - Others:
-


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Updates the GitHub bug-report template so it works for all accelerator vendors supported by HAMi.

The template now asks reporters for:

- The accelerator vendor and model
- The HAMi device backend and requested resource names
- Vendor diagnostic output
- Kubernetes and container-runtime versions
- Pod manifests, events, and relevant node annotations
- Logs from the affected accelerator's device plugin
- Scheduler, kubelet, and kernel logs

The NVIDIA-specific `nvidia-smi -a` command remains as an example instead of being presented as a requirement for every report.

The template also reminds users to remove credentials, tokens, registry secrets, private image names, and other sensitive information before sharing manifests, configuration files, or logs.

**Which issue(s) this PR fixes**:

Fixes #2667

**Special notes for your reviewer**:

This is a documentation-only change to `.github/ISSUE_TEMPLATE/bug-report.md`.

The existing YAML front matter and automatic `kind/bug` label are unchanged.

Validation completed:

- `make verify`
- `make test`
- `make build`
- `git diff --check`
- Focused validation of the template metadata and required prompts
<img width="1657" height="890" alt="Screenshot from 2026-08-15 05-54-34" src="https://github.com/user-attachments/assets/76ac0184-786a-444e-b233-3be506dcf1fd" />
<img width="1657" height="890" alt="Screenshot from 2026-08-15 05-55-42" src="https://github.com/user-attachments/assets/484b7d42-6273-4aeb-965f-6cd520b67d8e" />
<img width="1587" height="314" alt="Screenshot from 2026-08-15 05-56-19" src="https://github.com/user-attachments/assets/8c7c9f41-cfb4-4c6b-a9a7-73d13149fd23" />

Hardware validation is not applicable because this change does not affect device allocation, scheduling, or in-container isolation.

**Does this PR introduce a user-facing change?**:

Yes. People opening bug reports will see vendor-neutral diagnostic fields and a reminder to remove sensitive information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced the bug report template to collect structured diagnostic and environment information.
  * Added guidance to redact sensitive data before submitting reports.
  * Removed outdated Docker-specific prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->