### PR TITLE
Feat/scheduler poddisruptionbudget

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -77,6 +77,8 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.livenessProbe` | Whether to enable liveness probe | `false` |
 | `scheduler.leaderElect` | Whether to enable leader election | `true` |
 | `scheduler.replicas` | Number of replicas | `1` |
+| `scheduler.podDisruptionBudget.minAvailable` | Minimum number of available scheduler pods during voluntary disruptions (only rendered when `scheduler.leaderElect` is `true` and `scheduler.replicas` is greater than `1`) | `1` |
+| `scheduler.podDisruptionBudget.maxUnavailable` | Maximum number of unavailable scheduler pods during voluntary disruptions; takes precedence over `minAvailable` when set | unset |
 
 ### Kube Scheduler Configuration
 

--- a/charts/hami/templates/scheduler/pdb.yaml
+++ b/charts/hami/templates/scheduler/pdb.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.scheduler.leaderElect (gt (int .Values.scheduler.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hami-vgpu.scheduler" . }}
+  namespace: {{ include "hami-vgpu.namespace" . }}
+  labels:
+    app.kubernetes.io/component: hami-scheduler
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
+    {{- with .Values.global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations }}
+  annotations: {{ toYaml .Values.global.annotations | nindent 4}}
+  {{- end }}
+spec:
+  {{- if hasKey .Values.scheduler.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.scheduler.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.scheduler.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: hami-scheduler
+      {{- include "hami-vgpu.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -83,6 +83,11 @@ scheduler:
   leaderElect: true
   # when leaderElect is true, replicas is available, otherwise replicas is 1.
   replicas: 1
+  # podDisruptionBudget only renders when leaderElect is true and replicas > 1;
+  # with a single replica it would block all voluntary node drains.
+  podDisruptionBudget:
+    minAvailable: 1
+    # maxUnavailable: 1
   kubeScheduler:
     # @param enabled indicate whether to run kube-scheduler container in the scheduler pod, it's true by default.
     enabled: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`hami-scheduler` already supports multi-replica, leader-elected HA — `scheduler.leaderElect: true` unlocks `scheduler.replicas > 1` (`charts/hami/values.yaml:83-85`), backed by real leader-election flags in
`cmd/scheduler/main.go:83-85` and a `podAntiAffinity` rule already gated the same way (`charts/hami/templates/scheduler/deployment.yaml:194-207`). But the chart shipped no `PodDisruptionBudget`, so a routine node drain or cluster upgrade could evict every scheduler replica at once under default Kubernetes
eviction behavior, defeating the purpose of enabling `leaderElect`.

Adds `charts/hami/templates/scheduler/pdb.yaml`, rendered only when `scheduler.leaderElect` is true, plus a `scheduler.podDisruptionBudget` values block (`enabled`, `minAvailable`, `maxUnavailable`) for configuration.
Defaults to `minAvailable: 1`, a no-op for the common single-replica install.

**Which issue(s) this PR fixes**:
Fixes #2773

**I am using AI Assistance(Claude code) for the PR description and for verifing the test cases and also that solution has been implment or not.**

**Does this PR introduce a user-facing change?**:

    Adds an optional PodDisruptionBudget for the hami-scheduler Deployment,  enabled by default whenever `scheduler.leaderElect` is true. No effect on   single-replica installs.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional scheduler Pod Disruption Budget support for highly available scheduler deployments.
  * Supports configuring minimum available or maximum unavailable scheduler pods during disruptions.

* **Documentation**
  * Documented Pod Disruption Budget settings and activation requirements.
  * Updated the device configuration example to use the current MIG profile allowlist format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->