### PR TITLE
fix(device): reject malformed and negative device allocation annotations

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -499,28 +499,45 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 	}
 	cd := strings.Split(str, OneContainerMultiDeviceSplitSymbol)
 	contdev := ContainerDevices{}
-	tmpdev := ContainerDevice{}
 	klog.V(5).Infof("Start to decode container device %s", str)
 	for _, val := range cd {
-		if strings.Contains(val, ",") {
-			tmpstr := strings.Split(val, ",")
-			if len(tmpstr) < 4 {
-				return nil, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
-			}
-			tmpdev.UUID = tmpstr[0]
-			tmpdev.Type = tmpstr[1]
-			devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid memory field: %w", err)
-			}
-			tmpdev.Usedmem = int32(devmem)
-			devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid core field: %w", err)
-			}
-			tmpdev.Usedcores = int32(devcores)
-			contdev = append(contdev, tmpdev)
+		if val == "" {
+			continue
 		}
+		if !strings.Contains(val, ",") {
+			return nil, fmt.Errorf("malformed container device annotation segment: %q", val)
+		}
+		tmpstr := strings.Split(val, ",")
+		if len(tmpstr) < 4 {
+			return nil, fmt.Errorf("pod annotation format error, missing fields, do not use nodeName in task spec")
+		}
+		if tmpstr[0] == "" {
+			return nil, fmt.Errorf("pod annotation format error, missing device UUID")
+		}
+		if tmpstr[1] == "" {
+			return nil, fmt.Errorf("pod annotation format error, missing device type")
+		}
+		devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory field: %w", err)
+		}
+		if devmem < 0 {
+			return nil, fmt.Errorf("memory field must not be negative: %d", devmem)
+		}
+		devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid core field: %w", err)
+		}
+		if devcores < 0 {
+			return nil, fmt.Errorf("core field must not be negative: %d", devcores)
+		}
+		tmpdev := ContainerDevice{
+			UUID:      tmpstr[0],
+			Type:      tmpstr[1],
+			Usedmem:   int32(devmem),
+			Usedcores: int32(devcores),
+		}
+		contdev = append(contdev, tmpdev)
 	}
 	klog.V(5).Infof("Finished decoding container devices. Total devices: %d", len(contdev))
 	return contdev, nil

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -46,6 +46,195 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 	assert.DeepEqual(t, cd1, cd2)
 }
 
+func TestDecodeContainerDevices(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        ContainerDevices
+		expectError bool
+	}{
+		{
+			name:        "empty string returns empty ContainerDevices",
+			input:       "",
+			want:        ContainerDevices{},
+			expectError: false,
+		},
+		{
+			name:        "trailing delimiters only returns empty ContainerDevices",
+			input:       ":::",
+			want:        ContainerDevices{},
+			expectError: false,
+		},
+		{
+			name:  "valid single device",
+			input: "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76,NVIDIA,500,3:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76",
+					Type:      "NVIDIA",
+					Usedmem:   500,
+					Usedcores: 3,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid single device with zero resources",
+			input: "GPU-zero,NVIDIA,0,0:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-zero",
+					Type:      "NVIDIA",
+					Usedmem:   0,
+					Usedcores: 0,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "multiple valid devices",
+			input: "GPU-1,NVIDIA,1000,10:GPU-2,Cambricon,2000,20:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-1",
+					Type:      "NVIDIA",
+					Usedmem:   1000,
+					Usedcores: 10,
+				},
+				{
+					UUID:      "GPU-2",
+					Type:      "Cambricon",
+					Usedmem:   2000,
+					Usedcores: 20,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:  "existing valid fields preserved with extra optional fields",
+			input: "GPU-1,NVIDIA,1000,10,extra1,extra2:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-1",
+					Type:      "NVIDIA",
+					Usedmem:   1000,
+					Usedcores: 10,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "malformed segment without comma",
+			input:       "garbage",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "malformed segment without comma and with delimiter",
+			input:       "garbage:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "missing required fields (only 2 fields)",
+			input:       "GPU-1,NVIDIA:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "missing required fields (only 3 fields)",
+			input:       "GPU-1,NVIDIA,1000:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "empty device ID / UUID",
+			input:       ",NVIDIA,1000,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "empty device type",
+			input:       "GPU-1,,1000,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "negative memory value",
+			input:       "GPU-1,NVIDIA,-500,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "negative cores value",
+			input:       "GPU-1,NVIDIA,500,-1:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid non-numeric memory",
+			input:       "GPU-1,NVIDIA,invalid,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid non-numeric core",
+			input:       "GPU-1,NVIDIA,500,invalid:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "memory integer overflow",
+			input:       "GPU-1,NVIDIA,99999999999999999999999999,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "core integer overflow",
+			input:       "GPU-1,NVIDIA,500,99999999999999999999999999:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "valid device followed by malformed device fails entire decode",
+			input:       "GPU-1,NVIDIA,1000,10:malformed_segment:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "malformed device followed by valid device fails entire decode",
+			input:       "malformed_segment:GPU-1,NVIDIA,1000,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "valid device followed by negative resource fails entire decode",
+			input:       "GPU-1,NVIDIA,1000,10:GPU-2,NVIDIA,-100,10:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "negative resource followed by valid device fails entire decode",
+			input:       "GPU-1,NVIDIA,1000,-5:GPU-2,NVIDIA,1000,10:",
+			want:        nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeContainerDevices(tt.input)
+			if tt.expectError {
+				assert.Assert(t, err != nil, "expected error for input %q, got nil", tt.input)
+				assert.Assert(t, got == nil, "expected nil devices on error, got %+v", got)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestEmptyPodDeviceCoding(t *testing.T) {
 	pd1 := PodDevices{}
 	s := EncodePodDevices(inRequestDevices, pd1)
@@ -296,9 +485,60 @@ func Test_DecodePodDevices(t *testing.T) {
 
 func TestDecodePodDevices_BadAnnotation(t *testing.T) {
 	checklist := map[string]string{"NVIDIA": "hami.io/vgpu-devices-to-allocate"}
-	annos := map[string]string{"hami.io/vgpu-devices-to-allocate": "uuid,type,100:;"}
-	_, err := DecodePodDevices(checklist, annos)
-	assert.Assert(t, err != nil)
+	badAnnos := []struct {
+		name string
+		anno string
+	}{
+		{
+			name: "missing required fields (only 3 fields)",
+			anno: "uuid,type,100:;",
+		},
+		{
+			name: "malformed non-empty segment without comma",
+			anno: "malformed_annotation:;",
+		},
+		{
+			name: "negative memory in first container",
+			anno: "GPU-1,NVIDIA,-500,10:;",
+		},
+		{
+			name: "negative cores in second container",
+			anno: "GPU-1,NVIDIA,500,10:;GPU-2,NVIDIA,500,-1:;",
+		},
+		{
+			name: "empty UUID",
+			anno: ",NVIDIA,500,10:;",
+		},
+		{
+			name: "empty type",
+			anno: "GPU-1,,500,10:;",
+		},
+	}
+
+	for _, tt := range badAnnos {
+		t.Run(tt.name, func(t *testing.T) {
+			annos := map[string]string{"hami.io/vgpu-devices-to-allocate": tt.anno}
+			got, err := DecodePodDevices(checklist, annos)
+			assert.Assert(t, err != nil, "expected error for bad annotation %q, got nil", tt.anno)
+			assert.DeepEqual(t, got, PodDevices{})
+		})
+	}
+}
+
+func TestResourceAccounting_NegativeDecodedProtection(t *testing.T) {
+	// Proves that malformed negative allocation annotations cannot be decoded,
+	// preventing negative resource values from improperly decreasing Usedmem/Usedcores.
+	malformedAnno := "GPU-1,NVIDIA,-1000,-10:"
+	devices, err := DecodeContainerDevices(malformedAnno)
+	assert.Assert(t, err != nil, "DecodeContainerDevices must reject negative values")
+	assert.Assert(t, devices == nil, "returned devices must be nil on failure")
+
+	// Ensure PodDevices decoding also fails closed
+	checklist := map[string]string{"NVIDIA": "hami.io/vgpu-devices-to-allocate"}
+	podAnnos := map[string]string{"hami.io/vgpu-devices-to-allocate": malformedAnno + ";"}
+	podDevs, err := DecodePodDevices(checklist, podAnnos)
+	assert.Assert(t, err != nil, "DecodePodDevices must reject negative values")
+	assert.DeepEqual(t, podDevs, PodDevices{})
 }
 
 func TestMarshalNodeDevices(t *testing.T) {
@@ -1725,10 +1965,13 @@ func FuzzDecodeContainerDevices(f *testing.F) {
 
 func FuzzEncodeDecodeContainerDevices(f *testing.F) {
 	f.Add("GPU-uuid", "NVIDIA", int32(1024), int32(10))
-	f.Add("", "", int32(0), int32(0))
-	f.Add("GPU-boundary", "NVIDIA", int32(-2147483648), int32(2147483647))
+	f.Add("GPU-uuid2", "Cambricon", int32(0), int32(0))
+	f.Add("GPU-boundary", "NVIDIA", int32(2147483647), int32(2147483647))
 	f.Fuzz(func(t *testing.T, uuid, deviceType string, usedmem, usedcores int32) {
 		if strings.ContainsAny(uuid, ",:;") || strings.ContainsAny(deviceType, ",:;") {
+			t.Skip()
+		}
+		if uuid == "" || deviceType == "" || usedmem < 0 || usedcores < 0 {
 			t.Skip()
 		}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2707,7 +2707,7 @@ func Test_SchedulerTerminatingPodRetainsCache(t *testing.T) {
 	podDevces := device.PodDevices{
 		nvidia.NvidiaGPUDevice: device.PodSingleDevice{
 			[]device.ContainerDevice{
-				{Idx: 0, UUID: "GPU0", Usedmem: 1000, Usedcores: 10},
+				{Idx: 0, UUID: "GPU0", Type: nvidia.NvidiaGPUDevice, Usedmem: 1000, Usedcores: 10},
 			},
 		},
 	}
@@ -2808,11 +2808,11 @@ func Test_onUpdatePod_InitContainerShrink(t *testing.T) {
 		nvidia.NvidiaGPUDevice: device.PodSingleDevice{
 			// Init container (index 0)
 			{{
-				Idx: 0, UUID: "GPU0", Usedmem: 20000, Usedcores: 10,
+				Idx: 0, UUID: "GPU0", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 10,
 			}},
 			// App container (index 1)
 			{{
-				Idx: 0, UUID: "GPU0", Usedmem: 10000, Usedcores: 5,
+				Idx: 0, UUID: "GPU0", Type: nvidia.NvidiaGPUDevice, Usedmem: 10000, Usedcores: 5,
 			}},
 		},
 	}


### PR DESCRIPTION
# What type of PR is this?

/kind bug

## What this PR does / why we need it

`DecodeContainerDevices()` currently accepts malformed device allocation annotation data in several cases.

Non-empty malformed segments without the expected structure can be silently ignored, allowing a valid portion of an annotation to be decoded while invalid data is discarded. The decoder also accepts empty device UUID/type fields and negative memory/core values.

Negative resource values are particularly problematic because decoded `Usedmem` and `Usedcores` values are subsequently used by device resource-accounting paths. A negative value can therefore incorrectly reduce the tracked resource usage.

This PR makes device allocation annotation decoding fail closed by validating every device entry before it is accepted.

### Changes

- Reject non-empty malformed annotation segments instead of silently skipping them.
- Validate that required device UUID and device type fields are present.
- Reject negative GPU memory values.
- Reject negative GPU core values.
- Continue rejecting invalid/non-numeric resource values and integer overflow through `strconv.ParseInt`.
- Prevent partial device allocations from being returned when any annotation entry is invalid.
- Scope `ContainerDevice` construction to each decoded entry.
- Preserve existing handling of empty annotations and trailing/empty delimiters.
- Preserve the existing annotation format and valid allocation behavior.

## Which issue(s) does this PR fix?

Fixes #2756

## Regression coverage

The tests cover:

- Valid single-device annotations.
- Valid multiple-device annotations.
- Zero memory/core values.
- Existing optional fields.
- Empty annotations and trailing delimiters.
- Malformed segments without commas.
- Missing required fields.
- Empty device UUID.
- Empty device type.
- Negative memory.
- Negative cores.
- Non-numeric memory/core values.
- Integer overflow.
- Mixed valid and malformed annotations.
- Mixed valid and negative-resource annotations.
- Pod-level malformed allocation annotations.
- Protection against negative decoded values reaching resource accounting.
- Encode/decode fuzz coverage.

## Validation

The following checks were completed:

- `gofmt -w pkg/device/devices.go pkg/device/devices_test.go` — passed
- `git diff --check` — passed
- Targeted `go test` for decoder, pod decoder, resource-accounting, and fuzz tests — passed
- `CGO_ENABLED=0 go test ./pkg/device/...` — passed across the standalone device packages
- `go vet ./pkg/device` — passed
- `golangci-lint run ./pkg/device` — passed with no lint issues in the modified files

The NVIDIA package requires NVML/CGO headers that are unavailable in the local Windows environment. This is an environment limitation and is unrelated to the changes in this PR. The affected non-NVML device packages and root `pkg/device` package were validated successfully.

## Does this PR introduce a user-facing change?

No.

This change only makes invalid device allocation annotations fail validation instead of allowing malformed or negative resource values to be interpreted as valid allocation state.

Valid existing annotations and their existing format remain unchanged.

## AI Assistance Disclosure

AI assistance from Claude and Antigravity was used during codebase investigation, root-cause analysis, implementation assistance, test development, review of the decoder and its callers, validation planning, and analysis of potential edge cases.

The final implementation was manually reviewed against the existing HAMi annotation format and resource-accounting behavior. The changes were validated by the contributor using targeted and package-level tests, `go vet`, `golangci-lint`, `gofmt`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when reading container device configurations.
  * Malformed entries, missing identifiers or types, negative resources, and invalid values are now rejected instead of silently ignored.
  * Prevented invalid multi-device configurations from being partially accepted or incorrectly affecting resource accounting.
  * Improved handling of device allocations for terminating pods and init-container resource adjustments.

* **Tests**
  * Added comprehensive coverage for valid, malformed, incomplete, negative, non-numeric, and overflowing device resource values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->