### PR TITLE
fix(amd): validate GPU count is a positive integer in MutateAdmission

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -76,8 +76,13 @@ func (dev *AMDDevices) CommonWord() string {
 }
 
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
+	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
 	if ok {
+		countValue, countIsInteger := count.AsInt64()
+		if !countIsInteger || countValue < 1 {
+			return false, fmt.Errorf("%s must be a positive integer", dev.resourceCountName)
+		}
+
 		core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
 		if coreRequested {
 			corePercentage, coreIsInteger := core.AsInt64()

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -82,6 +82,28 @@ func Test_MutateAdmission(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "rejects zero gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects negative gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(-1, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
 			name: "rejects zero core percentage",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`MutateAdmission` in the AMD device plugin validates that the core-percentage
value is a valid integer between 1-100, but never validates the GPU count
itself. A pod could request a zero or negative GPU count and still be
admitted without error. This PR adds the same positive-integer validation
already used for core percentage, applied to the count value as well.

**Which issue(s) this PR fixes**:

Fixes #2679

**Special notes for your reviewer**:

This PR addresses only the invalid-count part of #2679. The issue also
describes memory-only/core-only requests as "bypassing GPU quota and
scheduling" — but that's currently the tested, intended behavior per the
existing test cases in device_test.go (e.g. "gpu memory in limits" and
"core percentage in limits" both expect `want: true`). Changing that looks
like a separate design decision, so I've left it out of this PR and would
welcome maintainer guidance on whether/how that should change.

**Does this PR introduce a user-facing change?**:

Yes — AMD GPU pods that previously requested a zero or negative
`amd.com/gpu` count and were silently admitted will now be rejected with
a clear validation error at admission time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for configured AMD GPU device counts.
  * Invalid values, including zero, negative numbers, and non-integers, are now rejected with a clear error.

**AI assistance disclosure:** I used Claude (Anthropic) to help identify the
missing GPU-count validation, draft the code fix and test cases. I reviewed, understood, and manually applied all
changes myself.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->