### PR TITLE
fix(device/amd): validate GPU count and default GPU count to 1 for me…

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -76,25 +76,88 @@ func (dev *AMDDevices) CommonWord() string {
 }
 
 func (dev *AMDDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
-	if ok {
+	count, countRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)]
+	reqCount, reqRequested := ctr.Resources.Requests[corev1.ResourceName(dev.resourceCountName)]
+
+	if countRequested || reqRequested {
+		if countRequested {
+			n, isInt := count.AsInt64()
+			if !isInt || n <= 0 || n > math.MaxInt32 {
+				return false, fmt.Errorf("%s must be a positive integer between 1 and %d", dev.resourceCountName, math.MaxInt32)
+			}
+		}
+		if reqRequested {
+			n, isInt := reqCount.AsInt64()
+			if !isInt || n <= 0 || n > math.MaxInt32 {
+				return false, fmt.Errorf("%s must be a positive integer between 1 and %d", dev.resourceCountName, math.MaxInt32)
+			}
+		}
+		if countRequested && reqRequested {
+			limitN, _ := count.AsInt64()
+			reqN, _ := reqCount.AsInt64()
+			if limitN != reqN {
+				return false, fmt.Errorf("conflicting %s request (%d) and limit (%d)", dev.resourceCountName, reqN, limitN)
+			}
+		}
+		if !countRequested && reqRequested {
+			if ctr.Resources.Limits == nil {
+				ctr.Resources.Limits = corev1.ResourceList{}
+			}
+			ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)] = reqCount
+		} else if countRequested && !reqRequested {
+			if ctr.Resources.Requests == nil {
+				ctr.Resources.Requests = corev1.ResourceList{}
+			}
+			ctr.Resources.Requests[corev1.ResourceName(dev.resourceCountName)] = count
+		}
+
 		core, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+		if !coreRequested {
+			core, coreRequested = ctr.Resources.Requests[corev1.ResourceName(dev.resourceCoreName)]
+		}
 		if coreRequested {
 			corePercentage, coreIsInteger := core.AsInt64()
 			if !coreIsInteger || corePercentage < 1 || corePercentage > 100 {
 				return false, fmt.Errorf("%s must be an integer percentage between 1 and 100", dev.resourceCoreName)
 			}
 		}
+		return true, nil
+	}
 
+	_, memRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceMemoryName)]
+	if !memRequested {
+		_, memRequested = ctr.Resources.Requests[corev1.ResourceName(dev.resourceMemoryName)]
 	}
-	if !ok && dev.resourceMemoryName != "" {
-		_, ok = ctr.Resources.Limits[corev1.ResourceName(dev.resourceMemoryName)]
+	_, coreRequested := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+	if !coreRequested {
+		_, coreRequested = ctr.Resources.Requests[corev1.ResourceName(dev.resourceCoreName)]
 	}
-	if !ok && dev.resourceCoreName != "" {
-		_, ok = ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+
+	if (memRequested && dev.resourceMemoryName != "") || (coreRequested && dev.resourceCoreName != "") {
+		if coreRequested {
+			core, ok := ctr.Resources.Limits[corev1.ResourceName(dev.resourceCoreName)]
+			if !ok {
+				core = ctr.Resources.Requests[corev1.ResourceName(dev.resourceCoreName)]
+			}
+			corePercentage, coreIsInteger := core.AsInt64()
+			if !coreIsInteger || corePercentage < 1 || corePercentage > 100 {
+				return false, fmt.Errorf("%s must be an integer percentage between 1 and 100", dev.resourceCoreName)
+			}
+		}
+		gpuQty := *resource.NewQuantity(1, resource.DecimalSI)
+		if ctr.Resources.Limits == nil {
+			ctr.Resources.Limits = corev1.ResourceList{}
+		}
+		ctr.Resources.Limits[corev1.ResourceName(dev.resourceCountName)] = gpuQty
+
+		if ctr.Resources.Requests == nil {
+			ctr.Resources.Requests = corev1.ResourceList{}
+		}
+		ctr.Resources.Requests[corev1.ResourceName(dev.resourceCountName)] = gpuQty
+		return true, nil
 	}
-	klog.Infoln("MutateAdmission result", ok)
-	return ok, nil
+
+	return false, nil
 }
 
 func (dev *AMDDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -71,7 +71,7 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "requests only (limits empty) -> false",
+			name: "requests only (limits empty) -> true and syncs limits",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -79,7 +79,7 @@ func Test_MutateAdmission(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "rejects zero core percentage",
@@ -118,6 +118,101 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "rejects zero gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(0, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects negative gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(-1, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects fractional gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": resource.MustParse("1.5"),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "rejects overflow gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(math.MaxInt32+1, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "accepts max int32 gpu count",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(math.MaxInt32, resource.DecimalSI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "rejects invalid core percentage in memory-only container",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu-mem":      *resource.NewQuantity(1024, resource.DecimalSI),
+						"amd.com/gpu-core-pct": *resource.NewQuantity(105, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "must be an integer percentage between 1 and 100",
+		},
+		{
+			name: "gpu memory in limits with existing request -> preserves request and syncs limits",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu-mem": *resource.NewQuantity(1024, resource.DecimalSI),
+					},
+					Requests: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(5, resource.DecimalSI),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "conflicting count in limits and requests",
+			ctr: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+					Requests: corev1.ResourceList{
+						"amd.com/gpu": *resource.NewQuantity(5, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: "conflicting amd.com/gpu request",
+		},
+		{
 			name: "no resources",
 			ctr: &corev1.Container{
 				Resources: corev1.ResourceRequirements{
@@ -142,6 +237,30 @@ func Test_MutateAdmission(t *testing.T) {
 			}
 			assert.NilError(t, err)
 			assert.Equal(t, tt.want, got)
+			if got && (tt.name == "gpu memory in limits" || tt.name == "core percentage in limits") {
+				limitQty, ok := tt.ctr.Resources.Limits["amd.com/gpu"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, limitQty.Value(), int64(1))
+
+				reqQty, ok := tt.ctr.Resources.Requests["amd.com/gpu"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, reqQty.Value(), int64(1))
+
+				req := dev.GenerateResourceRequests(tt.ctr)
+				assert.Equal(t, req.Nums, int32(1))
+			}
+			if got && tt.name == "gpu memory in limits with existing request -> preserves request and syncs limits" {
+				limitQty, ok := tt.ctr.Resources.Limits["amd.com/gpu"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, limitQty.Value(), int64(5))
+
+				reqQty, ok := tt.ctr.Resources.Requests["amd.com/gpu"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, reqQty.Value(), int64(5))
+
+				req := dev.GenerateResourceRequests(tt.ctr)
+				assert.Equal(t, req.Nums, int32(5))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a GPU quota and scheduling bypass vulnerability in the AMD device backend (`pkg/device/amd/device.go`):

1. **Validation of GPU Count (`amd.com/gpu`)**: `MutateAdmission` now validates that `amd.com/gpu` is a positive integer between 1 and `math.MaxInt32`. Invalid counts (e.g. `0`, `-1`, or decimals) are rejected during admission instead of bypassing scheduling.
2. **Default Count Injection for Memory/Core-Only Requests**: When a container requests `amd.com/gpu-mem` or `amd.com/gpu-core-pct` without `amd.com/gpu`, `MutateAdmission` defaults `ctr.Resources.Limits["amd.com/gpu"] = 1`. This ensures `GenerateResourceRequests` computes `Nums: 1`, guaranteeing the pod is tracked against GPU quotas, scored by the scheduler extender, and allocated a device.
3. **Unit Tests Added**: Added test cases in `pkg/device/amd/device_test.go` covering invalid GPU count rejection and default count mutation for memory/core-only containers.

**Which issue(s) this PR fixes**:
Fixes #2679

**Special notes for your reviewer**:
- Per `CONTRIBUTING.md`, AI assistance was used for initial codebase exploration and generating test boilerplate.
- All functional changes are scoped strictly to `pkg/device/amd/`.

**Does this PR introduce a user-facing change?**:

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AMD GPU and Hygon DCU counts now require valid positive whole numbers within supported limits.
  - Conflicting resource counts between requests and limits are rejected.
  - Specified counts are synchronized across requests and limits when only one is provided.
  - Memory- or core-only requests now receive a default device count of one.
  - AMD core percentages must be between 1% and 100%.
  - Invalid device requests are rejected with clearer validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->