### PR TITLE
fix(scheduler): respect HAMI_NODELOCK_EXPIRE env when --node-lock-timeout flag is absent

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -54,7 +54,7 @@ var (
 		Short: "kubernetes vgpu scheduler",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flag.PrintPFlags(cmd.Flags())
-			return start()
+			return start(cmd)
 		},
 	}
 )
@@ -109,10 +109,17 @@ func injectProfilingRoute(router *httprouter.Router) {
 	})
 }
 
-func start() error {
-	// Initialize node lock timeout from config
-	nodelock.NodeLockTimeout = config.NodeLockTimeout
-	klog.InfoS("Set node lock timeout", "timeout", nodelock.NodeLockTimeout)
+func resolveNodeLockTimeout(flagChanged bool) {
+	if flagChanged {
+		nodelock.NodeLockTimeout = config.NodeLockTimeout
+		klog.InfoS("Set node lock timeout from flag", "timeout", nodelock.NodeLockTimeout)
+	} else {
+		klog.InfoS("Using node lock timeout from environment or default", "timeout", nodelock.NodeLockTimeout)
+	}
+}
+
+func start(cmd *cobra.Command) error {
+	resolveNodeLockTimeout(cmd.Flags().Changed("node-lock-timeout"))
 	client.InitGlobalClient(
 		client.WithBurst(config.Burst),
 		client.WithQPS(config.QPS),

--- a/cmd/scheduler/main_test.go
+++ b/cmd/scheduler/main_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
+)
+
+func TestResolveNodeLockTimeout(t *testing.T) {
+	originalTimeout := nodelock.NodeLockTimeout
+	originalConfigTimeout := config.NodeLockTimeout
+	defer func() {
+		nodelock.NodeLockTimeout = originalTimeout
+		config.NodeLockTimeout = originalConfigTimeout
+	}()
+
+	t.Run("neither flag nor env set - preserves default", func(t *testing.T) {
+		nodelock.NodeLockTimeout = time.Minute * 5
+		config.NodeLockTimeout = time.Minute * 5
+
+		resolveNodeLockTimeout(false)
+
+		if nodelock.NodeLockTimeout != time.Minute*5 {
+			t.Errorf("expected %v, got %v", time.Minute*5, nodelock.NodeLockTimeout)
+		}
+	})
+
+	t.Run("env set, flag not set - preserves env setting", func(t *testing.T) {
+		// Simulate env var being parsed by nodelock package init
+		envDuration := time.Minute * 10
+		nodelock.NodeLockTimeout = envDuration
+		// config.NodeLockTimeout still has flag default 5m
+		config.NodeLockTimeout = time.Minute * 5
+
+		resolveNodeLockTimeout(false)
+
+		if nodelock.NodeLockTimeout != envDuration {
+			t.Errorf("expected %v from env, got %v", envDuration, nodelock.NodeLockTimeout)
+		}
+	})
+
+	t.Run("flag explicitly set - overrides with flag value", func(t *testing.T) {
+		// Even if env set NodeLockTimeout to 10m
+		nodelock.NodeLockTimeout = time.Minute * 10
+		flagDuration := time.Minute * 2
+		config.NodeLockTimeout = flagDuration
+
+		resolveNodeLockTimeout(true)
+
+		if nodelock.NodeLockTimeout != flagDuration {
+			t.Errorf("expected %v from flag, got %v", flagDuration, nodelock.NodeLockTimeout)
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Helm chart has `scheduler.nodeLockExpire` which sets `HAMI_NODELOCK_EXPIRE` env var on the scheduler pod. The nodelock package reads this in `init()` and sets `NodeLockTimeout` correctly. But then in `start()`, we do:

```go
nodelock.NodeLockTimeout = config.NodeLockTimeout
```

`config.NodeLockTimeout` comes from the `--node-lock-timeout` cobra flag which defaults to 5m. Since cobra always fills in the default even when the flag isn't passed, this line overwrites whatever the env var set. So `scheduler.nodeLockExpire` in the Helm chart literally does nothing.

I used `cmd.Flags().Changed("node-lock-timeout")` to check if the flag was actually passed by the user. If it was, use the flag value. If not, keep whatever `init()` set from the env var.

After this fix the precedence is:
1. `--node-lock-timeout` flag (if explicitly passed)
2. `HAMI_NODELOCK_EXPIRE` env var
3. default 5m

Fixes #2692

**AI Disclosure**: I used Gemini to help explore the codebase and understand the cobra flag flow, but I identified the root cause myself by tracing through `nodelock.go` init -> `main.go` start. The fix and testing were done with AI assistance.

**How was this tested?**

- `go build ./cmd/scheduler/...` passes
- `go test ./pkg/util/nodelock/... -run TestSetupNodeLockTimeout` passes
- all existing nodelock tests still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduler handling of the node-lock timeout setting.
  - Explicit command-line values now take precedence, while environment-provided and default settings are preserved when no flag is specified.
  - Added logging to indicate which timeout source was selected.

- **Tests**
  - Added coverage for default, environment-derived, and explicitly configured timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->