### PR TITLE
fix(scheduler): reject filter requests with no Pod instead of panicking

### DIFF
--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -61,6 +61,12 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 			extenderFilterResult = &extenderv1.ExtenderFilterResult{
 				Error: err.Error(),
 			}
+		} else if extenderArgs.Pod == nil {
+			err := fmt.Errorf("extender args missing pod")
+			klog.ErrorS(err, "Rejecting filter request with no pod")
+			extenderFilterResult = &extenderv1.ExtenderFilterResult{
+				Error: err.Error(),
+			}
 		} else {
 			synced := s.WaitForCacheSync(r.Context())
 			if !synced {

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -208,6 +208,41 @@ func TestPredicateRoute_DecodeError(t *testing.T) {
 	}
 }
 
+func TestPredicateRoute_NilPod(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "pod field omitted", body: `{"NodeNames":["node1"]}`},
+		{name: "pod field explicitly null", body: `{"Pod":null,"NodeNames":["node1"]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/predicate", strings.NewReader(tt.body))
+			w := httptest.NewRecorder()
+
+			s := &scheduler.Scheduler{}
+			handler := PredicateRoute(s)
+
+			// Must not panic when Pod is missing/null.
+			handler(w, req, nil)
+
+			if w.Code != 200 {
+				t.Errorf("expected 200 (error reported in body, not status), got %d", w.Code)
+			}
+
+			var result extenderv1.ExtenderFilterResult
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+			if result.Error == "" {
+				t.Error("expected a missing-pod error to be reported in the filter result")
+			}
+		})
+	}
+}
+
 func TestPredicateRoute_CacheNotSynced(t *testing.T) {
 	args := extenderv1.ExtenderArgs{Pod: &corev1.Pod{}}
 	body, err := json.Marshal(args)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`PredicateRoute` in `pkg/scheduler/routes/route.go` decodes the incoming `ExtenderArgs` and passes them straight to `Scheduler.Filter` without checking whether `Pod` is set. `Filter`'s very first statement unconditionally reads `args.Pod.Name` for logging, so a `/filter` request with a missing or null `Pod` field panics with a nil pointer dereference before any of the handler's existing error handling ever runs.

This PR rejects such requests up front, the same way decode failures and cache-sync failures are already handled in this function: it returns a normal `ExtenderFilterResult` with a populated `Error` field instead of letting a nil `Pod` reach `Filter`.

**Which issue(s) this PR fixes**:
Fixes #2599
Fixes #2598

**Special notes for your reviewer**:

Both linked issues are currently closed as completed, but the bug is still present on `master`. The only PR that attempted to fix it, #2680, closed without merging, and its guard only covered the `klog.ErrorS(..., extenderArgs.Pod.Name)` call in `route.go`'s error-logging branch — not the actual crash site, which is the first line of `Scheduler.Filter` itself (`pkg/scheduler/scheduler.go`). That line executes before the error-logging branch is ever reached, so guarding only the log call would not have prevented the panic. This PR instead stops a nil `Pod` from reaching `Filter` at all.

I confirmed the panic directly by calling `Scheduler.Filter` with an empty `ExtenderArgs{}` in a throwaway test before writing the fix (`runtime error: invalid memory address or nil pointer dereference`), and confirmed `Filter` has no other callers besides this route, so the route-level guard is a complete fix.

Added `TestPredicateRoute_NilPod`, covering both the "Pod" field omitted and explicitly-`null` cases, alongside the existing `TestPredicateRoute_DecodeError` / `TestPredicateRoute_CacheNotSynced` tests in the same file.

Ran locally: `go build ./...`, `go test ./pkg/scheduler/... -short --race -count=1`, `golangci-lint run ./pkg/scheduler/routes/...`, and `make verify` (license headers, staticcheck, import aliases) — all pass.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a scheduler extender panic when the /filter endpoint received a request with a missing or null Pod field.
```

**AI assistance disclosure**:

I used Gemini to help locate this bug and draft the fix and tests; I reviewed the change, ran the verification described above, and can walk through how it works.