### PR TITLE
docs: update bug report template to support all accelerator vendors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -14,20 +14,28 @@ labels: kind/bug
 
 **How to reproduce it (as minimally and precisely as possible)**:
 
-**Anything else we need to know?**:
-
-- The output of `nvidia-smi -a` on your host
-- Your docker or containerd configuration file (e.g: `/etc/docker/daemon.json`)
-- The hami-device-plugin container logs
-- The hami-scheduler container logs
-- The kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
-- Any relevant kernel output lines from `dmesg`
-
 **Environment**:
-- HAMi version:
-- nvidia driver or other AI device driver version:
-- Docker version from `docker version`
-- Docker command, image and tag used
-- Kernel version from `uname -a`
-- Others:
 
+- HAMi version:
+- Accelerator vendor and model (e.g., NVIDIA A100, Ascend 910B, AMD MI250X, Hygon, MetaX, Enflame, Kunlun, Iluvatar, MThreads, Biren, AWS Neuron):
+- HAMi device backend (e.g., nvidia-device-plugin, ascend-device-plugin, cambricon-device-plugin, etc.):
+- Vendor driver version:
+- Vendor runtime version (e.g., CUDA, CANN, ROCm, etc.):
+- Container runtime and version (e.g., containerd 1.7, Docker 24.0):
+- Kubernetes version:
+- Kernel version (`uname -a`):
+
+**Logs and diagnostics**:
+
+> Remove all credentials, tokens, registry secrets, and other private information before posting.
+
+- Pod YAML or the relevant resource section:
+- Pod events (`kubectl describe pod <pod-name>`):
+- Node annotations (`kubectl get node <node-name> -o yaml`):
+- HAMi scheduler logs:
+- HAMi device-plugin logs:
+- Kubelet logs (`sudo journalctl -r -u kubelet`):
+- Relevant `dmesg` output:
+- Vendor-specific diagnostic output (e.g., `nvidia-smi -a` for NVIDIA, `npu-smi info` for Ascend, `rocm-smi` for AMD — include if available):
+
+**Additional context**:


### PR DESCRIPTION
## What changed

Rewrote \.github/ISSUE_TEMPLATE/bug-report.md\ to be vendor-neutral instead of NVIDIA-centric. Added fields for all supported accelerator vendors (NVIDIA, Ascend, Cambricon, AMD, Hygon, MetaX, Enflame, Kunlun, Iluvatar, MThreads, Biren, AWS Neuron).

## Why it changed

HAMi supports many accelerator vendors beyond NVIDIA. The previous template requested \
vidia-smi\ output as a general requirement, which made triage harder for non-NVIDIA users. A vendor-neutral template improves report quality.

## Related issue

Fixes #2667

## Checklist

- [x] Template is vendor-neutral
- [x] Covers all supported accelerator vendors
- [x] Includes credential removal reminder
- [x] Remains concise and user-friendly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the bug report template with structured environment details, including accelerator, runtime, Kubernetes, and kernel information.
  * Added guided diagnostic fields for configuration, events, annotations, logs, and vendor tools.
  * Added a reminder to remove sensitive information before submitting reports.
  * Replaced older environment prompts with a streamlined “Additional context” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->