### PR TITLE
fix(skill): align vGPU metrics summary with actual codebase definitions

### DIFF
--- a/skill/hami-vgpu-metrics-summary/SKILL.md
+++ b/skill/hami-vgpu-metrics-summary/SKILL.md
@@ -157,6 +157,7 @@ These are the primary metrics if `--legacy-metrics=false`:
 
 **Namespace/quota-level aggregation**
 - `hami_resource_quota_used`
+- `hami_resource_quota_limit`
 
 **Build metadata**
 - `hami_build_info`
@@ -184,14 +185,45 @@ If the scheduler is started with `--legacy-metrics=true`, the same allocation st
 **Namespace/quota-level aggregation**
 - `QuotaUsed`
 
-#### C. Runtime-only vGPU monitor metrics
+#### C. Runtime-only vGPU monitor metrics (current names)
 These come from `cmd/vGPUmonitor/metrics.go` and should be treated separately:
-- `hami_host_gpu_memory_used_bytes`
-- `hami_host_gpu_utilization_ratio`
-- `hami_vgpu_memory_used_bytes`
-- `hami_vgpu_memory_limit_bytes`
+
+**Host device runtime metrics**
+- `hami_host_gpu_memory_used_bytes` — physical GPU memory usage
+- `hami_host_gpu_utilization_ratio` — physical GPU core utilization (0-100)
+- `hami_host_gpu_memory_controller_utilization_ratio` — GPU memory controller utilization
+
+**Per-container vGPU runtime metrics**
+- `hami_vgpu_memory_used_bytes` — vGPU memory usage per container
+- `hami_vgpu_memory_limit_bytes` — vGPU memory limit per container
+- `hami_container_device_memory_bytes` — container device memory usage
+- `hami_container_device_utilization_ratio` — container device SM utilization
+- `hami_container_last_kernel_elapsed_seconds` — seconds since last kernel execution
+- `hami_vgpu_memory_context_bytes` — memory context size
+- `hami_vgpu_memory_module_bytes` — memory module size
+- `hami_vgpu_memory_buffer_bytes` — memory buffer size
+
+**MIG runtime identity**
+- `hami_mig_device_info` — MIG runtime identity per container
 
 Use them only as **runtime complements**. They do not replace scheduler allocation metrics for namespace/device allocation summaries.
+
+#### D. Backward-compatible legacy vGPU monitor metrics
+If the vGPU monitor is started with `--legacy-metrics=true`, the same runtime state is also emitted under older names:
+
+**Host device runtime metrics**
+- `HostGPUMemoryUsage` — physical GPU memory usage
+- `HostCoreUtilization` — physical GPU core utilization
+
+**Per-container vGPU runtime metrics**
+- `vGPU_device_memory_usage_in_bytes` — vGPU memory usage per container
+- `vGPU_device_memory_limit_in_bytes` — vGPU memory limit per container
+- `Device_memory_desc_of_container` — container device memory description
+- `Device_utilization_desc_of_container` — container device utilization
+- `Device_last_kernel_of_container` — last kernel execution time
+
+**MIG runtime identity**
+- `MigInfo` — MIG runtime identity per container
 
 Ignore unrelated generic Prometheus metrics unless they help with context.
 
@@ -733,9 +765,19 @@ If the user asks in English, answer in English.
 | `hami_vgpu_core_allocated_ratio` / `vGPUCoreAllocated` | GPU core share allocated to a container | pod/container |
 | `hami_vgpu_memory_allocated_bytes` / `vGPUMemoryAllocated` | GPU memory allocated to a container | pod/container |
 | `hami_resource_quota_used` / `QuotaUsed` | Namespace-level quota usage | namespace |
-| `hami_host_gpu_memory_used_bytes` | Runtime physical GPU memory used from vGPU monitor | runtime/device |
-| `hami_host_gpu_utilization_ratio` | Runtime physical GPU utilization from vGPU monitor | runtime/device |
-| `hami_vgpu_memory_used_bytes` | Runtime per-container vGPU memory used from vGPU monitor | runtime/container |
+| `hami_resource_quota_limit` | Namespace-level quota limit | namespace |
+| `hami_host_gpu_memory_used_bytes` / `HostGPUMemoryUsage` | Runtime physical GPU memory used from vGPU monitor | runtime/device |
+| `hami_host_gpu_utilization_ratio` / `HostCoreUtilization` | Runtime physical GPU utilization from vGPU monitor | runtime/device |
+| `hami_host_gpu_memory_controller_utilization_ratio` | Runtime GPU memory controller utilization from vGPU monitor | runtime/device |
+| `hami_vgpu_memory_used_bytes` / `vGPU_device_memory_usage_in_bytes` | Runtime per-container vGPU memory used from vGPU monitor | runtime/container |
+| `hami_vgpu_memory_limit_bytes` / `vGPU_device_memory_limit_in_bytes` | Runtime per-container vGPU memory limit from vGPU monitor | runtime/container |
+| `hami_container_device_memory_bytes` / `Device_memory_desc_of_container` | Container device memory usage from vGPU monitor | runtime/container |
+| `hami_container_device_utilization_ratio` / `Device_utilization_desc_of_container` | Container device SM utilization from vGPU monitor | runtime/container |
+| `hami_container_last_kernel_elapsed_seconds` / `Device_last_kernel_of_container` | Seconds since last kernel execution from vGPU monitor | runtime/container |
+| `hami_vgpu_memory_context_bytes` | Memory context size from vGPU monitor | runtime/container |
+| `hami_vgpu_memory_module_bytes` | Memory module size from vGPU monitor | runtime/container |
+| `hami_vgpu_memory_buffer_bytes` | Memory buffer size from vGPU monitor | runtime/container |
+| `hami_mig_device_info` / `MigInfo` | MIG runtime identity per container from vGPU monitor | runtime/container |
 | `hami_build_info` | HAMi version/build metadata | cluster |
 
 ---


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Aligns the `hami-vgpu-metrics-summary` skill file with the actual Prometheus metrics defined in the codebase. The skill was outdated — it only listed 4 out of 12 vGPU monitor metrics and was missing the `hami_resource_quota_limit` scheduler metric, which would cause incomplete analysis when using the skill against live clusters.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Doc-only change to` skill/hami-vgpu-metrics-summary/SKILL.md`. Metrics were cross-checked against `cmd/scheduler/metrics.go` and `cmd/vGPUmonitor/metrics.go`.

**Does this PR introduce a user-facing change?**:

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the `hami_resource_quota_limit` scheduler metric to the main and quick-reference lists.
  - Expanded vGPU monitoring documentation to cover current and legacy runtime metrics.
  - Clarified host, container, memory, utilization, kernel, context, module, buffer, and MIG metrics.
  - Documented how runtime metrics complement scheduler allocation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->