### PR TITLE
test(pkg/device): add nil guards and unit tests for pod and node parsing

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -571,6 +571,10 @@ func PlatternMIG(n *MigInUse, templates []Geometry, templateIdx int) {
 }
 
 func CheckHealth(devType string, resourceCountName string, node *corev1.Node) (bool, bool) {
+	if node == nil {
+		return false, false
+	}
+
 	handshake := node.Annotations[util.HandshakeAnnos[devType]]
 	if strings.Contains(handshake, "Requesting") {
 		_, timestampStr, found := strings.Cut(handshake, "_")
@@ -634,6 +638,11 @@ func ExtractMigTemplatesFromUUID(uuid string) (int, int, error) {
 }
 
 func Resourcereqs(pod *corev1.Pod) (counts PodDeviceRequests) {
+	if pod == nil {
+		klog.V(4).InfoS("Nil pod passed to Resourcereqs")
+		return nil
+	}
+
 	// Total containers = init containers + regular containers
 	totalContainers := len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
 	counts = make(PodDeviceRequests, totalContainers)
@@ -654,6 +663,9 @@ func Resourcereqs(pod *corev1.Pod) (counts PodDeviceRequests) {
 			"containerIndex", i,
 			"containerName", pod.Spec.InitContainers[i].Name)
 		for idx, val := range devices {
+			if val == nil {
+				continue
+			}
 			request := val.GenerateResourceRequests(&pod.Spec.InitContainers[i])
 			if request.Nums > 0 {
 				cnt += request.Nums
@@ -672,6 +684,9 @@ func Resourcereqs(pod *corev1.Pod) (counts PodDeviceRequests) {
 			"containerIndex", initContainerOffset+i,
 			"containerName", pod.Spec.Containers[i].Name)
 		for idx, val := range devices {
+			if val == nil {
+				continue
+			}
 			request := val.GenerateResourceRequests(&pod.Spec.Containers[i])
 			if request.Nums > 0 {
 				cnt += request.Nums

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1846,3 +1846,14 @@ func TestDecodeNodeDevicesLegacyFormat(t *testing.T) {
 		},
 	}, decoded)
 }
+
+func TestResourcereqs_NilPod(t *testing.T) {
+	counts := Resourcereqs(nil)
+	assert.Equal(t, 0, len(counts))
+}
+
+func TestCheckHealth_NilNode(t *testing.T) {
+	got1, got2 := CheckHealth("NVIDIA", "nvidia.com/gpu", nil)
+	assert.Equal(t, false, got1)
+	assert.Equal(t, false, got2)
+}


### PR DESCRIPTION
**Description**

Added explicit nil checks and safety guards in pkg/device/devices.go to prevent potential nil pointer dereference panics when handling uninitialized or nil Kubernetes Pod and Node objects during device allocation and health checking. 
Added unit test cases in pkg/device/devices_test.go to cover nil inputs and maintain code coverage.

**Changes Made**

- pkg/device/devices.go: Added defensive nil checks to Resourcereqs and CheckHealth before accessing Pod or Node specs/annotations.
- pkg/device/devices_test.go: Added TestResourcereqs_NilPod and TestCheckHealth_NilNode test cases to validate robust execution without panicking.

**Testing Completed**

- [x] Passed all local unit tests via go test ./pkg/device
- [x] Verified zero panics when passing nil values to Resourcereqs and CheckHealth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when health checks receive missing node information.
  * Prevented resource requirement processing from failing when pod data is unavailable.
  * Safely skips unavailable device implementations during container processing.
  * Added safeguards for missing annotations and validated handling of empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->