### PR TITLE
cleanup: remove unused nodeNamesLen function from scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -694,13 +694,6 @@ func buildTransientNodeInfo(node *corev1.Node) (*device.NodeInfo, error) {
 	return nodeInfo, nil
 }
 
-func nodeNamesLen(nodeNames *[]string) int {
-	if nodeNames == nil {
-		return 0
-	}
-	return len(*nodeNames)
-}
-
 func nodeListLen(nodes *corev1.NodeList) int {
 	if nodes == nil {
 		return 0


### PR DESCRIPTION
## What was removed

The \
odeNamesLen(nodeNames *[]string) int\ helper function in \pkg/scheduler/scheduler.go\.

## Why it was removed

During a static analysis pass of the scheduler codebase, it was identified that \
odeNamesLen\ is dead code with no callers anywhere in the repository. Removing unused code reduces maintenance overhead and improves overall code quality.

## How was this tested

- Verified via codebase-wide search that \
odeNamesLen\ has zero call sites
- Ran \go build ./...\ to confirm the project compiles without the function
- Ran \go vet ./pkg/scheduler/...\ to confirm no issues

## Related issue

Fixes #2694

## Checklist

- [x] Code follows the project's contribution guidelines
- [x] Change is scoped to a single unused function removal
- [x] No new functionality or behavioral changes introduced
- [x] Verified the function has no callers in the codebase
- [x] Project builds and passes vet after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code with no changes to user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->