### PR TITLE
fix(scheduler): don't let node-lock-timeout flag default clobber HAMI_NODELOCK_EXPIRE

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -110,8 +110,11 @@ func injectProfilingRoute(router *httprouter.Router) {
 }
 
 func start() error {
-	// Initialize node lock timeout from config
-	nodelock.NodeLockTimeout = config.NodeLockTimeout
+	// Only override the environment-derived value when the flag was explicitly
+	// set, so HAMI_NODELOCK_EXPIRE isn't clobbered by the flag's default.
+	if rootCmd.Flags().Changed("node-lock-timeout") {
+		nodelock.NodeLockTimeout = config.NodeLockTimeout
+	}
 	klog.InfoS("Set node lock timeout", "timeout", nodelock.NodeLockTimeout)
 	client.InitGlobalClient(
 		client.WithBurst(config.Burst),


### PR DESCRIPTION
## Summary
- `start()` in `cmd/scheduler/main.go` unconditionally assigns `config.NodeLockTimeout` (populated from the `--node-lock-timeout` flag, default `5m`) into `nodelock.NodeLockTimeout`, after `setupNodeLockTimeout()` already read `HAMI_NODELOCK_EXPIRE` from the environment in `init()`.
- The flag's default therefore always wins, so the chart's `scheduler.nodeLockExpire` value (which only sets the env var) has no effect.
- Fix: only apply the flag's value when it was actually set (`rootCmd.Flags().Changed("node-lock-timeout")`), restoring the intended flag > env > default precedence.

Fixes #2692

## Test plan
- [x] `go build ./cmd/scheduler/...` succeeds
- [ ] Not yet re-verified against a live cluster with the repro steps from #2692; happy to do that before merge if maintainers want it confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the environment-configured node lock expiration when the node-lock timeout option is not explicitly provided.
  * Prevented the default timeout value from unintentionally overriding existing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->