### PR TITLE
Fixed Scheduler returning false

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -160,7 +160,14 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	return err
 }
 func AllInitContainersSucceeded(pod *corev1.Pod) bool {
-	if len(pod.Status.InitContainerStatuses) == 0 {
+	if pod == nil {
+		return false
+	}
+	initContainers := len(pod.Spec.InitContainers)
+	if initContainers == 0 {
+		return false
+	}
+	if len(pod.Status.InitContainerStatuses) != initContainers {
 		return false
 	}
 	for _, s := range pod.Status.InitContainerStatuses {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -170,6 +170,22 @@ func AllInitContainersSucceeded(pod *corev1.Pod) bool {
 	if len(pod.Status.InitContainerStatuses) != initContainers {
 		return false
 	}
+	remaining := make(map[string]struct{}, initContainers)
+	for _, container := range pod.Spec.InitContainers {
+		remaining[container.Name] = struct{}{}
+	}
+	for _, s := range pod.Status.InitContainerStatuses {
+		if _, ok := remaining[s.Name]; !ok {
+			return false
+		}
+		if s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		delete(remaining, s.Name)
+	}
+	return len(remaining) == 0
+		return false
+	}
 	for _, s := range pod.Status.InitContainerStatuses {
 		if s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
 			return false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -184,14 +184,6 @@ func AllInitContainersSucceeded(pod *corev1.Pod) bool {
 		delete(remaining, s.Name)
 	}
 	return len(remaining) == 0
-		return false
-	}
-	for _, s := range pod.Status.InitContainerStatuses {
-		if s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 func PatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -538,6 +538,72 @@ func Test_AllContainersCreated(t *testing.T) {
 	}
 }
 
+func Test_AllInitContainersSucceeded(t *testing.T) {
+	tests := []struct {
+		name string
+		args *corev1.Pod
+		want bool
+	}{
+		{
+			name: "missing init container statuses",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a"},
+						{Name: "init-b"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-a",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all init containers terminated successfully",
+			args: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a"},
+						{Name: "init-b"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "init-a",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+						{
+							Name: "init-b",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := AllInitContainersSucceeded(test.args)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestIsPodGroupMember(t *testing.T) {
 	podGroupName := "my-training-job"
 	emptyPodGroupName := ""


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Fixes the false result which schedular is generating on completion of only one init-container.

**Which issue(s) this PR fixes**:
Fixes #2749 

**Special notes for your reviewer**:
<img width="1585" height="759" alt="image" src="https://github.com/user-attachments/assets/1844ee65-ef76-4f7b-bf58-94db44aa2261" />

**Does this PR introduce a user-facing change?**:
Yes... for next `release-note`: fixed scheduler device, so init container resources are released only after statuses are reported for all init containers.

> This PR was authored with assistance from Codex for help me implementing the core fix logic for init-container validation in `util.go`, and `util_test.go` to cover missing init-container statuses.
> I have fully reviewed and tested all logics and AI-generated code. The implementation was validated to ensure the scheduler correctly evaluates all init containers before returning a result. All tests pass locally and attached with the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of init-container completion status.
  * Ensured only declared init containers are evaluated.
  * Pods with missing, incomplete, or unsuccessful init-container status now correctly report as unsuccessful.
  * Successfully completed init containers continue to be recognized correctly.

* **Tests**
  * Added coverage for missing statuses and successful init-container completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->