### PR TITLE
fix(scheduler,util): guard against nil pointer panics in extender rou…

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -73,7 +73,11 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 			} else {
 				extenderFilterResult, err = s.Filter(extenderArgs)
 				if err != nil {
-					klog.ErrorS(err, "Filter error for pod", "pod", extenderArgs.Pod.Name)
+					podName := ""
+					if extenderArgs.Pod != nil {
+						podName = extenderArgs.Pod.Name
+					}
+					klog.ErrorS(err, "Filter error for pod", "pod", podName)
 					extenderFilterResult = &extenderv1.ExtenderFilterResult{
 						Error: err.Error(),
 					}
@@ -151,6 +155,10 @@ func WebHookRoute() httprouter.Handle {
 	}
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		klog.V(5).Infof("Handling webhook request on %s", r.URL.Path)
+		if h == nil {
+			http.Error(w, "Webhook handler not initialized", http.StatusInternalServerError)
+			return
+		}
 		h.ServeHTTP(w, r)
 	}
 }

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -258,3 +258,37 @@ func TestBind_DecodeError(t *testing.T) {
 		t.Error("expected a decode error to be reported in the bind result")
 	}
 }
+
+func TestPredicateRoute_NilPodInArgs(t *testing.T) {
+	// ExtenderArgs with nil Pod
+	args := extenderv1.ExtenderArgs{Pod: nil}
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body)).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	s := &scheduler.Scheduler{}
+	handler := PredicateRoute(s)
+	// Must not panic when logging nil pod
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestWebHookRoute_HandlerExecution(t *testing.T) {
+	handler := WebHookRoute()
+	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+
+	// Should not panic regardless of webhook state
+	handler(w, req, nil)
+}
+

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -267,19 +267,20 @@ func TestPredicateRoute_NilPodInArgs(t *testing.T) {
 		t.Fatalf("failed to marshal args: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body)).WithContext(ctx)
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
-	s := &scheduler.Scheduler{}
+	s := scheduler.NewScheduler()
 	handler := PredicateRoute(s)
-	// Must not panic when logging nil pod
+	// Must not panic when handling nil pod during filter processing
 	handler(w, req, nil)
 
 	if w.Code != 200 {
 		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var result extenderv1.ExtenderFilterResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 }
 
@@ -288,7 +289,10 @@ func TestWebHookRoute_HandlerExecution(t *testing.T) {
 	req := httptest.NewRequest("POST", "/webhook", strings.NewReader("{}"))
 	w := httptest.NewRecorder()
 
-	// Should not panic regardless of webhook state
 	handler(w, req, nil)
+	if w.Code == 0 {
+		t.Error("expected non-zero response status code")
+	}
 }
+
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -137,6 +137,9 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 }
 
 func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
 	type patchMetadata struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 	}
@@ -160,6 +163,9 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	return err
 }
 func AllInitContainersSucceeded(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	if len(pod.Status.InitContainerStatuses) == 0 {
 		return false
 	}
@@ -249,6 +255,9 @@ func MarkAnnotationsToDelete(devType string, nn string) error {
 }
 
 func RemoveNodeAnnotation(node *corev1.Node, annotationKeys ...string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
 	annos := make(map[string]any, len(annotationKeys))
 	for _, key := range annotationKeys {
 		annos[key] = nil
@@ -320,6 +329,10 @@ func AllContainersCreated(pod *corev1.Pod) bool {
 
 // EmitNodeWarningEvent emits a Warning event on the given Node with deduplication.
 func EmitNodeWarningEvent(node *corev1.Node, reason, message string, dedupWindow time.Duration) {
+	if node == nil {
+		klog.Warning("cannot emit node event: node is nil")
+		return
+	}
 	c := client.GetClient()
 	if c == nil {
 		klog.Warningf("cannot emit node event for %s: Kubernetes client not initialized", node.Name)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -932,12 +932,13 @@ func TestAllInitContainersSucceeded_NilPod(t *testing.T) {
 }
 
 func TestPatchNodeAnnotations_NilNode(t *testing.T) {
-	err := PatchNodeAnnotations(nil, map[string]string{"foo": "bar"})
+	err := PatchNodeAnnotations(nil, map[string]string{"hami.io/test": "bar"})
 	assert.ErrorContains(t, err, "node is nil")
 }
 
 func TestRemoveNodeAnnotation_NilNode(t *testing.T) {
-	err := RemoveNodeAnnotation(nil, "foo")
+	err := RemoveNodeAnnotation(nil, "hami.io/test")
 	assert.ErrorContains(t, err, "node is nil")
 }
+
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -919,4 +919,25 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 		// Old event still present plus one new event.
 		assert.Equal(t, 2, len(events.Items))
 	})
+
+	t.Run("nil node does not panic", func(t *testing.T) {
+		client.KubeClient = fake.NewClientset()
+		// Must not panic when node is nil
+		EmitNodeWarningEvent(nil, reason, msg1, dedupWindow)
+	})
 }
+
+func TestAllInitContainersSucceeded_NilPod(t *testing.T) {
+	assert.Equal(t, false, AllInitContainersSucceeded(nil))
+}
+
+func TestPatchNodeAnnotations_NilNode(t *testing.T) {
+	err := PatchNodeAnnotations(nil, map[string]string{"foo": "bar"})
+	assert.ErrorContains(t, err, "node is nil")
+}
+
+func TestRemoveNodeAnnotation_NilNode(t *testing.T) {
+	err := RemoveNodeAnnotation(nil, "foo")
+	assert.ErrorContains(t, err, "node is nil")
+}
+


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds defensive `nil` pointer guard checks and unit test coverage to prevent runtime server panics in the HAMi scheduler extender and utility functions:

1. **`pkg/scheduler/routes/route.go`**:
   - **`PredicateRoute`**: Guarded `extenderArgs.Pod.Name` access when handling filter errors to prevent panics if `extenderArgs.Pod` is `nil`.
   - **`WebHookRoute`**: Added `if h == nil` guard before `h.ServeHTTP(w, r)` to return HTTP 500 cleanly if `NewWebHook()` failed during initialization.

2. **`pkg/util/util.go`**:
   - Added `nil` node guards to `EmitNodeWarningEvent`, `PatchNodeAnnotations`, and `RemoveNodeAnnotation`.
   - Added `nil` pod guard to `AllInitContainersSucceeded`.

3. **Unit Tests Added**:
   - `pkg/scheduler/routes/route_test.go`: Added `TestPredicateRoute_NilPodInArgs` and `TestWebHookRoute_HandlerExecution`.
   - `pkg/util/util_test.go`: Added `TestEmitNodeWarningEvent_NilNode`, `TestAllInitContainersSucceeded_NilPod`, `TestPatchNodeAnnotations_NilNode`, and `TestRemoveNodeAnnotation_NilNode`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- All changes pass `make verify`, `make lint`, and unit tests with race detection (`go test -race`).
- Per project guidelines in `CONTRIBUTING.md`, AI assistance was used for initial codebase exploration and test boilerplate generation.

**Does this PR introduce a user-facing change?**:

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests with missing pod or node data to prevent crashes.
  * Webhook requests now return a clear HTTP 500 error when the handler is unavailable.
  * Invalid nil inputs now produce safe errors or default results instead of unexpected behavior.

* **Tests**
  * Added regression coverage for missing resources, webhook execution, and safe error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->