### PR TITLE
feat(scheduler): export hami_resource_quota_limit gauge metric

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -281,12 +281,17 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 	}
 }
 
-// collectQuotaMetrics emits per-namespace resource quota usage.
+// collectQuotaMetrics emits per-namespace resource quota usage and limits.
 func (cc ClusterManagerCollector) collectQuotaMetrics(ch chan<- prometheus.Metric, legacy bool) {
 	quotaUsedDesc := prometheus.NewDesc(
 		"hami_resource_quota_used",
 		"resourcequota usage for a certain device",
 		[]string{"namespace", "quota_name", "limit"}, nil,
+	)
+	quotaLimitDesc := prometheus.NewDesc(
+		"hami_resource_quota_limit",
+		"resourcequota limit for a certain device",
+		[]string{"namespace", "quota_name"}, nil,
 	)
 	var legacyQuotaUsed *prometheus.Desc
 	if legacy {
@@ -300,6 +305,9 @@ func (cc ClusterManagerCollector) collectQuotaMetrics(ch chan<- prometheus.Metri
 		for quotaname, q := range *val {
 			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
 				klog.V(4).Infof("Failed to send quotaUsedDesc metric: %v", err)
+			}
+			if err := sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
+				klog.V(4).Infof("Failed to send quotaLimitDesc metric: %v", err)
 			}
 			if legacy {
 				sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -306,8 +306,10 @@ func (cc ClusterManagerCollector) collectQuotaMetrics(ch chan<- prometheus.Metri
 			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
 				klog.V(4).Infof("Failed to send quotaUsedDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
-				klog.V(4).Infof("Failed to send quotaLimitDesc metric: %v", err)
+			if q.LimitSet {
+				if err := sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
+					klog.V(4).Infof("Failed to send quotaLimitDesc metric: %v", err)
+				}
 			}
 			if legacy {
 				sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -438,6 +438,10 @@ func TestClusterManagerCollectorQuotaMetrics(t *testing.T) {
 			metricsProvider: provider,
 		}
 		want := `
+# HELP hami_resource_quota_limit resourcequota limit for a certain device
+# TYPE hami_resource_quota_limit gauge
+hami_resource_quota_limit{namespace="team-a",quota_name="nvidia.com/gpucore"} 100
+hami_resource_quota_limit{namespace="team-a",quota_name="nvidia.com/gpumem"} 8192
 # HELP hami_resource_quota_used resourcequota usage for a certain device
 # TYPE hami_resource_quota_used gauge
 hami_resource_quota_used{limit="100",namespace="team-a",quota_name="nvidia.com/gpucore"} 50
@@ -447,6 +451,7 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 			collector,
 			strings.NewReader(want),
 			"hami_resource_quota_used",
+			"hami_resource_quota_limit",
 		); err != nil {
 			t.Fatalf("unexpected non-legacy collecting result:\n%s", err)
 		}
@@ -462,6 +467,10 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 # TYPE QuotaUsed gauge
 QuotaUsed{limit="100",quotaName="nvidia.com/gpucore",quotanamespace="team-a"} 50
 QuotaUsed{limit="8192",quotaName="nvidia.com/gpumem",quotanamespace="team-a"} 4096
+# HELP hami_resource_quota_limit resourcequota limit for a certain device
+# TYPE hami_resource_quota_limit gauge
+hami_resource_quota_limit{namespace="team-a",quota_name="nvidia.com/gpucore"} 100
+hami_resource_quota_limit{namespace="team-a",quota_name="nvidia.com/gpumem"} 8192
 # HELP hami_resource_quota_used resourcequota usage for a certain device
 # TYPE hami_resource_quota_used gauge
 hami_resource_quota_used{limit="100",namespace="team-a",quota_name="nvidia.com/gpucore"} 50
@@ -471,6 +480,7 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 			collector,
 			strings.NewReader(want),
 			"hami_resource_quota_used",
+			"hami_resource_quota_limit",
 			"QuotaUsed",
 		); err != nil {
 			t.Fatalf("unexpected legacy collecting result:\n%s", err)

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -487,3 +487,39 @@ hami_resource_quota_used{limit="8192",namespace="team-a",quota_name="nvidia.com/
 		}
 	})
 }
+
+func TestClusterManagerCollectorQuotaUnconfiguredLimit(t *testing.T) {
+	const (
+		ns      = "team-b"
+		memName = "nvidia.com/gpumem"
+	)
+
+	unconfQm := device.NewQuotaManager()
+	unconfQm.Quotas[ns] = &device.DeviceQuota{
+		memName: &device.Quota{Used: 1024, Limit: 0, LimitSet: false},
+	}
+	t.Cleanup(func() { delete(unconfQm.Quotas, ns) })
+
+	unconfProvider := &fakeMetricsProvider{
+		nodeUsage:    map[string]*schedulerpkg.NodeUsage{},
+		quotaManager: unconfQm,
+		podManager:   device.NewPodManager(),
+	}
+	collector := ClusterManagerCollector{
+		ClusterManager:  &ClusterManager{LegacyMetrics: false},
+		metricsProvider: unconfProvider,
+	}
+	want := `
+# HELP hami_resource_quota_used resourcequota usage for a certain device
+# TYPE hami_resource_quota_used gauge
+hami_resource_quota_used{limit="0",namespace="team-b",quota_name="nvidia.com/gpumem"} 1024
+`
+	if err := promtestutil.CollectAndCompare(
+		collector,
+		strings.NewReader(want),
+		"hami_resource_quota_used",
+		"hami_resource_quota_limit",
+	); err != nil {
+		t.Fatalf("unexpected unconfigured limit collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**: In cmd/scheduler/metrics.go, resource quota limits were previously exposed only as a string label (`limit="100"`) inside hami_resource_quota_used. 

This caused two problems:
1. PromQL cannot perform arithmetic on label values, making used / limit utilization queries impossible without hardcoding limits in recording rules.
2. Updating a quota limit created a new time series and abandoned the old one.

This PR adds hami_resource_quota_limit as a dedicated numeric gauge metric with labels `[]string{"namespace", "quota_name"}`. `hami_resource_quota_used` and legacy `QuotaUsed` are kept unchanged for backward compatibility.

**Which issue(s) this PR fixes**:
Fixes #2713

**Special notes for your reviewer**: Nope

disclosure: Antigravity was used to audit.

**Does this PR introduce a user-facing change?**:
```release-note
feat(scheduler): export hami_resource_quota_limit gauge metric for PromQL utilization queries
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metric reporting configured resource quota limits alongside existing quota usage metrics.
  * Quota limit metrics are available in both standard and legacy metric outputs.
  * Metrics include the resource namespace, quota name, and configured limit value.
* **Bug Fixes**
  * Unconfigured quota limits continue to report usage with a limit of `0` without emitting a separate limit metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->