### PR TITLE
ci: allow manual dispatch of the Trivy image scan

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -2,6 +2,7 @@ name: Trivy Scan
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch: {}
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Adds workflow_dispatch to the nightly Trivy scan so alert-clearing fixes can be verified right after merge instead of waiting for the next cron run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually trigger image security scans in addition to scheduled scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->