### PR TITLE
fix(nvidia): guard int32 narrowing in GenerateResourceRequests

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -521,17 +522,38 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 	}
 	if ok {
 		if n, ok := v.AsInt64(); ok {
+			if n <= 0 || n > math.MaxInt32 {
+				klog.ErrorS(nil, "nvidia device count request is out of range", "container", ctr.Name, "request", n)
+				return device.ContainerDeviceRequest{}
+			}
 			memnum := 0
 			mem, ok := ctr.Resources.Limits[resourceMem]
 			if !ok {
 				mem, ok = ctr.Resources.Requests[resourceMem]
 			}
 			if ok {
+				// Negative quantities such as -1m return ok=false from AsInt64, so reject by sign first.
+				if mem.Sign() < 0 {
+					klog.ErrorS(nil, "nvidia device memory request is negative", "container", ctr.Name, "request", mem.String())
+					return device.ContainerDeviceRequest{}
+				}
 				memnums, ok := mem.AsInt64()
 				if ok {
+					// nvidia memory is in MB, so an over-int32 value such as a byte quantity 16Gi is a wrong-unit mistake.
+					if memnums > math.MaxInt32 {
+						klog.ErrorS(nil, "nvidia device memory request is out of range; memory unit is treated as MB not Byte, so a quantity such as 16Gi is invalid, request 16384 for 16GB instead",
+							"container", ctr.Name, "request", mem.String())
+						return device.ContainerDeviceRequest{}
+					}
 					if dev.config.MemoryFactor > 1 {
 						rawMemnums := memnums
+						// memnums is bounded by math.MaxInt32 and MemoryFactor is int32, so this product cannot overflow int64.
 						memnums = memnums * int64(dev.config.MemoryFactor)
+						if memnums > math.MaxInt32 {
+							klog.ErrorS(nil, "nvidia device memory request overflows int32 after applying memory factor",
+								"container", ctr.Name, "raw", rawMemnums, "scaled", memnums, "factor", dev.config.MemoryFactor)
+							return device.ContainerDeviceRequest{}
+						}
 						klog.V(4).Infof("Update memory request. before %d, after %d, factor %d", rawMemnums, memnums, dev.config.MemoryFactor)
 					}
 					memnum = int(memnums)
@@ -573,6 +595,10 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 			if ok {
 				corenums, ok := core.AsInt64()
 				if ok {
+					if corenums < 0 || corenums > math.MaxInt32 {
+						klog.ErrorS(nil, "nvidia device core request is out of range", "container", ctr.Name, "request", core.String())
+						return device.ContainerDeviceRequest{}
+					}
 					corenum = int32(corenums)
 				}
 			}

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -1915,6 +1915,128 @@ func TestGenerateResourceRequests_MemoryFactor(t *testing.T) {
 	assert.Equal(t, result.Memreq, int32(2048))
 }
 
+// Test_GenerateResourceRequests_OutOfRangeValues checks that out-of-range values are rejected, not silently wrapped.
+func Test_GenerateResourceRequests_OutOfRangeValues(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+		MemoryFactor:                 1,
+	}
+	dev := InitNvidiaDevice(config)
+
+	tests := []struct {
+		name string
+		ctr  *corev1.Container
+		want device.ContainerDeviceRequest
+	}{
+		{
+			// 16Gi in bytes wraps to 0 when narrowed to int32; nvidia memory is counted in MB.
+			name: "memory requested in bytes exceeds int32 range",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem": resource.MustParse("16Gi"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			// -1m makes AsInt64 return ok=false, so it must be rejected by sign, not defaulted.
+			name: "negative fractional memory request",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem": resource.MustParse("-1m"),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			// A plain whole -100 passes AsInt64 (ok=true), so it must be rejected by sign before the int32 narrowing.
+			name: "negative whole memory request",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpumem": *resource.NewQuantity(-100, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized device count exceeds int32 range",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu": *resource.NewQuantity(2200000000, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "negative core request",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpucores": *resource.NewQuantity(-1, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+		{
+			name: "oversized core request exceeds int32 range",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+						"nvidia.com/gpucores": *resource.NewQuantity(2200000000, resource.DecimalSI),
+					},
+				},
+			},
+			want: device.ContainerDeviceRequest{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dev.GenerateResourceRequests(tt.ctr)
+			assert.DeepEqual(t, result, tt.want)
+		})
+	}
+}
+
+// Test_GenerateResourceRequests_MemoryFactorOverflow covers a value that fits int32 but overflows after MemoryFactor.
+func Test_GenerateResourceRequests_MemoryFactorOverflow(t *testing.T) {
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpumem",
+		ResourceCoreName:             "nvidia.com/gpucores",
+		ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+		MemoryFactor:                 10,
+	}
+	dev := InitNvidiaDevice(config)
+	ctr := &corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				// 300000000 fits int32 but 300000000*10 overflows it.
+				"nvidia.com/gpu":    *resource.NewQuantity(1, resource.BinarySI),
+				"nvidia.com/gpumem": *resource.NewQuantity(300000000, resource.DecimalSI),
+			},
+		},
+	}
+	result := dev.GenerateResourceRequests(ctr)
+	assert.DeepEqual(t, result, device.ContainerDeviceRequest{})
+}
+
 func TestGenerateResourceRequests_DefaultMemory(t *testing.T) {
 	config := NvidiaConfig{
 		ResourceCountName:            "nvidia.com/gpu",


### PR DESCRIPTION
**What type of PR is this?**
Bug  Fix

**What this PR does / why we need it**:

`GenerateResourceRequests` in the nvidia backend converts user-controlled `int64` resource limits (device count, memory, cores) into the `int32` fields of `ContainerDeviceRequest` (`Nums`, `Memreq`, `Coresreq`) without bounds checking. A value exceeding `math.MaxInt32` silently wraps to a small or negative number that flows into `Fit()`. Since nvidia is the default and most widely used backend, this is the highest-impact instance of the overflow class already fixed elsewhere.

Concretely, `nvidia.com/gpumem: 16Gi` (a plausible wrong-unit mistake, since `gpumem` is counted in MB) yields `AsInt64() == 17179869184`, and `int32(17179869184) == 0`. Because the raw int value is non-zero, the `mempnum == 101 && memnum == 0` default is skipped, so `Memreq`/`MemPercentagereq` land at 0/101. In `Fit()` the `k.Memreq > 0` branch is false and the `MemPercentagereq != 101` branch is false, so `memreq` stays 0 and the `Totalmem - Usedmem < memreq` check can never reject the card. The pod is booked with zero GPU memory reservation, causing oversubscription and OOM for other workloads on the same card.

This PR adds range guards that return the existing empty `ContainerDeviceRequest{}` rejection sentinel before every `int32()` narrowing, matching the pattern from #2388 (hygon, metax-sgpu) and #2601 (ascend). Memory is guarded both before and after the `MemoryFactor` multiplication, and negative quantities are rejected by sign first.

**Which issue(s) this PR fixes**:
Fixes #2718

**Special notes for your reviewer**:

- Guards four conversion points: device count, memory pre-factor, memory post-factor (after `MemoryFactor` scaling), and cores.
- Negative quantities are rejected via `mem.Sign() < 0` before `AsInt64`, because a negative fractional quantity such as `-1m` returns `ok=false` from `AsInt64` and would otherwise slip past the range check (same reasoning as the reviewer's request on #2601).
- Following the maintainer's suggestion on #2285/#2601 that an over-int32 memory value is almost always a wrong-unit mistake, the memory error message states that nvidia memory is treated as MB not Byte, and that `16384` should be requested for 16 GB.
- Scope is the int32 overflow case only, matching #2388/#2601. The memory-percentage path already clamps and is unchanged.
- Tests cover pre-factor overflow (`16Gi`), post-factor overflow after `MemoryFactor`, oversized device count, and negative/oversized core and memory requests. Each was confirmed to fail before the guard and pass after.
- Change is scoped to the scheduler extender, so unit tests are used rather than on-hardware validation, consistent with #2388 and #2601.

**Does this PR introduce a user-facing change?**:

```
Oversized or invalid NVIDIA device resource requests (for example a gpumem request such as 16Gi, or values exceeding the int32 range) are now rejected instead of silently wrapping to an incorrect value.
```

AI assistance disclosure: I used AI assistance (opencode) to help audit the backends, implement the guards, and draft the regression tests. I reviewed the change and verified the new tests fail without the guards and pass with them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NVIDIA resource requests with negative, excessively large, or overflowing GPU, memory, scaled memory, and core values are now rejected safely.
  * Invalid requests return an empty device request instead of being silently accepted or wrapping to incorrect values.

* **Tests**
  * Added coverage for out-of-range values and memory scaling overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->