### PR TITLE
fix(examples): align MLU resource names with default configuration

### DIFF
--- a/examples/mlu/default_use.yaml
+++ b/examples/mlu/default_use.yaml
@@ -22,5 +22,5 @@ spec:
           resources:
             limits:
               cambricon.com/vmlu: "1"
-              cambricon.com/mlu370.smlu.vmemory: "20"
-              cambricon.com/mlu370.smlu.vcore: "10"
+              cambricon.com/mlu.smlu.vmemory: "20"
+              cambricon.com/mlu.smlu.vcore: "10"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR updates the MLU resource names in `examples/mlu/default_use.yaml`.

The example used:

- `cambricon.com/mlu370.smlu.vmemory`
- `cambricon.com/mlu370.smlu.vcore`

HAMi's default Helm values and scheduler configuration use:

- `cambricon.com/mlu.smlu.vmemory`
- `cambricon.com/mlu.smlu.vcore`

Because the names did not match, HAMi could not recognize the memory and core quantities from the example.

This change makes the example consistent with the default configuration. No scheduler or device allocation code is changed.

**Which issue(s) this PR fixes**:

Fixes #2695

**Special notes for your reviewer**:

Validation performed:

- Parsed `examples/mlu/default_use.yaml` successfully.
- Verified that all three MLU resource names match `charts/hami/values.yaml`.
- Verified that `mlu370.smlu.*` no longer appears in the MLU examples.
- `go test ./pkg/device/cambricon -short --race -count=1` passed.
- `make verify` passed.
- `make test` passed.
- `make build` passed.
- `git diff --check` passed.

Real Cambricon MLU hardware validation was not performed. This PR changes only an example manifest and does not modify runtime allocation or isolation code.

**Does this PR introduce a user-facing change?**:

Yes. The default MLU example now uses resource names that match HAMi's default configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment resource settings to use the generic MLU resource prefix for virtual memory and virtual core limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->