### PR TITLE
[Feature] Expose Hardware Health and Error Metrics in vGPUmonitor (Fixes #2717)

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -433,12 +433,9 @@ func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometh
 		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		hostGPUTemperaturedesc,
-		prometheus.GaugeValue,
-		float64(temp),
-		nodeName, fmt.Sprint(index), uuid, deviceName,
-	)
+	if err := sendMetric(ch, hostGPUTemperaturedesc, prometheus.GaugeValue, float64(temp), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+		klog.Errorf("Failed to send hostGPUTemperaturedesc metric: %v", err)
+	}
 
 	return nil
 }
@@ -471,12 +468,9 @@ func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Me
 		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		hostGPUPowerUsagedesc,
-		prometheus.GaugeValue,
-		float64(powerMilliwatts)/1000.0,
-		nodeName, fmt.Sprint(index), uuid, deviceName,
-	)
+	if err := sendMetric(ch, hostGPUPowerUsagedesc, prometheus.GaugeValue, float64(powerMilliwatts)/1000.0, nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+		klog.Errorf("Failed to send hostGPUPowerUsagedesc metric: %v", err)
+	}
 
 	return nil
 }
@@ -516,12 +510,9 @@ func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus
 			continue
 		}
 
-		ch <- prometheus.MustNewConstMetric(
-			hostGPUEccErrorsdesc,
-			prometheus.CounterValue,
-			float64(count),
-			nodeName, fmt.Sprint(index), uuid, deviceName, entry.label,
-		)
+		if err := sendMetric(ch, hostGPUEccErrorsdesc, prometheus.CounterValue, float64(count), nodeName, fmt.Sprint(index), uuid, deviceName, entry.label); err != nil {
+			klog.Errorf("Failed to send hostGPUEccErrorsdesc metric: %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -73,6 +73,23 @@ var (
 		[]string{"device_index", "device_uuid", "device_type"}, nil,
 	)
 
+	hostGPUTemperaturedesc = prometheus.NewDesc(
+		"hami_host_gpu_temperature_celsius",
+		"GPU temperature in degrees Celsius",
+		[]string{"device_index", "device_uuid", "device_type"}, nil,
+	)
+
+	hostGPUPowerUsagedesc = prometheus.NewDesc(
+		"hami_host_gpu_power_usage_watts",
+		"GPU power draw in watts",
+		[]string{"device_index", "device_uuid", "device_type"}, nil,
+	)
+
+	hostGPUEccErrorsdesc = prometheus.NewDesc(
+		"hami_host_gpu_ecc_errors_total",
+		"Lifetime aggregate ECC errors",
+		[]string{"device_index", "device_uuid", "device_type", "error_type"}, nil,
+	)
 	ctrvGPUdesc = prometheus.NewDesc(
 		"hami_vgpu_memory_used_bytes",
 		"vGPU device memory usage in bytes",
@@ -195,6 +212,9 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ctrvGPUlimitdesc
 	ch <- hostGPUUtilizationdesc
 	ch <- hostGPUMemoryUtilizationdesc
+	ch <- hostGPUTemperaturedesc
+	ch <- hostGPUPowerUsagedesc
+	ch <- hostGPUEccErrorsdesc
 	ch <- ctrDeviceMemorydesc
 	ch <- ctrDeviceUtilizationdesc
 	ch <- ctrDeviceLastKernelDesc
@@ -292,6 +312,18 @@ func (cc ClusterManagerCollector) collectGPUDeviceMetrics(ch chan<- prometheus.M
 		return err
 	}
 
+	if err := cc.collectGPUTemperatureMetrics(ch, hdev, index); err != nil {
+		return err
+	}
+
+	if err := cc.collectGPUPowerMetrics(ch, hdev, index); err != nil {
+		return err
+	}
+
+	if err := cc.collectGPUEccErrorMetrics(ch, hdev, index); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -369,6 +401,112 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 		fmt.Sprint(index), uuid, deviceName,
 	); err != nil {
 		return fmt.Errorf("nvml send memory controller utilization: %w", err)
+	}
+
+	return nil
+}
+
+func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+	temp, nvret := hdev.GetTemperature(nvml.TEMPERATURE_GPU)
+	if nvret == nvml.ERROR_NOT_SUPPORTED {
+		klog.V(3).Infof("Temperature metrics not supported for device %d, skipping", index)
+		return nil
+	}
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetTemperature err: %s", nvml.ErrorString(nvret))
+	}
+
+	uuid, nvret := hdev.GetUUID()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName, nvret := hdev.GetName()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName = "NVIDIA-" + deviceName
+
+	ch <- prometheus.MustNewConstMetric(
+		hostGPUTemperaturedesc,
+		prometheus.GaugeValue,
+		float64(temp),
+		fmt.Sprint(index), uuid, deviceName,
+	)
+
+	return nil
+}
+
+func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+	// GetPowerUsage returns milliwatts; convert to watts.
+	powerMilliwatts, nvret := hdev.GetPowerUsage()
+	if nvret == nvml.ERROR_NOT_SUPPORTED {
+		klog.V(3).Infof("Power usage metrics not supported for device %d, skipping", index)
+		return nil
+	}
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetPowerUsage err: %s", nvml.ErrorString(nvret))
+	}
+
+	uuid, nvret := hdev.GetUUID()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName, nvret := hdev.GetName()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName = "NVIDIA-" + deviceName
+
+	ch <- prometheus.MustNewConstMetric(
+		hostGPUPowerUsagedesc,
+		prometheus.GaugeValue,
+		float64(powerMilliwatts)/1000.0,
+		fmt.Sprint(index), uuid, deviceName,
+	)
+
+	return nil
+}
+
+func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+	uuid, nvret := hdev.GetUUID()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName, nvret := hdev.GetName()
+	if nvret != nvml.SUCCESS {
+		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName = "NVIDIA-" + deviceName
+
+	for _, entry := range []struct {
+		errorType nvml.MemoryErrorType
+		label     string
+	}{
+		{nvml.MEMORY_ERROR_TYPE_CORRECTED, "corrected"},
+		{nvml.MEMORY_ERROR_TYPE_UNCORRECTED, "uncorrected"},
+	} {
+		count, nvret := hdev.GetTotalEccErrors(entry.errorType, nvml.AGGREGATE_ECC)
+		if nvret == nvml.ERROR_NOT_SUPPORTED {
+			klog.V(3).Infof("ECC %s error metrics not supported for device %d, skipping", entry.label, index)
+			continue
+		}
+		if nvret != nvml.SUCCESS {
+			klog.Errorf("nvml GetTotalEccErrors (%s) err for device %d: %s", entry.label, index, nvml.ErrorString(nvret))
+			continue
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			hostGPUEccErrorsdesc,
+			prometheus.GaugeValue,
+			float64(count),
+			fmt.Sprint(index), uuid, deviceName, entry.label,
+		)
 	}
 
 	return nil

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -298,36 +298,79 @@ func (cc ClusterManagerCollector) getDeviceCount() (int, error) {
 	return devnum, nil
 }
 
+// gpuDeviceIdentity holds the per-device labels shared by every metric
+// collector for one GPU: the node name, and the UUID/name NVML reports for
+// the device. Resolved once per device per scrape by resolveGPUDeviceIdentity
+// and passed down, instead of each collector independently calling
+// hdev.GetUUID()/hdev.GetName() and re-checking the node name env var.
+type gpuDeviceIdentity struct {
+	nodeName   string
+	uuid       string
+	deviceName string
+}
+
+func (cc ClusterManagerCollector) resolveGPUDeviceIdentity(hdev nvml.Device) (gpuDeviceIdentity, error) {
+	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return gpuDeviceIdentity{}, fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
+
+	uuid, nvret := hdev.GetUUID()
+	if nvret != nvml.SUCCESS {
+		return gpuDeviceIdentity{}, fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
+	}
+
+	deviceName, nvret := hdev.GetName()
+	if nvret != nvml.SUCCESS {
+		return gpuDeviceIdentity{}, fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
+	}
+
+	return gpuDeviceIdentity{
+		nodeName:   nodeName,
+		uuid:       uuid,
+		deviceName: "NVIDIA-" + deviceName,
+	}, nil
+}
+
 func (cc ClusterManagerCollector) collectGPUDeviceMetrics(ch chan<- prometheus.Metric, index int) error {
 	hdev, nvret := nvml.DeviceGetHandleByIndex(index)
 	if nvret != nvml.SUCCESS {
 		return fmt.Errorf("nvml DeviceGetHandleByIndex err: %s", nvml.ErrorString(nvret))
 	}
 
-	if err := cc.collectGPUMemoryMetrics(ch, hdev, index); err != nil {
+	identity, err := cc.resolveGPUDeviceIdentity(hdev)
+	if err != nil {
 		return err
 	}
 
-	if err := cc.collectGPUUtilizationMetrics(ch, hdev, index); err != nil {
-		return err
+	// Each collector below is independent: a failure in one (e.g.
+	// temperature, which not every GPU/driver combination supports) must not
+	// prevent the others (e.g. power, ECC) from being collected for this
+	// device, so failures are logged rather than returned.
+	if err := cc.collectGPUMemoryMetrics(ch, hdev, index, identity); err != nil {
+		klog.Errorf("Failed to collect GPU memory metrics for device %d: %v", index, err)
 	}
 
-	if err := cc.collectGPUTemperatureMetrics(ch, hdev, index); err != nil {
-		return err
+	if err := cc.collectGPUUtilizationMetrics(ch, hdev, index, identity); err != nil {
+		klog.Errorf("Failed to collect GPU utilization metrics for device %d: %v", index, err)
 	}
 
-	if err := cc.collectGPUPowerMetrics(ch, hdev, index); err != nil {
-		return err
+	if err := cc.collectGPUTemperatureMetrics(ch, hdev, index, identity); err != nil {
+		klog.Errorf("Failed to collect GPU temperature metrics for device %d: %v", index, err)
 	}
 
-	if err := cc.collectGPUEccErrorMetrics(ch, hdev, index); err != nil {
-		return err
+	if err := cc.collectGPUPowerMetrics(ch, hdev, index, identity); err != nil {
+		klog.Errorf("Failed to collect GPU power metrics for device %d: %v", index, err)
+	}
+
+	if err := cc.collectGPUEccErrorMetrics(ch, hdev, index, identity); err != nil {
+		klog.Errorf("Failed to collect GPU ECC error metrics for device %d: %v", index, err)
 	}
 
 	return nil
 }
 
-func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int, identity gpuDeviceIdentity) error {
 	memory, ret := hdev.GetMemoryInfo()
 	if ret == nvml.ERROR_NOT_SUPPORTED {
 		klog.V(3).Infof("Memory metrics not supported for device %d (unified memory architecture), skipping", index)
@@ -337,38 +380,16 @@ func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.M
 		return fmt.Errorf("nvml get memory error ret=%d", ret)
 	}
 
-	uuid, nvret := hdev.GetUUID()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName, nvret := hdev.GetName()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName = "NVIDIA-" + deviceName
-
-	nodeName := os.Getenv(util.NodeNameEnvName)
-	if nodeName == "" {
-		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
-	}
-
-	if err := sendMetric(ch, hostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := sendMetric(ch, hostGPUdesc, prometheus.GaugeValue, float64(memory.Used), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUdesc metric: %v", err)
 	}
 
-	sendLegacyMetric(ch, legacyHostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName)
+	sendLegacyMetric(ch, legacyHostGPUdesc, prometheus.GaugeValue, float64(memory.Used), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName)
 
 	return nil
 }
 
-func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
-	nodeName := os.Getenv(util.NodeNameEnvName)
-	if nodeName == "" {
-		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
-	}
-
+func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int, identity gpuDeviceIdentity) error {
 	utilRates, nvret := hdev.GetUtilizationRates()
 	if nvret == nvml.ERROR_NOT_SUPPORTED {
 		klog.V(3).Infof("GPU utilization metrics not supported for device %d, skipping", index)
@@ -378,27 +399,15 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 		return fmt.Errorf("nvml GetUtilizationRates err: %s", nvml.ErrorString(nvret))
 	}
 
-	uuid, nvret := hdev.GetUUID()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName, nvret := hdev.GetName()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName = "NVIDIA-" + deviceName
-
-	if err := sendMetric(ch, hostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := sendMetric(ch, hostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUUtilizationdesc metric: %v", err)
 	}
 
-	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName)
+	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName)
 
 	if err := sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
 		float64(utilRates.Memory),
-		fmt.Sprint(index), uuid, deviceName,
+		fmt.Sprint(index), identity.uuid, identity.deviceName,
 	); err != nil {
 		return fmt.Errorf("nvml send memory controller utilization: %w", err)
 	}
@@ -406,7 +415,7 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	return nil
 }
 
-func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int, identity gpuDeviceIdentity) error {
 	temp, nvret := hdev.GetTemperature(nvml.TEMPERATURE_GPU)
 	if nvret == nvml.ERROR_NOT_SUPPORTED {
 		klog.V(3).Infof("Temperature metrics not supported for device %d, skipping", index)
@@ -416,31 +425,14 @@ func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometh
 		return fmt.Errorf("nvml GetTemperature err: %s", nvml.ErrorString(nvret))
 	}
 
-	uuid, nvret := hdev.GetUUID()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName, nvret := hdev.GetName()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName = "NVIDIA-" + deviceName
-
-	nodeName := os.Getenv(util.NodeNameEnvName)
-	if nodeName == "" {
-		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
-	}
-
-	if err := sendMetric(ch, hostGPUTemperaturedesc, prometheus.GaugeValue, float64(temp), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := sendMetric(ch, hostGPUTemperaturedesc, prometheus.GaugeValue, float64(temp), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUTemperaturedesc metric: %v", err)
 	}
 
 	return nil
 }
 
-func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
+func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int, identity gpuDeviceIdentity) error {
 	// GetPowerUsage returns milliwatts; convert to watts.
 	powerMilliwatts, nvret := hdev.GetPowerUsage()
 	if nvret == nvml.ERROR_NOT_SUPPORTED {
@@ -451,48 +443,14 @@ func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Me
 		return fmt.Errorf("nvml GetPowerUsage err: %s", nvml.ErrorString(nvret))
 	}
 
-	uuid, nvret := hdev.GetUUID()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName, nvret := hdev.GetName()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName = "NVIDIA-" + deviceName
-
-	nodeName := os.Getenv(util.NodeNameEnvName)
-	if nodeName == "" {
-		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
-	}
-
-	if err := sendMetric(ch, hostGPUPowerUsagedesc, prometheus.GaugeValue, float64(powerMilliwatts)/1000.0, nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := sendMetric(ch, hostGPUPowerUsagedesc, prometheus.GaugeValue, float64(powerMilliwatts)/1000.0, identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUPowerUsagedesc metric: %v", err)
 	}
 
 	return nil
 }
 
-func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int) error {
-	uuid, nvret := hdev.GetUUID()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetUUID err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName, nvret := hdev.GetName()
-	if nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml GetName err: %s", nvml.ErrorString(nvret))
-	}
-
-	deviceName = "NVIDIA-" + deviceName
-
-	nodeName := os.Getenv(util.NodeNameEnvName)
-	if nodeName == "" {
-		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
-	}
-
+func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus.Metric, hdev nvml.Device, index int, identity gpuDeviceIdentity) error {
 	for _, entry := range []struct {
 		errorType nvml.MemoryErrorType
 		label     string
@@ -510,7 +468,7 @@ func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus
 			continue
 		}
 
-		if err := sendMetric(ch, hostGPUEccErrorsdesc, prometheus.CounterValue, float64(count), nodeName, fmt.Sprint(index), uuid, deviceName, entry.label); err != nil {
+		if err := sendMetric(ch, hostGPUEccErrorsdesc, prometheus.CounterValue, float64(count), identity.nodeName, fmt.Sprint(index), identity.uuid, identity.deviceName, entry.label); err != nil {
 			klog.Errorf("Failed to send hostGPUEccErrorsdesc metric: %v", err)
 		}
 	}

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -76,19 +76,19 @@ var (
 	hostGPUTemperaturedesc = prometheus.NewDesc(
 		"hami_host_gpu_temperature_celsius",
 		"GPU temperature in degrees Celsius",
-		[]string{"device_index", "device_uuid", "device_type"}, nil,
+		[]string{"node", "device_index", "device_uuid", "device_type"}, nil,
 	)
 
 	hostGPUPowerUsagedesc = prometheus.NewDesc(
 		"hami_host_gpu_power_usage_watts",
 		"GPU power draw in watts",
-		[]string{"device_index", "device_uuid", "device_type"}, nil,
+		[]string{"node", "device_index", "device_uuid", "device_type"}, nil,
 	)
 
 	hostGPUEccErrorsdesc = prometheus.NewDesc(
 		"hami_host_gpu_ecc_errors_total",
 		"Lifetime aggregate ECC errors",
-		[]string{"device_index", "device_uuid", "device_type", "error_type"}, nil,
+		[]string{"node", "device_index", "device_uuid", "device_type", "error_type"}, nil,
 	)
 	ctrvGPUdesc = prometheus.NewDesc(
 		"hami_vgpu_memory_used_bytes",
@@ -428,11 +428,16 @@ func (cc ClusterManagerCollector) collectGPUTemperatureMetrics(ch chan<- prometh
 
 	deviceName = "NVIDIA-" + deviceName
 
+	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
+
 	ch <- prometheus.MustNewConstMetric(
 		hostGPUTemperaturedesc,
 		prometheus.GaugeValue,
 		float64(temp),
-		fmt.Sprint(index), uuid, deviceName,
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
 	return nil
@@ -461,11 +466,16 @@ func (cc ClusterManagerCollector) collectGPUPowerMetrics(ch chan<- prometheus.Me
 
 	deviceName = "NVIDIA-" + deviceName
 
+	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
+
 	ch <- prometheus.MustNewConstMetric(
 		hostGPUPowerUsagedesc,
 		prometheus.GaugeValue,
 		float64(powerMilliwatts)/1000.0,
-		fmt.Sprint(index), uuid, deviceName,
+		nodeName, fmt.Sprint(index), uuid, deviceName,
 	)
 
 	return nil
@@ -483,6 +493,11 @@ func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus
 	}
 
 	deviceName = "NVIDIA-" + deviceName
+
+	nodeName := os.Getenv(util.NodeNameEnvName)
+	if nodeName == "" {
+		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
+	}
 
 	for _, entry := range []struct {
 		errorType nvml.MemoryErrorType
@@ -505,7 +520,7 @@ func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus
 			hostGPUEccErrorsdesc,
 			prometheus.GaugeValue,
 			float64(count),
-			fmt.Sprint(index), uuid, deviceName, entry.label,
+			nodeName, fmt.Sprint(index), uuid, deviceName, entry.label,
 		)
 	}
 

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -518,7 +518,7 @@ func (cc ClusterManagerCollector) collectGPUEccErrorMetrics(ch chan<- prometheus
 
 		ch <- prometheus.MustNewConstMetric(
 			hostGPUEccErrorsdesc,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(count),
 			nodeName, fmt.Sprint(index), uuid, deviceName, entry.label,
 		)

--- a/cmd/vGPUmonitor/metrics_extra_test.go
+++ b/cmd/vGPUmonitor/metrics_extra_test.go
@@ -173,12 +173,13 @@ func TestHostGPUMetrics_SendMetricError(t *testing.T) {
 
 	cc := ClusterManagerCollector{}
 	ch := make(chan prometheus.Metric, 10)
+	identity := testGPUIdentity(nodeName, "GPU-123", "NVIDIA-Tesla")
 
-	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Errorf("expected no error from collectGPUMemoryMetrics even if descriptor is bad")
 	}
 
-	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Errorf("expected no error from collectGPUUtilizationMetrics even if descriptor is bad")
 	}
 }

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -111,10 +111,34 @@ func TestHostGPUMetricsMissingNodeName(t *testing.T) {
 		GetNameFunc: func() (string, nvml.Return) {
 			return "Tesla T4", nvml.SUCCESS
 		},
+		GetTemperatureFunc: func(nvml.TemperatureSensors) (uint32, nvml.Return) {
+			return 45, nvml.SUCCESS
+		},
+		GetPowerUsageFunc: func() (uint32, nvml.Return) {
+			return 150000, nvml.SUCCESS
+		},
+		GetTotalEccErrorsFunc: func(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return) {
+			return 5, nvml.SUCCESS
+		},
 	}
 	err = cc.collectGPUMemoryMetrics(nil, mockDev, 0)
 	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
 		t.Errorf("expected missing node name error from collectGPUMemoryMetrics, got: %v", err)
+	}
+
+	err = cc.collectGPUTemperatureMetrics(nil, mockDev, 0)
+	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from collectGPUTemperatureMetrics, got: %v", err)
+	}
+
+	err = cc.collectGPUPowerMetrics(nil, mockDev, 0)
+	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from collectGPUPowerMetrics, got: %v", err)
+	}
+
+	err = cc.collectGPUEccErrorMetrics(nil, mockDev, 0)
+	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from collectGPUEccErrorMetrics, got: %v", err)
 	}
 }
 
@@ -134,6 +158,15 @@ func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
 		GetNameFunc: func() (string, nvml.Return) {
 			return "Tesla T4", nvml.SUCCESS
 		},
+		GetTemperatureFunc: func(nvml.TemperatureSensors) (uint32, nvml.Return) {
+			return 45, nvml.SUCCESS
+		},
+		GetPowerUsageFunc: func() (uint32, nvml.Return) {
+			return 150000, nvml.SUCCESS
+		},
+		GetTotalEccErrorsFunc: func(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return) {
+			return 5, nvml.SUCCESS
+		},
 	}
 
 	initLegacyDescriptors()
@@ -151,14 +184,26 @@ func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
 		t.Fatalf("collectGPUUtilizationMetrics failed: %v", err)
 	}
 
+	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUTemperatureMetrics failed: %v", err)
+	}
+
+	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUPowerMetrics failed: %v", err)
+	}
+
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("collectGPUEccErrorMetrics failed: %v", err)
+	}
+
 	close(ch)
 
 	count := 0
 	for range ch {
 		count++
 	}
-	if count < 4 {
-		t.Errorf("expected at least 4 metrics, got %d", count)
+	if count < 8 {
+		t.Errorf("expected at least 8 metrics, got %d", count)
 	}
 }
 

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -91,54 +91,68 @@ func TestHostGPUMetricsDescriptorsIncludeNodeLabel(t *testing.T) {
 	}
 }
 
-func TestHostGPUMetricsMissingNodeName(t *testing.T) {
+// testGPUIdentity builds a gpuDeviceIdentity for tests that call one of the
+// per-metric collectors directly, bypassing resolveGPUDeviceIdentity (whose
+// own behavior - including the missing-node-name and NVML GetUUID/GetName
+// failure paths - is covered separately by TestResolveGPUDeviceIdentity*
+// below, now that identity resolution is centralized there instead of being
+// repeated in every collector).
+func testGPUIdentity(node, uuid, name string) gpuDeviceIdentity {
+	return gpuDeviceIdentity{nodeName: node, uuid: uuid, deviceName: name}
+}
+
+func TestResolveGPUDeviceIdentityMissingNodeName(t *testing.T) {
 	t.Setenv(util.NodeNameEnvName, "")
 
 	cc := ClusterManagerCollector{}
-
-	err := cc.collectGPUUtilizationMetrics(nil, nil, 0)
-	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
-		t.Errorf("expected missing node name error from collectGPUUtilizationMetrics, got: %v", err)
-	}
-
 	mockDev := &nvmlmock.Device{
-		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
-			return nvml.Memory{Used: 100}, nvml.SUCCESS
-		},
 		GetUUIDFunc: func() (string, nvml.Return) {
 			return "GPU-1234", nvml.SUCCESS
 		},
 		GetNameFunc: func() (string, nvml.Return) {
 			return "Tesla T4", nvml.SUCCESS
 		},
-		GetTemperatureFunc: func(nvml.TemperatureSensors) (uint32, nvml.Return) {
-			return 45, nvml.SUCCESS
-		},
-		GetPowerUsageFunc: func() (uint32, nvml.Return) {
-			return 150000, nvml.SUCCESS
-		},
-		GetTotalEccErrorsFunc: func(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return) {
-			return 5, nvml.SUCCESS
-		},
-	}
-	err = cc.collectGPUMemoryMetrics(nil, mockDev, 0)
-	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
-		t.Errorf("expected missing node name error from collectGPUMemoryMetrics, got: %v", err)
 	}
 
-	err = cc.collectGPUTemperatureMetrics(nil, mockDev, 0)
-	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
-		t.Errorf("expected missing node name error from collectGPUTemperatureMetrics, got: %v", err)
+	if _, err := cc.resolveGPUDeviceIdentity(mockDev); err == nil || !strings.Contains(err.Error(), "node name environment variable") {
+		t.Errorf("expected missing node name error from resolveGPUDeviceIdentity, got: %v", err)
+	}
+}
+
+func TestResolveGPUDeviceIdentityNVMLErrors(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+	cc := ClusterManagerCollector{}
+
+	uuidErrDev := &nvmlmock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) { return "", nvml.ERROR_UNKNOWN },
+	}
+	if _, err := cc.resolveGPUDeviceIdentity(uuidErrDev); err == nil || !strings.Contains(err.Error(), "GetUUID") {
+		t.Errorf("expected a GetUUID error from resolveGPUDeviceIdentity, got: %v", err)
 	}
 
-	err = cc.collectGPUPowerMetrics(nil, mockDev, 0)
-	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
-		t.Errorf("expected missing node name error from collectGPUPowerMetrics, got: %v", err)
+	nameErrDev := &nvmlmock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) { return "GPU-1234", nvml.SUCCESS },
+		GetNameFunc: func() (string, nvml.Return) { return "", nvml.ERROR_UNKNOWN },
+	}
+	if _, err := cc.resolveGPUDeviceIdentity(nameErrDev); err == nil || !strings.Contains(err.Error(), "GetName") {
+		t.Errorf("expected a GetName error from resolveGPUDeviceIdentity, got: %v", err)
+	}
+}
+
+func TestResolveGPUDeviceIdentitySuccess(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+	cc := ClusterManagerCollector{}
+	mockDev := &nvmlmock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) { return "GPU-1234", nvml.SUCCESS },
+		GetNameFunc: func() (string, nvml.Return) { return "Tesla T4", nvml.SUCCESS },
 	}
 
-	err = cc.collectGPUEccErrorMetrics(nil, mockDev, 0)
-	if err == nil || !strings.Contains(err.Error(), "node name environment variable") {
-		t.Errorf("expected missing node name error from collectGPUEccErrorMetrics, got: %v", err)
+	identity, err := cc.resolveGPUDeviceIdentity(mockDev)
+	if err != nil {
+		t.Fatalf("resolveGPUDeviceIdentity failed: %v", err)
+	}
+	if identity.nodeName != "test-node" || identity.uuid != "GPU-1234" || identity.deviceName != "NVIDIA-Tesla T4" {
+		t.Errorf("unexpected identity: %+v", identity)
 	}
 }
 
@@ -173,26 +187,27 @@ func TestHostGPUMetricsCollectionSuccess(t *testing.T) {
 	cc := ClusterManagerCollector{
 		ClusterManager: &ClusterManager{LegacyMetrics: true},
 	}
+	identity := testGPUIdentity("test-node", "GPU-12345678-1234-1234-1234-123456789012", "NVIDIA-Tesla T4")
 
 	ch := make(chan prometheus.Metric, 10)
 
-	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUMemoryMetrics failed: %v", err)
 	}
 
-	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUUtilizationMetrics failed: %v", err)
 	}
 
-	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUTemperatureMetrics failed: %v", err)
 	}
 
-	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUPowerMetrics failed: %v", err)
 	}
 
-	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUEccErrorMetrics failed: %v", err)
 	}
 
@@ -238,7 +253,8 @@ func TestCollectMemoryControllerUtilizationValue(t *testing.T) {
 	ch := make(chan prometheus.Metric, 10)
 	c := &ClusterManager{Zone: "test-zone", LegacyMetrics: false}
 	cc := ClusterManagerCollector{ClusterManager: c}
-	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+	identity := testGPUIdentity("test-node", "GPU-abc123", "NVIDIA-A100")
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("collectGPUUtilizationMetrics: %v", err)
 	}
 	close(ch)
@@ -274,12 +290,13 @@ func TestHostGPUMetricsNotSupportedGracefullySkipped(t *testing.T) {
 
 	cc := ClusterManagerCollector{}
 	ch := make(chan prometheus.Metric, 10)
+	identity := testGPUIdentity("test-node", "GPU-1234", "NVIDIA-Tesla T4")
 
-	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Errorf("expected collectGPUMemoryMetrics to return nil on ERROR_NOT_SUPPORTED, got: %v", err)
 	}
 
-	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Errorf("expected collectGPUUtilizationMetrics to return nil on ERROR_NOT_SUPPORTED, got: %v", err)
 	}
 
@@ -308,14 +325,15 @@ func TestHostGPUMetricsUnsupported(t *testing.T) {
 
 	cc := ClusterManagerCollector{}
 	ch := make(chan prometheus.Metric, 10)
+	identity := testGPUIdentity("test-node", "GPU-1234", "NVIDIA-Tesla T4")
 
-	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("expected nil error for unsupported temperature, got: %v", err)
 	}
-	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("expected nil error for unsupported power, got: %v", err)
 	}
-	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("expected nil error for unsupported ECC, got: %v", err)
 	}
 
@@ -343,16 +361,21 @@ func TestHostGPUMetricsError(t *testing.T) {
 	}
 
 	cc := ClusterManagerCollector{}
+	identity := testGPUIdentity("test-node", "GPU-1234", "NVIDIA-Tesla T4")
 
-	if err := cc.collectGPUTemperatureMetrics(nil, mockDev, 0); err == nil {
+	if err := cc.collectGPUTemperatureMetrics(nil, mockDev, 0, identity); err == nil {
 		t.Fatalf("expected error for temperature, got nil")
 	}
-	if err := cc.collectGPUPowerMetrics(nil, mockDev, 0); err == nil {
+	if err := cc.collectGPUPowerMetrics(nil, mockDev, 0, identity); err == nil {
 		t.Fatalf("expected error for power, got nil")
 	}
 
+	// A failing temperature/power collector above must not prevent ECC from
+	// still being collected independently - see the review discussion on
+	// PR #2732 (collectGPUDeviceMetrics used to return on the first error,
+	// which skipped every collector after it for that device).
 	ch := make(chan prometheus.Metric, 10)
-	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0, identity); err != nil {
 		t.Fatalf("expected nil error for ECC even when unknown error occurs (it continues), got: %v", err)
 	}
 	close(ch)

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -350,7 +350,7 @@ func TestHostGPUMetricsError(t *testing.T) {
 	if err := cc.collectGPUPowerMetrics(nil, mockDev, 0); err == nil {
 		t.Fatalf("expected error for power, got nil")
 	}
-	
+
 	ch := make(chan prometheus.Metric, 10)
 	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
 		t.Fatalf("expected nil error for ECC even when unknown error occurs (it continues), got: %v", err)

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -288,3 +288,75 @@ func TestHostGPUMetricsNotSupportedGracefullySkipped(t *testing.T) {
 		t.Errorf("expected 0 metrics emitted for unsupported device, got: %d", count)
 	}
 }
+
+func TestHostGPUMetricsUnsupported(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+
+	mockDev := &nvmlmock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) { return "GPU-1234", nvml.SUCCESS },
+		GetNameFunc: func() (string, nvml.Return) { return "Tesla T4", nvml.SUCCESS },
+		GetTemperatureFunc: func(nvml.TemperatureSensors) (uint32, nvml.Return) {
+			return 0, nvml.ERROR_NOT_SUPPORTED
+		},
+		GetPowerUsageFunc: func() (uint32, nvml.Return) {
+			return 0, nvml.ERROR_NOT_SUPPORTED
+		},
+		GetTotalEccErrorsFunc: func(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return) {
+			return 0, nvml.ERROR_NOT_SUPPORTED
+		},
+	}
+
+	cc := ClusterManagerCollector{}
+	ch := make(chan prometheus.Metric, 10)
+
+	if err := cc.collectGPUTemperatureMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("expected nil error for unsupported temperature, got: %v", err)
+	}
+	if err := cc.collectGPUPowerMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("expected nil error for unsupported power, got: %v", err)
+	}
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("expected nil error for unsupported ECC, got: %v", err)
+	}
+
+	close(ch)
+	for range ch {
+		t.Fatalf("expected no metrics emitted for unsupported hardware")
+	}
+}
+
+func TestHostGPUMetricsError(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+
+	mockDev := &nvmlmock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) { return "GPU-1234", nvml.SUCCESS },
+		GetNameFunc: func() (string, nvml.Return) { return "Tesla T4", nvml.SUCCESS },
+		GetTemperatureFunc: func(nvml.TemperatureSensors) (uint32, nvml.Return) {
+			return 0, nvml.ERROR_UNKNOWN
+		},
+		GetPowerUsageFunc: func() (uint32, nvml.Return) {
+			return 0, nvml.ERROR_UNKNOWN
+		},
+		GetTotalEccErrorsFunc: func(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return) {
+			return 0, nvml.ERROR_UNKNOWN
+		},
+	}
+
+	cc := ClusterManagerCollector{}
+
+	if err := cc.collectGPUTemperatureMetrics(nil, mockDev, 0); err == nil {
+		t.Fatalf("expected error for temperature, got nil")
+	}
+	if err := cc.collectGPUPowerMetrics(nil, mockDev, 0); err == nil {
+		t.Fatalf("expected error for power, got nil")
+	}
+	
+	ch := make(chan prometheus.Metric, 10)
+	if err := cc.collectGPUEccErrorMetrics(ch, mockDev, 0); err != nil {
+		t.Fatalf("expected nil error for ECC even when unknown error occurs (it continues), got: %v", err)
+	}
+	close(ch)
+	for range ch {
+		t.Fatalf("expected no metrics emitted for errored hardware")
+	}
+}

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -73,6 +73,9 @@ on the metrics port; the scheduler and the vGPU monitor each expose a subset):
 | `hami_container_device_utilization_ratio` | vGPU monitor | Per-container utilization (0-100). |
 | `hami_scheduler_is_leader` | scheduler | 1 when this instance is the active leader, 0 otherwise. |
 | `hami_scheduler_cache_synced` | scheduler | 1 when the internal node/device cache is fully synced, 0 otherwise. |
+| `hami_host_gpu_temperature_celsius` | vGPU monitor | GPU die temperature in °C. |
+| `hami_host_gpu_power_usage_watts` | vGPU monitor | GPU board power draw in watts. |
+| `hami_host_gpu_ecc_errors_total` | vGPU monitor | Lifetime ECC errors (corrected/uncorrected). |
 
 > Utilization and core-allocation metrics are reported on a 0-100 scale. The
 > node memory-allocation ratio is reported on a 0-1 scale and uses Grafana's


### PR DESCRIPTION
## Description
This PR addresses issue #2717 by exposing three new hardware health metrics in the `vGPUmonitor` Prometheus collector:
- `hami_host_gpu_temperature_celsius`
- `hami_host_gpu_power_usage_watts`
- `hami_host_gpu_ecc_errors_total`

The implementation uses the existing `go-nvml` dependency APIs (`GetTemperature`, `GetPowerUsage`, `GetTotalEccErrors`) and gracefully handles `ERROR_NOT_SUPPORTED` on setups where these metrics cannot be retrieved, following the established error handling pattern in `collectGPUMemoryMetrics`. 

The `dashboards/README.md` was also updated to include the new metrics in the reference table.

## Testing
- Verified `go vet` and `go test ./cmd/vGPUmonitor/...` pass cleanly, including the pedantic registry validation test.
- Since these are read-only NVML query APIs that gracefully handle unsupported states, they behave safely without physical hardware disruption. 

> This PR was authored with the assistance of Antigravity AI. I have fully reviewed the implementation to ensure the queries handle NVML errors gracefully according to the established codebase patterns and have validated that it conforms to all HAMi contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host GPU memory-controller utilization metrics.
  * Added GPU temperature and power usage metrics, with power reported in watts.
  * Added aggregate corrected and uncorrected ECC error metrics.
  * Unsupported metrics are skipped gracefully when unavailable.
  * GPU metrics include node labels for easier filtering.

* **Documentation**
  * Updated dashboard metrics documentation to include the new GPU metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->