### PR TITLE
docs: document undocumented vGPU monitor metrics

### DIFF
--- a/skill/hami-vgpu-metrics-summary/SKILL.md
+++ b/skill/hami-vgpu-metrics-summary/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: hami_vgpu_metrics_summarizer
+name: hami-vgpu-metrics-summary
 
 description: A comprehensive analysis skill for summarizing HAMi vGPU metrics from Prometheus-style `/metrics` output. It organizes GPU allocation by node, device, pod, and namespace, and produces clear reports covering vGPU core allocation, memory allocation, allocation-based utilization, sharing density, and namespace-level usage patterns.
 ---
@@ -190,6 +190,13 @@ These come from `cmd/vGPUmonitor/metrics.go` and should be treated separately:
 - `hami_host_gpu_utilization_ratio`
 - `hami_vgpu_memory_used_bytes`
 - `hami_vgpu_memory_limit_bytes`
+- `hami_container_device_memory_bytes`
+- `hami_container_device_utilization_ratio`
+- `hami_container_last_kernel_elapsed_seconds`
+- `hami_mig_device_info`
+- `hami_vgpu_memory_context_bytes`
+- `hami_vgpu_memory_module_bytes`
+- `hami_vgpu_memory_buffer_bytes`
 
 Use them only as **runtime complements**. They do not replace scheduler allocation metrics for namespace/device allocation summaries.
 
@@ -737,6 +744,12 @@ If the user asks in English, answer in English.
 | `hami_host_gpu_utilization_ratio` | Runtime physical GPU utilization from vGPU monitor | runtime/device |
 | `hami_vgpu_memory_used_bytes` | Runtime per-container vGPU memory used from vGPU monitor | runtime/container |
 | `hami_build_info` | HAMi version/build metadata | cluster |
+| `hami_container_device_memory_bytes` | Per-container device memory usage | pod/container |
+| `hami_container_last_kernel_elapsed_seconds` | Seconds since the container's last CUDA kernel execution | pod/container |
+| `hami_mig_device_info` | MIG runtime identity (mig_uuid, profile, gpu_instance_id, compute_instance_id) for a container's allocation | pod/container |
+| `hami_vgpu_memory_context_bytes` | Per-container GPU memory used by CUDA context | pod/container |
+| `hami_vgpu_memory_module_bytes` | Per-container GPU memory used by loaded CUDA modules | pod/container |
+| `hami_vgpu_memory_buffer_bytes` | Per-container GPU memory used by allocated buffers | pod/container |
 
 ---
 


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
cmd/vGPUmonitor/metrics.go exports 7 Prometheus metrics from the vGPU monitor (hami_container_device_memory_bytes, hami_container_device_utilization_ratio, hami_container_last_kernel_elapsed_seconds, hami_mig_device_info, hami_vgpu_memory_context_bytes, hami_vgpu_memory_module_bytes, hami_vgpu_memory_buffer_bytes) that were missing from the skill/hami-vgpu-metrics-summary/SKILL.md metrics reference. This meant anyone (or any agent) using this skill to interpret HAMi metrics would be blind to these signals — notably hami_container_last_kernel_elapsed_seconds, which is useful for detecting idle GPU allocations, and the MIG identity/memory-breakdown metrics.

This PR adds all 7 to the "Runtime-only vGPU monitor metrics" list and the "Quick Reference: Important HAMi Metrics" table, so the doc matches what the code actually exports.

Also fixes the skill name: in frontmatter — it was hami_vgpu_metrics_summarizer (underscores, doesn't match the folder), which fails skill-name validation requiring lowercase/hyphens-only and an exact match to the containing folder (hami-vgpu-metrics-summary).

Which issue(s) this PR fixes:
Fixes #2685 
Special notes for your reviewer:
This is docs-only — no .go files touched, metric behavior is unchanged. While tracing the emission code for these metrics I noticed hami_container_device_memory_bytes is set to the same value as hami_vgpu_memory_used_bytes (both = memoryTotal), while the context/module/buffer breakdown is emitted as separate metrics rather than as labels the way the legacy Device_memory_desc_of_container metric did it. I raised this as an open question in the linked issue — happy to update the description here if you can confirm the intended semantics.

Does this PR introduce a user-facing change?:

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded runtime metrics coverage to include container device memory, kernel elapsed time, MIG identity, and CUDA context, module, and buffer memory metrics.
  * Added the newly supported metrics to the quick-reference table.
* **Bug Fixes**
  * Improved vGPU-monitor-only fallback summaries, which now clearly indicate when allocation and quota conclusions are incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->