### PR TITLE
ci: move release workflow write permissions to job level

### DIFF
--- a/.github/workflows/call-release-image-hamicore.yaml
+++ b/.github/workflows/call-release-image-hamicore.yaml
@@ -21,15 +21,17 @@ on:
       tagoverride:
         required: false
         type: string
-# id-token is needed for keyless cosign signing
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    # id-token is needed for keyless cosign signing
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -21,15 +21,17 @@ on:
       tagoverride:
         required: false
         type: string
-# id-token is needed for keyless cosign signing
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    # id-token is needed for keyless cosign signing
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/call-release-notes.yaml
+++ b/.github/workflows/call-release-notes.yaml
@@ -8,13 +8,15 @@ on:
         required: true
         type: string
 
-# updates the github release page
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   generate-release-notes:
     runs-on: ubuntu-latest
+    # updates the github release page
+    permissions:
+      contents: write
     steps:
     - name: Download Artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
/kind cleanup
Scopes the release workflows to top-level `contents: read` and grants `packages: write`, `id-token: write`, and `contents: write` only at the job level where they are needed. Resolves the open Scorecard Token-Permissions finding on `call-release-notes.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted workflow permissions to the minimum required at each scope.
  * Kept release image publishing and signing capabilities limited to the build job.
  * Limited release note generation to the permissions needed to update release pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->