### PR TITLE
fix test crash in client test

### DIFF
--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -28,6 +28,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Variables for testing.
+var (
+	buildConfigFromFlags = clientcmd.BuildConfigFromFlags
+	inClusterConfig      = rest.InClusterConfig
+)
+
 type Client struct {
 	// Embedded kubernetes.Interface to avoid name conflicts.
 	kubernetes.Interface
@@ -92,10 +98,10 @@ func loadKubeConfig() (*rest.Config, error) {
 		kubeConfigPath = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	config, err := buildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
 		klog.Infof("BuildConfigFromFlags failed for file %s: %v. Using in-cluster config.", kubeConfigPath, err)
-		return rest.InClusterConfig()
+		return inClusterConfig()
 	}
 	return config, nil
 }

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -40,7 +40,6 @@ func TestGetClient(t *testing.T) {
 		buildConfigErr error
 		inCluster      *rest.Config
 		inClusterErr   error
-		expectError    bool
 	}{
 		{
 			name:           "Success from kubeconfig",
@@ -49,7 +48,6 @@ func TestGetClient(t *testing.T) {
 			buildConfigErr: nil,
 			inCluster:      nil,
 			inClusterErr:   nil,
-			expectError:    false,
 		},
 		{
 			name:           "Fallback to in-cluster config",
@@ -58,7 +56,6 @@ func TestGetClient(t *testing.T) {
 			buildConfigErr: errors.New("kubeconfig error"),
 			inCluster:      &rest.Config{Host: "https://in-cluster.example.com"},
 			inClusterErr:   nil,
-			expectError:    false,
 		},
 	}
 
@@ -84,19 +81,14 @@ func TestGetClient(t *testing.T) {
 			defer os.Setenv("KUBECONFIG", oldKubeConfig)
 
 			// Reset sync.Once and initialize the global client using the injected mocks
+			KubeClient = nil
 			once = sync.Once{}
 			InitGlobalClient()
 
 			// Call GetClient and check the result.
 			client := GetClient()
-			if tt.expectError {
-				if client != nil {
-					t.Errorf("Expected error, but got a valid client")
-				}
-			} else {
-				if client == nil {
-					t.Errorf("Expected a valid client, but got nil")
-				}
+			if client == nil {
+				t.Errorf("Expected a valid client, but got nil")
 			}
 		})
 	}

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -29,18 +29,10 @@ import (
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-// Mock functions for testing.
-var (
-	buildConfigFromFlags = clientcmd.BuildConfigFromFlags
-	inClusterConfig      = rest.InClusterConfig
 )
 
 // TestGetClient tests the GetClient function.
 func TestGetClient(t *testing.T) {
-	InitGlobalClient()
 	tests := []struct {
 		name           string
 		kubeConfig     string
@@ -91,6 +83,10 @@ func TestGetClient(t *testing.T) {
 			os.Setenv("KUBECONFIG", tt.kubeConfig)
 			defer os.Setenv("KUBECONFIG", oldKubeConfig)
 
+			// Reset sync.Once and initialize the global client using the injected mocks
+			once = sync.Once{}
+			InitGlobalClient()
+
 			// Call GetClient and check the result.
 			client := GetClient()
 			if tt.expectError {
@@ -110,6 +106,13 @@ func TestGetClient(t *testing.T) {
 func TestClientWithOptions(t *testing.T) {
 	KubeClient = nil
 	once = sync.Once{}
+
+	// Mock the config loader to prevent failure on environments without kubeconfig
+	oldBuildConfigFromFlags := buildConfigFromFlags
+	buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+		return &rest.Config{Host: "https://example.com"}, nil
+	}
+	defer func() { buildConfigFromFlags = oldBuildConfigFromFlags }()
 
 	timeout := 1
 	client, _ := NewClient(WithTimeout(timeout))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves a logic flaw in the `client` test suite where the `InitGlobalClient` function was prematurely invoked before the necessary mock functions were injected. 

Previously, `InitGlobalClient` was invoked outside the main table-driven test loop. Because it leverages `sync.Once` and was executing the un-mocked functions, the test suite would immediately crash with a `klog.Fatalf` if the developer running the tests did not have a valid `~/.kube/config` present on their local machine.

This PR re-wires the mocks to ensure they are actually evaluated by the underlying config loader and safely initializes the client strictly inside the test loop after the mocks are set. This allows the test suite to execute successfully and independently of the host machine's configuration.

**Which issue(s) this PR fixes**:
Fixes #2682 

**Special notes for your reviewer**:
The global `sync.Once` variable is now reset on each loop iteration to ensure that the mocked fallback execution paths are successfully and uniquely evaluated for each test case.

**AI Disclosure**: 
This PR was developed with the assistance of an AI coding assistant. All logic changes and test implementations have been manually reviewed, verified, and thoroughly tested locally before submission.


**Does this PR introduce a user-facing change?**: 
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage and isolation for Kubernetes client configuration.
  * Added support for reliably testing configuration-loading scenarios, including in-cluster fallback behavior.
  * Verified client creation with optional configuration settings and multiple initialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->