### PR TITLE
fix(nodelock): serialize expired-lock recovery

### DIFF
--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -132,6 +132,10 @@ func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
 	nodeLock.Lock()
 	defer nodeLock.Unlock()
 
+	return setNodeLockLocked(nodeName, lockname, pods)
+}
+
+func setNodeLockLocked(nodeName string, lockname string, pods *corev1.Pod) error {
 	ctx := context.Background()
 	node, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -181,6 +185,10 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 	nodeLock.Lock()
 	defer nodeLock.Unlock()
 
+	return releaseNodeLockLocked(nodeName, lockname, pod, skipNodeLockOwnerCheck)
+}
+
+func releaseNodeLockLocked(nodeName string, lockname string, pod *corev1.Pod, skipNodeLockOwnerCheck bool) error {
 	ctx := context.Background()
 	node, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -239,13 +247,18 @@ func ReleaseNodeLock(nodeName string, lockname string, pod *corev1.Pod, skipNode
 }
 
 func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
+	// Acquire per-node lock instead of global lock
+	nodeLock := nodeLocks.getLock(nodeName)
+	nodeLock.Lock()
+	defer nodeLock.Unlock()
+
 	ctx := context.Background()
 	node, err := client.GetClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	if _, ok := node.Annotations[NodeLockKey]; !ok {
-		return SetNodeLock(nodeName, lockname, pods)
+		return setNodeLockLocked(nodeName, lockname, pods)
 	}
 	lockTime, ns, previousPodName, err := ParseNodeLock(node.Annotations[NodeLockKey])
 	if err != nil {
@@ -256,7 +269,7 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 	if time.Since(lockTime) > NodeLockTimeout {
 		klog.InfoS("Node lock expired", "node", nodeName, "lockTime", lockTime, "timeout", NodeLockTimeout)
 		skipOwnerCheck = true
-	} else if ns == pods.Namespace && previousPodName == pods.Name {
+	} else if pods != nil && ns == pods.Namespace && previousPodName == pods.Name {
 		// The lock is already held by this exact pod. lockAllDevices calls
 		// LockNode once per device vendor a pod requests resources from, so
 		// a pod requesting resources from two or more vendors (e.g. both
@@ -265,9 +278,8 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 		// become schedulable. Treat this as already acquired.
 		klog.V(4).InfoS("Node lock already held by this pod, treating as acquired", "node", nodeName, "podName", pods.Name)
 		return nil
-	} else
-	// Check dangling nodeLock
-	if ns != "" && previousPodName != "" {
+	} else if ns != "" && previousPodName != "" {
+		// Check dangling nodeLock
 		if _, err := client.GetClient().CoreV1().Pods(ns).Get(ctx, previousPodName, metav1.GetOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				klog.ErrorS(err, "Failed to get pod of NodeLock", "podName", previousPodName, "namespace", ns)
@@ -279,12 +291,12 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 	}
 
 	if skipOwnerCheck {
-		err = ReleaseNodeLock(nodeName, lockname, pods, true)
+		err = releaseNodeLockLocked(nodeName, lockname, pods, true)
 		if err != nil {
 			klog.ErrorS(err, "Failed to release node lock", "node", nodeName)
 			return err
 		}
-		return SetNodeLock(nodeName, lockname, pods)
+		return setNodeLockLocked(nodeName, lockname, pods)
 	}
 
 	return fmt.Errorf("node %s has been locked within %v: %w", nodeName, NodeLockTimeout, ErrNodeLockContention)

--- a/pkg/util/nodelock/nodelock.go
+++ b/pkg/util/nodelock/nodelock.go
@@ -61,6 +61,9 @@ var (
 		Factor:   2.0,
 		Jitter:   0.5,
 	}
+
+	// beforeLockNodeMutexHook is an optional test hook called right before acquiring the per-node mutex in LockNode.
+	beforeLockNodeMutexHook func(nodeName string, pods *corev1.Pod)
 )
 
 // nodeLockManager manages locks on a per-node basis to allow concurrent
@@ -127,6 +130,9 @@ func setupNodeLockTimeout() {
 }
 
 func SetNodeLock(nodeName string, lockname string, pods *corev1.Pod) error {
+	if pods == nil {
+		return fmt.Errorf("cannot set node lock: pod is nil")
+	}
 	// Acquire per-node lock instead of global lock
 	nodeLock := nodeLocks.getLock(nodeName)
 	nodeLock.Lock()
@@ -247,6 +253,12 @@ func releaseNodeLockLocked(nodeName string, lockname string, pod *corev1.Pod, sk
 }
 
 func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
+	if pods == nil {
+		return fmt.Errorf("cannot lock node: pod is nil")
+	}
+	if beforeLockNodeMutexHook != nil {
+		beforeLockNodeMutexHook(nodeName, pods)
+	}
 	// Acquire per-node lock instead of global lock
 	nodeLock := nodeLocks.getLock(nodeName)
 	nodeLock.Lock()
@@ -269,7 +281,7 @@ func LockNode(nodeName string, lockname string, pods *corev1.Pod) error {
 	if time.Since(lockTime) > NodeLockTimeout {
 		klog.InfoS("Node lock expired", "node", nodeName, "lockTime", lockTime, "timeout", NodeLockTimeout)
 		skipOwnerCheck = true
-	} else if pods != nil && ns == pods.Namespace && previousPodName == pods.Name {
+	} else if ns == pods.Namespace && previousPodName == pods.Name {
 		// The lock is already held by this exact pod. lockAllDevices calls
 		// LockNode once per device vendor a pod requests resources from, so
 		// a pod requesting resources from two or more vendors (e.g. both

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -1211,7 +1211,14 @@ func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 	)
 	client.KubeClient = clientSet
 
-	podBStarted := make(chan struct{})
+	podBAtMutex := make(chan struct{})
+	beforeLockNodeMutexHook = func(n string, p *corev1.Pod) {
+		if p != nil && p.Name == podB.Name {
+			close(podBAtMutex)
+		}
+	}
+	t.Cleanup(func() { beforeLockNodeMutexHook = nil })
+
 	podBResult := make(chan error, 1)
 
 	// Intercept the first patch (ReleaseNodeLock during Pod A's recovery)
@@ -1220,14 +1227,14 @@ func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 	clientSet.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
 		patchCount++
 		if patchCount == 1 {
-			// Pod A is releasing the expired lock. Launch Pod B's LockNode concurrently.
+			// Pod A is releasing the expired lock while holding the per-node mutex.
+			// Launch Pod B's LockNode concurrently.
 			go func() {
-				close(podBStarted)
 				podBResult <- LockNode(nodeName, "", podB)
 			}()
-			// Wait for Pod B goroutine to have launched
-			<-podBStarted
-			// Ensure Pod B is waiting on the per-node mutex and has not returned
+			// Wait until Pod B has actually reached the per-node mutex boundary.
+			<-podBAtMutex
+			// Ensure Pod B is waiting on the per-node mutex and has not returned.
 			select {
 			case res := <-podBResult:
 				t.Errorf("Pod B should not complete while Pod A holds the per-node lock, got: %v", res)
@@ -1260,5 +1267,65 @@ func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 	ownerA := NodeLockSep + GeneratePodNamespaceName(podA, NodeLockSep)
 	if !strings.HasSuffix(lockStr, ownerA) {
 		t.Fatalf("expected node lock to belong to Pod A (%s), got: %s", ownerA, lockStr)
+	}
+}
+
+// TestLockNodeNilPodWithExpiredLock verifies that LockNode fails immediately
+// when called with a nil pod, without releasing or mutating existing node locks.
+func TestLockNodeNilPodWithExpiredLock(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "nil-pod-expired-node"
+
+	expiredLockTime := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	expiredLockValue := expiredLockTime + NodeLockSep + "old-ns" + NodeLockSep + "old-pod"
+
+	clientSet := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				NodeLockKey: expiredLockValue,
+			},
+		},
+	})
+	client.KubeClient = clientSet
+
+	err := LockNode(nodeName, "", nil)
+	if err == nil {
+		t.Fatal("expected LockNode(..., nil) to fail, got nil")
+	}
+	expectedErrMsg := "cannot lock node: pod is nil"
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("expected error %q, got %q", expectedErrMsg, err.Error())
+	}
+
+	// Verify the existing node lock was NOT removed or mutated
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	if got := node.Annotations[NodeLockKey]; got != expiredLockValue {
+		t.Fatalf("expected node lock annotation to remain %q, got %q", expiredLockValue, got)
+	}
+}
+
+// TestSetNodeLockNilPod verifies that SetNodeLock fails immediately when called with a nil pod.
+func TestSetNodeLockNilPod(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "nil-pod-set-node"
+
+	clientSet := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	})
+	client.KubeClient = clientSet
+
+	err := SetNodeLock(nodeName, "", nil)
+	if err == nil {
+		t.Fatal("expected SetNodeLock(..., nil) to fail, got nil")
+	}
+	expectedErrMsg := "cannot set node lock: pod is nil"
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("expected error %q, got %q", expectedErrMsg, err.Error())
 	}
 }

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -771,6 +771,12 @@ func TestSetNodeLockRaceIsRetryable(t *testing.T) {
 	}
 	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "test-ns"}}
 	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "test-ns"}}
+	if _, err := client.KubeClient.CoreV1().Pods(podA.Namespace).Create(context.TODO(), podA, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create podA: %v", err)
+	}
+	if _, err := client.KubeClient.CoreV1().Pods(podB.Namespace).Create(context.TODO(), podB, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create podB: %v", err)
+	}
 	raceLock := nodeLocks.getLock(nodeName)
 	raceLock.Lock()
 	results := make(chan error, 2)
@@ -955,5 +961,304 @@ func TestSetupNodeLockTimeout(t *testing.T) {
 				t.Errorf("got %v, want %v", NodeLockTimeout, tt.want)
 			}
 		})
+	}
+}
+
+// TestLockNodeExpiredRecoveryRace verifies that when multiple callers concurrently
+// attempt to LockNode on an expired lock, recovery is serialized per node: exactly
+// one caller acquires the lock, the other observes contention, and the winning
+// lock is never cleared or overwritten.
+func TestLockNodeExpiredRecoveryRace(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeLocks = newNodeLockManager()
+	nodeName := "expired-recovery-node"
+
+	// Create node with an expired lock (10 minutes ago)
+	expiredLockTime := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	expiredLockValue := expiredLockTime + NodeLockSep + "old-ns" + NodeLockSep + "old-pod"
+
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				NodeLockKey: expiredLockValue,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "test-ns"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "test-ns"}}
+
+	if _, err := client.KubeClient.CoreV1().Pods(podA.Namespace).Create(context.TODO(), podA, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create pod-a fixture: %v", err)
+	}
+	if _, err := client.KubeClient.CoreV1().Pods(podB.Namespace).Create(context.TODO(), podB, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create pod-b fixture: %v", err)
+	}
+
+	// Pre-lock to align both goroutines at LockNode entry
+	alignLock := nodeLocks.getLock(nodeName)
+	alignLock.Lock()
+
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, pod := range []*corev1.Pod{podA, podB} {
+		wg.Add(1)
+		go func(p *corev1.Pod) {
+			defer wg.Done()
+			results <- LockNode(nodeName, "", p)
+		}(pod)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	alignLock.Unlock()
+	wg.Wait()
+	close(results)
+
+	var successes, contentions int
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case IsNodeLockContention(err):
+			contentions++
+		default:
+			t.Fatalf("unexpected error from LockNode: %v", err)
+		}
+	}
+
+	if successes != 1 || contentions != 1 {
+		t.Fatalf("expected exactly 1 winner and 1 contention out of 2 concurrent expired recovery calls, got successes=%d contentions=%d", successes, contentions)
+	}
+
+	// Verify the node annotation belongs to one of the two pods and was not erased
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	lockStr, ok := node.Annotations[NodeLockKey]
+	if !ok {
+		t.Fatal("expected node lock annotation to exist, but was absent")
+	}
+
+	ownerA := NodeLockSep + GeneratePodNamespaceName(podA, NodeLockSep)
+	ownerB := NodeLockSep + GeneratePodNamespaceName(podB, NodeLockSep)
+	if !strings.HasSuffix(lockStr, ownerA) && !strings.HasSuffix(lockStr, ownerB) {
+		t.Fatalf("expected node lock to belong to pod-a or pod-b, got: %s", lockStr)
+	}
+}
+
+// TestLockNodeDanglingRecoveryRace verifies that when multiple callers concurrently
+// attempt LockNode on a dangling lock (pod deleted), recovery is serialized per node:
+// exactly one caller acquires the lock and the winning lock is preserved.
+func TestLockNodeDanglingRecoveryRace(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeLocks = newNodeLockManager()
+	nodeName := "dangling-recovery-node"
+
+	// Create node with a fresh lock owned by a non-existent pod
+	freshLockTime := time.Now().Format(time.RFC3339)
+	danglingLockValue := freshLockTime + NodeLockSep + "dead-ns" + NodeLockSep + "dead-pod"
+
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				NodeLockKey: danglingLockValue,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "test-ns"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "test-ns"}}
+
+	if _, err := client.KubeClient.CoreV1().Pods(podA.Namespace).Create(context.TODO(), podA, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create pod-a fixture: %v", err)
+	}
+	if _, err := client.KubeClient.CoreV1().Pods(podB.Namespace).Create(context.TODO(), podB, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create pod-b fixture: %v", err)
+	}
+
+	alignLock := nodeLocks.getLock(nodeName)
+	alignLock.Lock()
+
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, pod := range []*corev1.Pod{podA, podB} {
+		wg.Add(1)
+		go func(p *corev1.Pod) {
+			defer wg.Done()
+			results <- LockNode(nodeName, "", p)
+		}(pod)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	alignLock.Unlock()
+	wg.Wait()
+	close(results)
+
+	var successes, contentions int
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case IsNodeLockContention(err):
+			contentions++
+		default:
+			t.Fatalf("unexpected error from LockNode: %v", err)
+		}
+	}
+
+	if successes != 1 || contentions != 1 {
+		t.Fatalf("expected exactly 1 winner and 1 contention out of 2 concurrent dangling recovery calls, got successes=%d contentions=%d", successes, contentions)
+	}
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	lockStr, ok := node.Annotations[NodeLockKey]
+	if !ok {
+		t.Fatal("expected node lock annotation to exist, but was absent")
+	}
+
+	ownerA := NodeLockSep + GeneratePodNamespaceName(podA, NodeLockSep)
+	ownerB := NodeLockSep + GeneratePodNamespaceName(podB, NodeLockSep)
+	if !strings.HasSuffix(lockStr, ownerA) && !strings.HasSuffix(lockStr, ownerB) {
+		t.Fatalf("expected node lock to belong to pod-a or pod-b, got: %s", lockStr)
+	}
+}
+
+// TestLockNodePreservesValidUnexpiredLock verifies that a valid unexpired lock held
+// by a live pod cannot be stolen by another caller.
+func TestLockNodePreservesValidUnexpiredLock(t *testing.T) {
+	client.KubeClient = fake.NewClientset()
+	nodeLocks = newNodeLockManager()
+	nodeName := "valid-lock-node"
+
+	livePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "live-pod", Namespace: "live-ns"}}
+	if _, err := client.KubeClient.CoreV1().Pods(livePod.Namespace).Create(context.TODO(), livePod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create live pod: %v", err)
+	}
+
+	freshLockTime := time.Now().Format(time.RFC3339)
+	lockValue := freshLockTime + NodeLockSep + livePod.Namespace + NodeLockSep + livePod.Name
+
+	_, err := client.KubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				NodeLockKey: lockValue,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	callerPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "caller-pod", Namespace: "other-ns"}}
+	if _, err := client.KubeClient.CoreV1().Pods(callerPod.Namespace).Create(context.TODO(), callerPod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create caller-pod fixture: %v", err)
+	}
+
+	err = LockNode(nodeName, "", callerPod)
+	if err == nil {
+		t.Fatal("expected LockNode to fail on valid unexpired lock, but succeeded")
+	}
+	if !IsNodeLockContention(err) {
+		t.Fatalf("expected ErrNodeLockContention, got: %v", err)
+	}
+
+	node, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	if got := node.Annotations[NodeLockKey]; got != lockValue {
+		t.Fatalf("expected node lock to remain %q, got %q", lockValue, got)
+	}
+}
+
+// TestLockNodeDeterministicExpiredRecoverySerialization uses controlled synchronization
+// to prove that a second LockNode caller cannot interleave during another caller's
+// expired-lock recovery.
+func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
+	nodeLocks = newNodeLockManager()
+	nodeName := "deterministic-recovery-node"
+
+	expiredLockTime := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	expiredLockValue := expiredLockTime + NodeLockSep + "old-ns" + NodeLockSep + "old-pod"
+
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "test-ns"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "test-ns"}}
+
+	clientSet := fake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					NodeLockKey: expiredLockValue,
+				},
+			},
+		},
+		podA,
+		podB,
+	)
+	client.KubeClient = clientSet
+
+	podBStarted := make(chan struct{})
+	podBResult := make(chan error, 1)
+
+	// Intercept the first patch (ReleaseNodeLock during Pod A's recovery)
+	// and verify that Pod B's LockNode cannot proceed while Pod A is in recovery.
+	patchCount := 0
+	clientSet.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		patchCount++
+		if patchCount == 1 {
+			// Pod A is releasing the expired lock. Launch Pod B's LockNode concurrently.
+			go func() {
+				close(podBStarted)
+				podBResult <- LockNode(nodeName, "", podB)
+			}()
+			// Wait for Pod B goroutine to have launched
+			<-podBStarted
+			// Ensure Pod B is waiting on the per-node mutex and has not returned
+			select {
+			case res := <-podBResult:
+				t.Errorf("Pod B should not complete while Pod A holds the per-node lock, got: %v", res)
+			default:
+				// Expected: Pod B is blocked waiting for Pod A to finish recovery
+			}
+		}
+		return false, nil, nil
+	})
+
+	if err := LockNode(nodeName, "", podA); err != nil {
+		t.Fatalf("Pod A LockNode failed: %v", err)
+	}
+
+	// Now Pod A is done and released the per-node mutex. Pod B should finish with contention.
+	err := <-podBResult
+	if err == nil {
+		t.Fatal("Pod B should have failed with contention, but succeeded")
+	}
+	if !IsNodeLockContention(err) {
+		t.Fatalf("Pod B expected ErrNodeLockContention, got: %v", err)
+	}
+
+	// Final verification: node lock is intact for Pod A
+	node, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	lockStr := node.Annotations[NodeLockKey]
+	ownerA := NodeLockSep + GeneratePodNamespaceName(podA, NodeLockSep)
+	if !strings.HasSuffix(lockStr, ownerA) {
+		t.Fatalf("expected node lock to belong to Pod A (%s), got: %s", ownerA, lockStr)
 	}
 }

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -1186,7 +1186,8 @@ func TestLockNodePreservesValidUnexpiredLock(t *testing.T) {
 
 // TestLockNodeDeterministicExpiredRecoverySerialization uses controlled synchronization
 // to prove that a second LockNode caller cannot interleave during another caller's
-// expired-lock recovery.
+// expired-lock recovery window (after the stale lock is released and before the
+// replacement lock is acquired).
 func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 	nodeLocks = newNodeLockManager()
 	nodeName := "deterministic-recovery-node"
@@ -1221,23 +1222,35 @@ func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 
 	podBResult := make(chan error, 1)
 
-	// Intercept the first patch (ReleaseNodeLock during Pod A's recovery)
-	// and verify that Pod B's LockNode cannot proceed while Pod A is in recovery.
-	patchCount := 0
+	var (
+		patchCount int
+		pausedOnce bool
+	)
+
+	// Intercept patch operations to count when the stale lock has been released (Patch #1).
 	clientSet.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
 		patchCount++
-		if patchCount == 1 {
-			// Pod A is releasing the expired lock while holding the per-node mutex.
-			// Launch Pod B's LockNode concurrently.
+		return false, nil, nil
+	})
+
+	// Intercept the first node get after stale lock release (which occurs at the start
+	// of setNodeLockLocked) to pause Pod A in the release -> reacquire window and give
+	// Pod B an opportunity to attempt LockNode.
+	clientSet.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		getAction, ok := action.(k8stesting.GetAction)
+		if ok && getAction.GetName() == nodeName && patchCount == 1 && !pausedOnce {
+			pausedOnce = true
+			// Pod A is paused after releasing the stale lock and before acquiring the replacement lock.
+			// Launch Pod B's LockNode concurrently during this critical recovery gap.
 			go func() {
 				podBResult <- LockNode(nodeName, "", podB)
 			}()
 			// Wait until Pod B has actually reached the per-node mutex boundary.
 			<-podBAtMutex
-			// Ensure Pod B is waiting on the per-node mutex and has not returned.
+			// Ensure Pod B is blocked waiting for Pod A to finish recovery and has not returned.
 			select {
 			case res := <-podBResult:
-				t.Errorf("Pod B should not complete while Pod A holds the per-node lock, got: %v", res)
+				t.Errorf("Pod B should not complete while Pod A is in the recovery window, got: %v", res)
 			default:
 				// Expected: Pod B is blocked waiting for Pod A to finish recovery
 			}

--- a/pkg/util/nodelock/nodelock_test.go
+++ b/pkg/util/nodelock/nodelock_test.go
@@ -1247,6 +1247,11 @@ func TestLockNodeDeterministicExpiredRecoverySerialization(t *testing.T) {
 			}()
 			// Wait until Pod B has actually reached the per-node mutex boundary.
 			<-podBAtMutex
+			// Yield the processor to allow Pod B's goroutine to execute its lock attempt.
+			// If the implementation were non-atomic (the bug), Pod B would acquire the lock,
+			// mutate the node, and finish immediately. Under the fixed atomic implementation,
+			// Pod B is blocked on nodeLock.Lock() because Pod A holds the per-node mutex.
+			runtime.Gosched()
 			// Ensure Pod B is blocked waiting for Pod A to finish recovery and has not returned.
 			select {
 			case res := <-podBResult:


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`LockNode()` can recover expired or dangling node locks by releasing the existing lock and acquiring a new one. Previously, the state check, stale-lock release, and new lock acquisition were not serialized as one atomic operation.

Although `SetNodeLock()` and `ReleaseNodeLock()` individually used the per-node mutex, multiple concurrent `LockNode()` callers could observe the same expired or dangling lock before either recovery completed.

This created a race where one scheduler could acquire a recovered lock and have that lock subsequently removed by another concurrent recovery attempt. Both callers could return success even though only the final lock remained valid.

This PR serializes the complete expired/dangling lock recovery transaction per node.

### Changes

- Protect the complete `LockNode()` state inspection and recovery flow with the existing per-node mutex.
- Extract internal locked helpers for setting and releasing node locks to avoid recursive mutex acquisition.
- Re-check the latest node lock state after waiting for a competing recovery operation.
- Ensure only one concurrent caller can successfully recover an expired or dangling lock.
- Preserve existing same-owner reentrancy behavior.
- Preserve contention behavior for valid unexpired locks.
- Preserve concurrency between locks on different nodes.
- Reject nil pod arguments before any lock state is inspected or modified.
- Add deterministic synchronization to the recovery concurrency test so it verifies that a competing caller has actually reached the mutex boundary.

## Which issue(s) does this PR fix?

Fixes #2681

## Special notes for your reviewer

The fix intentionally uses the existing per-node `nodeLockManager` rather than introducing a new synchronization mechanism.

The mutex is held for the complete `LockNode()` operation on the affected node, including:

1. Reading the current node lock state.
2. Checking expiration or dangling ownership.
3. Releasing a stale lock when necessary.
4. Acquiring the replacement lock.
5. Returning the final result.

The internal `setNodeLockLocked` and `releaseNodeLockLocked` helpers assume the caller already holds the per-node mutex. The existing public `SetNodeLock()` and `ReleaseNodeLock()` APIs continue to acquire the mutex themselves.

This prevents recursive locking while preserving the existing API behavior.

Concurrent callers targeting different nodes continue to use independent mutexes and are not unnecessarily serialized.

Nil pod validation is performed at the beginning of `LockNode()` and `SetNodeLock()`, before any node state or lock annotation can be modified.

### Regression coverage

The tests cover:

- Concurrent expired-lock recovery with exactly one successful owner.
- Concurrent dangling-lock recovery with exactly one successful owner.
- Preservation of an existing valid unexpired lock.
- Deterministic serialization of the release → acquire recovery sequence.
- Verification that a competing caller has reached the per-node mutex before the recovery sequence is released.
- Retryable contention behavior in `SetNodeLock()`.
- Same-pod reentrancy behavior.
- Concurrent locking of different nodes.
- Nil pod passed to `LockNode()` with an expired lock.
- Nil pod passed to `SetNodeLock()`.

## Validation

The following checks were completed:

- `go test ./pkg/util/nodelock/...` — passed
- `go test -v -run 'LockNode|NodeLock' -count=20` — passed, 20/20 iterations
- `go vet ./pkg/util/nodelock/...` — passed
- `golangci-lint run ./pkg/util/nodelock/...` — passed
- `gofmt` — passed
- `git diff --check` — passed

The race detector was attempted but is blocked by the local Windows CGO compiler environment (`cc1.exe: 64-bit mode not compiled in`). The normal concurrency test suite and 20-run stress test passed successfully.

## Does this PR introduce a user-facing change?

No.

This is a concurrency correctness fix in the internal node-lock recovery path. Nil pod arguments are now rejected safely before any lock mutation instead of potentially reaching a recovery path that could dereference the nil pod.

## AI Assistance Disclosure

AI assistance from Claude and Antigravity was used during codebase investigation, root-cause analysis, implementation assistance, regression-test development, concurrency/race analysis, review-comment analysis, and validation of this change.

The resulting implementation and tests were reviewed against the existing HAMi codebase and node-lock semantics, including same-owner reentrancy, lock contention, retry behavior, nil-pod handling, and per-node concurrency. The final changes were validated by the contributor using the project's unit tests, concurrency stress tests, vet, lint, formatting, and diff-check workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-lock handling to prevent recursive locking and race conditions during recovery.
  * Correctly recovers expired or dangling locks while preserving valid, unexpired locks.
  * Rejects nil pod requests immediately without changing existing lock state.
  * Ensures concurrent lock attempts are serialized consistently and safely.

* **Tests**
  * Added coverage for concurrent recovery, deterministic lock serialization, valid-lock preservation, and invalid pod requests.
  * Added verification that recovery behavior remains stable when multiple lock attempts occur simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->