### PR TITLE
fix(scheduler): include init container requests in device locking

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -131,28 +131,14 @@ func (dev *AMDDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]s
 }
 
 func (dev *AMDDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, NodeLockAMD, p)
 }
 
 func (dev *AMDDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, NodeLockAMD, p, false)

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -256,14 +256,7 @@ func (dev *Devices) PatchAnnotations(pod *corev1.Pod, annoInput *map[string]stri
 }
 
 func (dev *Devices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 
@@ -271,14 +264,7 @@ func (dev *Devices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 }
 
 func (dev *Devices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 

--- a/pkg/device/biren/device.go
+++ b/pkg/device/biren/device.go
@@ -96,28 +96,14 @@ func (dev *BirenDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (
 }
 
 func (dev *BirenDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, nodelock.NodeLockKey, p)
 }
 
 func (dev *BirenDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, nodelock.NodeLockKey, p, false)

--- a/pkg/device/biren/device_test.go
+++ b/pkg/device/biren/device_test.go
@@ -423,18 +423,44 @@ func TestDevices_LockNode(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "Test with no containers",
+			name:        "no containers — skip lock",
 			node:        &corev1.Node{},
 			pod:         &corev1.Pod{Spec: corev1.PodSpec{}},
 			hasLock:     false,
 			expectError: false,
 		},
 		{
-			name: "Test with non-zero resource requests",
+			name: "regular-container GPU request — acquires lock",
 			node: &corev1.Node{},
 			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				"birentech.com/gpu": resource.MustParse("1"),
 			}}}}}},
+			hasLock:     true,
+			expectError: false,
+		},
+		{
+			name: "init-container-only GPU request — acquires lock",
+			node: &corev1.Node{},
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"birentech.com/gpu": resource.MustParse("1"),
+				}}}},
+				Containers: []corev1.Container{{Name: "cpu-app"}},
+			}},
+			hasLock:     true,
+			expectError: false,
+		},
+		{
+			name: "init+regular GPU request — acquires lock",
+			node: &corev1.Node{},
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"birentech.com/gpu": resource.MustParse("1"),
+				}}}},
+				Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"birentech.com/gpu": resource.MustParse("1"),
+				}}}},
+			}},
 			hasLock:     true,
 			expectError: false,
 		},

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -123,14 +123,7 @@ func (dev *CambriconDevices) setNodeLock(node *corev1.Node) error {
 }
 
 func (dev *CambriconDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	if _, ok := n.Annotations[DsmluLockTime]; !ok {

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -733,3 +733,22 @@ func CheckType(annos map[string]string, cardType, useKey, noUseKey string) bool 
 	}
 	return true
 }
+
+// PodRequiresDevice returns true if any container (init container or regular container)
+// in the pod requests resources from the specified device generator.
+func PodRequiresDevice(dev Devices, p *corev1.Pod) bool {
+	if p == nil || dev == nil {
+		return false
+	}
+	for i := range p.Spec.InitContainers {
+		if dev.GenerateResourceRequests(&p.Spec.InitContainers[i]).Nums > 0 {
+			return true
+		}
+	}
+	for i := range p.Spec.Containers {
+		if dev.GenerateResourceRequests(&p.Spec.Containers[i]).Nums > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1869,3 +1869,106 @@ func TestDecodeNodeDevicesLegacyFormat(t *testing.T) {
 		},
 	}, decoded)
 }
+
+func TestPodRequiresDevice(t *testing.T) {
+	mockDev := &mockDevices{
+		resourceRequest: ContainerDeviceRequest{
+			Nums:     1,
+			Type:     "NVIDIA",
+			Memreq:   1000,
+			Coresreq: 10,
+		},
+	}
+
+	gpuCtr := corev1.Container{
+		Name: "gpu-ctr",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("1"),
+			},
+		},
+	}
+	noGpuCtr := corev1.Container{
+		Name: "no-gpu-ctr",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu": resource.MustParse("1"),
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		dev  Devices
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "nil pod returns false",
+			dev:  mockDev,
+			pod:  nil,
+			want: false,
+		},
+		{
+			name: "nil dev returns false",
+			dev:  nil,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{gpuCtr},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no device request in init or regular containers",
+			dev:  mockDev,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{noGpuCtr},
+					Containers:     []corev1.Container{noGpuCtr},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "regular-container-only request",
+			dev:  mockDev,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{noGpuCtr},
+					Containers:     []corev1.Container{gpuCtr},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "init-container-only request",
+			dev:  mockDev,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{gpuCtr},
+					Containers:     []corev1.Container{noGpuCtr},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "init and regular container requests",
+			dev:  mockDev,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{gpuCtr},
+					Containers:     []corev1.Container{gpuCtr},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PodRequiresDevice(tt.dev, tt.pod)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -101,28 +101,14 @@ func checkDCUtype(annos map[string]string, cardtype string) bool {
 }
 
 func (dev *DCUDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, NodeLockDCU, p)
 }
 
 func (dev *DCUDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, NodeLockDCU, p, false)

--- a/pkg/device/hygon/device_test.go
+++ b/pkg/device/hygon/device_test.go
@@ -697,11 +697,37 @@ func TestDevices_LockNode(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Test with non-zero resource requests",
+			name: "Test with regular container resource requests",
 			node: &corev1.Node{},
 			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				"hygon.com/dcunum": resource.MustParse("1"),
 			}}}}}},
+			hasLock:     true,
+			expectError: false,
+		},
+		{
+			name: "Test with init container resource requests",
+			node: &corev1.Node{},
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"hygon.com/dcunum": resource.MustParse("1"),
+				}}}},
+				Containers: []corev1.Container{{Name: "cpu-app"}},
+			}},
+			hasLock:     true,
+			expectError: false,
+		},
+		{
+			name: "Test with init and regular container resource requests",
+			node: &corev1.Node{},
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"hygon.com/dcunum": resource.MustParse("1"),
+				}}}},
+				Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					"hygon.com/dcunum": resource.MustParse("1"),
+				}}}},
+			}},
 			hasLock:     true,
 			expectError: false,
 		},
@@ -746,21 +772,23 @@ func TestDevices_LockNode(t *testing.T) {
 
 func TestDevices_ReleaseNodeLock(t *testing.T) {
 	tests := []struct {
-		name        string
-		node        *corev1.Node
-		pod         *corev1.Pod
-		hasLock     bool
-		expectError bool
+		name           string
+		node           *corev1.Node
+		pod            *corev1.Pod
+		lockAnnotation string
+		hasLock        bool
+		expectError    bool
 	}{
 		{
-			name:        "Test with no containers",
-			node:        &corev1.Node{},
-			pod:         &corev1.Pod{Spec: corev1.PodSpec{}},
-			hasLock:     true,
-			expectError: false,
+			name:           "Test with no containers",
+			node:           &corev1.Node{},
+			pod:            &corev1.Pod{Spec: corev1.PodSpec{}},
+			lockAnnotation: "lock-values,default,nozerorr",
+			hasLock:        true,
+			expectError:    false,
 		},
 		{
-			name: "Test with non-zero resource requests",
+			name: "Test with regular container resource requests",
 			node: &corev1.Node{},
 			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Name:      "nozerorr",
@@ -768,8 +796,22 @@ func TestDevices_ReleaseNodeLock(t *testing.T) {
 			}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 				"hygon.com/dcunum": resource.MustParse("1"),
 			}}}}}},
-			hasLock:     false,
-			expectError: false,
+			lockAnnotation: "lock-values,default,nozerorr",
+			hasLock:        false,
+			expectError:    false,
+		},
+		{
+			name: "Test with init container resource requests",
+			node: &corev1.Node{},
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      "init-dcunum",
+				Namespace: "default",
+			}, Spec: corev1.PodSpec{InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				"hygon.com/dcunum": resource.MustParse("1"),
+			}}}}}},
+			lockAnnotation: "lock-values,default,init-dcunum",
+			hasLock:        false,
+			expectError:    false,
 		},
 	}
 
@@ -780,7 +822,7 @@ func TestDevices_ReleaseNodeLock(t *testing.T) {
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "testNode",
-					Annotations: map[string]string{"test-annotation-key": "test-annotation-value", device.InRequestDevices["DCU"]: "some-value", NodeLockDCU: "lock-values,default,nozerorr"},
+					Annotations: map[string]string{"test-annotation-key": "test-annotation-value", device.InRequestDevices["DCU"]: "some-value", NodeLockDCU: tt.lockAnnotation},
 				},
 			}
 

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -154,14 +154,7 @@ func (dev *IluvatarDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[str
 }
 
 func (dev *IluvatarDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 
@@ -169,14 +162,7 @@ func (dev *IluvatarDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 }
 
 func (dev *IluvatarDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -134,28 +134,14 @@ func (dev *KunlunVDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[stri
 }
 
 func (dev *KunlunVDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, NodeLock, p)
 }
 
 func (dev *KunlunVDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, NodeLock, p, false)

--- a/pkg/device/kunlun/vdevice_test.go
+++ b/pkg/device/kunlun/vdevice_test.go
@@ -314,12 +314,40 @@ func Test_KunlunVDevices_LockNode(t *testing.T) {
 			hasLock: false,
 		},
 		{
-			name: "container requesting xpu locks node",
+			name: "regular container requesting xpu locks node",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
 					corev1.ResourceName(KunlunResourceVCount): resource.MustParse("1"),
 				}},
 			}}}},
+			hasLock: true,
+		},
+		{
+			name: "init-container-only requesting xpu locks node",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						corev1.ResourceName(KunlunResourceVCount): resource.MustParse("1"),
+					}},
+				}},
+				Containers: []corev1.Container{{Name: "cpu-app"}},
+			}},
+			hasLock: true,
+		},
+		{
+			name: "init+regular both requesting xpu locks node",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						corev1.ResourceName(KunlunResourceVCount): resource.MustParse("1"),
+					}},
+				}},
+				Containers: []corev1.Container{{
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						corev1.ResourceName(KunlunResourceVCount): resource.MustParse("1"),
+					}},
+				}},
+			}},
 			hasLock: true,
 		},
 	}

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -171,16 +171,7 @@ func (sdev *MetaxSDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[stri
 }
 
 func (sdev *MetaxSDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-
-	for _, val := range p.Spec.Containers {
-		if (sdev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !device.PodRequiresDevice(sdev, p) {
 		return nil
 	}
 
@@ -188,16 +179,7 @@ func (sdev *MetaxSDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
 }
 
 func (sdev *MetaxSDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-
-	for _, val := range p.Spec.Containers {
-		if (sdev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-
-	if !found {
+	if !device.PodRequiresDevice(sdev, p) {
 		return nil
 	}
 

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -266,28 +266,14 @@ func (dev *NvidiaGPUDevices) CheckHealth(devType string, n *corev1.Node) (bool, 
 }
 
 func (dev *NvidiaGPUDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, NodeLockNvidia, p)
 }
 
 func (dev *NvidiaGPUDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, NodeLockNvidia, p, false)

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2165,15 +2165,63 @@ func TestLockNode(t *testing.T) {
 			name: "no GPU containers — skip lock",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pod-no-gpu", Namespace: "default"},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init-no-gpu"}},
+					Containers:     []corev1.Container{{Name: "app"}},
+				},
 			},
 			hasLock: false,
 		},
 		{
-			name: "has GPU container — acquires lock",
+			name: "regular-container-only GPU request — acquires lock",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pod-gpu", Namespace: "default"},
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "gpu-app",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
+				},
+			},
+			hasLock: true,
+		},
+		{
+			name: "init-container-only GPU request — acquires lock",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-init-gpu", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name: "gpu-init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: "cpu-app",
+					}},
+				},
+			},
+			hasLock: true,
+		},
+		{
+			name: "init and regular container GPU request — acquires lock",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-init-and-reg-gpu", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name: "gpu-init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
 					Containers: []corev1.Container{{
 						Name: "gpu-app",
 						Resources: corev1.ResourceRequirements{
@@ -2450,18 +2498,23 @@ func TestReleaseNodeLock(t *testing.T) {
 	tests := []struct {
 		name    string
 		pod     *corev1.Pod
+		lockVal string
 		hasLock bool
 	}{
 		{
 			name: "no GPU containers — skip release, lock remains",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pod-no-gpu", Namespace: "default"},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init-no-gpu"}},
+					Containers:     []corev1.Container{{Name: "app"}},
+				},
 			},
+			lockVal: "lock-values,default,pod-no-gpu",
 			hasLock: true,
 		},
 		{
-			name: "has GPU container — releases lock",
+			name: "regular-container-only GPU request — releases lock",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pod-gpu", Namespace: "default"},
 				Spec: corev1.PodSpec{
@@ -2475,6 +2528,52 @@ func TestReleaseNodeLock(t *testing.T) {
 					}},
 				},
 			},
+			lockVal: "lock-values,default,pod-gpu",
+			hasLock: false,
+		},
+		{
+			name: "init-container-only GPU request — releases lock",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-init-gpu", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name: "gpu-init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
+					Containers: []corev1.Container{{Name: "cpu-app"}},
+				},
+			},
+			lockVal: "lock-values,default,pod-init-gpu",
+			hasLock: false,
+		},
+		{
+			name: "init and regular container GPU request — releases lock",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-init-reg-gpu", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name: "gpu-init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: "gpu-app",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"nvidia.com/gpu": *resource.NewQuantity(1, resource.BinarySI),
+							},
+						},
+					}},
+				},
+			},
+			lockVal: "lock-values,default,pod-init-reg-gpu",
 			hasLock: false,
 		},
 	}
@@ -2482,11 +2581,15 @@ func TestReleaseNodeLock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client.KubeClient = fake.NewClientset()
+			lockVal := tt.lockVal
+			if lockVal == "" {
+				lockVal = "lock-values,default," + tt.pod.Name
+			}
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
 					Annotations: map[string]string{
-						nodelock.NodeLockKey: "lock-values,default,pod-gpu",
+						nodelock.NodeLockKey: lockVal,
 					},
 				},
 			}

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -98,28 +98,14 @@ func (dev *VastaiDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) 
 }
 
 func (dev *VastaiDevices) LockNode(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.LockNode(n.Name, nodelock.NodeLockKey, p)
 }
 
 func (dev *VastaiDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error {
-	found := false
-	for _, val := range p.Spec.Containers {
-		if (dev.GenerateResourceRequests(&val).Nums) > 0 {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !device.PodRequiresDevice(dev, p) {
 		return nil
 	}
 	return nodelock.ReleaseNodeLock(n.Name, nodelock.NodeLockKey, p, false)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

HAMi's resource request calculation accounts for device requests from both init containers and regular containers. However, the device node-locking implementations were checking only `pod.Spec.Containers`.

As a result, a pod with a HAMi GPU/device request exclusively in an init container could be scheduled and have its resources accounted for without acquiring the corresponding device node lock.

This creates an inconsistency between resource accounting and node locking and can allow concurrent scheduling operations to bypass the synchronization intended for device allocation.

## Changes

- Added `PodRequiresDevice()` in `pkg/device/devices.go` to determine whether a pod requires a particular device.
- The helper checks both `InitContainers` and regular `Containers`.
- Updated the affected device backends to use the shared helper for `LockNode()` and `ReleaseNodeLock()`.
- Added regression coverage for init-container-only and combined init/regular container requests.
- Preserved existing backend-specific locking behavior.

## Affected device backends

- NVIDIA
- Hygon
- Cambricon
- Iluvatar
- Biren
- MetaX
- Kunlun
- AMD
- Ascend
- VASTAI

## Which issue(s) does this PR fix?

Fixes #2745

## Regression coverage

The tests cover:

- Regular-container-only device requests.
- Init-container-only device requests.
- Device requests in both init and regular containers.
- Pods without relevant device requests.
- `LockNode()` behavior.
- `ReleaseNodeLock()` behavior.
- Nil pod/device inputs for the shared helper.
- Multiple affected device backends.

The init-container-only regression cases fail against the previous `Spec.Containers`-only implementation and pass with this fix.

## Validation

- `go test ./pkg/device/...` — 12/13 packages passed.
- NVIDIA tests are blocked by the local NVML/CGO environment and are unrelated to this change.
- `go vet ./pkg/device/{amd,ascend,biren,cambricon,hygon,iluvatar,kunlun,metax,vastai}/...` — passed.
- `git diff --check` — passed.
- `gofmt` — verified.

## Does this PR introduce a user-facing change?

No.

This is a scheduler/device-locking correctness fix. It ensures that init-container device requests receive the same node-lock treatment as equivalent regular-container requests.

## Special notes for reviewers

The fix intentionally centralizes device-request detection instead of maintaining separate `InitContainers`/`Containers` loops across each device backend.

`PodRequiresDevice()` uses the same `GenerateResourceRequests()` semantics as the existing resource-request calculation and checks init containers before regular containers.

Cambricon's existing unconditional `ReleaseNodeLock()` behavior is preserved because its locking mechanism differs from the pod-keyed node-lock implementation used by the other affected backends.

No changes were made to the node-lock recovery implementation from PR #2733.

## AI Assistance Disclosure

AI assistance from Claude and Antigravity was used during codebase investigation, root-cause analysis, implementation assistance, regression-test development, code review, and validation of this change.

The final implementation was reviewed against the existing HAMi codebase and device-locking behavior. The contributor independently verified the affected backends, confirmed that the shared helper matches the existing resource-request semantics, reviewed the resulting diff, and ran the relevant tests, vet, formatting, and diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device requirement detection for pods using init containers, regular containers, or both.
  * Node locking and unlocking now consistently occur only when a pod requests the relevant device.

* **Tests**
  * Expanded coverage for device requests across container types, including pods without device requirements and mixed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->