### PR TITLE
fix(device-plugin): disable in-container control for exclusive GPU allocations

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_refactor_test.go
@@ -27,9 +27,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
@@ -148,12 +148,12 @@ func mockAllocateGlobals(t *testing.T, pod *corev1.Pod) {
 
 func TestPopNextContainerDevices(t *testing.T) {
 	tests := []struct {
-		name         string
-		containers   []corev1.Container
-		podSingleDev device.PodSingleDevice
-		wantName     string
-		wantUUID     string
-		wantErr      string
+		name          string
+		containers    []corev1.Container
+		podSingleDev  device.PodSingleDevice
+		wantName      string
+		wantUUID      string
+		wantErr       string
 		wantRemaining int
 	}{
 		{
@@ -808,4 +808,65 @@ func TestAllocate_PatchErasedAnnotationError(t *testing.T) {
 	_, err := plugin.Allocate(context.Background(), request)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "patch not allowed")
+}
+
+func exclusiveControlPod(env []corev1.EnvVar, annotation string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": annotation,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0", Env: env}},
+		},
+	}
+}
+
+func allocateSingle(t *testing.T, pod *corev1.Pod) *kubeletdevicepluginv1beta1.ContainerAllocateResponse {
+	t.Helper()
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+	return response.ContainerResponses[0]
+}
+
+func TestAllocate_ExclusiveGPU_AutoDisablesControl(t *testing.T) {
+	ctr := allocateSingle(t, exclusiveControlPod(nil, "GPU-aaa,NVIDIA,0,100:;"))
+	require.Equal(t, "true", ctr.Envs["CUDA_DISABLE_CONTROL"])
+	require.False(t, hasLdSoPreloadMount(ctr.Mounts))
+}
+
+func TestAllocate_ExclusiveGPU_ExplicitFalseKeepsControl(t *testing.T) {
+	env := []corev1.EnvVar{{Name: "CUDA_DISABLE_CONTROL", Value: "false"}}
+	ctr := allocateSingle(t, exclusiveControlPod(env, "GPU-aaa,NVIDIA,0,100:;"))
+	_, set := ctr.Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, set)
+	require.True(t, hasLdSoPreloadMount(ctr.Mounts))
+}
+
+func TestAllocate_LimitlessSharedGPU_KeepsControl(t *testing.T) {
+	ctr := allocateSingle(t, exclusiveControlPod(nil, "GPU-aaa,NVIDIA,0,0:;"))
+	_, set := ctr.Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, set)
+	require.True(t, hasLdSoPreloadMount(ctr.Mounts))
+}
+
+func TestAllocate_ExclusiveCoresWithMemoryCap_KeepsControl(t *testing.T) {
+	ctr := allocateSingle(t, exclusiveControlPod(nil, "GPU-aaa,NVIDIA,3000,100:;"))
+	_, set := ctr.Envs["CUDA_DISABLE_CONTROL"]
+	require.False(t, set)
+	require.True(t, hasLdSoPreloadMount(ctr.Mounts))
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -853,10 +853,23 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						HostPath: "/tmp/vgpulock",
 						ReadOnly: false},
 				)
+				// An exclusive allocation (full cores, no memory cap) shares its card
+				// with no other pod, so the interception library adds no isolation and
+				// can deadlock NCCL init (#2641). Skipping it drops the pod from
+				// vGPUmonitor's per-pod metrics, since nothing writes the cache file.
+				exclusive := len(devreq) > 0
+				for _, dev := range devreq {
+					if dev.Usedcores != 100 || dev.Usedmem != 0 {
+						exclusive = false
+						break
+					}
+				}
 				found := false
+				userSet := false
 				for _, val := range currentCtr.Env {
 					if strings.Compare(val.Name, "CUDA_DISABLE_CONTROL") == 0 {
 						// if env existed but is set to false or can not be parsed, ignore
+						userSet = true
 						t, _ := strconv.ParseBool(val.Value)
 						if !t {
 							continue
@@ -865,6 +878,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						found = true
 						break
 					}
+				}
+				if exclusive && !userSet {
+					found = true
+					response.Envs["CUDA_DISABLE_CONTROL"] = "true"
+					klog.InfoS("exclusive GPU allocation, disabling in-container control", "pod", klog.KObj(current), "container", currentCtr.Name)
 				}
 				if !found {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",


### PR DESCRIPTION
Auto-sets CUDA_DISABLE_CONTROL=true only for exclusive allocations (full cores, no memory cap), where the interception library adds no isolation and can deadlock NCCL init; fixes #2641.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically sets `CUDA_DISABLE_CONTROL=true` for eligible exclusive GPU allocations without memory limits.
  * Preserves explicitly configured `CUDA_DISABLE_CONTROL` values, including false or invalid settings.

* **Bug Fixes**
  * Improved environment handling for exclusive GPU workloads to prevent unnecessary control enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->