### PR TITLE
feat: add groundwork for NUMA-aware device refit

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -632,10 +632,12 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 	response := &kubeletdevicepluginv1beta1.PreferredAllocationResponse{}
 
 	var annotatedRequests device.PodSingleDevice
+	var pendingPod *corev1.Pod
 	nodename := os.Getenv(util.NodeNameEnvName)
 	if nodename != "" {
 		current, err := getPendingPod(ctx, nodename)
 		if err == nil && current != nil {
+			pendingPod = current
 			if podRequests, decodeErr := device.DecodePodDevices(device.InRequestDevices, current.Annotations); decodeErr == nil {
 				annotatedRequests = podRequests[nvidia.NvidiaGPUDevice]
 			}
@@ -662,10 +664,39 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 				})
 			} else {
 				klog.Warningf("err: %v", err)
+				plugin.reportAnnotatedDeviceMismatch(pendingPod, idx, err)
 			}
 		}
 	}
 	return response, nil
+}
+
+// errAnnotatedDeviceUnavailable indicates kubelet's available device set
+// contains no replica of a scheduler-annotated GPU, typically because the
+// Topology Manager restricted the allocation to a different NUMA node.
+var errAnnotatedDeviceUnavailable = errors.New("no available slice device found for annotated GPU")
+
+// reportAnnotatedDeviceMismatch surfaces an annotated-GPU mismatch for Pods
+// that opt into NUMA alignment via the hami.io/numa-alignment annotation.
+// Detection only: the preferred allocation response is left unchanged, so
+// kubelet still falls back to its own device selection. The NUMA refit that
+// acts on this condition is tracked in issue #2080.
+func (plugin *NvidiaDevicePlugin) reportAnnotatedDeviceMismatch(pod *corev1.Pod, containerRequest int, err error) {
+	if pod == nil || plugin.operatingMode == nvidia.MigMode || !errors.Is(err, errAnnotatedDeviceUnavailable) {
+		return
+	}
+
+	mode, parseErr := util.GetNumaAlignmentModeByPod(pod)
+	if parseErr != nil {
+		klog.Warningf("ignoring invalid numa-alignment annotation on pod %s/%s: %v", pod.Namespace, pod.Name, parseErr)
+		return
+	}
+	if mode == util.NumaAlignmentNone {
+		return
+	}
+
+	klog.InfoS("scheduler-annotated GPU has no replica in kubelet's available devices; NUMA refit is not implemented yet, so kubelet will select a device on its own",
+		"err", err, "pod", klog.KObj(pod), "containerRequest", containerRequest, "numaAlignment", string(mode))
 }
 
 func (plugin *NvidiaDevicePlugin) selectPreferredDeviceIDsFromAnnotatedDevices(available, required []string, desired device.ContainerDevices, allocationSize int) ([]string, error) {
@@ -699,13 +730,17 @@ func (plugin *NvidiaDevicePlugin) selectPreferredDeviceIDsFromAnnotatedDevices(a
 		}
 		candidates := availableByPhysical[physicalID]
 		if len(candidates) == 0 {
-			return nil, fmt.Errorf("no available slice device found for annotated GPU %s", physicalID)
+			return nil, fmt.Errorf("%w %s", errAnnotatedDeviceUnavailable, physicalID)
 		}
 		selected = append(selected, candidates[0])
 		availableByPhysical[physicalID] = candidates[1:]
 	}
 
 	if len(selected) != allocationSize {
+		// This can also indicate kubelet-vs-scheduler divergence, for
+		// example MustIncludeDeviceIDs carrying replicas of a GPU the
+		// scheduler never annotated. Classifying that case is deferred to
+		// the NUMA refit (issue #2080).
 		return nil, fmt.Errorf("preferred allocation selected %d devices, want %d", len(selected), allocationSize)
 	}
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_numa_alignment_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_numa_alignment_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+const (
+	numaTestGPUA = "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	numaTestGPUB = "GPU-bbbbbbbb-1111-2222-3333-444444444444"
+)
+
+func TestSelectPreferredMismatchErrorIsTyped(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{}
+
+	// The annotated GPU has no replica in kubelet's available set.
+	_, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(
+		[]string{numaTestGPUB + "-0", numaTestGPUB + "-1"},
+		nil,
+		device.ContainerDevices{{UUID: numaTestGPUA, Type: nvidia.NvidiaGPUDevice}},
+		1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errAnnotatedDeviceUnavailable)
+	require.EqualError(t, err, fmt.Sprintf("no available slice device found for annotated GPU %s", numaTestGPUA))
+}
+
+func TestSelectPreferredOtherErrorsAreNotTyped(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{}
+
+	// Fewer annotated devices than the requested allocation size.
+	_, err := plugin.selectPreferredDeviceIDsFromAnnotatedDevices(
+		[]string{numaTestGPUA + "-0"},
+		nil,
+		device.ContainerDevices{{UUID: numaTestGPUA, Type: nvidia.NvidiaGPUDevice}},
+		2)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, errAnnotatedDeviceUnavailable))
+}
+
+func TestGetPreferredAllocationMismatchResponseUnchanged(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		availableIDs  []string
+		wantResponses int
+		wantDeviceIDs []string
+	}{
+		{
+			name:         "without numa-alignment annotation",
+			annotations:  map[string]string{},
+			availableIDs: []string{numaTestGPUB + "-0", numaTestGPUB + "-1"},
+		},
+		{
+			name:         "best-effort",
+			annotations:  map[string]string{util.NumaAlignmentAnnotationKey: "best-effort"},
+			availableIDs: []string{numaTestGPUB + "-0", numaTestGPUB + "-1"},
+		},
+		{
+			name:         "strict is not accepted yet",
+			annotations:  map[string]string{util.NumaAlignmentAnnotationKey: "strict"},
+			availableIDs: []string{numaTestGPUB + "-0", numaTestGPUB + "-1"},
+		},
+		{
+			name:         "invalid value",
+			annotations:  map[string]string{util.NumaAlignmentAnnotationKey: "bogus"},
+			availableIDs: []string{numaTestGPUB + "-0", numaTestGPUB + "-1"},
+		},
+		{
+			// Positive control: with the annotated GPU's replica available
+			// the same harness returns a preferred response, proving the
+			// mismatch cases above exercise the selection path rather than
+			// passing vacuously.
+			name:          "annotated GPU available returns preferred devices",
+			annotations:   map[string]string{util.NumaAlignmentAnnotationKey: "best-effort"},
+			availableIDs:  []string{numaTestGPUA + "-0", numaTestGPUB + "-0"},
+			wantResponses: 1,
+			wantDeviceIDs: []string{numaTestGPUA + "-0"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupInRequestDevices(t)
+
+			annotations := map[string]string{
+				"hami.io/vgpu-devices-to-allocate": device.EncodePodSingleDevice(device.PodSingleDevice{
+					device.ContainerDevices{{UUID: numaTestGPUA, Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+				}),
+			}
+			for key, value := range test.annotations {
+				annotations[key] = value
+			}
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:        "numa-pod",
+				Namespace:   "default",
+				Annotations: annotations,
+			}}
+
+			t.Setenv(util.NodeNameEnvName, "node-a")
+			mockAllocateGlobals(t, pod)
+
+			plugin := &NvidiaDevicePlugin{}
+			response, err := plugin.GetPreferredAllocation(context.Background(), &kubeletdevicepluginv1beta1.PreferredAllocationRequest{
+				ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerPreferredAllocationRequest{{
+					AvailableDeviceIDs: test.availableIDs,
+					AllocationSize:     1,
+				}},
+			})
+
+			// Detection must not change the response: on a mismatch no
+			// preferred devices are returned and no error is propagated to
+			// kubelet, exactly as before this feature.
+			require.NoError(t, err)
+			require.Len(t, response.ContainerResponses, test.wantResponses)
+			if test.wantResponses > 0 {
+				require.ElementsMatch(t, test.wantDeviceIDs, response.ContainerResponses[0].DeviceIDs)
+			}
+		})
+	}
+}
+
+func TestReportAnnotatedDeviceMismatch(t *testing.T) {
+	mismatch := fmt.Errorf("%w %s", errAnnotatedDeviceUnavailable, numaTestGPUA)
+	podWithMode := func(mode string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:        "numa-pod",
+			Namespace:   "default",
+			Annotations: map[string]string{util.NumaAlignmentAnnotationKey: mode},
+		}}
+	}
+	const mismatchMessage = "scheduler-annotated GPU has no replica in kubelet's available devices"
+
+	tests := []struct {
+		name          string
+		plugin        *NvidiaDevicePlugin
+		pod           *corev1.Pod
+		err           error
+		wantLogged    string
+		wantPrefix    string
+		wantFields    []string
+		wantNoLogging bool
+	}{
+		{
+			name:          "nil pod is silent",
+			plugin:        &NvidiaDevicePlugin{},
+			pod:           nil,
+			err:           mismatch,
+			wantNoLogging: true,
+		},
+		{
+			name:          "mig mode is silent",
+			plugin:        &NvidiaDevicePlugin{operatingMode: nvidia.MigMode},
+			pod:           podWithMode("best-effort"),
+			err:           mismatch,
+			wantNoLogging: true,
+		},
+		{
+			name:          "unrelated error is silent",
+			plugin:        &NvidiaDevicePlugin{},
+			pod:           podWithMode("best-effort"),
+			err:           errors.New("unrelated"),
+			wantNoLogging: true,
+		},
+		{
+			name:          "pod without the annotation is silent",
+			plugin:        &NvidiaDevicePlugin{},
+			pod:           &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "plain-pod", Namespace: "default"}},
+			err:           mismatch,
+			wantNoLogging: true,
+		},
+		{
+			name:       "invalid annotation is warned about",
+			plugin:     &NvidiaDevicePlugin{},
+			pod:        podWithMode("bogus"),
+			err:        mismatch,
+			wantLogged: "ignoring invalid numa-alignment annotation",
+		},
+		{
+			name:       "best-effort mismatch is reported at info severity",
+			plugin:     &NvidiaDevicePlugin{},
+			pod:        podWithMode("best-effort"),
+			err:        mismatch,
+			wantLogged: mismatchMessage,
+			wantPrefix: "I",
+			wantFields: []string{`numaAlignment="best-effort"`, "default/numa-pod", "containerRequest=0"},
+		},
+		{
+			name:       "strict warns as invalid until the refit lands",
+			plugin:     &NvidiaDevicePlugin{},
+			pod:        podWithMode("strict"),
+			err:        mismatch,
+			wantLogged: "ignoring invalid numa-alignment annotation",
+			wantPrefix: "W",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			klog.SetOutput(&buf)
+			klog.LogToStderr(false)
+			defer func() {
+				klog.SetOutput(os.Stderr)
+				klog.LogToStderr(true)
+			}()
+
+			test.plugin.reportAnnotatedDeviceMismatch(test.pod, 0, test.err)
+			klog.Flush()
+
+			logged := buf.String()
+			if test.wantNoLogging {
+				// Unrelated goroutines may log concurrently; assert only
+				// that OUR messages are absent.
+				require.NotContains(t, logged, mismatchMessage)
+				require.NotContains(t, logged, "numa-alignment annotation")
+				return
+			}
+			require.Contains(t, logged, test.wantLogged)
+			if test.wantPrefix != "" {
+				var matched string
+				for _, line := range strings.Split(logged, "\n") {
+					if strings.Contains(line, test.wantLogged) {
+						matched = line
+						break
+					}
+				}
+				require.True(t, strings.HasPrefix(matched, test.wantPrefix),
+					"expected severity %q, got line %q", test.wantPrefix, matched)
+			}
+			for _, field := range test.wantFields {
+				require.Contains(t, logged, field)
+			}
+		})
+	}
+}

--- a/pkg/device/numa_refit.go
+++ b/pkg/device/numa_refit.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+// NumaRefitRequest asks the scheduler to re-run its normal fit for one
+// container of an already-bound Pod, restricted to the physical devices whose
+// replicas kubelet's Topology Manager left in the allocation's available set.
+// The device plugin sends it when the scheduler-annotated device has no
+// replica in that set. See the NUMA alignment design discussion in issue
+// Project-HAMi/HAMi#2080.
+type NumaRefitRequest struct {
+	// PodUID guards against reusing a stale Pod object of the same name.
+	PodUID       string `json:"podUID"`
+	PodNamespace string `json:"podNamespace"`
+	PodName      string `json:"podName"`
+	NodeName     string `json:"nodeName"`
+	// ContainerIndex is the Pod container position the refit applies to,
+	// counting init containers first, matching PodDevices ordering. Senders
+	// must derive it from the Pod's current to-allocate annotation state,
+	// not from kubelet request positions, which shift as annotation entries
+	// are consumed during allocation.
+	ContainerIndex int `json:"containerIndex"`
+	// ContainerName optionally names the container at ContainerIndex so the
+	// scheduler can cross-check the index against the Pod spec and refuse a
+	// mismatched request.
+	ContainerName string `json:"containerName,omitempty"`
+	// DeviceType is the device vendor type the refit applies to, for
+	// example "NVIDIA".
+	DeviceType string `json:"deviceType"`
+	// AllowedDeviceUUIDs lists the physical device IDs kubelet can still
+	// satisfy the allocation from. The refit must select among these only.
+	AllowedDeviceUUIDs []string `json:"allowedDeviceUUIDs"`
+}
+
+// NumaRefitResponse carries the scheduler's decision for a NumaRefitRequest.
+// Failures are reported in-band, mirroring the /filter and /bind routes.
+type NumaRefitResponse struct {
+	Succeeded bool `json:"succeeded"`
+	// ContainerDevices holds the reselected devices for the container in
+	// EncodeContainerDevices format when Succeeded is true. The format does
+	// not carry CustomInfo, so MIG selections are out of scope until MIG
+	// support gets its own design, matching the hami-core-first scoping in
+	// issue #2080.
+	ContainerDevices string `json:"containerDevices,omitempty"`
+	// FailureReason explains why the refit was refused, for example no
+	// allowed device having enough memory or cores.
+	FailureReason string `json:"failureReason,omitempty"`
+}

--- a/pkg/device/numa_refit_test.go
+++ b/pkg/device/numa_refit_test.go
@@ -30,6 +30,7 @@ func TestNumaRefitRequestJSONRoundTrip(t *testing.T) {
 		PodName:            "numa-pod",
 		NodeName:           "node-1",
 		ContainerIndex:     1,
+		ContainerName:      "main",
 		DeviceType:         "NVIDIA",
 		AllowedDeviceUUIDs: []string{"GPU-aaaa", "GPU-bbbb"},
 	}
@@ -43,15 +44,16 @@ func TestNumaRefitRequestJSONRoundTrip(t *testing.T) {
 }
 
 func TestNumaRefitRequestJSONFieldNames(t *testing.T) {
-	raw, err := json.Marshal(NumaRefitRequest{})
+	raw, err := json.Marshal(NumaRefitRequest{ContainerName: "main"})
 	assert.NilError(t, err)
 
 	var fields map[string]any
 	assert.NilError(t, json.Unmarshal(raw, &fields))
-	for _, key := range []string{"podUID", "podNamespace", "podName", "nodeName", "containerIndex", "deviceType", "allowedDeviceUUIDs"} {
+	for _, key := range []string{"podUID", "podNamespace", "podName", "nodeName", "containerIndex", "containerName", "deviceType", "allowedDeviceUUIDs"} {
 		_, ok := fields[key]
 		assert.Assert(t, ok, "missing wire field %q", key)
 	}
+	assert.Equal(t, fields["containerName"], "main")
 }
 
 func TestNumaRefitResponseCarriesEncodedContainerDevices(t *testing.T) {

--- a/pkg/device/numa_refit_test.go
+++ b/pkg/device/numa_refit_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNumaRefitRequestJSONRoundTrip(t *testing.T) {
+	request := NumaRefitRequest{
+		PodUID:             "8a7e2f31-1a67-4d7b-8f1e-3a2b1c4d5e6f",
+		PodNamespace:       "default",
+		PodName:            "numa-pod",
+		NodeName:           "node-1",
+		ContainerIndex:     1,
+		DeviceType:         "NVIDIA",
+		AllowedDeviceUUIDs: []string{"GPU-aaaa", "GPU-bbbb"},
+	}
+
+	raw, err := json.Marshal(request)
+	assert.NilError(t, err)
+
+	var decoded NumaRefitRequest
+	assert.NilError(t, json.Unmarshal(raw, &decoded))
+	assert.DeepEqual(t, decoded, request)
+}
+
+func TestNumaRefitRequestJSONFieldNames(t *testing.T) {
+	raw, err := json.Marshal(NumaRefitRequest{})
+	assert.NilError(t, err)
+
+	var fields map[string]any
+	assert.NilError(t, json.Unmarshal(raw, &fields))
+	for _, key := range []string{"podUID", "podNamespace", "podName", "nodeName", "containerIndex", "deviceType", "allowedDeviceUUIDs"} {
+		_, ok := fields[key]
+		assert.Assert(t, ok, "missing wire field %q", key)
+	}
+}
+
+func TestNumaRefitResponseCarriesEncodedContainerDevices(t *testing.T) {
+	devices := ContainerDevices{
+		{UUID: "GPU-aaaa", Type: "NVIDIA", Usedmem: 20000, Usedcores: 30},
+	}
+	response := NumaRefitResponse{
+		Succeeded:        true,
+		ContainerDevices: EncodeContainerDevices(devices),
+	}
+
+	raw, err := json.Marshal(response)
+	assert.NilError(t, err)
+
+	var decoded NumaRefitResponse
+	assert.NilError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, decoded.Succeeded, true)
+
+	roundTripped, err := DecodeContainerDevices(decoded.ContainerDevices)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, roundTripped, devices)
+}
+
+func TestNumaRefitResponseFailureOmitsDevices(t *testing.T) {
+	raw, err := json.Marshal(NumaRefitResponse{Succeeded: false, FailureReason: "no allowed device fits"})
+	assert.NilError(t, err)
+
+	var fields map[string]any
+	assert.NilError(t, json.Unmarshal(raw, &fields))
+	_, hasDevices := fields["containerDevices"]
+	assert.Assert(t, !hasDevices)
+	assert.Equal(t, fields["failureReason"], "no allowed device fits")
+}

--- a/pkg/scheduler/numa_refit.go
+++ b/pkg/scheduler/numa_refit.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// AllowedSetUnmatched reports that a restricted fit found no device of the
+// requested type in the allowed set, distinguishing an ID mismatch (for
+// example replica IDs sent instead of physical UUIDs) from real capacity
+// exhaustion.
+const AllowedSetUnmatched = "AllowedDeviceSetUnmatched"
+
+// restrictNodeUsage returns a copy of node whose devices of deviceType are
+// limited to the physical device IDs in allowedUUIDs. Devices of other types
+// are kept, so requests spanning several vendors keep fitting. Policy,
+// NumaBind, and per-device usage are preserved, so the policy-chain sort and
+// Fit observe the restricted set exactly as they would a smaller node. Node
+// and NodeInfo are shared because the fit never mutates them; each surviving
+// device is deep-copied so usage accounting cannot touch the original.
+// Unknown IDs are ignored. node must be non-nil, as in fitInDevices.
+func restrictNodeUsage(node *NodeUsage, deviceType string, allowedUUIDs []string) *NodeUsage {
+	allowed := make(map[string]struct{}, len(allowedUUIDs))
+	for _, id := range allowedUUIDs {
+		allowed[id] = struct{}{}
+	}
+
+	restricted := &NodeUsage{
+		Node:     node.Node,
+		NodeInfo: node.NodeInfo,
+		Devices: policy.DeviceUsageList{
+			Policy:   node.Devices.Policy,
+			NumaBind: node.Devices.NumaBind,
+		},
+	}
+	for _, deviceList := range node.Devices.DeviceLists {
+		if deviceList == nil || deviceList.Device == nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(deviceList.Device.Type), strings.ToLower(deviceType)) {
+			if _, ok := allowed[deviceList.Device.ID]; !ok {
+				continue
+			}
+		}
+		restricted.Devices.DeviceLists = append(restricted.Devices.DeviceLists,
+			&policy.DeviceListsScore{Device: deviceList.Device.DeepCopy(), Score: deviceList.Score})
+	}
+	return restricted
+}
+
+// fitInRestrictedDevices runs the standard policy-chain fit for the
+// deviceType requests with candidates limited to the allowed physical
+// devices, preserving binpack, spread, mutex, and numa ordering. It backs
+// the NUMA alignment refit (issue #2080): when kubelet's Topology Manager
+// restricts an allocation to replicas of devices the scheduler did not pick,
+// the refit re-runs the same fit over kubelet's set instead of adopting
+// kubelet's choice unchecked. Requests of other device types are ignored so
+// a single-type refit cannot silently reselect unrelated vendors' devices.
+// It fails with AllowedSetUnmatched when no device of deviceType on the node
+// is in the allowed set.
+//
+// Contract for the production caller (the refit endpoint):
+//   - node must come fresh from buildNodeUsage/getNodesUsage built with this
+//     pod, so Policy and NumaBind reflect the pod's own scheduling
+//     annotations; the sort reads them from node.Devices while Fit reads the
+//     pod annotations directly, and they must agree.
+//   - nodeInfo must be the node's populated NodeInfo when the pod selects
+//     the topology-aware policy, which reads GPU pair scores from it.
+//   - This helper only computes a placement on a restricted copy; the
+//     caller must hold the scheduler's allocation lock across snapshot, fit,
+//     annotation patch, and reservation move, and release the pod's own
+//     usage from the snapshot before fitting.
+//
+// The selected devices are appended to devinput.
+func fitInRestrictedDevices(node *NodeUsage, requests device.ContainerDeviceRequests, deviceType string, allowedUUIDs []string, pod *corev1.Pod, nodeInfo *device.NodeInfo, devinput *device.PodDevices, weights util.DeviceScoringWeights) (bool, string) {
+	typeRequests := device.ContainerDeviceRequests{}
+	for key, request := range requests {
+		if request.Type == deviceType {
+			typeRequests[key] = request
+		}
+	}
+	if len(typeRequests) == 0 {
+		return false, "no " + deviceType + " request to refit"
+	}
+
+	restricted := restrictNodeUsage(node, deviceType, allowedUUIDs)
+	if len(getNodeResources(*restricted, deviceType)) == 0 {
+		return false, AllowedSetUnmatched
+	}
+	return fitInDevices(restricted, typeRequests, pod, nodeInfo, devinput, weights)
+}

--- a/pkg/scheduler/numa_refit_test.go
+++ b/pkg/scheduler/numa_refit_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+func refitTestNode(policyName string, numaBind bool, devices ...*device.DeviceUsage) *NodeUsage {
+	lists := make([]*policy.DeviceListsScore, 0, len(devices))
+	for _, d := range devices {
+		lists = append(lists, &policy.DeviceListsScore{Device: d})
+	}
+	return &NodeUsage{
+		Node:    &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		Devices: policy.DeviceUsageList{Policy: policyName, NumaBind: numaBind, DeviceLists: lists},
+	}
+}
+
+func refitTestPod(annotations map[string]string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:        "refit-pod",
+		Namespace:   "default",
+		Annotations: annotations,
+	}}
+}
+
+func refitTestRequest(nums, memreq, coresreq int32) device.ContainerDeviceRequests {
+	return device.ContainerDeviceRequests{
+		nvidia.NvidiaGPUDevice: device.ContainerDeviceRequest{
+			Nums:     nums,
+			Type:     nvidia.NvidiaGPUDevice,
+			Memreq:   memreq,
+			Coresreq: coresreq,
+		},
+	}
+}
+
+func selectedUUIDs(devinput device.PodDevices) []string {
+	uuids := []string{}
+	for _, containers := range devinput {
+		for _, containerDevices := range containers {
+			for _, d := range containerDevices {
+				uuids = append(uuids, d.UUID)
+			}
+		}
+	}
+	return uuids
+}
+
+func TestRestrictNodeUsagePreservesPolicyAndOriginal(t *testing.T) {
+	deviceA := makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 3, 10, 40000, 30000, 30, 100)
+	deviceB := makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100)
+	deviceC := makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100)
+	node := refitTestNode("binpack", true, deviceA, deviceB, deviceC)
+
+	restricted := restrictNodeUsage(node, nvidia.NvidiaGPUDevice, []string{"GPU-b", "GPU-c", "GPU-unknown"})
+
+	assert.Equal(t, len(restricted.Devices.DeviceLists), 2)
+	assert.Equal(t, restricted.Devices.DeviceLists[0].Device.ID, "GPU-b")
+	assert.Equal(t, restricted.Devices.DeviceLists[1].Device.ID, "GPU-c")
+	assert.Equal(t, restricted.Devices.Policy, "binpack")
+	assert.Equal(t, restricted.Devices.NumaBind, true)
+
+	// The original node keeps its full device list and is not aliased.
+	assert.Equal(t, len(node.Devices.DeviceLists), 3)
+	restricted.Devices.DeviceLists[0].Device.Used = 99
+	assert.Equal(t, deviceB.Used, int32(2))
+}
+
+func TestRestrictNodeUsageEmptyAllowedSet(t *testing.T) {
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100))
+
+	restricted := restrictNodeUsage(node, nvidia.NvidiaGPUDevice, nil)
+	assert.Equal(t, len(restricted.Devices.DeviceLists), 0)
+}
+
+func TestFitInRestrictedDevicesMatchesFitOnSmallerNode(t *testing.T) {
+	build := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 3, 10, 40000, 30000, 30, 100),
+			makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100),
+			makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100),
+		}
+	}
+	allowed := []string{"GPU-b", "GPU-c"}
+
+	for _, policyName := range []string{"binpack", "spread", "binpack,numa", "spread,numa"} {
+		t.Run(policyName, func(t *testing.T) {
+			restrictedInput := device.PodDevices{}
+			fit, reason := fitInRestrictedDevices(
+				refitTestNode(policyName, false, build()...),
+				refitTestRequest(1, 4096, 10), nvidia.NvidiaGPUDevice, allowed,
+				refitTestPod(nil), &device.NodeInfo{}, &restrictedInput,
+				util.DefaultDeviceScoringWeights())
+			assert.Assert(t, fit, "restricted fit failed: %s", reason)
+
+			smallerNodeInput := device.PodDevices{}
+			devices := build()
+			smallerFit, smallerReason := fitInDevices(
+				refitTestNode(policyName, false, devices[1], devices[2]),
+				refitTestRequest(1, 4096, 10),
+				refitTestPod(nil), &device.NodeInfo{}, &smallerNodeInput,
+				util.DefaultDeviceScoringWeights())
+			assert.Assert(t, smallerFit, "smaller-node fit failed: %s", smallerReason)
+
+			assert.DeepEqual(t, selectedUUIDs(restrictedInput), selectedUUIDs(smallerNodeInput))
+		})
+	}
+}
+
+func TestFitInRestrictedDevicesHonorsPolicyOrdering(t *testing.T) {
+	build := func() *NodeUsage {
+		return refitTestNode("binpack", false,
+			makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 3, 10, 40000, 30000, 30, 100),
+			makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100),
+			makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100))
+	}
+
+	// Unrestricted binpack prefers the most utilized device that fits.
+	unrestrictedInput := device.PodDevices{}
+	fit, reason := fitInDevices(build(), refitTestRequest(1, 4096, 10),
+		refitTestPod(nil), &device.NodeInfo{}, &unrestrictedInput,
+		util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "unrestricted fit failed: %s", reason)
+	assert.DeepEqual(t, selectedUUIDs(unrestrictedInput), []string{"GPU-a"})
+
+	// Restricted to the other two devices, binpack still applies among them.
+	restrictedInput := device.PodDevices{}
+	fit, reason = fitInRestrictedDevices(build(), refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-b", "GPU-c"},
+		refitTestPod(nil), &device.NodeInfo{}, &restrictedInput,
+		util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "restricted fit failed: %s", reason)
+	assert.DeepEqual(t, selectedUUIDs(restrictedInput), []string{"GPU-b"})
+}
+
+func TestFitInRestrictedDevicesMultiGPUWithoutNumaBind(t *testing.T) {
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 3, 10, 40000, 30000, 30, 100),
+		makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100),
+		makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100))
+
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(node, refitTestRequest(2, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-b", "GPU-c"},
+		refitTestPod(nil), &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+
+	assert.Assert(t, fit, "multi-GPU restricted fit failed: %s", reason)
+	uuids := selectedUUIDs(devinput)
+	assert.Equal(t, len(uuids), 2)
+	for _, id := range uuids {
+		assert.Assert(t, id == "GPU-b" || id == "GPU-c", "device %s is outside the allowed set", id)
+	}
+}
+
+func TestFitInRestrictedDevicesNoOpWhenPickAllowed(t *testing.T) {
+	build := func() *NodeUsage {
+		return refitTestNode("binpack", false,
+			makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 3, 10, 40000, 30000, 30, 100),
+			makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100),
+			makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100))
+	}
+
+	unrestrictedInput := device.PodDevices{}
+	fit, reason := fitInDevices(build(), refitTestRequest(1, 4096, 10),
+		refitTestPod(nil), &device.NodeInfo{}, &unrestrictedInput,
+		util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "unrestricted fit failed: %s", reason)
+
+	// Allowing every device makes the restricted fit a no-op: it must pick
+	// exactly what the unrestricted fit picks.
+	restrictedInput := device.PodDevices{}
+	fit, reason = fitInRestrictedDevices(build(), refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a", "GPU-b", "GPU-c"},
+		refitTestPod(nil), &device.NodeInfo{}, &restrictedInput,
+		util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "superset restricted fit failed: %s", reason)
+
+	assert.DeepEqual(t, selectedUUIDs(restrictedInput), selectedUUIDs(unrestrictedInput))
+}
+
+func TestFitInRestrictedDevicesEnforcesCapacity(t *testing.T) {
+	// GPU-a would fit but is not allowed; the allowed GPU-b lacks memory.
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+		makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 9, 10, 8192, 8000, 20, 100))
+
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(node, refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-b"},
+		refitTestPod(nil), &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardInsufficientMemory),
+		"reason %q should mention %s", reason, common.CardInsufficientMemory)
+}
+
+func TestFitInRestrictedDevicesEmptyAllowedSet(t *testing.T) {
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100))
+
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(node, refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, nil, refitTestPod(nil), &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+
+	assert.Equal(t, fit, false)
+	assert.Equal(t, reason, AllowedSetUnmatched)
+}
+
+func TestRestrictNodeUsageKeepsOtherDeviceTypes(t *testing.T) {
+	otherDevice := makeDevice("OTHER-a", 0, "SomeOtherVendor", 0, 10, 40000, 0, 0, 100)
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+		makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+		otherDevice)
+
+	restricted := restrictNodeUsage(node, nvidia.NvidiaGPUDevice, []string{"GPU-b"})
+
+	// Only the NVIDIA list is restricted; the other vendor's device stays.
+	assert.Equal(t, len(restricted.Devices.DeviceLists), 2)
+	assert.Equal(t, restricted.Devices.DeviceLists[0].Device.ID, "GPU-b")
+	assert.Equal(t, restricted.Devices.DeviceLists[1].Device.ID, "OTHER-a")
+}
+
+func TestFitInRestrictedDevicesUnmatchedAllowedSet(t *testing.T) {
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100))
+
+	// Replica-style IDs instead of physical UUIDs must fail loudly instead
+	// of reading as capacity exhaustion.
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(node, refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a-0", "GPU-a-1"},
+		refitTestPod(nil), &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+
+	assert.Equal(t, fit, false)
+	assert.Equal(t, reason, AllowedSetUnmatched)
+}
+
+func TestFitInRestrictedDevicesIgnoresOtherTypeRequests(t *testing.T) {
+	node := refitTestNode("binpack", false,
+		makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100))
+
+	requests := device.ContainerDeviceRequests{
+		"OtherVendor": device.ContainerDeviceRequest{Nums: 1, Type: "OtherVendor", Memreq: 100},
+	}
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(node, requests, nvidia.NvidiaGPUDevice,
+		[]string{"GPU-a"}, refitTestPod(nil), &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+
+	// A single-type refit must not silently fit unrelated vendors' requests.
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, "request to refit"), "reason: %s", reason)
+	assert.Equal(t, len(devinput), 0)
+}
+
+func TestFitInRestrictedDevicesUsesPodPolicyAnnotation(t *testing.T) {
+	nodeInfo := &device.NodeInfo{
+		ID: "node-1", Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		Devices: map[string][]device.DeviceInfo{nvidia.NvidiaGPUDevice: {
+			{ID: "GPU-a", Count: 10, Devmem: 40000, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
+			{ID: "GPU-b", Count: 10, Devmem: 40000, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
+			{ID: "GPU-c", Count: 10, Devmem: 40000, Devcore: 100, Numa: 1, Type: nvidia.NvidiaGPUDevice, Health: true},
+		}},
+	}
+	usedByID := map[string]int32{"GPU-a": 3, "GPU-b": 2, "GPU-c": 1}
+
+	run := func(policy string) []string {
+		pod := refitTestPod(map[string]string{util.GPUSchedulerPolicyAnnotationKey: policy})
+		// The production caller must hand fitInRestrictedDevices a NodeUsage
+		// freshly built for this pod, so its policy annotation is inherited.
+		node := buildNodeUsage(nodeInfo, pod)
+		for _, deviceList := range node.Devices.DeviceLists {
+			used := usedByID[deviceList.Device.ID]
+			deviceList.Device.Used = used
+			deviceList.Device.Usedmem = used * 10000
+			deviceList.Device.Usedcores = used * 10
+		}
+		devinput := device.PodDevices{}
+		fit, reason := fitInRestrictedDevices(node, refitTestRequest(1, 4096, 10),
+			nvidia.NvidiaGPUDevice, []string{"GPU-b", "GPU-c"},
+			pod, &device.NodeInfo{}, &devinput, util.DefaultDeviceScoringWeights())
+		assert.Assert(t, fit, "fit failed under policy %q: %s", policy, reason)
+		return selectedUUIDs(devinput)
+	}
+
+	assert.DeepEqual(t, run("binpack"), []string{"GPU-b"})
+	assert.DeepEqual(t, run("spread"), []string{"GPU-c"})
+}
+
+func TestFitInRestrictedDevicesMutexPolicy(t *testing.T) {
+	mutexPod := refitTestPod(map[string]string{util.GPUSchedulerPolicyAnnotationKey: "mutex"})
+	build := func() *NodeUsage {
+		return refitTestNode("mutex", false,
+			makeDevice("GPU-a", 0, nvidia.NvidiaGPUDevice, 1, 10, 40000, 10000, 10, 100),
+			makeDevice("GPU-b", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+			makeDevice("GPU-c", 1, nvidia.NvidiaGPUDevice, 2, 10, 40000, 20000, 20, 100))
+	}
+
+	// Mutex only allocates idle GPUs: the busy allowed device is skipped.
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(build(), refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a", "GPU-b"},
+		mutexPod, &device.NodeInfo{}, &devinput, util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "mutex restricted fit failed: %s", reason)
+	assert.DeepEqual(t, selectedUUIDs(devinput), []string{"GPU-b"})
+
+	// When every allowed device is busy, mutex refuses the refit.
+	busyInput := device.PodDevices{}
+	fit, reason = fitInRestrictedDevices(build(), refitTestRequest(1, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a", "GPU-c"},
+		mutexPod, &device.NodeInfo{}, &busyInput, util.DefaultDeviceScoringWeights())
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.ExclusiveDeviceAllocateConflict), "reason: %s", reason)
+}
+
+func TestFitInRestrictedDevicesKeepsNumaBind(t *testing.T) {
+	numaBindPod := refitTestPod(map[string]string{nvidia.NumaBind: "true"})
+	build := func() *NodeUsage {
+		return refitTestNode("binpack", true,
+			makeDevice("GPU-a0", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+			makeDevice("GPU-b0", 0, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+			makeDevice("GPU-c1", 1, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100),
+			makeDevice("GPU-d1", 1, nvidia.NvidiaGPUDevice, 0, 10, 40000, 0, 0, 100))
+	}
+
+	// Both allowed devices share NUMA node 0, so a 2-GPU numa-bind request fits.
+	devinput := device.PodDevices{}
+	fit, reason := fitInRestrictedDevices(build(), refitTestRequest(2, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a0", "GPU-b0"},
+		numaBindPod, &device.NodeInfo{}, &devinput,
+		util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "same-numa restricted fit failed: %s", reason)
+	uuids := selectedUUIDs(devinput)
+	assert.Equal(t, len(uuids), 2)
+	for _, id := range uuids {
+		assert.Assert(t, id == "GPU-a0" || id == "GPU-b0", "unexpected device %s", id)
+	}
+
+	// One allowed device per NUMA node cannot satisfy numa-bind for 2 GPUs.
+	crossNumaInput := device.PodDevices{}
+	fit, _ = fitInRestrictedDevices(build(), refitTestRequest(2, 4096, 10),
+		nvidia.NvidiaGPUDevice, []string{"GPU-a0", "GPU-c1"},
+		numaBindPod, &device.NodeInfo{}, &crossNumaInput,
+		util.DefaultDeviceScoringWeights())
+	assert.Equal(t, fit, false)
+}

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -68,6 +68,12 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.V(3).Infof(template+" - Pod already has different scheduler assigned", req.Namespace, req.Name, req.UID)
 		return admission.Allowed("pod already has different scheduler assigned")
 	}
+	// Reject invalid numa-alignment values at admission, so a typo surfaces
+	// to the user instead of only appearing in a device-plugin log later.
+	if _, err := util.GetNumaAlignmentModeByPod(pod); err != nil {
+		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
+		return admission.Denied(err.Error())
+	}
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"flag"
+	"strings"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -36,6 +37,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device/hygon"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 func TestHandle(t *testing.T) {
@@ -1207,6 +1209,69 @@ func TestFitResourceQuota_SidecarOrdering(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := fitResourceQuota(tc.pod); got != tc.fit {
 				t.Errorf("fitResourceQuota() = %v, want %v", got, tc.fit)
+			}
+		})
+	}
+}
+
+func TestHandleNumaAlignmentAnnotation(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		wantDenied bool
+	}{
+		{name: "best-effort is admitted", value: "best-effort", wantDenied: false},
+		{name: "invalid value is denied", value: "bogus", wantDenied: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "numa-pod",
+					Namespace:   "default",
+					Annotations: map[string]string{util.NumaAlignmentAnnotationKey: test.value},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+						},
+					}},
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+			podBytes, err := runtime.Encode(codec, pod)
+			if err != nil {
+				t.Fatalf("Error encoding pod: %v", err)
+			}
+
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "test-uid", Namespace: "default", Name: "numa-pod",
+					Object: runtime.RawExtension{Raw: podBytes},
+				},
+			}
+
+			wh, err := NewWebHook()
+			if err != nil {
+				t.Fatalf("Error creating webhook: %v", err)
+			}
+			resp := wh.Handle(context.Background(), req)
+
+			if test.wantDenied {
+				if resp.Allowed {
+					t.Fatalf("expected denial, got allowed: %+v", resp.Result)
+				}
+				if !strings.Contains(resp.Result.Message, "invalid") {
+					t.Fatalf("expected invalid-annotation message, got %q", resp.Result.Message)
+				}
+			} else if !resp.Allowed {
+				t.Fatalf("expected admission, got denied: %+v", resp.Result)
 			}
 		})
 	}

--- a/pkg/util/numa_alignment.go
+++ b/pkg/util/numa_alignment.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NumaAlignmentMode selects how HAMi handles a mismatch between the
+// scheduler-selected GPU and the NUMA-aligned replicas kubelet's Topology
+// Manager restricts an allocation to. It is distinct from the
+// nvidia.com/numa-bind annotation, which requests GPU-to-GPU co-location on
+// one NUMA node at scheduling time.
+//
+// Only best-effort exists today. A strict mode that fails the allocation on
+// an unreconcilable mismatch is introduced together with the NUMA refit that
+// can actually enforce it (issue #2080), so the annotation never promises
+// semantics that are not implemented yet.
+type NumaAlignmentMode string
+
+const (
+	// NumaAlignmentNone means the Pod does not opt into NUMA alignment
+	// handling and mismatches are treated exactly as before.
+	NumaAlignmentNone NumaAlignmentMode = ""
+	// NumaAlignmentBestEffort surfaces a mismatch but never fails the
+	// allocation because of it.
+	NumaAlignmentBestEffort NumaAlignmentMode = "best-effort"
+)
+
+// GetNumaAlignmentModeByPod returns the Pod's NUMA alignment mode, or
+// NumaAlignmentNone when the Pod does not carry the annotation.
+func GetNumaAlignmentModeByPod(pod *corev1.Pod) (NumaAlignmentMode, error) {
+	if pod == nil || pod.Annotations == nil {
+		return NumaAlignmentNone, nil
+	}
+
+	value, ok := pod.Annotations[NumaAlignmentAnnotationKey]
+	if !ok {
+		return NumaAlignmentNone, nil
+	}
+
+	return ParseNumaAlignmentMode(value)
+}
+
+// ParseNumaAlignmentMode parses and validates a numa-alignment annotation
+// value. Values are case-insensitive and surrounding whitespace is ignored.
+func ParseNumaAlignmentMode(value string) (NumaAlignmentMode, error) {
+	switch mode := NumaAlignmentMode(strings.ToLower(strings.TrimSpace(value))); mode {
+	case NumaAlignmentBestEffort:
+		return mode, nil
+	default:
+		return NumaAlignmentNone, fmt.Errorf("invalid %s annotation %q: expected %q",
+			NumaAlignmentAnnotationKey, value, NumaAlignmentBestEffort)
+	}
+}

--- a/pkg/util/numa_alignment_test.go
+++ b/pkg/util/numa_alignment_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetNumaAlignmentModeByPod(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		want    NumaAlignmentMode
+		wantErr bool
+	}{
+		{
+			name: "nil pod defaults to none",
+			pod:  nil,
+			want: NumaAlignmentNone,
+		},
+		{
+			name: "pod without annotations defaults to none",
+			pod:  &corev1.Pod{},
+			want: NumaAlignmentNone,
+		},
+		{
+			name: "pod without the annotation defaults to none",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"other": "value"},
+			}},
+			want: NumaAlignmentNone,
+		},
+		{
+			name: "best-effort",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: "best-effort"},
+			}},
+			want: NumaAlignmentBestEffort,
+		},
+		{
+			name: "surrounding whitespace is tolerated",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: " best-effort "},
+			}},
+			want: NumaAlignmentBestEffort,
+		},
+		{
+			name: "upper case best-effort is accepted",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: "BEST-EFFORT"},
+			}},
+			want: NumaAlignmentBestEffort,
+		},
+		{
+			name: "strict is rejected until the refit can enforce it",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: "strict"},
+			}},
+			want:    NumaAlignmentNone,
+			wantErr: true,
+		},
+		{
+			name: "explicit empty value is rejected",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: ""},
+			}},
+			want:    NumaAlignmentNone,
+			wantErr: true,
+		},
+		{
+			name: "unknown value is rejected",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: "required"},
+			}},
+			want:    NumaAlignmentNone,
+			wantErr: true,
+		},
+		{
+			name: "boolean values from numa-bind are not valid modes",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{NumaAlignmentAnnotationKey: "true"},
+			}},
+			want:    NumaAlignmentNone,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetNumaAlignmentModeByPod(test.pod)
+			if test.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, got, test.want)
+		})
+	}
+}
+
+func TestParseNumaAlignmentModeErrorMentionsKeyAndValue(t *testing.T) {
+	_, err := ParseNumaAlignmentMode("bogus")
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, NumaAlignmentAnnotationKey)
+	assert.ErrorContains(t, err, "bogus")
+}

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -89,6 +89,10 @@ const (
 	GPUSchedulerPolicyAnnotationKey = "hami.io/gpu-scheduler-policy"
 	// DeviceScoringWeightsAnnotationKey configures per-Pod slot, core, and memory scoring weights.
 	DeviceScoringWeightsAnnotationKey = "hami.io/device-scoring-weights"
+	// NumaAlignmentAnnotationKey is a per-Pod annotation selecting how HAMi
+	// reconciles the scheduler-selected GPU with the NUMA-aligned replica
+	// preferred by kubelet's Topology Manager. See NumaAlignmentMode.
+	NumaAlignmentAnnotationKey = "hami.io/numa-alignment"
 )
 
 func (s SchedulerPolicyName) String() string {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Groundwork for the NUMA refit from #2080 (Phase 2 of the NUMA work; Phase 1 was #2065). When kubelet's Topology Manager restricts an allocation to a GPU the scheduler did not pick, HAMi's runtime and accounting can disagree. The fix is a scheduler-side refit (#2731, stacked on this PR); this PR lands the pieces it needs, with no behavior change:

- New pod annotation `hami.io/numa-alignment` with a `best-effort` mode. `strict` is not accepted yet — it arrives in #2731 together with the enforcement, so the annotation never promises something it doesn't do. This is a new annotation on purpose: `nvidia.com/numa-bind` means GPU-to-GPU co-location and is unrelated.
- Request/response types for the refit API.
- A scheduler helper that runs the existing device fit against a restricted set of physical GPUs. Policy behavior (binpack, spread, mutex, policy chains, numa-bind, the pod's own policy annotation) is covered by unit tests.
- The device plugin logs the mismatch for opted-in pods instead of silently swallowing it. The response to kubelet is unchanged.

**Which issue(s) this PR fixes**:

Part of #2080. The refit itself is #2731.

**Special notes for your reviewer**:

- Scheduler parts are unit-tested. The device-plugin change is log-only and was also checked on real hardware (8x NVIDIA RTX PRO 6000 Blackwell Server Edition, driver 610.43.02, Kubernetes v1.35.6, Topology Manager `single-numa-node`): pods without the annotation behave exactly as before; opted-in pods get one extra log line on a mismatch.
- User docs for the annotation land with #2731, which enables the behavior.

AI assistance disclosure: written primarily with Claude Code, directed and reviewed by me. The design follows the #2080 discussion.

**Does this PR introduce a user-facing change?**:

```release-note
Added the hami.io/numa-alignment pod annotation (best-effort): HAMi logs when kubelet's Topology Manager restricts an allocation away from the scheduler-selected GPU. Detection only; reconciliation lands with the NUMA refit (#2080).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional per-Pod NUMA alignment configuration using the `hami.io/numa-alignment` annotation.
  - Added validation that rejects invalid NUMA alignment values during admission.
  - Added NUMA-aware device refitting that honors kubelet-approved assignments while preserving scheduling policies and topology information.
  - Added structured request and response contracts for NUMA scheduling refits.

- **Bug Fixes**
  - Improved reporting of annotated-device and NUMA alignment mismatches while preserving fallback behavior.
  - Corrected quota calculations for cumulative sidecar and init-container resource requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->