### PR TITLE
fix stale claim that AMD node lock is unimplemented

### DIFF
--- a/docs/develop/amd-vgpu.md
+++ b/docs/develop/amd-vgpu.md
@@ -106,7 +106,7 @@ HSA_CU_MASK=0:0-75;1:0-75
 Each `CU_list` uses HSA's CU ID-list grammar, for example `0-3,8,10-12`.
 
 Exclusivity of CU ranges across pods on a device is enforced under the AMD
-node lock (`AMDDevices.LockNode` and `ReleaseNodeLock` which are unimplemented now).
+node lock (`AMDDevices.LockNode` and `ReleaseNodeLock`).
 
 ## 5. Resource model and core_limit -> CU mask
 


### PR DESCRIPTION
**/kind documentation**
## What this PR does / why we need it
`docs/develop/amd-vgpu.md` says that `AMDDevices.LockNode` and `ReleaseNodeLock` are "unimplemented now." This is no longer correct. Both methods are implemented in `pkg/device/amd/device.go`.
The methods first check whether the pod requests an AMD GPU and then use the shared `nodelock` package to handle `LockNode` and `ReleaseNodeLock`.
The outdated documentation could make it seem like AMD node-level locking is not implemented.This PR updates the documentation to match the current implementation:* Before: `...enforced under the AMD node lock (AMDDevices.LockNode and ReleaseNodeLock which are unimplemented now).`* After: `...enforced under the AMD node lock (AMDDevices.LockNode and ReleaseNodeLock).`
## Which issue(s) this PR fixes
Fixes #2707
## Special notes for reviewer
This is a documentation-only change. No code, tests, or other documentation sections were modified.
Only `docs/develop/amd-vgpu.md` was changed, with one line updated.The implementation was checked in `pkg/device/amd/device.go:133-159` to confirm that the documentation matches the current behavior.`git diff --check` was also run successfully.No unit or e2e tests were run because this change only updates documentation.
## Does this PR introduce a user-facing change?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AMD vGPU protocol documentation to accurately reflect the implementation status of device node locking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->