### PR TITLE
test(util): add unit test coverage for GetNode, AllInitContainersSucceeded, and PatchNodeAnnotations

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1021,6 +1021,9 @@ func TestAllInitContainersSucceeded(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+
 	t.Run("empty node name", func(t *testing.T) {
 		client.KubeClient = fake.NewClientset()
 		node, err := GetNode("")
@@ -1029,9 +1032,7 @@ func TestGetNode(t *testing.T) {
 	})
 
 	t.Run("uninitialized client", func(t *testing.T) {
-		oldClient := client.KubeClient
 		client.KubeClient = nil
-		defer func() { client.KubeClient = oldClient }()
 
 		node, err := GetNode("some-node")
 		assert.Assert(t, err != nil)
@@ -1059,6 +1060,9 @@ func TestGetNode(t *testing.T) {
 }
 
 func TestPatchNodeAnnotations(t *testing.T) {
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+
 	t.Run("successful patch", func(t *testing.T) {
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1087,10 +1091,11 @@ func TestPatchNodeAnnotations(t *testing.T) {
 		client.KubeClient = fake.NewClientset()
 
 		annotations := map[string]string{
-			"test-key": "test-value",
+			"hami.io/test-key": "test-value",
 		}
 		err := PatchNodeAnnotations(node, annotations)
 		assert.Assert(t, err != nil)
 	})
 }
+
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -920,3 +920,177 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 		assert.Equal(t, 2, len(events.Items))
 	})
 }
+
+func TestAllInitContainersSucceeded(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "no init container statuses",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "init container state terminated is nil",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "init-1",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "init container exit code non-zero",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all init containers succeeded with exit code 0",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+						{
+							Name: "init-2",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "one init container succeeded and one failed",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+						{
+							Name: "init-2",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 137},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AllInitContainersSucceeded(tt.pod)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetNode(t *testing.T) {
+	t.Run("empty node name", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset()
+		node, err := GetNode("")
+		assert.Assert(t, err != nil)
+		assert.Assert(t, node == nil)
+	})
+
+	t.Run("uninitialized client", func(t *testing.T) {
+		oldClient := client.KubeClient
+		client.KubeClient = nil
+		defer func() { client.KubeClient = oldClient }()
+
+		node, err := GetNode("some-node")
+		assert.Assert(t, err != nil)
+		assert.Assert(t, node == nil)
+	})
+
+	t.Run("node not found", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset()
+		node, err := GetNode("non-existent-node")
+		assert.Assert(t, err != nil)
+		assert.Assert(t, node == nil)
+	})
+
+	t.Run("successful fetch", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-node",
+			},
+		})
+		node, err := GetNode("valid-node")
+		assert.NilError(t, err)
+		assert.Assert(t, node != nil)
+		assert.Equal(t, "valid-node", node.Name)
+	})
+}
+
+func TestPatchNodeAnnotations(t *testing.T) {
+	t.Run("successful patch", func(t *testing.T) {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-to-patch",
+			},
+		}
+		client.KubeClient = fake.NewClientset(node)
+
+		annotations := map[string]string{
+			"hami.io/test-annotation": "patched-value",
+		}
+		err := PatchNodeAnnotations(node, annotations)
+		assert.NilError(t, err)
+
+		patchedNode, getErr := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "node-to-patch", metav1.GetOptions{})
+		assert.NilError(t, getErr)
+		assert.Equal(t, "patched-value", patchedNode.Annotations["hami.io/test-annotation"])
+	})
+
+	t.Run("non-existent node patch fails", func(t *testing.T) {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "non-existent-node",
+			},
+		}
+		client.KubeClient = fake.NewClientset()
+
+		annotations := map[string]string{
+			"test-key": "test-value",
+		}
+		err := PatchNodeAnnotations(node, annotations)
+		assert.Assert(t, err != nil)
+	})
+}
+


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Adds unit test coverage for previously untested utility functions in `pkg/util/util_test.go`:
- `TestGetNode`: tests empty node name handling, uninitialized client, non-existent node errors, and successful node fetching.
- `TestAllInitContainersSucceeded`: tests empty init container statuses, running init containers, failed init containers, and successful completion cases.
- `TestPatchNodeAnnotations`: tests successful node annotation patching and non-existent node errors.

This increases `pkg/util` test coverage from 76.1% to **87.2%**.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested with `go test ./pkg/util/... -v`.

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**AI assistance disclosure**:
AI assistance was used to draft unit tests and verify test execution.

**Checklist**:
- [x] Scoped to `pkg/util/util_test.go`
- [x] Commit is signed off (DCO)
- [x] Followed CONTRIBUTING.md guidelines
- [x] AI assistance disclosed above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for verifying init-container completion across missing, running, failed, and successful states.
  * Added tests for successful and failed node retrieval scenarios.
  * Added tests for successful and failed node annotation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->