### PR TITLE
test: modernize environment variable mocking using t.Setenv

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -19,7 +19,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	v1 "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
@@ -81,16 +80,10 @@ func mustStrategies(t *testing.T, strategies ...string) v1.DeviceListStrategies 
 
 func newTestPlugin(t *testing.T) *NvidiaDevicePlugin {
 	t.Helper()
-	prevHookPath := os.Getenv("HOOK_PATH")
+	t.Setenv("HOOK_PATH", "/tmp/hami-test-hookpath")
 	prevHostHookPath := hostHookPath
-	os.Setenv("HOOK_PATH", "/tmp/hami-test-hookpath")
 	hostHookPath = "/tmp/hami-test-hookpath"
 	t.Cleanup(func() {
-		if prevHookPath != "" {
-			os.Setenv("HOOK_PATH", prevHookPath)
-		} else {
-			os.Unsetenv("HOOK_PATH")
-		}
 		hostHookPath = prevHostHookPath
 	})
 	logLevel := nvidia.Error

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -87,9 +87,7 @@ func TestGetClient(t *testing.T) {
 			defer func() { inClusterConfig = oldInClusterConfig }()
 
 			// Set the KUBECONFIG environment variable.
-			oldKubeConfig := os.Getenv("KUBECONFIG")
-			os.Setenv("KUBECONFIG", tt.kubeConfig)
-			defer os.Setenv("KUBECONFIG", oldKubeConfig)
+			t.Setenv("KUBECONFIG", tt.kubeConfig)
 
 			// Call GetClient and check the result.
 			client := GetClient()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
This PR modernizes the environment variable mocking in the test suite by replacing manual `os.Getenv`, `os.Setenv`, and `os.Unsetenv` calls with the Go 1.17+ standard `t.Setenv()`.

The previous pattern of manually tracking and deferring `os.Setenv` restoration has several drawbacks:
1. It results in unhandled errors (as `os.Setenv` returns an `error` that was ignored).
2. It is not thread-safe and can cause test pollution or race conditions if tests are run concurrently.

By using `t.Setenv()`, the `testing` package automatically handles state tracking and cleanup, ensuring perfectly safe and isolated test environments with significantly less boilerplate. The unused `"os"` package import in `alloc_refactor_test.go` was also cleaned up.

**Which issue(s) this PR fixes**:
Fixes #2730

**Special notes for your reviewer**:
This is a pure Go testing cleanup. No functional changes were made to the core plugin logic or Kubernetes interactions. All affected tests pass successfully.

I consulted an AI assistant to help identify these testing anti-patterns, but I manually reviewed, integrated, and verified the final solution myself.

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by automatically restoring temporary environment settings after test execution.
  * Simplified test setup and cleanup for device plugin and client configuration scenarios.
  * Removed an unused test dependency, reducing maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->