### PR TITLE
fix(amd): require the device count in MutateAdmission

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -76,7 +76,7 @@ func (dev *AMDDevices) CommonWord() string {
 }
 
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
+	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 	if !ok {
 		// A container that does not request the AMD device count is not a HAMi
 		// GPU request. GenerateResourceRequests and LockNode both key off the
@@ -85,6 +85,14 @@ func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bo
 		// every later stage treats it as a non-GPU pod: quota is skipped, the
 		// filter passes on all nodes, and the pod binds with no device reserved.
 		return false, nil
+	}
+	// Validate the count value, not just its presence: GenerateResourceRequests
+	// rejects a non-integer, non-positive, or out-of-range count and yields an
+	// empty request, so admitting such a value here would reintroduce the same
+	// "admitted but never scheduled/locked" divergence this guard closes.
+	countValue, countIsInteger := count.AsInt64()
+	if !countIsInteger || countValue <= 0 || countValue > math.MaxInt32 {
+		return false, fmt.Errorf("%s must be a positive integer no greater than %d", dev.resourceCountName, math.MaxInt32)
 	}
 	if core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]; coreRequested {
 		corePercentage, coreIsInteger := core.AsInt64()

--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -77,21 +77,20 @@ func (dev *AMDDevices) CommonWord() string {
 
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
-	if ok {
-		core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
-		if coreRequested {
-			corePercentage, coreIsInteger := core.AsInt64()
-			if !coreIsInteger || corePercentage < 1 || corePercentage > 100 {
-				return false, fmt.Errorf("%s must be an integer percentage between 1 and 100", dev.resourceCoreName)
-			}
+	if !ok {
+		// A container that does not request the AMD device count is not a HAMi
+		// GPU request. GenerateResourceRequests and LockNode both key off the
+		// count resource, so admitting a memory- or core-only container here
+		// would rewrite the pod's scheduler name to the HAMi extender while
+		// every later stage treats it as a non-GPU pod: quota is skipped, the
+		// filter passes on all nodes, and the pod binds with no device reserved.
+		return false, nil
+	}
+	if core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]; coreRequested {
+		corePercentage, coreIsInteger := core.AsInt64()
+		if !coreIsInteger || corePercentage < 1 || corePercentage > 100 {
+			return false, fmt.Errorf("%s must be an integer percentage between 1 and 100", dev.resourceCoreName)
 		}
-
-	}
-	if !ok && dev.resourceMemoryName != "" {
-		_, ok = ctr.Resources.Limits[corev1.ResourceName(dev.resourceMemoryName)]
-	}
-	if !ok && dev.resourceCoreName != "" {
-		_, ok = ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
 	}
 	klog.Infoln("MutateAdmission result", ok)
 	return ok, nil

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -82,6 +82,17 @@ func Test_MutateAdmission(t *testing.T) {
 			wantErr: "must be a positive integer",
 		},
 		{
+			name: "accepts count at int32 max",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(math.MaxInt32, resource.DecimalSI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "rejects count above int32 max",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
@@ -182,6 +193,7 @@ func Test_MutateAdmission(t *testing.T) {
 			got, err := dev.MutateAdmission(tt.ctr, &corev1.Pod{})
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, tt.want, got)
 				return
 			}
 			assert.NilError(t, err)

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -49,6 +49,50 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "rejects zero count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects negative count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(-1, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects non-integer count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": resource.MustParse("500m"),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects count above int32 max",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": resource.MustParse("2147483648"),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
 			name: "gpu memory only (no count) -> false",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -49,7 +49,7 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "gpu memory in limits",
+			name: "gpu memory only (no count) -> false",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -57,10 +57,10 @@ func Test_MutateAdmission(t *testing.T) {
 					},
 				},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "core percentage in limits",
+			name: "core percentage only (no count) -> false",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -68,7 +68,7 @@ func Test_MutateAdmission(t *testing.T) {
 					},
 				},
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "requests only (limits empty) -> false",


### PR DESCRIPTION
Fixes #2679

**What this fixes**

`AMDDevices.MutateAdmission` admits a container that requests only `amd.com/gpu-mem` and/or `amd.com/gpu-core-pct` without the `amd.com/gpu` count. Because the webhook sets `pod.Spec.SchedulerName` whenever any backend's `MutateAdmission` returns `true`, such a pod is routed to the HAMi extender as a GPU workload — but `GenerateResourceRequests` and `LockNode` both gate on the **count** resource, so they produce `Nums=0` and take no lock. The pod then:

- skips the namespace GPU quota check (`fitResourceQuota` `continue`s on `Nums==0`),
- passes the scheduler filter on every node (`hasHAMiResource` stays `false`),
- binds with **no AMD device reserved** and no `hami.io/amd-devices-allocated` annotation.

No error surfaces anywhere. AMD is the only backend with this gap: nvidia backfills the count in `mutateContainerResource` to keep the paths consistent; metax checks the count in both. The documented AMD pod spec (`docs/develop/amd-vgpu.md`) always sets `amd.com/gpu`.

**Fix**

Gate `MutateAdmission` on the count resource so it agrees with `GenerateResourceRequests` and `LockNode`. Core-percentage range validation is unchanged when the count is present. Two unit-test cases that encoded the old behavior (`mem-only`, `core-only` → `true`) are corrected to `false` and renamed. Follow-up commits also validate the count value itself (positive integer ≤ `math.MaxInt32`) to close the same divergence for invalid counts.

**Testing:** `go test ./pkg/device/amd/...` passes (13/13 `MutateAdmission` subtests); gofmt/goimports/vet/build clean.

**Alternative considered:** mirror nvidia by backfilling `amd.com/gpu=1` when mem/core is present without a count. Rejected as larger/behavioral — AMD has no `DefaultGPUNum` config and no device-plugin yet, so requiring the count (matching every other AMD code path and the docs) is the minimal, consistent fix.

This change was prepared with AI assistance (per CONTRIBUTING.md); all changes were reviewed and verified by me.


## Summary by CodeRabbit

* **Bug Fixes**
  * AMD GPU admission now requires an explicit, positive whole-number GPU device count.
  * Invalid counts—including zero, negative, fractional, or oversized values—are rejected.
  * Requests specifying only GPU memory or core percentage are no longer accepted as GPU requests.
  * Core percentage validation remains enforced when a valid GPU count is provided.
