### PR TITLE
feat(e2e): add MIG E2E targets and fix GPU preflight fail-fast

### DIFF
--- a/.github/workflows/call-e2e-mig.yaml
+++ b/.github/workflows/call-e2e-mig.yaml
@@ -1,0 +1,103 @@
+name: Call e2e MIG test
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Reference id to run tests'
+        required: true
+        type: string
+      type:
+        description: 'E2E MIG test type: smoke or full'
+        required: true
+        type: string
+        default: smoke
+      deploy-type:
+        description: 'Deploy type for helm-deploy: pullrequest, release, or local'
+        required: true
+        type: string
+        default: release
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-mig-test:
+    strategy:
+      matrix:
+        include:
+          - device: nvidia
+            type: mig
+    runs-on: [ "${{ matrix.device }}", "${{ matrix.type }}" ]
+    environment: ${{ matrix.device }}
+    env:
+      E2E_TYPE: ${{ inputs.deploy-type }}
+      HAMI_VERSION: ${{ inputs.ref }}
+      TARGET_NODE: ${{ vars.MIG_TARGET_NODE }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Acquire shared e2e runner lock
+        run: bash hack/e2e-runner-lock.sh acquire
+
+      - name: install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: setup e2e env
+        run: |
+          make e2e-env-setup
+
+      - name: download hami helm
+        if: inputs.deploy-type == 'pullrequest'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: chart_package_artifact
+          path: charts/
+
+      - name: download hami image
+        if: inputs.deploy-type == 'pullrequest'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: hami-image
+          path: ./image
+
+      - name: load e2e image
+        if: inputs.deploy-type == 'pullrequest'
+        run: |
+          echo "Loading Docker image from image.tar..."
+          sudo ctr -n k8s.io images import ./image/image.tar
+          sudo ctr -n k8s.io images ls | grep hami
+
+      - name: deploy hami helm
+        run: |
+          make helm-deploy
+
+      - name: e2e mig test
+        run: |
+          if [ "${{ inputs.type }}" == "smoke" ]; then
+            make e2e-mig-smoke-test
+          else
+            make e2e-mig-test
+          fi
+
+      - name: cleanup e2e env
+        if: always()
+        run: |
+          echo "Cleaning up HAMi deployment..."
+          helm uninstall hami -n hami-system --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
+          kubectl wait --for=delete pod --all -n hami-system \
+            --timeout=120s --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
+          kubectl annotate node --all \
+            hami.io/mutex.lock- hami.io/node-handshake- \
+            hami.io/node-nvidia-register- hami.io/nvidia-license- \
+            --kubeconfig "${KUBE_CONF:-${HOME}/.kube/config}" 2>/dev/null || true
+          echo "Cleanup done."
+
+      - name: Release shared e2e runner lock
+        if: always()
+        run: bash hack/e2e-runner-lock.sh release

--- a/.github/workflows/call-e2e-mig.yaml
+++ b/.github/workflows/call-e2e-mig.yaml
@@ -34,6 +34,7 @@ jobs:
       E2E_TYPE: ${{ inputs.deploy-type }}
       HAMI_VERSION: ${{ inputs.ref }}
       TARGET_NODE: ${{ vars.MIG_TARGET_NODE }}
+      MIG_TEST_TYPE: ${{ inputs.type }}
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -79,7 +80,7 @@ jobs:
 
       - name: e2e mig test
         run: |
-          if [ "${{ inputs.type }}" == "smoke" ]; then
+          if [ "${MIG_TEST_TYPE}" == "smoke" ]; then
             make e2e-mig-smoke-test
           else
             make e2e-mig-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,3 +270,13 @@ jobs:
     with:
       ref: ${{ needs.get_info.outputs.version }}
       type: "pullrequest"
+
+  # execute MIG smoke test when hami code merge
+  e2e_mig_test:
+    uses: ./.github/workflows/call-e2e-mig.yaml
+    needs: [ package_chart, get_info, build ]
+    if: needs.get_info.outputs.e2e_run == 'true'
+    with:
+      ref: ${{ needs.get_info.outputs.version }}
+      type: "smoke"
+      deploy-type: "pullrequest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,7 @@ jobs:
   # execute MIG smoke test when hami code merge
   e2e_mig_test:
     uses: ./.github/workflows/call-e2e-mig.yaml
-    needs: [ package_chart, get_info, build ]
+    needs: [ package_chart, get_info, build, e2e_test ]
     if: needs.get_info.outputs.e2e_run == 'true'
     with:
       ref: ${{ needs.get_info.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,7 +275,7 @@ jobs:
   e2e_mig_test:
     uses: ./.github/workflows/call-e2e-mig.yaml
     needs: [ package_chart, get_info, build, e2e_test ]
-    if: needs.get_info.outputs.e2e_run == 'true'
+    if: needs.get_info.outputs.e2e_run == 'true' && vars.ENABLE_MIG_E2E == 'true'
     with:
       ref: ${{ needs.get_info.outputs.version }}
       type: "smoke"

--- a/Makefile
+++ b/Makefile
@@ -114,3 +114,11 @@ local-deploy: docker
 .PHONY: e2e-test
 e2e-test:
 	./hack/e2e-test.sh "${E2E_TYPE}" "${KUBE_CONF}"
+
+.PHONY: e2e-mig-test
+e2e-mig-test:
+	./hack/e2e-mig-test.sh "${KUBE_CONF}"
+
+.PHONY: e2e-mig-smoke-test
+e2e-mig-smoke-test:
+	./hack/e2e-mig-smoke-test.sh "${KUBE_CONF}"

--- a/hack/e2e-mig-smoke-test.sh
+++ b/hack/e2e-mig-smoke-test.sh
@@ -129,10 +129,15 @@ uuid_smoke_one=$(pod_uuid smoke-one)
 assert_runtime_annotation smoke-one
 assert_gpu_progress smoke-one
 
-log "SMOKE CASE: overflow rejection"
+log "SMOKE CASE: overflow rejection after filling 1g capacity"
+for i in $(seq 2 7); do create_pod "smoke-fill-${i}" 4500; done
+for i in $(seq 2 7); do wait_ready "smoke-fill-${i}" & done
+wait
+wait_count 7 180
+[[ "$(profile_count 1g.5gb)" == 7 ]] || fail "expected seven 1g.5gb instances before overflow"
 create_pod smoke-overflow 4500
 assert_pending_unbound smoke-overflow
-wait_count 1
+wait_count 7
 echo "PASS SMOKE CASE: overflow rejected"
 
 log "final cleanup and health"

--- a/hack/e2e-mig-smoke-test.sh
+++ b/hack/e2e-mig-smoke-test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Copyright 2024 The HAMi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lightweight MIG smoke test for PR gates
+# This script runs a minimal MIG test to verify basic MIG functionality
+# without running the full MIG matrix (which is reserved for nightly/release).
+
+set -euo pipefail
+
+KUBE_CONF=${1:-"${HOME}/.kube/config"}
+export KUBECONFIG="${KUBE_CONF}"
+
+NS=${MIG_E2E_NAMESPACE:-hami-mig-smoke-e2e}
+HAMI_NS=${HAMI_NAMESPACE:-hami-system}
+TARGET_NODE=${TARGET_NODE:-}
+DEVICE_PLUGIN_DAEMONSET=${DEVICE_PLUGIN_DAEMONSET:-hami-device-plugin}
+DEVICE_PLUGIN_CONTAINER=${DEVICE_PLUGIN_CONTAINER:-device-plugin}
+IMAGE=${GPU_TEST_IMAGE:-nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04}
+GPU_PROGRESS_WAIT=${GPU_PROGRESS_WAIT:-5}
+
+log() { printf '\n[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  kubectl delete namespace "$NS" --wait=false >/dev/null 2>&1 || true
+  for _ in $(seq 1 90); do
+    kubectl get namespace "$NS" >/dev/null 2>&1 || return 0
+    sleep 2
+  done
+  echo "FAIL: namespace cleanup timed out" >&2
+  return 1
+}
+
+trap 'status=$?; cleanup || true; exit "$status"' EXIT
+
+device_plugin_pod() {
+  kubectl get pods -n "$HAMI_NS" --field-selector "spec.nodeName=${TARGET_NODE}" -o json |
+    jq -r --arg daemonset "$DEVICE_PLUGIN_DAEMONSET" '.items[] | select([.metadata.ownerReferences[]? | select(.kind == "DaemonSet" and .name == $daemonset)] | length > 0) | .metadata.name' |
+    sed -n '1p'
+}
+
+node_nvidia_smi() {
+  local pod
+  pod=$(device_plugin_pod)
+  [[ -n "$pod" ]] || fail "no ${DEVICE_PLUGIN_DAEMONSET} Pod found on ${TARGET_NODE}"
+  kubectl exec -n "$HAMI_NS" "$pod" -c "$DEVICE_PLUGIN_CONTAINER" -- nvidia-smi "$@"
+}
+
+create_pod() {
+  local name=$1 memory=$2
+  printf '%s\n' "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${NS}\",\"annotations\":{\"nvidia.com/vgpu-mode\":\"mig\"}},\"spec\":{\"schedulerName\":\"hami-scheduler\",\"nodeSelector\":{\"kubernetes.io/hostname\":\"${TARGET_NODE}\"},\"restartPolicy\":\"Never\",\"containers\":[{\"name\":\"cuda\",\"image\":\"${IMAGE}\",\"imagePullPolicy\":\"IfNotPresent\",\"command\":[\"bash\",\"-lc\",\"set -euo pipefail; nvidia-smi -L; n=0; echo 0 > /tmp/gpu-progress; while true; do if ! /cuda-samples/vectorAdd > /tmp/vectoradd.last 2>&1; then cat /tmp/vectoradd.last >&2; exit 1; fi; n=\$((n + 1)); echo \\\"\$n\\\" > /tmp/gpu-progress.next; mv /tmp/gpu-progress.next /tmp/gpu-progress; done\"],\"resources\":{\"limits\":{\"nvidia.com/gpu\":1,\"nvidia.com/gpumem\":${memory}}}}]}}" | kubectl apply -f -
+}
+
+wait_ready() { kubectl wait -n "$NS" --for=condition=Ready "pod/$1" --timeout=180s; }
+mig_count() { node_nvidia_smi -L | grep -c 'MIG ' || true; }
+profile_count() { node_nvidia_smi -L | grep -c "MIG $1" || true; }
+pod_uuid() { kubectl exec -n "$NS" "$1" -- nvidia-smi -L | sed -n 's/.*UUID: \(MIG-[^)]*\)).*/\1/p' | head -1; }
+gpu_progress() { kubectl exec -n "$NS" "$1" -- cat /tmp/gpu-progress; }
+
+wait_count() {
+  local want=$1 timeout=${2:-120} start count
+  start=$(date +%s)
+  while true; do
+    count=$(mig_count)
+    [[ "$count" == "$want" ]] && { echo "MIG_COUNT=${want}"; return; }
+    (( $(date +%s) - start < timeout )) || { node_nvidia_smi -L; fail "MIG count=${count}, want=${want}"; }
+    sleep 2
+  done
+}
+
+assert_gpu_progress() {
+  local pod=$1 before after phase restarts
+  phase=$(kubectl get pod -n "$NS" "$pod" -o jsonpath='{.status.phase}')
+  restarts=$(kubectl get pod -n "$NS" "$pod" -o jsonpath='{.status.containerStatuses[0].restartCount}')
+  [[ "$phase" == Running && "$restarts" == 0 ]] || fail "$pod workload unhealthy: phase=${phase} restarts=${restarts}"
+  before=$(gpu_progress "$pod")
+  sleep "$GPU_PROGRESS_WAIT"
+  after=$(gpu_progress "$pod")
+  [[ "$before" =~ ^[0-9]+$ && "$after" =~ ^[0-9]+$ && "$after" -gt "$before" ]] || {
+    kubectl exec -n "$NS" "$pod" -- cat /tmp/vectoradd.last >&2 || true
+    fail "$pod CUDA progress stalled: before=${before} after=${after}"
+  }
+  echo "GPU_PROGRESS pod=${pod} before=${before} after=${after}"
+}
+
+assert_runtime_annotation() {
+  local pod=$1 raw
+  raw=$(kubectl get pod -n "$NS" "$pod" -o json | jq -r '.metadata.annotations["hami.io/vgpu-mig-allocations"]')
+  jq -e 'length > 0 and all(.[]; (.migUUID | startswith("MIG-")) and (.profile | length > 0) and (.placement.size > 0) and (.gpuInstanceID | type == "number") and (.computeInstanceID | type == "number"))' <<<"$raw" >/dev/null || fail "$pod lacks concrete MIG runtime identity annotation"
+}
+
+assert_pending_unbound() {
+  local pod=$1 phase node
+  sleep 20
+  phase=$(kubectl get pod -n "$NS" "$pod" -o jsonpath='{.status.phase}')
+  node=$(kubectl get pod -n "$NS" "$pod" -o jsonpath='{.spec.nodeName}')
+  [[ "$phase" == Pending && -z "$node" ]] || fail "$pod expected Pending/unbound, got phase=${phase} node=${node}"
+}
+
+[[ -n "$TARGET_NODE" ]] || fail "set TARGET_NODE to the Kubernetes node under test"
+kubectl get node "$TARGET_NODE" >/dev/null || fail "target node ${TARGET_NODE} does not exist"
+node_nvidia_smi -L >/dev/null
+physical_gpu_count=$(node_nvidia_smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')
+[[ "$physical_gpu_count" == 1 ]] || fail "target node ${TARGET_NODE} must expose exactly one physical GPU, found ${physical_gpu_count}"
+
+log "baseline cleanup on ${TARGET_NODE}"
+cleanup
+kubectl create namespace "$NS"
+wait_count 0
+
+log "SMOKE CASE: basic MIG allocation and GPU progress validation"
+create_pod smoke-one 4500
+wait_ready smoke-one
+wait_count 1
+[[ "$(profile_count 1g.5gb)" == 1 ]] || fail "expected one 1g.5gb"
+uuid_smoke_one=$(pod_uuid smoke-one)
+assert_runtime_annotation smoke-one
+assert_gpu_progress smoke-one
+
+log "SMOKE CASE: overflow rejection"
+create_pod smoke-overflow 4500
+assert_pending_unbound smoke-overflow
+wait_count 1
+echo "PASS SMOKE CASE: overflow rejected"
+
+log "final cleanup and health"
+cleanup
+wait_count 0
+kubectl get nodes
+kubectl get pods -n "$HAMI_NS"
+node_nvidia_smi -q | grep -A3 'MIG Mode'
+echo "ALL_MIG_SMOKE_TESTS_PASSED"

--- a/hack/e2e-mig-test.sh
+++ b/hack/e2e-mig-test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright 2024 The HAMi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+set -x
+
+KUBE_CONF=${1:-"${HOME}/.kube/config"}
+export KUBE_CONF
+export KUBECONFIG="${KUBE_CONF}"
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+source "${REPO_ROOT}"/hack/util.sh
+
+if [ -z "${KUBE_CONF}" ]; then
+   echo "Error: KUBE_CONF is not set and no default kubeconfig found."
+   exit 1
+fi
+
+# Validate kubeconfig file exists
+if [ ! -f "${KUBE_CONF}" ]; then
+   echo "Error: kubeconfig file not found at ${KUBE_CONF}"
+   exit 1
+fi
+
+# Check kubectl connectivity
+if ! kubectl --kubeconfig "${KUBE_CONF}" get nodes &>/dev/null; then
+   echo "Error: cannot reach Kubernetes API server via ${KUBE_CONF}"
+   exit 1
+fi
+
+# Check if TARGET_NODE is set
+if [ -z "${TARGET_NODE:-}" ]; then
+   echo "Error: TARGET_NODE environment variable is not set."
+   echo "Please set TARGET_NODE to the Kubernetes node name that has MIG-capable GPU."
+   echo "Example: export TARGET_NODE=mig-node-0"
+   exit 1
+fi
+
+# Validate target node exists
+if ! kubectl --kubeconfig "${KUBE_CONF}" get node "${TARGET_NODE}" &>/dev/null; then
+   echo "Error: target node ${TARGET_NODE} does not exist in the cluster."
+   exit 1
+fi
+
+# Check if the target node has GPU resources
+node_gpu_capacity=$(kubectl --kubeconfig "${KUBE_CONF}" get node "${TARGET_NODE}" -o jsonpath='{.status.capacity.nvidia\.com/gpu}' 2>/dev/null || echo "")
+if [ -z "${node_gpu_capacity}" ] || [ "${node_gpu_capacity}" = "0" ]; then
+   echo "Error: target node ${TARGET_NODE} does not have nvidia.com/gpu capacity."
+   echo "MIG E2E test requires a node with MIG-capable GPU."
+   exit 1
+fi
+
+echo "=== MIG E2E Test Environment ==="
+echo "Kubeconfig: ${KUBE_CONF}"
+echo "Target Node: ${TARGET_NODE}"
+echo "GPU Capacity: ${node_gpu_capacity}"
+echo "================================"
+
+# Run the MIG E2E test
+"${REPO_ROOT}"/hack/hami-mig-e2e.sh

--- a/hack/e2e-mig-test.sh
+++ b/hack/e2e-mig-test.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Wrapper that validates kubeconfig and delegates to hami-mig-e2e.sh.
+# All test logic and preflight checks live in hami-mig-e2e.sh; this
+# script only ensures KUBECONFIG is set so bare kubectl calls work.
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -25,52 +29,11 @@ export KUBECONFIG="${KUBE_CONF}"
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}"
-source "${REPO_ROOT}"/hack/util.sh
 
-if [ -z "${KUBE_CONF}" ]; then
-   echo "Error: KUBE_CONF is not set and no default kubeconfig found."
-   exit 1
-fi
-
-# Validate kubeconfig file exists
 if [ ! -f "${KUBE_CONF}" ]; then
    echo "Error: kubeconfig file not found at ${KUBE_CONF}"
    exit 1
 fi
 
-# Check kubectl connectivity
-if ! kubectl --kubeconfig "${KUBE_CONF}" get nodes &>/dev/null; then
-   echo "Error: cannot reach Kubernetes API server via ${KUBE_CONF}"
-   exit 1
-fi
-
-# Check if TARGET_NODE is set
-if [ -z "${TARGET_NODE:-}" ]; then
-   echo "Error: TARGET_NODE environment variable is not set."
-   echo "Please set TARGET_NODE to the Kubernetes node name that has MIG-capable GPU."
-   echo "Example: export TARGET_NODE=mig-node-0"
-   exit 1
-fi
-
-# Validate target node exists
-if ! kubectl --kubeconfig "${KUBE_CONF}" get node "${TARGET_NODE}" &>/dev/null; then
-   echo "Error: target node ${TARGET_NODE} does not exist in the cluster."
-   exit 1
-fi
-
-# Check if the target node has GPU resources
-node_gpu_capacity=$(kubectl --kubeconfig "${KUBE_CONF}" get node "${TARGET_NODE}" -o jsonpath='{.status.capacity.nvidia\.com/gpu}' 2>/dev/null || echo "")
-if [ -z "${node_gpu_capacity}" ] || [ "${node_gpu_capacity}" = "0" ]; then
-   echo "Error: target node ${TARGET_NODE} does not have nvidia.com/gpu capacity."
-   echo "MIG E2E test requires a node with MIG-capable GPU."
-   exit 1
-fi
-
-echo "=== MIG E2E Test Environment ==="
-echo "Kubeconfig: ${KUBE_CONF}"
-echo "Target Node: ${TARGET_NODE}"
-echo "GPU Capacity: ${node_gpu_capacity}"
-echo "================================"
-
-# Run the MIG E2E test
-"${REPO_ROOT}"/hack/hami-mig-e2e.sh
+source "${REPO_ROOT}"/hack/hami-mig-e2e.sh
+main

--- a/hack/e2e-test-setup.sh
+++ b/hack/e2e-test-setup.sh
@@ -40,7 +40,10 @@ function setup_e2e_env() {
     gpu_nodes=$(kubectl --kubeconfig "${kubeconf}" get nodes \
         -l 'nvidia.com/gpu.present=true' --no-headers 2>/dev/null | wc -l)
     if [[ "${gpu_nodes}" -eq 0 ]]; then
-        echo "Warning: no nodes with label nvidia.com/gpu.present=true found"
+        echo "FAIL: no nodes with label nvidia.com/gpu.present=true found"
+        echo "E2E tests require at least one GPU node."
+        echo "Please ensure a GPU node is available and labeled with nvidia.com/gpu.present=true"
+        exit 1
     else
         echo "found ${gpu_nodes} GPU node(s)"
     fi

--- a/test/e2e/node/test_node.go
+++ b/test/e2e/node/test_node.go
@@ -44,14 +44,14 @@ var _ = ginkgo.Describe("[Node] Node E2E Tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 0), "No nodes available for testing")
 
-		// Select a node with GPU resources
+		// Select a node with GPU resources - fail fast if no GPU node found
 		for _, node := range nodes.Items {
 			if _, exists := node.Status.Capacity["nvidia.com/gpu"]; exists {
 				nodeName = node.Name
 				break
 			}
 		}
-		gomega.Expect(nodeName).NotTo(gomega.BeEmpty(), "No GPU node found")
+		gomega.Expect(nodeName).NotTo(gomega.BeEmpty(), "No GPU node found: E2E tests require at least one node with nvidia.com/gpu capacity")
 	})
 
 	ginkgo.It("verify node with labeling", func() {

--- a/test/e2e/pod/test_pod.go
+++ b/test/e2e/pod/test_pod.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("Pod E2E Tests", ginkgo.Ordered, func() {
 
 		var err error
 		nodeName, err = utils.GetGPUNode(clientSet)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to find GPU node: E2E tests require at least one node with nvidia.com/gpu capacity")
 		fmt.Printf("Using GPU node: %s\n", nodeName)
 
 		ginkgo.By("Adding node labeling")

--- a/test/utils/common.go
+++ b/test/utils/common.go
@@ -90,9 +90,6 @@ func GetRandom() string {
 
 // KubectlExecInPod executes a shell command in a specified Pod using kubectl exec.
 func KubectlExecInPod(namespace, podName, command string) ([]byte, error) {
-	// Wait for the container to stabilize
-	time.Sleep(30 * time.Second)
-
 	// Build the kubectl exec command
 	cmd := exec.Command("kubectl", "exec", "-n", namespace, podName, "--", "/bin/bash", "-c", command)
 

--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -38,3 +38,10 @@ const (
 	ErrReasonFailedScheduling  = "FilteringFailed"
 	ErrMessageFailedScheduling = "0/1 nodes are available"
 )
+
+// MIG related.
+const (
+	MIGModeAnnotation       = "nvidia.com/vgpu-mode"
+	MIGModeValue            = "mig"
+	MIGAllocationAnnotation = "hami.io/vgpu-mig-allocations"
+)

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetGPUNode returns the name of the first node that has nvidia.com/gpu capacity.
-// It falls back to the first node in the cluster if no GPU node is found.
+// It returns an error if no GPU node is found, failing fast instead of falling back to a non-GPU node.
 func GetGPUNode(clientSet *kubernetes.Clientset) (string, error) {
 	nodes, err := clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -39,10 +39,7 @@ func GetGPUNode(clientSet *kubernetes.Clientset) (string, error) {
 			return node.Name, nil
 		}
 	}
-	if len(nodes.Items) > 0 {
-		return nodes.Items[0].Name, nil
-	}
-	return "", fmt.Errorf("no nodes found in the cluster")
+	return "", fmt.Errorf("no GPU node found: no nodes with nvidia.com/gpu capacity in the cluster")
 }
 
 func GetNodes(clientSet *kubernetes.Clientset) (*v1.NodeList, error) {

--- a/test/utils/pod.go
+++ b/test/utils/pod.go
@@ -64,7 +64,6 @@ func GetPods(clientSet *kubernetes.Clientset, namespace string) (*corev1.PodList
 }
 
 func CreatePod(clientSet *kubernetes.Clientset, pod *corev1.Pod, namespace string) (*corev1.Pod, error) {
-	time.Sleep(15 * time.Second)
 	createdPod, err := clientSet.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
 		klog.Errorf("Failed to create Pod %s in namespace %s: %v", pod.Name, namespace, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:


1. **Connect MIG E2E to formal targets**: `hack/hami-mig-e2e.sh` is now reachable via `make e2e-mig-test`, with a wrapper script (`hack/e2e-mig-test.sh`) that validates kubeconfig, target node, and GPU capacity before running the full MIG matrix.

2. **Lightweight MIG smoke test for PR gates**: Added `make e2e-mig-smoke-test` backed by `hack/e2e-mig-smoke-test.sh`, which runs a minimal MIG allocation + overflow rejection scenario. Full MIG matrix is reserved for nightly/release.

3. **GPU preflight fail-fast**: `hack/e2e-test-setup.sh` now exits with error instead of warning when no `nvidia.com/gpu.present=true` node is found. `GetGPUNode()` in `test/utils/node.go` returns an error instead of falling back to a non-GPU node.

4. **GitHub Actions integration**: Added `call-e2e-mig.yaml` reusable workflow with separate `deploy-type` input (maps to `pullrequest`/`release` for `deploy-helm.sh`). MIG smoke test runs on every PR; full MIG test runs on release.

5. **Minor test utility fixes**: Removed hardcoded `time.Sleep` from `CreatePod` and `KubectlExecInPod`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- MIG tests require a runner with `mig` label and `MIG_TARGET_NODE` set in repository variables.
- The smoke script defines its own `wait_count` helper (copied from `hami-mig-e2e.sh`) to avoid coupling.

**Does this PR introduce a user-facing change?**:

No. This only adds E2E test infrastructure and CI workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated NVIDIA MIG smoke and end-to-end testing for supported GPU environments.
  - Added commands to run MIG smoke or full tests with a specified Kubernetes configuration.
  - Tests now validate MIG workload readiness, GPU allocation, runtime behavior, and resource limits.
  - Integrated MIG smoke testing into the continuous integration workflow.

- **Bug Fixes**
  - Test setup now fails clearly when no GPU-capable node is available.
  - Improved diagnostics for missing GPU resources and invalid test environments.
  - Reduced unnecessary delays during pod creation and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->