### PR TITLE
Fix bug about auto-memory trim when using hami-core mode for vNPU

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -325,22 +325,7 @@ func (dev *Devices) GenerateResourceRequests(ctr *corev1.Container) device.Conta
 						memnums = memnums * int64(dev.config.MemoryFactor)
 						klog.V(4).Infof("Update Ascend memory request. before %d, after %d, factor %d", rawMemnums, memnums, dev.config.MemoryFactor)
 					}
-					// If "core" is requested, it explicitly indicates the use of soft-partitioning.
-					isCoreRequested := false
-					if ascendResourceCore != "" {
-						_, isCoreRequested = ctr.Resources.Limits[ascendResourceCore]
-						if !isCoreRequested {
-							_, isCoreRequested = ctr.Resources.Requests[ascendResourceCore]
-						}
-					}
-
-					if isCoreRequested {
-						// Soft-partitioning: Use the raw value directly.
-						memnum = int(memnums)
-					} else {
-						m, _ := dev.trimMemory(memnums)
-						memnum = int(m)
-					}
+					memnum = int(memnums)
 				}
 			}
 

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -1284,13 +1284,17 @@ func Test_GenerateResourceRequests_VNPUCoreMode(t *testing.T) {
 					ResourceName:       "huawei.com/Ascend910B3",
 					ResourceCoreName:   "huawei.com/Ascend910B3-core",
 					ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+					MemoryAllocatable:  32768,
+					MemoryCapacity:     32768,
+					Templates: []Template{
+						{Name: "vir08", Memory: 8738, AICore: 8},
+						{Name: "vir16", Memory: 17476, AICore: 16},
+					},
 				},
 			}
 			result := dev.GenerateResourceRequests(&test.args)
 
-			assert.Equal(t, result.Memreq, test.want.Memreq)
-			assert.Equal(t, result.Coresreq, test.want.Coresreq)
-			assert.Equal(t, result.Type, test.want.Type)
+			assert.Equal(t, result, test.want)
 		})
 	}
 }
@@ -1347,7 +1351,7 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 			want: device.ContainerDeviceRequest{
 				Nums:             int32(1),
 				Type:             "Ascend910A",
-				Memreq:           int32(2184),
+				Memreq:           int32(1280),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(0),
 			},
@@ -1386,7 +1390,7 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 			want: device.ContainerDeviceRequest{
 				Nums:             int32(1),
 				Type:             "Ascend910A",
-				Memreq:           int32(17476),
+				Memreq:           int32(12800),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(0),
 			},
@@ -1425,7 +1429,7 @@ func Test_GenerateResourceRequestsFactor(t *testing.T) {
 			want: device.ContainerDeviceRequest{
 				Nums:             int32(1),
 				Type:             "Ascend910A",
-				Memreq:           int32(2184),
+				Memreq:           int32(128),
 				MemPercentagereq: int32(0),
 				Coresreq:         int32(0),
 			},


### PR DESCRIPTION

/kind bug

That bug happens when you submit a job requesting a 'HAMi-core' mode vNPU node, but doesn't specify any 'vnpu-core' resources, in that case, your device memory will be errorly trimmed according to templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Ascend device memory requests to use the calculated memory value directly.
  * Updated vNPU core-mode resource calculations for more accurate memory scaling across different factors.

* **Tests**
  * Expanded validation of complete device resource requests and updated expected results for multiple memory factors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->