### PR TITLE
fix(awsneuron): prevent odd NeuronCore request truncation

### DIFF
--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -79,7 +79,18 @@ func (dev *AWSNeuronDevices) CommonWord() string {
 func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 	if !ok {
-		_, ok = ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+		core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+		if !coreRequested {
+			return false, nil
+		}
+		coreCount, isInteger := core.AsInt64()
+		if !isInteger {
+			return false, fmt.Errorf("%s must be an integer", dev.resourceCoreName)
+		}
+		if coreCount > 1 && coreCount%2 != 0 {
+			return false, fmt.Errorf("%s must be 1 or a multiple of 2", dev.resourceCoreName)
+		}
+		ok = true
 	}
 	return ok, nil
 }
@@ -246,10 +257,7 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 				klog.InfoS("Detected awsNeuron device request",
 					"container", ctr.Name,
 					"deviceCores", n)
-				num := 1
-				if n >= 2 {
-					num = int(n / 2)
-				}
+				num := n/2 + n%2
 				corenum := 1
 				if n >= 2 {
 					corenum = 2

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -18,6 +18,7 @@ package awsneuron
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -77,22 +78,45 @@ func (dev *AWSNeuronDevices) CommonWord() string {
 }
 
 func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
-	if !ok {
-		core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
-		if !coreRequested {
-			return false, nil
-		}
-		coreCount, isInteger := core.AsInt64()
-		if !isInteger {
-			return false, fmt.Errorf("%s must be an integer", dev.resourceCoreName)
-		}
-		if coreCount > 1 && coreCount%2 != 0 {
-			return false, fmt.Errorf("%s must be 1 or a multiple of 2", dev.resourceCoreName)
-		}
-		ok = true
+	_, countRequested := resourceQuantity(ctr, corev1.ResourceName(dev.resourceCountName))
+	if countRequested {
+		return true, nil
 	}
-	return ok, nil
+
+	core, coreRequested := resourceQuantity(ctr, corev1.ResourceName(dev.resourceCoreName))
+	if !coreRequested {
+		return false, nil
+	}
+	coreCount, err := dev.validateCoreRequest(core)
+	if err != nil {
+		return false, err
+	}
+	if coreCount > 1 && coreCount%2 != 0 {
+		return false, fmt.Errorf("%s must be 1 or a multiple of 2", dev.resourceCoreName)
+	}
+	return true, nil
+}
+
+func resourceQuantity(ctr *corev1.Container, name corev1.ResourceName) (resource.Quantity, bool) {
+	quantity, ok := ctr.Resources.Limits[name]
+	if !ok {
+		quantity, ok = ctr.Resources.Requests[name]
+	}
+	return quantity, ok
+}
+
+func (dev *AWSNeuronDevices) validateCoreRequest(core resource.Quantity) (int64, error) {
+	coreCount, isInteger := core.AsInt64()
+	if !isInteger {
+		return 0, fmt.Errorf("%s must be an integer", dev.resourceCoreName)
+	}
+	if coreCount <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", dev.resourceCoreName)
+	}
+	if coreCount > int64(math.MaxInt32)*2 {
+		return 0, fmt.Errorf("%s exceeds the maximum supported core count", dev.resourceCoreName)
+	}
+	return coreCount, nil
 }
 
 func (dev *AWSNeuronDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
@@ -230,10 +254,7 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 	klog.Info("Start to count awsNeuron devices for container ", ctr.Name)
 	awsResourceCount := corev1.ResourceName(dev.resourceCountName)
 	awsResourceCores := corev1.ResourceName(dev.resourceCoreName)
-	v, ok := ctr.Resources.Limits[awsResourceCount]
-	if !ok {
-		v, ok = ctr.Resources.Requests[awsResourceCount]
-	}
+	v, ok := resourceQuantity(ctr, awsResourceCount)
 	if ok {
 		if n, ok := v.AsInt64(); ok {
 			klog.InfoS("Detected awsNeuron device request",
@@ -248,12 +269,9 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 			}
 		}
 	} else {
-		core, ok := ctr.Resources.Limits[awsResourceCores]
-		if !ok {
-			core, ok = ctr.Resources.Requests[awsResourceCores]
-		}
+		core, ok := resourceQuantity(ctr, awsResourceCores)
 		if ok {
-			if n, ok := core.AsInt64(); ok {
+			if n, err := dev.validateCoreRequest(core); err == nil {
 				klog.InfoS("Detected awsNeuron device request",
 					"container", ctr.Name,
 					"deviceCores", n)
@@ -269,6 +287,8 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 					MemPercentagereq: 0,
 					Coresreq:         int32(corenum),
 				}
+			} else {
+				klog.ErrorS(err, "Invalid awsNeuron core request", "container", ctr.Name)
 			}
 		}
 	}

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -53,6 +53,8 @@ const (
 	AWSNeuronAllocated       = "NEURON_ALLOCATED"
 	AWSUsageInfo             = "awsusageinfo"
 	AWSNodeType              = "AWSNodeType"
+	maxAWSNeuronDeviceCount  = int64(math.MaxInt32)
+	maxAWSNeuronCoreCount    = maxAWSNeuronDeviceCount * 2
 )
 
 type AWSNeuronConfig struct {
@@ -78,16 +80,17 @@ func (dev *AWSNeuronDevices) CommonWord() string {
 }
 
 func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, countRequested := resourceQuantity(ctr, corev1.ResourceName(dev.resourceCountName))
+	count, countRequested := resourceQuantity(ctr, corev1.ResourceName(dev.resourceCountName))
 	if countRequested {
-		return true, nil
+		_, err := validateResourceRequest(count, dev.resourceCountName, maxAWSNeuronDeviceCount)
+		return err == nil, err
 	}
 
 	core, coreRequested := resourceQuantity(ctr, corev1.ResourceName(dev.resourceCoreName))
 	if !coreRequested {
 		return false, nil
 	}
-	coreCount, err := dev.validateCoreRequest(core)
+	coreCount, err := validateResourceRequest(core, dev.resourceCoreName, maxAWSNeuronCoreCount)
 	if err != nil {
 		return false, err
 	}
@@ -105,18 +108,18 @@ func resourceQuantity(ctr *corev1.Container, name corev1.ResourceName) (resource
 	return quantity, ok
 }
 
-func (dev *AWSNeuronDevices) validateCoreRequest(core resource.Quantity) (int64, error) {
-	coreCount, isInteger := core.AsInt64()
+func validateResourceRequest(quantity resource.Quantity, resourceName string, maxValue int64) (int64, error) {
+	value, isInteger := quantity.AsInt64()
 	if !isInteger {
-		return 0, fmt.Errorf("%s must be an integer", dev.resourceCoreName)
+		return 0, fmt.Errorf("%s must be an integer", resourceName)
 	}
-	if coreCount <= 0 {
-		return 0, fmt.Errorf("%s must be greater than 0", dev.resourceCoreName)
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", resourceName)
 	}
-	if coreCount > int64(math.MaxInt32)*2 {
-		return 0, fmt.Errorf("%s exceeds the maximum supported core count", dev.resourceCoreName)
+	if value > maxValue {
+		return 0, fmt.Errorf("%s must not exceed %d", resourceName, maxValue)
 	}
-	return coreCount, nil
+	return value, nil
 }
 
 func (dev *AWSNeuronDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
@@ -256,22 +259,25 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 	awsResourceCores := corev1.ResourceName(dev.resourceCoreName)
 	v, ok := resourceQuantity(ctr, awsResourceCount)
 	if ok {
-		if n, ok := v.AsInt64(); ok {
-			klog.InfoS("Detected awsNeuron device request",
-				"container", ctr.Name,
-				"deviceCount", n)
-			return device.ContainerDeviceRequest{
-				Nums:             int32(n),
-				Type:             AWSNeuronDevice,
-				Memreq:           0,
-				MemPercentagereq: 0,
-				Coresreq:         int32(dev.coresPerAWSNeuron),
-			}
+		n, err := validateResourceRequest(v, dev.resourceCountName, maxAWSNeuronDeviceCount)
+		if err != nil {
+			klog.ErrorS(err, "Invalid awsNeuron device request", "container", ctr.Name)
+			return device.ContainerDeviceRequest{}
+		}
+		klog.InfoS("Detected awsNeuron device request",
+			"container", ctr.Name,
+			"deviceCount", n)
+		return device.ContainerDeviceRequest{
+			Nums:             int32(n),
+			Type:             AWSNeuronDevice,
+			Memreq:           0,
+			MemPercentagereq: 0,
+			Coresreq:         int32(dev.coresPerAWSNeuron),
 		}
 	} else {
 		core, ok := resourceQuantity(ctr, awsResourceCores)
 		if ok {
-			if n, err := dev.validateCoreRequest(core); err == nil {
+			if n, err := validateResourceRequest(core, dev.resourceCoreName, maxAWSNeuronCoreCount); err == nil {
 				klog.InfoS("Detected awsNeuron device request",
 					"container", ctr.Name,
 					"deviceCores", n)

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -54,7 +54,10 @@ const (
 	AWSUsageInfo             = "awsusageinfo"
 	AWSNodeType              = "AWSNodeType"
 	maxAWSNeuronDeviceCount  = int64(math.MaxInt32)
-	maxAWSNeuronCoreCount    = maxAWSNeuronDeviceCount * 2
+	// maxCoresPerNeuronDevice caps per-device cores: addCoreUsage builds a
+	// two-bit mask and PatchAnnotations only emits the first two core indexes.
+	maxCoresPerNeuronDevice = int64(2)
+	maxAWSNeuronCoreCount   = maxAWSNeuronDeviceCount * maxCoresPerNeuronDevice
 )
 
 type AWSNeuronConfig struct {
@@ -94,8 +97,9 @@ func (dev *AWSNeuronDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 	if err != nil {
 		return false, err
 	}
-	if coreCount > 1 && coreCount%2 != 0 {
-		return false, fmt.Errorf("%s must be 1 or a multiple of 2", dev.resourceCoreName)
+	// Defer to the conversion path so the two cannot disagree.
+	if _, _, err := dev.splitCoreRequest(coreCount); err != nil {
+		return false, err
 	}
 	return true, nil
 }
@@ -120,6 +124,33 @@ func validateResourceRequest(quantity resource.Quantity, resourceName string, ma
 		return 0, fmt.Errorf("%s must not exceed %d", resourceName, maxValue)
 	}
 	return value, nil
+}
+
+// coresPerDevice reports NeuronCores per device. It is zero until a node is
+// registered, so callers without one fall back to the cap.
+func (dev *AWSNeuronDevices) coresPerDevice() int64 {
+	observed := int64(dev.coresPerAWSNeuron)
+	if observed <= 0 {
+		return maxCoresPerNeuronDevice
+	}
+	return min(observed, maxCoresPerNeuronDevice)
+}
+
+// splitCoreRequest maps a NeuronCore count onto devices. One core count applies
+// to every device, so counts that neither fit nor fill devices are rejected.
+func (dev *AWSNeuronDevices) splitCoreRequest(cores int64) (int32, int32, error) {
+	coresPerDevice := dev.coresPerDevice()
+	if cores <= coresPerDevice {
+		return 1, int32(cores), nil
+	}
+	if cores%coresPerDevice != 0 {
+		return 0, 0, fmt.Errorf("%s must be 1 or a multiple of %d, got %d", dev.resourceCoreName, coresPerDevice, cores)
+	}
+	nums := cores / coresPerDevice
+	if nums > maxAWSNeuronDeviceCount {
+		return 0, 0, fmt.Errorf("%s needs %d devices, which exceeds the maximum of %d", dev.resourceCoreName, nums, maxAWSNeuronDeviceCount)
+	}
+	return int32(nums), int32(coresPerDevice), nil
 }
 
 func (dev *AWSNeuronDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
@@ -277,24 +308,25 @@ func (dev *AWSNeuronDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 	} else {
 		core, ok := resourceQuantity(ctr, awsResourceCores)
 		if ok {
-			if n, err := validateResourceRequest(core, dev.resourceCoreName, maxAWSNeuronCoreCount); err == nil {
-				klog.InfoS("Detected awsNeuron device request",
-					"container", ctr.Name,
-					"deviceCores", n)
-				num := n/2 + n%2
-				corenum := 1
-				if n >= 2 {
-					corenum = 2
-				}
-				return device.ContainerDeviceRequest{
-					Nums:             int32(num),
-					Type:             AWSNeuronDevice,
-					Memreq:           0,
-					MemPercentagereq: 0,
-					Coresreq:         int32(corenum),
-				}
-			} else {
+			n, err := validateResourceRequest(core, dev.resourceCoreName, maxAWSNeuronCoreCount)
+			if err != nil {
 				klog.ErrorS(err, "Invalid awsNeuron core request", "container", ctr.Name)
+				return device.ContainerDeviceRequest{}
+			}
+			nums, coresreq, err := dev.splitCoreRequest(n)
+			if err != nil {
+				klog.ErrorS(err, "Invalid awsNeuron core request", "container", ctr.Name)
+				return device.ContainerDeviceRequest{}
+			}
+			klog.InfoS("Detected awsNeuron device request",
+				"container", ctr.Name,
+				"deviceCores", n)
+			return device.ContainerDeviceRequest{
+				Nums:             nums,
+				Type:             AWSNeuronDevice,
+				Memreq:           0,
+				MemPercentagereq: 0,
+				Coresreq:         coresreq,
 			}
 		}
 	}

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsneuron
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -77,6 +78,26 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "reject odd neuron core count greater than one",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"aws.amazon.com/neuroncore": *resource.NewQuantity(3, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2"),
+		},
+		{
 			name: "no neuron devices",
 			args: struct {
 				ctr *corev1.Container
@@ -101,8 +122,13 @@ func Test_MutateAdmission(t *testing.T) {
 				ResourceCoreName:  "aws.amazon.com/neuroncore",
 			}
 			dev := InitAWSNeuronDevice(config)
-			result, _ := dev.MutateAdmission(test.args.ctr, test.args.p)
+			result, err := dev.MutateAdmission(test.args.ctr, test.args.p)
 			assert.Equal(t, result, test.want)
+			if test.err == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, test.err.Error())
+			}
 		})
 	}
 }
@@ -435,6 +461,26 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				Memreq:           int32(0),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(1),
+			},
+		},
+		{
+			name: "round up odd neuron core request when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": resource.MustParse("3"),
+					},
+					Requests: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": resource.MustParse("3"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(2),
+				Type:             AWSNeuronDevice,
+				Memreq:           int32(0),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(2),
 			},
 		},
 	}

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -131,7 +131,7 @@ func Test_MutateAdmission(t *testing.T) {
 				},
 			},
 			want: false,
-			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2"),
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2, got 3"),
 		},
 		{
 			name: "reject request-only odd neuron core count greater than one",
@@ -149,7 +149,7 @@ func Test_MutateAdmission(t *testing.T) {
 				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
 			},
 			want: false,
-			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2"),
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2, got 3"),
 		},
 		{
 			name: "reject zero neuron core count",
@@ -583,7 +583,7 @@ func Test_GenerateResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name: "round up odd neuron core request when admission is bypassed",
+			name: "reject odd neuron core request when admission is bypassed",
 			args: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -594,16 +594,10 @@ func Test_GenerateResourceRequests(t *testing.T) {
 					},
 				},
 			},
-			want: device.ContainerDeviceRequest{
-				Nums:             int32(2),
-				Type:             AWSNeuronDevice,
-				Memreq:           int32(0),
-				MemPercentagereq: int32(0),
-				Coresreq:         int32(2),
-			},
+			want: device.ContainerDeviceRequest{},
 		},
 		{
-			name: "round up request-only odd neuron core request when admission is bypassed",
+			name: "reject request-only odd neuron core request when admission is bypassed",
 			args: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -611,13 +605,7 @@ func Test_GenerateResourceRequests(t *testing.T) {
 					},
 				},
 			},
-			want: device.ContainerDeviceRequest{
-				Nums:             int32(2),
-				Type:             AWSNeuronDevice,
-				Memreq:           int32(0),
-				MemPercentagereq: int32(0),
-				Coresreq:         int32(2),
-			},
+			want: device.ContainerDeviceRequest{},
 		},
 		{
 			name: "reject zero neuron core request when admission is bypassed",
@@ -663,6 +651,85 @@ func Test_GenerateResourceRequests(t *testing.T) {
 			dev.coresPerAWSNeuron = 2
 			result := dev.GenerateResourceRequests(test.args)
 			assert.DeepEqual(t, result, test.want)
+		})
+	}
+}
+
+// Test_splitCoreRequest covers the one place the core request shape is decided.
+func Test_splitCoreRequest(t *testing.T) {
+	tests := []struct {
+		name              string
+		coresPerAWSNeuron uint
+		cores             int64
+		wantNums          int32
+		wantCoresreq      int32
+		wantErr           string
+	}{
+		{
+			name:              "single core takes one device",
+			coresPerAWSNeuron: 2,
+			cores:             1,
+			wantNums:          1,
+			wantCoresreq:      1,
+		},
+		{
+			name:              "a full device is one device",
+			coresPerAWSNeuron: 2,
+			cores:             2,
+			wantNums:          1,
+			wantCoresreq:      2,
+		},
+		{
+			name:              "whole devices divide evenly",
+			coresPerAWSNeuron: 2,
+			cores:             6,
+			wantNums:          3,
+			wantCoresreq:      2,
+		},
+		{
+			name:              "odd count above one has no representable shape",
+			coresPerAWSNeuron: 2,
+			cores:             3,
+			wantErr:           "aws.amazon.com/neuroncore must be 1 or a multiple of 2, got 3",
+		},
+		{
+			// An Inferentia chip has four cores, but only two are addressable.
+			name:              "per-device cores above the addressable limit are bounded",
+			coresPerAWSNeuron: 4,
+			cores:             4,
+			wantNums:          2,
+			wantCoresreq:      2,
+		},
+		{
+			name:         "unknown per-device cores falls back to the addressable limit",
+			cores:        4,
+			wantNums:     2,
+			wantCoresreq: 2,
+		},
+		{
+			// One core per device divides evenly, leaving only the count bound.
+			name:              "device count stays within int32",
+			coresPerAWSNeuron: 1,
+			cores:             int64(math.MaxInt32) + 1,
+			wantErr:           "aws.amazon.com/neuroncore needs 2147483648 devices, which exceeds the maximum of 2147483647",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dev := InitAWSNeuronDevice(AWSNeuronConfig{
+				ResourceCountName: "aws.amazon.com/neuron",
+				ResourceCoreName:  "aws.amazon.com/neuroncore",
+			})
+			dev.coresPerAWSNeuron = test.coresPerAWSNeuron
+
+			nums, coresreq, err := dev.splitCoreRequest(test.cores)
+			if test.wantErr != "" {
+				assert.Error(t, err, test.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, nums, test.wantNums)
+			assert.Equal(t, coresreq, test.wantCoresreq)
 		})
 	}
 }

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -18,6 +18,7 @@ package awsneuron
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -96,6 +97,78 @@ func Test_MutateAdmission(t *testing.T) {
 			},
 			want: false,
 			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2"),
+		},
+		{
+			name: "reject request-only odd neuron core count greater than one",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"aws.amazon.com/neuroncore": *resource.NewQuantity(3, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be 1 or a multiple of 2"),
+		},
+		{
+			name: "reject zero neuron core count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"aws.amazon.com/neuroncore": *resource.NewQuantity(0, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be greater than 0"),
+		},
+		{
+			name: "reject negative neuron core count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"aws.amazon.com/neuroncore": *resource.NewQuantity(-2, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must be greater than 0"),
+		},
+		{
+			name: "reject neuron core count that overflows device count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"aws.amazon.com/neuroncore": *resource.NewQuantity(int64(math.MaxInt32)*2+2, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuroncore exceeds the maximum supported core count"),
 		},
 		{
 			name: "no neuron devices",
@@ -482,6 +555,56 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(2),
 			},
+		},
+		{
+			name: "round up request-only odd neuron core request when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": resource.MustParse("3"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{
+				Nums:             int32(2),
+				Type:             AWSNeuronDevice,
+				Memreq:           int32(0),
+				MemPercentagereq: int32(0),
+				Coresreq:         int32(2),
+			},
+		},
+		{
+			name: "reject zero neuron core request when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": resource.MustParse("0"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "reject negative neuron core request when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": resource.MustParse("-2"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "reject neuron core request that overflows device count when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"aws.amazon.com/neuroncore": *resource.NewQuantity(int64(math.MaxInt32)*2+2, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -60,6 +60,41 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "set request-only neuron number",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"aws.amazon.com/neuron": *resource.NewQuantity(2, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: true,
+		},
+		{
+			name: "reject request-only neuron number that overflows device count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"aws.amazon.com/neuron": *resource.NewQuantity(int64(math.MaxInt32)+1, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			},
+			want: false,
+			err:  fmt.Errorf("aws.amazon.com/neuron must not exceed 2147483647"),
+		},
+		{
 			name: "set neuron cores",
 			args: struct {
 				ctr *corev1.Container
@@ -168,7 +203,7 @@ func Test_MutateAdmission(t *testing.T) {
 				p: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
 			},
 			want: false,
-			err:  fmt.Errorf("aws.amazon.com/neuroncore exceeds the maximum supported core count"),
+			err:  fmt.Errorf("aws.amazon.com/neuroncore must not exceed 4294967294"),
 		},
 		{
 			name: "no neuron devices",
@@ -515,6 +550,17 @@ func Test_GenerateResourceRequests(t *testing.T) {
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(2),
 			},
+		},
+		{
+			name: "reject request-only neuron number that overflows device count when admission is bypassed",
+			args: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"aws.amazon.com/neuron": *resource.NewQuantity(int64(math.MaxInt32)+1, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
 		},
 		{
 			name: "allocate neuron core",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Rejects AWS Neuron core requests with unsupported odd counts greater than one during admission, instead of silently allocating fewer cores than requested.

If admission is bypassed, request conversion rounds the device count up so the scheduler never under-allocates the requested cores.

Adds regression coverage for admission validation and defensive request conversion.

**Which issue(s) this PR fixes**:
Fixes #2673

**Special notes for your reviewer**:

This is a scheduler-side validation and accounting change. It was validated with unit tests and does not require AWS Neuron hardware.

Validation:
- `gofmt`: passed for changed files
- AWS Neuron package tests: passed
- Targeted `golangci-lint`: passed with noo issues
- Import-alias verification: passed
- `make verify` / `make lint`
- `make test`

AI assistance disclosure:

Took help of Codex in understanding the nearby code and flow.

**Does this PR introduce a user-facing change?**:

```release-note
AWS Neuron requests for unsupported odd core counts greater than one are now rejected instead of being silently under-allocated.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for AWS Neuron device and core resource requests.
  * Invalid, zero, negative, overflowing, and unsupported odd core requests are now rejected with clear errors.
  * Resource allocation now consistently honors valid core requests without rounding.
  * Admission checks and resource allocation now apply consistent limits and validation.
  * Invalid requests no longer result in device allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->