### PR TITLE
cleanup: remove unused nodeNamesLen function from scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -707,12 +707,6 @@ func buildTransientNodeInfo(node *corev1.Node) (*device.NodeInfo, error) {
 	return nodeInfo, nil
 }
 
-func nodeNamesLen(nodeNames *[]string) int {
-	if nodeNames == nil {
-		return 0
-	}
-	return len(*nodeNames)
-}
 
 func nodeListLen(nodes *corev1.NodeList) int {
 	if nodes == nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -707,7 +707,6 @@ func buildTransientNodeInfo(node *corev1.Node) (*device.NodeInfo, error) {
 	return nodeInfo, nil
 }
 
-
 func nodeListLen(nodes *corev1.NodeList) int {
 	if nodes == nil {
 		return 0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR removes the `nodeNamesLen(nodeNames *[]string) int` helper function from `pkg/scheduler/scheduler.go`.

During a static analysis pass, it was discovered that this function is completely unused (dead code). Removing it cleans up the scheduler package, reduces technical debt, and clears unnecessary clutter.

Since this cleanup is strictly scoped to the scheduler extender, it does not affect device allocation or in-container isolation. Therefore, it respects Contribution Guideline #2 and can be safely merged using existing testing without requiring real GPU hardware validation.

**Which issue(s) this PR fixes**:
Fixes #2694

**Special notes for your reviewer**:
This is a pure dead-code removal. No functionality has been altered. 

> I consulted an AI assistant to safely remove this unused code, but I manually reviewed and verified the final solution myself.

**Does this PR introduce a user-facing change?**:
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code without changing user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->