### PR TITLE
feat(scheduler): account native sidecar container GPU resources

### DIFF
--- a/pkg/device/initContainer.go
+++ b/pkg/device/initContainer.go
@@ -20,16 +20,26 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 type deviceKey struct {
 	devType string
 	uuid    string
 }
+
 type usage struct {
 	mem   int32
 	cores int32
 	slots int32
+}
+
+func isSidecarAt(pod *corev1.Pod, cidx int) bool {
+	if cidx < 0 || cidx >= len(pod.Spec.InitContainers) {
+		return false
+	}
+	return util.IsSidecarContainer(&pod.Spec.InitContainers[cidx])
 }
 
 // CollapseInitContainerUsage returns the effective device usage for a pod.
@@ -40,12 +50,21 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	numInit := len(pod.Spec.InitContainers)
 	initPeak := make(map[deviceKey]usage)
 	appSum := make(map[deviceKey]usage)
+	sidecarSum := make(map[deviceKey]usage)
 
 	for devType, podSingle := range raw {
 		for cidx, ctrDevs := range podSingle {
 			for _, dev := range ctrDevs {
 				key := deviceKey{devType: devType, uuid: dev.UUID}
-				if cidx < numInit {
+				switch {
+				case cidx < numInit && isSidecarAt(pod, cidx):
+					cur := sidecarSum[key]
+					cur.mem += dev.Usedmem
+					cur.cores += dev.Usedcores
+					// Sidecars run concurrently with app containers: each occurrence is an additional slot.
+					cur.slots++
+					sidecarSum[key] = cur
+				case cidx < numInit:
 					cur := initPeak[key]
 					if dev.Usedmem > cur.mem {
 						cur.mem = dev.Usedmem
@@ -56,13 +75,11 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 					// Init containers run sequentially: peak concurrency is one slot per device.
 					cur.slots = 1
 					initPeak[key] = cur
-				} else {
+				default:
 					cur := appSum[key]
 					cur.mem += dev.Usedmem
 					cur.cores += dev.Usedcores
 					// App containers run concurrently: each occurrence is an additional slot.
-					// TODO: If PR #2584 changes sidecars to app-sum accounting, update this
-					// slot calculation to follow the same classification.
 					cur.slots++
 					appSum[key] = cur
 				}
@@ -73,14 +90,11 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	collapsed := make(PodDevices)
 	for devType := range raw {
 		uuidSet := make(map[string]struct{})
-		for k := range initPeak {
-			if k.devType == devType {
-				uuidSet[k.uuid] = struct{}{}
-			}
-		}
-		for k := range appSum {
-			if k.devType == devType {
-				uuidSet[k.uuid] = struct{}{}
+		for _, m := range []map[deviceKey]usage{initPeak, appSum, sidecarSum} {
+			for k := range m {
+				if k.devType == devType {
+					uuidSet[k.uuid] = struct{}{}
+				}
 			}
 		}
 
@@ -90,11 +104,11 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 		for uuid := range uuidSet {
 			initU := initPeak[deviceKey{devType, uuid}]
 			appU := appSum[deviceKey{devType, uuid}]
+			scU := sidecarSum[deviceKey{devType, uuid}]
 
-			effMem := max(initU.mem, appU.mem)
-			effCores := max(initU.cores, appU.cores)
-			// Raw entries carry no slot count; clamp to at least one.
-			effSlots := max(initU.slots, appU.slots, 1)
+			effMem := scU.mem + max(initU.mem, appU.mem)
+			effCores := scU.cores + max(initU.cores, appU.cores)
+			effSlots := max(scU.slots+max(initU.slots, appU.slots), 1)
 
 			containerDevs = append(containerDevs, ContainerDevice{
 				UUID:      uuid,
@@ -113,9 +127,7 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	return collapsed
 }
 
-// AppContainersOnlyDeviceUsage returns the device usage considering only app containers.
-// Used when init containers have finished and we want to shrink to app-only footprint.
-func AppContainersOnlyDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
+func SteadyStateDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	if raw == nil {
 		return nil
 	}
@@ -125,8 +137,8 @@ func AppContainersOnlyDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	for devType, podSingle := range raw {
 		sums := make(map[string]usage)
 		for cidx, ctrDevs := range podSingle {
-			if cidx < numInit {
-				continue // skip init containers
+			if cidx < numInit && !isSidecarAt(pod, cidx) {
+				continue
 			}
 			for _, dev := range ctrDevs {
 				s := sums[dev.UUID]

--- a/pkg/device/initContainer.go
+++ b/pkg/device/initContainer.go
@@ -24,11 +24,6 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
-type deviceKey struct {
-	devType string
-	uuid    string
-}
-
 type usage struct {
 	mem   int32
 	cores int32
@@ -48,74 +43,65 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 		return nil
 	}
 	numInit := len(pod.Spec.InitContainers)
-	initPeak := make(map[deviceKey]usage)
-	appSum := make(map[deviceKey]usage)
-	sidecarSum := make(map[deviceKey]usage)
 
-	for devType, podSingle := range raw {
-		for cidx, ctrDevs := range podSingle {
-			for _, dev := range ctrDevs {
-				key := deviceKey{devType: devType, uuid: dev.UUID}
-				switch {
-				case cidx < numInit && isSidecarAt(pod, cidx):
-					cur := sidecarSum[key]
-					cur.mem += dev.Usedmem
-					cur.cores += dev.Usedcores
-					// Sidecars run concurrently with app containers: each occurrence is an additional slot.
-					cur.slots++
-					sidecarSum[key] = cur
-				case cidx < numInit:
-					cur := initPeak[key]
-					if dev.Usedmem > cur.mem {
-						cur.mem = dev.Usedmem
-					}
-					if dev.Usedcores > cur.cores {
-						cur.cores = dev.Usedcores
-					}
-					// Init containers run sequentially: peak concurrency is one slot per device.
-					cur.slots = 1
-					initPeak[key] = cur
-				default:
-					cur := appSum[key]
-					cur.mem += dev.Usedmem
-					cur.cores += dev.Usedcores
-					// App containers run concurrently: each occurrence is an additional slot.
-					cur.slots++
-					appSum[key] = cur
-				}
-			}
-		}
+	type devState struct {
+		sc   usage // running sum of sidecars declared so far
+		peak usage // peak concurrent usage observed during the init phase
+		app  usage // sum over app containers
 	}
 
 	collapsed := make(PodDevices)
-	for devType := range raw {
-		uuidSet := make(map[string]struct{})
-		for _, m := range []map[deviceKey]usage{initPeak, appSum, sidecarSum} {
-			for k := range m {
-				if k.devType == devType {
-					uuidSet[k.uuid] = struct{}{}
+	for devType, podSingle := range raw {
+		states := make(map[string]*devState)
+		get := func(uuid string) *devState {
+			s, ok := states[uuid]
+			if !ok {
+				s = &devState{}
+				states[uuid] = s
+			}
+			return s
+		}
+
+		for cidx, ctrDevs := range podSingle {
+			switch {
+			case cidx < numInit && isSidecarAt(pod, cidx):
+				for _, dev := range ctrDevs {
+					s := get(dev.UUID)
+					// A sidecar starts and never exits: it permanently
+					// joins the set of running containers.
+					s.sc.mem += dev.Usedmem
+					s.sc.cores += dev.Usedcores
+					s.sc.slots++
+					s.peak.mem = max(s.peak.mem, s.sc.mem)
+					s.peak.cores = max(s.peak.cores, s.sc.cores)
+					s.peak.slots = max(s.peak.slots, s.sc.slots)
+				}
+			case cidx < numInit:
+				for _, dev := range ctrDevs {
+					s := get(dev.UUID)
+					s.peak.mem = max(s.peak.mem, s.sc.mem+dev.Usedmem)
+					s.peak.cores = max(s.peak.cores, s.sc.cores+dev.Usedcores)
+					s.peak.slots = max(s.peak.slots, s.sc.slots+1)
+				}
+			default:
+				for _, dev := range ctrDevs {
+					s := get(dev.UUID)
+					s.app.mem += dev.Usedmem
+					s.app.cores += dev.Usedcores
+					s.app.slots++
 				}
 			}
 		}
 
 		collapsedSingle := make(PodSingleDevice, 1)
 		var containerDevs ContainerDevices
-
-		for uuid := range uuidSet {
-			initU := initPeak[deviceKey{devType, uuid}]
-			appU := appSum[deviceKey{devType, uuid}]
-			scU := sidecarSum[deviceKey{devType, uuid}]
-
-			effMem := scU.mem + max(initU.mem, appU.mem)
-			effCores := scU.cores + max(initU.cores, appU.cores)
-			effSlots := max(scU.slots+max(initU.slots, appU.slots), 1)
-
+		for uuid, s := range states {
 			containerDevs = append(containerDevs, ContainerDevice{
 				UUID:      uuid,
 				Type:      devType,
-				Usedmem:   effMem,
-				Usedcores: effCores,
-				Slots:     effSlots,
+				Usedmem:   max(s.peak.mem, s.sc.mem+s.app.mem),
+				Usedcores: max(s.peak.cores, s.sc.cores+s.app.cores),
+				Slots:     max(max(s.peak.slots, s.sc.slots+s.app.slots), 1),
 			})
 		}
 		sort.Slice(containerDevs, func(i, j int) bool {

--- a/pkg/device/initContainer_test.go
+++ b/pkg/device/initContainer_test.go
@@ -389,7 +389,7 @@ func TestCollapseInitContainerUsage_SidecarAddsToAppSum(t *testing.T) {
 	}
 	expected := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80}},
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80, Slots: 2}},
 		},
 	}
 	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
@@ -411,14 +411,14 @@ func TestCollapseAndSteadyState_SidecarWithInitAndApp(t *testing.T) {
 	}
 	expectedCollapsed := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 22000, Usedcores: 70}},
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 22000, Usedcores: 70, Slots: 2}},
 		},
 	}
 	assert.DeepEqual(t, expectedCollapsed, CollapseInitContainerUsage(pod, raw))
 
 	expectedSteady := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 12000, Usedcores: 40}},
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 12000, Usedcores: 40, Slots: 2}},
 		},
 	}
 	assert.DeepEqual(t, expectedSteady, SteadyStateDeviceUsage(pod, raw))
@@ -436,7 +436,7 @@ func TestCollapseInitContainerUsage_NilRestartPolicyUnchanged(t *testing.T) {
 	}
 	expected := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}},
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40, Slots: 1}},
 		},
 	}
 	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
@@ -456,7 +456,7 @@ func TestCollapseInitContainerUsage_AllSidecars(t *testing.T) {
 	}
 	expected := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 9000, Usedcores: 35}},
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 9000, Usedcores: 35, Slots: 3}},
 		},
 	}
 	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
@@ -478,8 +478,8 @@ func TestCollapseInitContainerUsage_SidecarMultiUUID(t *testing.T) {
 	expected := PodDevices{
 		"NVIDIA": PodSingleDevice{
 			{
-				ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 40},
-				ContainerDevice{UUID: "gpu1", Type: "NVIDIA", Usedmem: 7000, Usedcores: 70},
+				ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 40, Slots: 2},
+				ContainerDevice{UUID: "gpu1", Type: "NVIDIA", Usedmem: 7000, Usedcores: 70, Slots: 1},
 			},
 		},
 	}

--- a/pkg/device/initContainer_test.go
+++ b/pkg/device/initContainer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package device
 
 import (
+	"fmt"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -246,16 +247,16 @@ func TestCollapseInitContainerUsage_MultiAppSameGPUSlots(t *testing.T) {
 	assert.Equal(t, result["NVIDIA"][0][0].Slots, int32(3))
 }
 
-func TestAppContainersOnlyDeviceUsage_NilInput(t *testing.T) {
-	result := AppContainersOnlyDeviceUsage(nil, nil)
+func TestSteadyStateDeviceUsage_NilInput(t *testing.T) {
+	result := SteadyStateDeviceUsage(nil, nil)
 	assert.Assert(t, result == nil)
 
 	pod := makePod("test", 1, 1)
-	result = AppContainersOnlyDeviceUsage(pod, nil)
+	result = SteadyStateDeviceUsage(pod, nil)
 	assert.Assert(t, result == nil)
 }
 
-func TestAppContainersOnlyDeviceUsage_OnlyAppContainers(t *testing.T) {
+func TestSteadyStateDeviceUsage_OnlyAppContainers(t *testing.T) {
 	pod := makePod("test", 0, 2)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
@@ -268,11 +269,11 @@ func TestAppContainersOnlyDeviceUsage_OnlyAppContainers(t *testing.T) {
 			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 300, Usedcores: 30, Slots: 2}},
 		},
 	}
-	result := AppContainersOnlyDeviceUsage(pod, raw)
+	result := SteadyStateDeviceUsage(pod, raw)
 	assert.DeepEqual(t, expected, result)
 }
 
-func TestAppContainersOnlyDeviceUsage_IgnoresInitContainers(t *testing.T) {
+func TestSteadyStateDeviceUsage_IgnoresInitContainers(t *testing.T) {
 	pod := makePod("test", 1, 2)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
@@ -286,11 +287,11 @@ func TestAppContainersOnlyDeviceUsage_IgnoresInitContainers(t *testing.T) {
 			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 300, Usedcores: 30, Slots: 2}},
 		},
 	}
-	result := AppContainersOnlyDeviceUsage(pod, raw)
+	result := SteadyStateDeviceUsage(pod, raw)
 	assert.DeepEqual(t, expected, result)
 }
 
-func TestAppContainersOnlyDeviceUsage_MultipleDeviceTypes(t *testing.T) {
+func TestSteadyStateDeviceUsage_MultipleDeviceTypes(t *testing.T) {
 	pod := makePod("test", 1, 1)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
@@ -310,11 +311,11 @@ func TestAppContainersOnlyDeviceUsage_MultipleDeviceTypes(t *testing.T) {
 			{ContainerDevice{UUID: "xpu0", Type: "kunlun", Usedmem: 400, Usedcores: 40, Slots: 1}},
 		},
 	}
-	result := AppContainersOnlyDeviceUsage(pod, raw)
+	result := SteadyStateDeviceUsage(pod, raw)
 	assert.DeepEqual(t, expected, result)
 }
 
-func TestAppContainersOnlyDeviceUsage_MultipleDevicesPerContainer(t *testing.T) {
+func TestSteadyStateDeviceUsage_MultipleDevicesPerContainer(t *testing.T) {
 	pod := makePod("test", 1, 1)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
@@ -336,13 +337,13 @@ func TestAppContainersOnlyDeviceUsage_MultipleDevicesPerContainer(t *testing.T) 
 			},
 		},
 	}
-	result := AppContainersOnlyDeviceUsage(pod, raw)
+	result := SteadyStateDeviceUsage(pod, raw)
 	assert.DeepEqual(t, expected, result)
 }
 
-// TestAppContainersOnlyDeviceUsage_MultiAppSameGPUSlots guards that the app-only
+// TestSteadyStateDeviceUsage_MultiAppSameGPUSlots guards that the steady-state
 // shrink path also preserves the per-container slot count.
-func TestAppContainersOnlyDeviceUsage_MultiAppSameGPUSlots(t *testing.T) {
+func TestSteadyStateDeviceUsage_MultiAppSameGPUSlots(t *testing.T) {
 	pod := makePod("test", 1, 2)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
@@ -351,6 +352,136 @@ func TestAppContainersOnlyDeviceUsage_MultiAppSameGPUSlots(t *testing.T) {
 			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 100, Usedcores: 10}}, // app1
 		},
 	}
-	result := AppContainersOnlyDeviceUsage(pod, raw)
+	result := SteadyStateDeviceUsage(pod, raw)
 	assert.Equal(t, result["NVIDIA"][0][0].Slots, int32(2))
+}
+
+// --- Sidecar container accounting (sidecarsContainer-design.md) ---
+
+func makePodWithSidecars(name string, initPolicies []*corev1.ContainerRestartPolicy, numApp int) *corev1.Pod {
+	initContainers := make([]corev1.Container, len(initPolicies))
+	for i, p := range initPolicies {
+		initContainers[i] = corev1.Container{Name: fmt.Sprintf("init-%d", i), RestartPolicy: p}
+	}
+	appContainers := make([]corev1.Container, numApp)
+	for i := range appContainers {
+		appContainers[i] = corev1.Container{Name: fmt.Sprintf("app-%d", i)}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: corev1.PodSpec{
+			InitContainers: initContainers,
+			Containers:     appContainers,
+		},
+	}
+}
+
+// Design case "oversubscription prevented": a 4000 sidecar plus a 4000 app
+// container on one card must account as 8000, not max(4000,4000)=4000.
+func TestCollapseInitContainerUsage_SidecarAddsToAppSum(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{&always}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}}, // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}}, // app
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// Design case "shrink restored": init 20000 + sidecar 2000 + app 10000 →
+// collapse = 2000 + max(20000, 10000) = 22000; steady state = 12000, and the
+// steady state must still contain the sidecar's share (the pin that a fixed
+// gate plus an unfixed target would violate).
+func TestCollapseAndSteadyState_SidecarWithInitAndApp(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil, &always}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 20000, Usedcores: 60}}, // init (regular)
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 2000, Usedcores: 10}},  // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 10000, Usedcores: 30}}, // app
+		},
+	}
+	expectedCollapsed := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 22000, Usedcores: 70}},
+		},
+	}
+	assert.DeepEqual(t, expectedCollapsed, CollapseInitContainerUsage(pod, raw))
+
+	expectedSteady := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 12000, Usedcores: 40}},
+		},
+	}
+	assert.DeepEqual(t, expectedSteady, SteadyStateDeviceUsage(pod, raw))
+}
+
+// A nil restartPolicy is a regular init container: results must be identical
+// to the pre-sidecar behavior (the "safe everywhere" property).
+func TestCollapseInitContainerUsage_NilRestartPolicyUnchanged(t *testing.T) {
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}}, // init
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}}, // app
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 40}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// All init containers are sidecars: init_peak = 0, so
+// effective = sidecar_sum + max(0, app_sum), and the steady state equals it.
+func TestCollapseInitContainerUsage_AllSidecars(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{&always, &always}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 3000, Usedcores: 10}}, // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 20}}, // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 1000, Usedcores: 5}},  // app
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 9000, Usedcores: 35}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+	assert.DeepEqual(t, expected, SteadyStateDeviceUsage(pod, raw))
+}
+
+// Per-UUID independence: sidecar on gpu0, regular init on gpu1, app on gpu0.
+// Missing per-UUID entries count as 0 before the max() and the addition.
+func TestCollapseInitContainerUsage_SidecarMultiUUID(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{&always, nil}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 2000, Usedcores: 10}}, // sidecar on gpu0
+			{ContainerDevice{UUID: "gpu1", Type: "NVIDIA", Usedmem: 7000, Usedcores: 70}}, // init on gpu1
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 3000, Usedcores: 30}}, // app on gpu0
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{
+				ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 40},
+				ContainerDevice{UUID: "gpu1", Type: "NVIDIA", Usedmem: 7000, Usedcores: 70},
+			},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
 }

--- a/pkg/device/initContainer_test.go
+++ b/pkg/device/initContainer_test.go
@@ -395,17 +395,19 @@ func TestCollapseInitContainerUsage_SidecarAddsToAppSum(t *testing.T) {
 	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
 }
 
-// Design case "shrink restored": init 20000 + sidecar 2000 + app 10000 →
-// collapse = 2000 + max(20000, 10000) = 22000; steady state = 12000, and the
-// steady state must still contain the sidecar's share (the pin that a fixed
-// gate plus an unfixed target would violate).
+// Design case "shrink restored": sidecar 2000 + init 20000 + app 10000.
+// The sidecar must be declared BEFORE the regular init for the design
+// numbers to hold — only then do the two overlap:
+// collapse = max(2000+20000, 2000+10000) = 22000, steady state = 12000.
+// The reverse declaration order is pinned by
+// TestCollapseInitContainerUsage_LateSidecarDoesNotInflatePeak.
 func TestCollapseAndSteadyState_SidecarWithInitAndApp(t *testing.T) {
 	always := corev1.ContainerRestartPolicyAlways
-	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil, &always}, 1)
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{&always, nil}, 1)
 	raw := PodDevices{
 		"NVIDIA": PodSingleDevice{
-			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 20000, Usedcores: 60}}, // init (regular)
 			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 2000, Usedcores: 10}},  // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 20000, Usedcores: 60}}, // init (regular)
 			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 10000, Usedcores: 30}}, // app
 		},
 	}
@@ -484,4 +486,100 @@ func TestCollapseInitContainerUsage_SidecarMultiUUID(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// Sidecar never overlaps with it — the init has exited when the sidecar
+// starts. Effective usage is max(5000, 8000) = 8000 on ONE slot, not
+// 5000+8000 on two.
+func TestCollapseInitContainerUsage_RegularThenSidecarNoOverlap(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil, &always}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 50}}, // init (regular)
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80}}, // sidecar
+			{}, // app without GPU
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80, Slots: 1}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// Same two containers in the opposite order: the sidecar starts first and
+// is still running while the regular init runs, so their usage stacks:
+// peak = 8000 + 5000 = 13000 on two slots. (This passes under both the old
+// and new formulas — it's the control showing overlap is still charged.)
+func TestCollapseInitContainerUsage_SidecarThenRegularOverlap(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{&always, nil}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 8000, Usedcores: 80}}, // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 50}}, // init (regular)
+			{}, // app without GPU
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 13000, Usedcores: 130, Slots: 2}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// Interleaved order exercises the per-step running sum: the second regular
+// init overlaps only with the sidecar declared before it.
+// Peak walks 5000 → max(5000, 3000) → max(5000, 3000+4000) = 7000;
+// steady state = 3000 + 1000 = 4000; effective = 7000.
+// The order-blind formula charged 3000 + max(5000, 1000) = 8000.
+func TestCollapseInitContainerUsage_InterleavedRunningSum(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil, &always, nil}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 5000, Usedcores: 10}}, // init (regular)
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 3000, Usedcores: 30}}, // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 4000, Usedcores: 20}}, // init (regular)
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 1000, Usedcores: 5}},  // app
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 7000, Usedcores: 50, Slots: 2}},
+		},
+	}
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+}
+
+// The design case's containers in the OLD declaration order: with the
+// regular init first, the late sidecar must not inflate the init-phase
+// peak. Collapse = max(20000, 2000+10000) = 20000 (was 22000 under the
+// order-blind formula), and the shrink target keeps the sidecar's share.
+func TestCollapseInitContainerUsage_LateSidecarDoesNotInflatePeak(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := makePodWithSidecars("test", []*corev1.ContainerRestartPolicy{nil, &always}, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 20000, Usedcores: 60}}, // init (regular)
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 2000, Usedcores: 10}},  // sidecar
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 10000, Usedcores: 30}}, // app
+		},
+	}
+	expectedCollapsed := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 20000, Usedcores: 60, Slots: 2}},
+		},
+	}
+	assert.DeepEqual(t, expectedCollapsed, CollapseInitContainerUsage(pod, raw))
+
+	expectedSteady := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 12000, Usedcores: 40, Slots: 2}},
+		},
+	}
+	assert.DeepEqual(t, expectedSteady, SteadyStateDeviceUsage(pod, raw))
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -202,22 +202,22 @@ func (s *Scheduler) onUpdatePod(oldObj, newObj any) {
 
 	s.podManager.UpdatePod(newPod)
 
-	if !pi.InitContainerResourceReleased && util.AllInitContainersSucceeded(newPod) {
+	if !pi.InitContainerResourceReleased && util.AllNonSidecarInitContainersSucceeded(newPod) {
 		rawDevices, err := device.DecodePodDevices(device.SupportDevices, newPod.Annotations)
 		if err != nil {
 			klog.ErrorS(err, "failed to decode pod devices during shrink", "pod", klog.KObj(newPod))
 			return
 		}
 
-		appOnlyDevices := device.AppContainersOnlyDeviceUsage(newPod, rawDevices)
+		steadyStateDevices := device.SteadyStateDeviceUsage(newPod, rawDevices)
 
-		oldDevices, ok := s.podManager.UpdatePodDevice(newPod, appOnlyDevices)
+		oldDevices, ok := s.podManager.UpdatePodDevice(newPod, steadyStateDevices)
 		if ok {
-			s.quotaManager.ReplaceUsage(newPod, oldDevices, appOnlyDevices)
-			klog.InfoS("Init containers completed, shrunk usage",
+			s.quotaManager.ReplaceUsage(newPod, oldDevices, steadyStateDevices)
+			klog.InfoS("Non-sidecar init containers completed, shrunk usage to steady state",
 				"pod", klog.KObj(newPod),
 				"oldUsage", oldDevices,
-				"newUsage", appOnlyDevices,
+				"newUsage", steadyStateDevices,
 			)
 		}
 	}

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -223,7 +223,7 @@ func applyPeakUsage(node *NodeUsage, appNodeCopy *NodeUsage, peakUsage map[strin
 	}
 }
 
-// fitInDevices keys rows by request type ("NVIDIA") while nodes may register model-specific types ("NVIDIA A100-SXM4-40GB"); union both so padding/merge never drops fitted rows.
+// fitInDevices keys rows by request type ("NVIDIA") while nodes may register model-specific types ("NVIDIA A100-SXM4-40GB"); union both so padding never drops fitted rows.
 func allocationTypeKeys(resourceReqs device.PodDeviceRequests, baseTypes map[string]struct{}) map[string]struct{} {
 	allocTypes := make(map[string]struct{}, len(baseTypes))
 	for typ := range baseTypes {
@@ -247,55 +247,37 @@ func sidecarInitIndexes(task *corev1.Pod) map[int]struct{} {
 	return idx
 }
 
-func allocateSidecarContainers(appNodeCopy *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
-	sidecarAllocs := make(device.PodDevices)
-
-	for i := 0; i < numInitContainers && i < len(resourceReqs); i++ {
-		req := resourceReqs[i]
-		_, isSidecar := sidecarIdx[i]
-		if !isSidecar || len(req) == 0 {
-			for typ := range allocTypes {
-				sidecarAllocs[typ] = append(sidecarAllocs[typ], device.ContainerDevices{})
-			}
-			continue
-		}
-		fit, reason := fitInDevices(appNodeCopy, req, task, nodeInfo, &sidecarAllocs, weights)
-		if !fit {
-			klog.V(4).InfoS("Sidecar container does not fit",
-				"pod", klog.KObj(task), "node", nodeID, "containerIndex", i, "reason", reason)
-			return nil, false, reason
-		}
-		for typ := range allocTypes {
-			if len(sidecarAllocs[typ]) == i {
-				sidecarAllocs[typ] = append(sidecarAllocs[typ], device.ContainerDevices{})
-			}
-		}
-	}
-	return sidecarAllocs, true, ""
-}
-
-func allocateInitContainers(initBase *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
+func allocateInitContainers(appNodeCopy *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
 	initAllocs := make(device.PodDevices)
 
 	for i, req := range resourceReqs {
 		if i >= numInitContainers {
 			break
 		}
-		_, isSidecar := sidecarIdx[i]
-		if isSidecar || len(req) == 0 {
+		if len(req) == 0 {
 			for typ := range allocTypes {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
 			}
 			continue
 		}
-		nodeCopy := initBase.DeepCopy()
-		fit, reason := fitInDevices(nodeCopy, req, task, nodeInfo, &initAllocs, weights)
-		if !fit {
-			klog.V(4).InfoS("Init container does not fit",
-				"pod", klog.KObj(task), "node", nodeID, "containerIndex", i, "reason", reason)
-			return nil, false, reason
+		if _, isSidecar := sidecarIdx[i]; isSidecar {
+			fit, reason := fitInDevices(appNodeCopy, req, task, nodeInfo, &initAllocs, weights)
+			if !fit {
+				klog.V(4).InfoS("Sidecar container does not fit",
+					"pod", klog.KObj(task), "node", nodeID, "containerIndex", i, "reason", reason)
+				return nil, false, reason
+			}
+			updatePeakUsage(peakUsage, appNodeCopy)
+		} else {
+			nodeCopy := appNodeCopy.DeepCopy()
+			fit, reason := fitInDevices(nodeCopy, req, task, nodeInfo, &initAllocs, weights)
+			if !fit {
+				klog.V(4).InfoS("Init container does not fit",
+					"pod", klog.KObj(task), "node", nodeID, "containerIndex", i, "reason", reason)
+				return nil, false, reason
+			}
+			updatePeakUsage(peakUsage, nodeCopy)
 		}
-		updatePeakUsage(peakUsage, nodeCopy)
 		for typ := range allocTypes {
 			if len(initAllocs[typ]) == i {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
@@ -303,28 +285,6 @@ func allocateInitContainers(initBase *NodeUsage, nodeID string, resourceReqs dev
 		}
 	}
 	return initAllocs, true, ""
-}
-
-func mergeInitRangeAllocs(allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, sidecarAllocs, initAllocs device.PodDevices) device.PodDevices {
-	merged := make(device.PodDevices)
-	for typ := range allocTypes {
-		rows := make(device.PodSingleDevice, 0, numInitContainers)
-		for i := range numInitContainers {
-			var row device.ContainerDevices
-			if _, ok := sidecarIdx[i]; ok {
-				if sidecarAllocs != nil && i < len(sidecarAllocs[typ]) {
-					row = sidecarAllocs[typ][i]
-				}
-			} else {
-				if initAllocs != nil && i < len(initAllocs[typ]) {
-					row = initAllocs[typ][i]
-				}
-			}
-			rows = append(rows, row)
-		}
-		merged[typ] = rows
-	}
-	return merged
 }
 
 func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
@@ -395,19 +355,9 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 	score.ComputeDefaultScore(appNodeCopy.Devices)
 	snapshot := score.SnapshotDevice(appNodeCopy.Devices)
 
-	var sidecarAllocs device.PodDevices
-	if len(sidecarIdx) > 0 {
-		allocs, fit, reason := allocateSidecarContainers(appNodeCopy, nodeID, resourceReqs, task, nodeInfo, allocTypes, sidecarIdx, numInitContainers, weights)
-		if !fit {
-			return nodeScoreResult{reason: reason}
-		}
-		sidecarAllocs = allocs
-	}
-
 	var initAllocs device.PodDevices
-	if numInitContainers > len(sidecarIdx) {
-		initBase := appNodeCopy.DeepCopy() // node + sidecars
-		allocs, fit, reason := allocateInitContainers(initBase, nodeID, resourceReqs, task, nodeInfo, allocTypes, sidecarIdx, numInitContainers, peakUsage, weights)
+	if numInitContainers > 0 {
+		allocs, fit, reason := allocateInitContainers(appNodeCopy, nodeID, resourceReqs, task, nodeInfo, allocTypes, sidecarIdx, numInitContainers, peakUsage, weights)
 		if !fit {
 			return nodeScoreResult{reason: reason}
 		}
@@ -418,9 +368,8 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 		return nodeScoreResult{reason: reason}
 	}
 
-	if numInitContainers > 0 {
-		mergedInit := mergeInitRangeAllocs(allocTypes, sidecarIdx, numInitContainers, sidecarAllocs, initAllocs)
-		for devType, initConList := range mergedInit {
+	if numInitContainers > 0 && initAllocs != nil {
+		for devType, initConList := range initAllocs {
 			score.Devices[devType] = append(initConList, score.Devices[devType]...)
 		}
 	}

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -223,20 +223,71 @@ func applyPeakUsage(node *NodeUsage, appNodeCopy *NodeUsage, peakUsage map[strin
 	}
 }
 
-func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
+func allocationTypeKeys(resourceReqs device.PodDeviceRequests, baseTypes map[string]struct{}) map[string]struct{} {
+	allocTypes := make(map[string]struct{}, len(baseTypes))
+	for typ := range baseTypes {
+		allocTypes[typ] = struct{}{}
+	}
+	for _, ctrReqs := range resourceReqs {
+		for _, req := range ctrReqs {
+			allocTypes[req.Type] = struct{}{}
+		}
+	}
+	return allocTypes
+}
+
+func sidecarInitIndexes(task *corev1.Pod) map[int]struct{} {
+	idx := make(map[int]struct{})
+	for i := range task.Spec.InitContainers {
+		if util.IsSidecarContainer(&task.Spec.InitContainers[i]) {
+			idx[i] = struct{}{}
+		}
+	}
+	return idx
+}
+
+func allocateSidecarContainers(appNodeCopy *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
+	sidecarAllocs := make(device.PodDevices)
+
+	for i := 0; i < numInitContainers && i < len(resourceReqs); i++ {
+		req := resourceReqs[i]
+		_, isSidecar := sidecarIdx[i]
+		if !isSidecar || len(req) == 0 {
+			for typ := range allocTypes {
+				sidecarAllocs[typ] = append(sidecarAllocs[typ], device.ContainerDevices{})
+			}
+			continue
+		}
+		fit, reason := fitInDevices(appNodeCopy, req, task, nodeInfo, &sidecarAllocs, weights)
+		if !fit {
+			klog.V(4).InfoS("Sidecar container does not fit",
+				"pod", klog.KObj(task), "node", nodeID, "containerIndex", i, "reason", reason)
+			return nil, false, reason
+		}
+		for typ := range allocTypes {
+			if len(sidecarAllocs[typ]) == i {
+				sidecarAllocs[typ] = append(sidecarAllocs[typ], device.ContainerDevices{})
+			}
+		}
+	}
+	return sidecarAllocs, true, ""
+}
+
+func allocateInitContainers(initBase *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
 	initAllocs := make(device.PodDevices)
 
 	for i, req := range resourceReqs {
 		if i >= numInitContainers {
 			break
 		}
-		if len(req) == 0 {
-			for typ := range baseTypes {
+		_, isSidecar := sidecarIdx[i]
+		if isSidecar || len(req) == 0 {
+			for typ := range allocTypes {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
 			}
 			continue
 		}
-		nodeCopy := node.DeepCopy()
+		nodeCopy := initBase.DeepCopy()
 		fit, reason := fitInDevices(nodeCopy, req, task, nodeInfo, &initAllocs, weights)
 		if !fit {
 			klog.V(4).InfoS("Init container does not fit",
@@ -244,13 +295,35 @@ func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.
 			return nil, false, reason
 		}
 		updatePeakUsage(peakUsage, nodeCopy)
-		for typ := range baseTypes {
+		for typ := range allocTypes {
 			if len(initAllocs[typ]) == i {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
 			}
 		}
 	}
 	return initAllocs, true, ""
+}
+
+func mergeInitRangeAllocs(allocTypes map[string]struct{}, sidecarIdx map[int]struct{}, numInitContainers int, sidecarAllocs, initAllocs device.PodDevices) device.PodDevices {
+	merged := make(device.PodDevices)
+	for typ := range allocTypes {
+		rows := make(device.PodSingleDevice, 0, numInitContainers)
+		for i := range numInitContainers {
+			var row device.ContainerDevices
+			if _, ok := sidecarIdx[i]; ok {
+				if sidecarAllocs != nil && i < len(sidecarAllocs[typ]) {
+					row = sidecarAllocs[typ][i]
+				}
+			} else {
+				if initAllocs != nil && i < len(initAllocs[typ]) {
+					row = initAllocs[typ][i]
+				}
+			}
+			rows = append(rows, row)
+		}
+		merged[typ] = rows
+	}
+	return merged
 }
 
 func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
@@ -305,19 +378,13 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 	}
 
 	baseTypes := nodeDeviceBaseTypes(node.Devices)
+	allocTypes := allocationTypeKeys(resourceReqs, baseTypes)
 	peakUsage := snapshotPeakUsage(node.Devices)
 	numInitContainers := len(task.Spec.InitContainers)
-
-	var initAllocs device.PodDevices
-	if numInitContainers > 0 {
-		allocs, fit, reason := allocateInitContainers(node, nodeID, resourceReqs, task, nodeInfo, baseTypes, numInitContainers, peakUsage, weights)
-		if !fit {
-			return nodeScoreResult{reason: reason}
-		}
-		initAllocs = allocs
-	}
+	sidecarIdx := sidecarInitIndexes(task)
 
 	appNodeCopy := node.DeepCopy()
+
 	score := policy.NodeScore{
 		NodeID:  nodeID,
 		Node:    node.Node,
@@ -327,12 +394,32 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 	score.ComputeDefaultScore(appNodeCopy.Devices)
 	snapshot := score.SnapshotDevice(appNodeCopy.Devices)
 
+	var sidecarAllocs device.PodDevices
+	if len(sidecarIdx) > 0 {
+		allocs, fit, reason := allocateSidecarContainers(appNodeCopy, nodeID, resourceReqs, task, nodeInfo, allocTypes, sidecarIdx, numInitContainers, weights)
+		if !fit {
+			return nodeScoreResult{reason: reason}
+		}
+		sidecarAllocs = allocs
+	}
+
+	var initAllocs device.PodDevices
+	if numInitContainers > len(sidecarIdx) {
+		initBase := appNodeCopy.DeepCopy() // node + sidecars
+		allocs, fit, reason := allocateInitContainers(initBase, nodeID, resourceReqs, task, nodeInfo, allocTypes, sidecarIdx, numInitContainers, peakUsage, weights)
+		if !fit {
+			return nodeScoreResult{reason: reason}
+		}
+		initAllocs = allocs
+	}
+
 	if reason, fit := allocateAppContainers(&score, appNodeCopy, resourceReqs, task, nodeInfo, baseTypes, numInitContainers, nodeID, weights); !fit {
 		return nodeScoreResult{reason: reason}
 	}
 
-	if numInitContainers > 0 && initAllocs != nil {
-		for devType, initConList := range initAllocs {
+	if numInitContainers > 0 {
+		mergedInit := mergeInitRangeAllocs(allocTypes, sidecarIdx, numInitContainers, sidecarAllocs, initAllocs)
+		for devType, initConList := range mergedInit {
 			score.Devices[devType] = append(initConList, score.Devices[devType]...)
 		}
 	}

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -287,7 +287,7 @@ func allocateInitContainers(appNodeCopy *NodeUsage, nodeID string, resourceReqs 
 	return initAllocs, true, ""
 }
 
-func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
+func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
 	appIndex := 0
 	for ctrid, n := range resourceReqs {
 		if ctrid < numInitContainers {
@@ -298,7 +298,7 @@ func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, reso
 			sums += int(k.Nums)
 		}
 		if sums == 0 {
-			for typ := range baseTypes {
+			for typ := range allocTypes {
 				score.Devices[typ] = append(score.Devices[typ], device.ContainerDevices{})
 			}
 			appIndex++
@@ -309,7 +309,7 @@ func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, reso
 			klog.V(4).InfoS(common.NodeUnfitPod, "pod", klog.KObj(task), "node", nodeID, "reason", reason)
 			return reason, false
 		}
-		for typ := range baseTypes {
+		for typ := range allocTypes {
 			if len(score.Devices[typ]) == appIndex {
 				score.Devices[typ] = append(score.Devices[typ], device.ContainerDevices{})
 			}
@@ -364,7 +364,7 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 		initAllocs = allocs
 	}
 
-	if reason, fit := allocateAppContainers(&score, appNodeCopy, resourceReqs, task, nodeInfo, baseTypes, numInitContainers, nodeID, weights); !fit {
+	if reason, fit := allocateAppContainers(&score, appNodeCopy, resourceReqs, task, nodeInfo, allocTypes, numInitContainers, nodeID, weights); !fit {
 		return nodeScoreResult{reason: reason}
 	}
 

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -223,6 +223,7 @@ func applyPeakUsage(node *NodeUsage, appNodeCopy *NodeUsage, peakUsage map[strin
 	}
 }
 
+// fitInDevices keys rows by request type ("NVIDIA") while nodes may register model-specific types ("NVIDIA A100-SXM4-40GB"); union both so padding/merge never drops fitted rows.
 func allocationTypeKeys(resourceReqs device.PodDeviceRequests, baseTypes map[string]struct{}) map[string]struct{} {
 	allocTypes := make(map[string]struct{}, len(baseTypes))
 	for typ := range baseTypes {

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -4497,12 +4497,9 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 		requests    device.PodDeviceRequests
 		wantDevices device.PodDevices
 		wantFailed  map[string]string
+		wantUsedmem int32
 	}{
 		{
-			// DSFans2014's review case: the regular init has exited before
-			// the sidecar starts, so 5000 and 8000 never coexist. Peak is
-			// 8000 <= 10000 and the node must fit. A two-phase allocation
-			// (all sidecars first) wrongly rejects this node.
 			name:     "regular then sidecar never overlap and fit",
 			totalMem: 10000,
 			inits:    []corev1.Container{initC("reg", false), initC("sc", true)},
@@ -4514,12 +4511,9 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 					{},        // app container without a GPU request
 				},
 			},
+			wantUsedmem: 8000,
 		},
 		{
-			// Same containers, opposite order: the sidecar is already
-			// running while the regular init runs, so 8000+5000=13000 is
-			// correctly charged and exceeds the card. Rejects under both
-			// the old and the ordered allocation (control).
 			name:       "sidecar then regular overlap and are rejected",
 			totalMem:   10000,
 			inits:      []corev1.Container{initC("sc", true), initC("reg", false)},
@@ -4527,11 +4521,6 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 			wantFailed: map[string]string{"node1": "1/1 CardInsufficientMemory"},
 		},
 		{
-			// Interleaved order exercises the running sidecar sum: the
-			// second regular init overlaps only the sidecar declared before
-			// it. Peak walks 5000 -> 3000 -> 3000+4000 = 7000 <= 7500, and
-			// the steady state is 3000+1000 = 4000. The two-phase
-			// allocation charged 3000+5000 = 8000 and rejected the node.
 			name:     "interleaved inits use the running sidecar sum",
 			totalMem: 7500,
 			inits:    []corev1.Container{initC("reg-a", false), initC("sc", true), initC("reg-b", false)},
@@ -4544,11 +4533,9 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 					row(1000),
 				},
 			},
+			wantUsedmem: 7000,
 		},
 		{
-			// Steady state must SUM sidecar and app: 4000+4000 = 8000 >
-			// 7500. Guards that the ordered walk still persists sidecars
-			// into the state the app containers are fitted against.
 			name:       "sidecar plus app steady state is summed",
 			totalMem:   7500,
 			inits:      []corev1.Container{initC("sc", true)},
@@ -4567,7 +4554,8 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 				},
 			}
 			failedNodes := map[string]string{}
-			got, err := (&Scheduler{}).calcScoreWithOptions(newNodes(tc.totalMem), tc.requests, pod, failedNodes, false, false)
+			nodes := newNodes(tc.totalMem)
+			got, err := (&Scheduler{}).calcScoreWithOptions(nodes, tc.requests, pod, failedNodes, false, false)
 			assert.NilError(t, err)
 
 			if tc.wantFailed != nil {
@@ -4578,6 +4566,9 @@ func Test_calcScore_SidecarInitOrdering(t *testing.T) {
 			assert.Equal(t, len(failedNodes), 0)
 			assert.Equal(t, len(got.NodeList), 1)
 			assert.DeepEqual(t, tc.wantDevices, got.NodeList[0].Devices)
+
+			usage := (*nodes)["node1"].Devices.DeviceLists[0].Device
+			assert.Equal(t, usage.Usedmem, tc.wantUsedmem)
 		})
 	}
 }

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -4446,3 +4446,138 @@ func Test_fitInDevices_MultiTypePartition(t *testing.T) {
 	assert.Equal(t, len((*devinput)["mockB"][0]), 1)
 	assert.Equal(t, (*devinput)["mockB"][0][0].UUID, "uuid-b")
 }
+
+func Test_calcScore_SidecarInitOrdering(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+
+	newNodes := func(totalMem int32) *map[string]*NodeUsage {
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		return &map[string]*NodeUsage{
+			"node1": {
+				Node:     node,
+				NodeInfo: &device.NodeInfo{ID: node.Name, Node: node},
+				Devices: policy.DeviceUsageList{
+					Policy: util.GPUSchedulerPolicyBinpack.String(),
+					DeviceLists: []*policy.DeviceListsScore{
+						{Device: &device.DeviceUsage{
+							ID: "uuid1", Index: 0, Type: nvidia.NvidiaGPUDevice, Health: true,
+							Count: 10, Used: 0, Totalcore: 100, Usedcores: 0,
+							Totalmem: totalMem, Usedmem: 0,
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	gpuReq := func(mem int32) map[string]device.ContainerDeviceRequest {
+		return map[string]device.ContainerDeviceRequest{
+			nvidia.NvidiaGPUDevice: {
+				Nums: 1, Type: nvidia.NvidiaGPUDevice, Memreq: mem, Coresreq: 10,
+			},
+		}
+	}
+	row := func(mem int32) device.ContainerDevices {
+		return device.ContainerDevices{
+			{Idx: 0, UUID: "uuid1", Type: nvidia.NvidiaGPUDevice, Usedcores: 10, Usedmem: mem},
+		}
+	}
+	initC := func(name string, sidecar bool) corev1.Container {
+		c := corev1.Container{Name: name}
+		if sidecar {
+			c.RestartPolicy = &always
+		}
+		return c
+	}
+
+	tests := []struct {
+		name        string
+		totalMem    int32
+		inits       []corev1.Container
+		requests    device.PodDeviceRequests
+		wantDevices device.PodDevices
+		wantFailed  map[string]string
+	}{
+		{
+			// DSFans2014's review case: the regular init has exited before
+			// the sidecar starts, so 5000 and 8000 never coexist. Peak is
+			// 8000 <= 10000 and the node must fit. A two-phase allocation
+			// (all sidecars first) wrongly rejects this node.
+			name:     "regular then sidecar never overlap and fit",
+			totalMem: 10000,
+			inits:    []corev1.Container{initC("reg", false), initC("sc", true)},
+			requests: device.PodDeviceRequests{gpuReq(5000), gpuReq(8000), {}},
+			wantDevices: device.PodDevices{
+				nvidia.NvidiaGPUDevice: device.PodSingleDevice{
+					row(5000), // regular init: transient, only in the peak
+					row(8000), // sidecar: persists into steady state
+					{},        // app container without a GPU request
+				},
+			},
+		},
+		{
+			// Same containers, opposite order: the sidecar is already
+			// running while the regular init runs, so 8000+5000=13000 is
+			// correctly charged and exceeds the card. Rejects under both
+			// the old and the ordered allocation (control).
+			name:       "sidecar then regular overlap and are rejected",
+			totalMem:   10000,
+			inits:      []corev1.Container{initC("sc", true), initC("reg", false)},
+			requests:   device.PodDeviceRequests{gpuReq(8000), gpuReq(5000), {}},
+			wantFailed: map[string]string{"node1": "1/1 CardInsufficientMemory"},
+		},
+		{
+			// Interleaved order exercises the running sidecar sum: the
+			// second regular init overlaps only the sidecar declared before
+			// it. Peak walks 5000 -> 3000 -> 3000+4000 = 7000 <= 7500, and
+			// the steady state is 3000+1000 = 4000. The two-phase
+			// allocation charged 3000+5000 = 8000 and rejected the node.
+			name:     "interleaved inits use the running sidecar sum",
+			totalMem: 7500,
+			inits:    []corev1.Container{initC("reg-a", false), initC("sc", true), initC("reg-b", false)},
+			requests: device.PodDeviceRequests{gpuReq(5000), gpuReq(3000), gpuReq(4000), gpuReq(1000)},
+			wantDevices: device.PodDevices{
+				nvidia.NvidiaGPUDevice: device.PodSingleDevice{
+					row(5000),
+					row(3000),
+					row(4000),
+					row(1000),
+				},
+			},
+		},
+		{
+			// Steady state must SUM sidecar and app: 4000+4000 = 8000 >
+			// 7500. Guards that the ordered walk still persists sidecars
+			// into the state the app containers are fitted against.
+			name:       "sidecar plus app steady state is summed",
+			totalMem:   7500,
+			inits:      []corev1.Container{initC("sc", true)},
+			requests:   device.PodDeviceRequests{gpuReq(4000), gpuReq(4000)},
+			wantFailed: map[string]string{"node1": "1/1 CardInsufficientMemory"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sidecar-order", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					InitContainers: tc.inits,
+					Containers:     []corev1.Container{{Name: "app"}},
+				},
+			}
+			failedNodes := map[string]string{}
+			got, err := (&Scheduler{}).calcScoreWithOptions(newNodes(tc.totalMem), tc.requests, pod, failedNodes, false, false)
+			assert.NilError(t, err)
+
+			if tc.wantFailed != nil {
+				assert.Equal(t, len(got.NodeList), 0)
+				assert.DeepEqual(t, tc.wantFailed, failedNodes)
+				return
+			}
+			assert.Equal(t, len(failedNodes), 0)
+			assert.Equal(t, len(got.NodeList), 1)
+			assert.DeepEqual(t, tc.wantDevices, got.NodeList[0].Devices)
+		})
+	}
+}

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 const template = "Processing admission hook for pod %v/%v, UID: %v"
@@ -146,7 +147,6 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 	for deviceName, dev := range device.GetDevices() {
 		resourceNames := dev.GetResourceNames()
 		if len(resourceNames.ResourceMemoryName) == 0 && len(resourceNames.ResourceCoreName) == 0 {
-			// Nothing this backend exposes can carry a quota.
 			continue
 		}
 
@@ -164,20 +164,25 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 			appCoresReq += int64(req.Coresreq) * int64(req.Nums)
 		}
 
-		// Init containers run sequentially, so the pod's effective request is
-		// max(sum(app containers), max(init containers)).
 		var initMemoryReq, initCoresReq int64
+		var sidecarMemoryReq, sidecarCoresReq int64
 		for i := range pod.Spec.InitContainers {
-			req := dev.GenerateResourceRequests(&pod.Spec.InitContainers[i])
+			c := &pod.Spec.InitContainers[i]
+			req := dev.GenerateResourceRequests(c)
 			if req.Nums == 0 {
+				continue
+			}
+			if util.IsSidecarContainer(c) {
+				sidecarMemoryReq += int64(req.Memreq) * int64(req.Nums)
+				sidecarCoresReq += int64(req.Coresreq) * int64(req.Nums)
 				continue
 			}
 			initMemoryReq = max(initMemoryReq, int64(req.Memreq)*int64(req.Nums))
 			initCoresReq = max(initCoresReq, int64(req.Coresreq)*int64(req.Nums))
 		}
 
-		memoryReq := max(appMemoryReq, initMemoryReq)
-		coresReq := max(appCoresReq, initCoresReq)
+		memoryReq := sidecarMemoryReq + max(appMemoryReq, initMemoryReq)
+		coresReq := sidecarCoresReq + max(appCoresReq, initCoresReq)
 		if memoryReq == 0 && coresReq == 0 {
 			continue
 		}

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -164,7 +164,7 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 			appCoresReq += int64(req.Coresreq) * int64(req.Nums)
 		}
 
-		var initMemoryReq, initCoresReq int64
+		var initPeakMemoryReq, initPeakCoresReq int64
 		var sidecarMemoryReq, sidecarCoresReq int64
 		for i := range pod.Spec.InitContainers {
 			c := &pod.Spec.InitContainers[i]
@@ -172,17 +172,21 @@ func fitResourceQuota(pod *corev1.Pod) bool {
 			if req.Nums == 0 {
 				continue
 			}
+			mem := int64(req.Memreq) * int64(req.Nums)
+			cores := int64(req.Coresreq) * int64(req.Nums)
 			if util.IsSidecarContainer(c) {
-				sidecarMemoryReq += int64(req.Memreq) * int64(req.Nums)
-				sidecarCoresReq += int64(req.Coresreq) * int64(req.Nums)
+				sidecarMemoryReq += mem
+				sidecarCoresReq += cores
+				initPeakMemoryReq = max(initPeakMemoryReq, sidecarMemoryReq)
+				initPeakCoresReq = max(initPeakCoresReq, sidecarCoresReq)
 				continue
 			}
-			initMemoryReq = max(initMemoryReq, int64(req.Memreq)*int64(req.Nums))
-			initCoresReq = max(initCoresReq, int64(req.Coresreq)*int64(req.Nums))
+			initPeakMemoryReq = max(initPeakMemoryReq, sidecarMemoryReq+mem)
+			initPeakCoresReq = max(initPeakCoresReq, sidecarCoresReq+cores)
 		}
 
-		memoryReq := sidecarMemoryReq + max(appMemoryReq, initMemoryReq)
-		coresReq := sidecarCoresReq + max(appCoresReq, initCoresReq)
+		memoryReq := max(initPeakMemoryReq, sidecarMemoryReq+appMemoryReq)
+		coresReq := max(initPeakCoresReq, sidecarCoresReq+appCoresReq)
 		if memoryReq == 0 && coresReq == 0 {
 			continue
 		}

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -1082,3 +1082,132 @@ func TestFitResourceQuota_InitContainerPeakSequence(t *testing.T) {
 		t.Fatal("Step 3 failed: pod2 should be allowed after pod1 init finished (total 10000+20000=30000)")
 	}
 }
+
+func TestFitResourceQuota_SidecarOrdering(t *testing.T) {
+	config.SchedulerName = "hami-scheduler"
+	sConfig := &config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "nvidia.com/gpu",
+			ResourceMemoryName:           "nvidia.com/gpumem",
+			ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+			ResourceCoreName:             "nvidia.com/gpucores",
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+			MemoryFactor:                 1,
+		},
+	}
+	if err := config.InitDevicesWithConfig(sConfig); err != nil {
+		t.Fatalf("Failed to initialize devices with config: %v", err)
+	}
+
+	qm := device.NewQuotaManager()
+	qm.Quotas["sc-order"] = &device.DeviceQuota{
+		"nvidia.com/gpumem":   &device.Quota{Used: 0, Limit: 10000, LimitSet: true},
+		"nvidia.com/gpucores": &device.Quota{Used: 0, Limit: 100, LimitSet: true},
+	}
+	// Headroom 7500 mem: sits between the ordered interleaved peak (7000)
+	// and the order-blind value (8000), and below the sidecar+app steady
+	// state (8000) of the design case.
+	qm.Quotas["sc-order-tight"] = &device.DeviceQuota{
+		"nvidia.com/gpumem": &device.Quota{Used: 0, Limit: 7500, LimitSet: true},
+	}
+	t.Cleanup(func() {
+		delete(qm.Quotas, "sc-order")
+		delete(qm.Quotas, "sc-order-tight")
+	})
+
+	always := corev1.ContainerRestartPolicyAlways
+	gpuInit := func(name string, mem, cores int64, sidecar bool) corev1.Container {
+		c := corev1.Container{
+			Name:  name,
+			Image: "busybox",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu":    resource.MustParse("1"),
+					"nvidia.com/gpumem": *resource.NewQuantity(mem, resource.DecimalSI),
+				},
+			},
+		}
+		if cores > 0 {
+			c.Resources.Limits["nvidia.com/gpucores"] = *resource.NewQuantity(cores, resource.DecimalSI)
+		}
+		if sidecar {
+			c.RestartPolicy = &always
+		}
+		return c
+	}
+	makePod := func(name, ns string, inits []corev1.Container, appMem int64) *corev1.Pod {
+		app := corev1.Container{Name: "app", Image: "busybox"}
+		if appMem > 0 {
+			app.Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu":    resource.MustParse("1"),
+					"nvidia.com/gpumem": *resource.NewQuantity(appMem, resource.DecimalSI),
+				},
+			}
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.PodSpec{
+				SchedulerName:  "hami-scheduler",
+				InitContainers: inits,
+				Containers:     []corev1.Container{app},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name string
+		pod  *corev1.Pod
+		fit  bool
+	}{
+		{
+			// test1 has exited before test2 starts: peak is
+			// max(5000, 8000) = 8000 mem and max(50, 80) = 80 cores.
+			name: "regular then sidecar never overlap (review case)",
+			pod: makePod("review-case", "sc-order", []corev1.Container{
+				gpuInit("test1", 5000, 50, false),
+				gpuInit("test2", 8000, 80, true),
+			}, 0),
+			fit: true,
+		},
+		{
+			// Same containers, opposite order: the sidecar is still
+			// running while the regular init runs, so 13000/130 is
+			// correctly charged and exceeds the quota.
+			name: "sidecar then regular overlap and are denied",
+			pod: makePod("review-case-reversed", "sc-order", []corev1.Container{
+				gpuInit("test2", 8000, 80, true),
+				gpuInit("test1", 5000, 50, false),
+			}, 0),
+			fit: false,
+		},
+		{
+			name: "interleaved inits use the running sidecar sum",
+			pod: makePod("interleaved", "sc-order-tight", []corev1.Container{
+				gpuInit("init-a", 5000, 0, false),
+				gpuInit("sc", 3000, 0, true),
+				gpuInit("init-b", 4000, 0, false),
+			}, 1000),
+			fit: true,
+		},
+		{
+			// Steady state must SUM sidecar and app (design case):
+			// 4000 + 4000 = 8000 > 7500. A max() here would wrongly admit.
+			name: "sidecar plus app steady state is summed",
+			pod: makePod("steady-sum", "sc-order-tight", []corev1.Container{
+				gpuInit("sc", 4000, 0, true),
+			}, 4000),
+			fit: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fitResourceQuota(tc.pod); got != tc.fit {
+				t.Errorf("fitResourceQuota() = %v, want %v", got, tc.fit)
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -159,12 +159,22 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	}
 	return err
 }
-func AllInitContainersSucceeded(pod *corev1.Pod) bool {
-	if len(pod.Status.InitContainerStatuses) == 0 {
+
+func AllNonSidecarInitContainersSucceeded(pod *corev1.Pod) bool {
+	if len(pod.Spec.InitContainers) == 0 {
 		return false
 	}
+	statusByName := make(map[string]corev1.ContainerStatus, len(pod.Status.InitContainerStatuses))
 	for _, s := range pod.Status.InitContainerStatuses {
-		if s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
+		statusByName[s.Name] = s
+	}
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if IsSidecarContainer(c) {
+			continue
+		}
+		s, ok := statusByName[c.Name]
+		if !ok || s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
 			return false
 		}
 	}
@@ -316,6 +326,11 @@ func AllContainersCreated(pod *corev1.Pod) bool {
 		return false
 	}
 	return len(pod.Status.ContainerStatuses) >= len(pod.Spec.Containers)
+}
+
+func IsSidecarContainer(c *corev1.Container) bool {
+	return c != nil && c.RestartPolicy != nil &&
+		*c.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }
 
 // EmitNodeWarningEvent emits a Warning event on the given Node with deduplication.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -920,3 +920,60 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 		assert.Equal(t, 2, len(events.Items))
 	})
 }
+
+func TestIsSidecarContainer(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	other := corev1.ContainerRestartPolicy("Never")
+
+	assert.Assert(t, !IsSidecarContainer(nil))
+	assert.Assert(t, !IsSidecarContainer(&corev1.Container{Name: "c"}))
+	assert.Assert(t, !IsSidecarContainer(&corev1.Container{Name: "c", RestartPolicy: &other}))
+	assert.Assert(t, IsSidecarContainer(&corev1.Container{Name: "c", RestartPolicy: &always}))
+}
+
+func TestAllNonSidecarInitContainersSucceeded(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	sidecar := corev1.Container{Name: "sc", RestartPolicy: &always}
+	initC := corev1.Container{Name: "init"} // nil restartPolicy → regular init
+
+	term0 := corev1.ContainerStatus{Name: "init",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}}
+	term1 := corev1.ContainerStatus{Name: "init",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}}
+	running := corev1.ContainerStatus{Name: "init",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+	scRunning := corev1.ContainerStatus{Name: "sc",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+	// A crash-looping sidecar momentarily shows Terminated exit 0 — the
+	// exit-0 gap from the design. It must be irrelevant to the gate.
+	scGap := corev1.ContainerStatus{Name: "sc",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}}
+
+	cases := []struct {
+		name   string
+		spec   []corev1.Container
+		status []corev1.ContainerStatus
+		want   bool
+	}{
+		{"no init containers", nil, nil, false},
+		{"init running, sidecar running", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{running, scRunning}, false},
+		{"init exit0, sidecar running", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{term0, scRunning}, true},
+		{"init exit0, sidecar in exit-0 gap", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{term0, scGap}, true},
+		{"init running, sidecar in exit-0 gap must NOT open gate", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{running, scGap}, false},
+		{"init nonzero exit holds", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{term1, scRunning}, false},
+		{"all sidecars: gate immediately satisfied", []corev1.Container{sidecar}, []corev1.ContainerStatus{scRunning}, true},
+		{"missing status for non-sidecar init", []corev1.Container{initC, sidecar}, []corev1.ContainerStatus{scRunning}, false},
+		{"plain init pod, all exit0 (legacy behavior)", []corev1.Container{initC}, []corev1.ContainerStatus{term0}, true},
+		{"plain init pod, still running (legacy behavior)", []corev1.Container{initC}, []corev1.ContainerStatus{running}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Spec:   corev1.PodSpec{InitContainers: tc.spec},
+				Status: corev1.PodStatus{InitContainerStatuses: tc.status},
+			}
+			got := AllNonSidecarInitContainersSucceeded(pod)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR implements sidecar GPU accounting per design #2584 . A sidecar is an init container with restartPolicy: Always. Unlike normalinit containers, it never exit, it keeps running parallely with the app containers. So its GPU memory must be added on
top,
                           effectiveUsage =  max(init_peak, app_sum+ sidecar_sum )
Before this PR, HAMi treated sidecars like normal init containers, so their GPU usage was under counted and the card could be oversubscribed. Now sidecars are summed with app containers everywhere usage collapse, scheduler scoring, the post-init shrink, and webhook quota admission.
this pr also changed the shrink now shrink waits only for the NON-sidecar init containers to finish, and the shrunk usage keeps the sidecar's share. A crash-looping sidecar briefly showing "exited 0" can no longer trigger an early shrink.



**Which issue(s) this PR fixes**:
Part  of : #2563 

Ai Disclosure : I used AI for writing the test , optimizing the code logic and understanding the code behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added support for restartable sidecar init containers in device allocation, usage tracking, and resource quota calculations.
* Resource shrinking now occurs after all non-sidecar init containers complete.
* Added accurate GPU slot accounting for workloads with multiple application containers.

## Bug Fixes
* Improved per-device usage calculations across sidecars, init containers, and applications.
* Preserved correct allocation behavior for mixed and interleaved container workloads.
* Improved device lock handling and scheduling reliability.
* Added clearer handling for stale device allocations and missing usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->