### PR TITLE
docs: support all accelerator vendors in bug report template (#2667)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,6 +16,7 @@ labels: kind/bug
 
 **Anything else we need to know?**:
 
+<!-- Remove credentials, tokens, registry secrets, and other private information before sharing logs or configuration files. -->
 - Accelerator diagnostic command output on host (e.g., `nvidia-smi -a`, `npu-smi info`, `cnmon`, `rocm-smi`, or vendor equivalent)
 - Your docker or containerd configuration file (e.g: `/etc/docker/daemon.json` or `/etc/containerd/config.toml`)
 - The hami-device-plugin container logs
@@ -28,5 +29,8 @@ labels: kind/bug
 - Accelerator vendor & architecture (e.g., NVIDIA, Huawei Ascend, Cambricon, Hygon, AMD, MetaX, Moore Threads, Iluvatar, AWS Neuron, etc.):
 - Driver and runtime toolkit version (e.g., NVIDIA Driver/CUDA, Ascend CANN, Cambricon Neuware, ROCm, etc.):
 - Container runtime & version (`docker version` or `crictl version`)
+- Kubernetes version:
+- Pod YAML, resource request configuration, or pod events:
+- Workload image and tag (redact private image names and state when redacted):
 - Kernel version from `uname -a`
 - Others:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,8 +16,8 @@ labels: kind/bug
 
 **Anything else we need to know?**:
 
-- The output of `nvidia-smi -a` on your host
-- Your docker or containerd configuration file (e.g: `/etc/docker/daemon.json`)
+- Accelerator diagnostic command output on host (e.g., `nvidia-smi -a`, `npu-smi info`, `cnmon`, `rocm-smi`, or vendor equivalent)
+- Your docker or containerd configuration file (e.g: `/etc/docker/daemon.json` or `/etc/containerd/config.toml`)
 - The hami-device-plugin container logs
 - The hami-scheduler container logs
 - The kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
@@ -25,9 +25,8 @@ labels: kind/bug
 
 **Environment**:
 - HAMi version:
-- nvidia driver or other AI device driver version:
-- Docker version from `docker version`
-- Docker command, image and tag used
+- Accelerator vendor & architecture (e.g., NVIDIA, Huawei Ascend, Cambricon, Hygon, AMD, MetaX, Moore Threads, Iluvatar, AWS Neuron, etc.):
+- Driver and runtime toolkit version (e.g., NVIDIA Driver/CUDA, Ascend CANN, Cambricon Neuware, ROCm, etc.):
+- Container runtime & version (`docker version` or `crictl version`)
 - Kernel version from `uname -a`
 - Others:
-


### PR DESCRIPTION
Resolves #2667.

Updates .github/ISSUE_TEMPLATE/bug_report.md to expand host diagnostic command options and environment specifications to support all the heterogeneous AI accelerator vendors like (NVIDIA, Huawei Ascend, Cambricon, AMD, Hygon, MetaX, Moore Threads, etc.) rather than defaulting solely to NVIDIA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template to collect broader accelerator, driver, toolkit, and container runtime details.
  * Added prompts for multi-vendor accelerator environments and vendor-specific configuration information.
  * Replaced NVIDIA- and Docker-focused questions with more general diagnostic fields.
  * Removed the Docker command, image, and tag fields to streamline environment reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->