### PR TITLE
fix(device/hygon): validate DCU count and default DCU count to 1 for memory/core-only requests

### DIFF
--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -92,8 +92,67 @@ func ParseConfig(fs *flag.FlagSet) {
 }
 
 func (dev *DCUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
-	_, ok := ctr.Resources.Limits[corev1.ResourceName(HygonResourceCount)]
-	return ok, nil
+	count, countRequested := ctr.Resources.Limits[corev1.ResourceName(HygonResourceCount)]
+	reqCount, reqRequested := ctr.Resources.Requests[corev1.ResourceName(HygonResourceCount)]
+
+	if countRequested || reqRequested {
+		if countRequested {
+			n, isInt := count.AsInt64()
+			if !isInt || n <= 0 || n > math.MaxInt32 {
+				return false, fmt.Errorf("%s must be a positive integer between 1 and %d", HygonResourceCount, math.MaxInt32)
+			}
+		}
+		if reqRequested {
+			n, isInt := reqCount.AsInt64()
+			if !isInt || n <= 0 || n > math.MaxInt32 {
+				return false, fmt.Errorf("%s must be a positive integer between 1 and %d", HygonResourceCount, math.MaxInt32)
+			}
+		}
+		if countRequested && reqRequested {
+			limitN, _ := count.AsInt64()
+			reqN, _ := reqCount.AsInt64()
+			if limitN != reqN {
+				return false, fmt.Errorf("conflicting %s request (%d) and limit (%d)", HygonResourceCount, reqN, limitN)
+			}
+		}
+		if !countRequested && reqRequested {
+			if ctr.Resources.Limits == nil {
+				ctr.Resources.Limits = corev1.ResourceList{}
+			}
+			ctr.Resources.Limits[corev1.ResourceName(HygonResourceCount)] = reqCount
+		} else if countRequested && !reqRequested {
+			if ctr.Resources.Requests == nil {
+				ctr.Resources.Requests = corev1.ResourceList{}
+			}
+			ctr.Resources.Requests[corev1.ResourceName(HygonResourceCount)] = count
+		}
+		return true, nil
+	}
+
+	_, memRequested := ctr.Resources.Limits[corev1.ResourceName(HygonResourceMemory)]
+	if !memRequested {
+		_, memRequested = ctr.Resources.Requests[corev1.ResourceName(HygonResourceMemory)]
+	}
+	_, coreRequested := ctr.Resources.Limits[corev1.ResourceName(HygonResourceCores)]
+	if !coreRequested {
+		_, coreRequested = ctr.Resources.Requests[corev1.ResourceName(HygonResourceCores)]
+	}
+
+	if memRequested || coreRequested {
+		gpuQty := *resource.NewQuantity(1, resource.DecimalSI)
+		if ctr.Resources.Limits == nil {
+			ctr.Resources.Limits = corev1.ResourceList{}
+		}
+		ctr.Resources.Limits[corev1.ResourceName(HygonResourceCount)] = gpuQty
+
+		if ctr.Resources.Requests == nil {
+			ctr.Resources.Requests = corev1.ResourceList{}
+		}
+		ctr.Resources.Requests[corev1.ResourceName(HygonResourceCount)] = gpuQty
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func checkDCUtype(annos map[string]string, cardtype string) bool {

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -69,15 +69,173 @@ func Test_MutateAdmission(t *testing.T) {
 			want: true,
 			err:  nil,
 		},
+		{
+			name: "dcu memory in limits -> synthesizes count in limits and requests",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcumem": resource.MustParse("1024"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: true,
+			err:  nil,
+		},
+		{
+			name: "requests only (limits empty) -> true and syncs limits",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("1"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: true,
+			err:  nil,
+		},
+		{
+			name: "rejects zero dcu count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("0"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: false,
+			err:  fmt.Errorf("hygon.com/dcunum must be a positive integer between 1 and 2147483647"),
+		},
+		{
+			name: "rejects negative dcu count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("-1"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: false,
+			err:  fmt.Errorf("hygon.com/dcunum must be a positive integer between 1 and 2147483647"),
+		},
+		{
+			name: "rejects fractional dcu count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("1.5"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: false,
+			err:  fmt.Errorf("hygon.com/dcunum must be a positive integer between 1 and 2147483647"),
+		},
+		{
+			name: "rejects overflow dcu count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": *resource.NewQuantity(math.MaxInt32+1, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: false,
+			err:  fmt.Errorf("hygon.com/dcunum must be a positive integer between 1 and 2147483647"),
+		},
+		{
+			name: "accepts max int32 dcu count",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": *resource.NewQuantity(math.MaxInt32, resource.DecimalSI),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: true,
+			err:  nil,
+		},
+		{
+			name: "conflicting count in limits and requests",
+			args: struct {
+				ctr *corev1.Container
+				p   *corev1.Pod
+			}{
+				ctr: &corev1.Container{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("1"),
+						},
+						Requests: corev1.ResourceList{
+							"hygon.com/dcunum": resource.MustParse("5"),
+						},
+					},
+				},
+				p: &corev1.Pod{},
+			},
+			want: false,
+			err:  fmt.Errorf("conflicting hygon.com/dcunum request"),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dev := DCUDevices{}
 			result, err := dev.MutateAdmission(test.args.ctr, test.args.p)
-			if err != test.err {
-				klog.InfoS("set to resource limits failed")
+			if test.err != nil {
+				assert.ErrorContains(t, err, test.err.Error())
+				return
 			}
+			assert.NilError(t, err)
 			assert.Equal(t, result, test.want)
+			if result && test.name == "dcu memory in limits -> synthesizes count in limits and requests" {
+				limitQty, ok := test.args.ctr.Resources.Limits["hygon.com/dcunum"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, limitQty.Value(), int64(1))
+
+				reqQty, ok := test.args.ctr.Resources.Requests["hygon.com/dcunum"]
+				assert.Equal(t, ok, true)
+				assert.Equal(t, reqQty.Value(), int64(1))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a DCU quota and scheduling bypass issue in the Hygon DCU device backend (`pkg/device/hygon/device.go`):

1. **Validation of DCU Count (`hygon.com/dcunum`)**: `MutateAdmission` now validates that `hygon.com/dcunum` is a positive integer between 1 and `math.MaxInt32`. Invalid counts (e.g. `0`, `-1`, or decimals) are rejected during admission.
2. **Synchronized Default Count Injection**: When a container requests `hygon.com/dcumem` or `hygon.com/dcucores` without `hygon.com/dcunum`, `MutateAdmission` defaults `hygon.com/dcunum = 1` in both `Limits` and `Requests` maps. This ensures `GenerateResourceRequests` computes `Nums: 1`, guaranteeing the pod is tracked against DCU quotas, scored by the scheduler extender, and allocated a device.
3. **Unit Tests Added**: Extended `pkg/device/hygon/device_test.go` to test invalid DCU count rejection and default count synthesis across `Limits` and `Requests`.

**Which issue(s) this PR fixes**:

**Special notes for reviewer**:
- Per `CONTRIBUTING.md`, AI assistance was used for initial codebase exploration and generating test boilerplate.
- All functional changes are scoped strictly to `pkg/device/hygon/`.

**Does this PR introduce a user-facing change?**:

NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DCU resource validation for zero, negative, fractional, and conflicting counts.
  * Automatically synchronizes DCU counts between resource requests and limits when only one is provided.
  * Memory-only or core-only requests now default to one DCU.
  * Requests without recognized DCU resources remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->