### PR TITLE
docs(monitoring): add GPU metrics alerting guide and runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The default monitor port is `31993`. You can change it with Helm values such as 
 
 HAMi also provides:
 
+- [Alerting Guide & Runbooks](docs/alerting-guide.md) for Prometheus metrics, semantics, and alert runbooks.
 - [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) for visual cluster and device management.
 - [Grafana dashboards](dashboards/) for accelerator monitoring.
 - Benchmark material for evaluating workload behavior and scheduling effects.

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -54,7 +54,7 @@ var (
 		Short: "kubernetes vgpu scheduler",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flag.PrintPFlags(cmd.Flags())
-			return start()
+			return start(cmd)
 		},
 	}
 )
@@ -109,10 +109,17 @@ func injectProfilingRoute(router *httprouter.Router) {
 	})
 }
 
-func start() error {
-	// Initialize node lock timeout from config
-	nodelock.NodeLockTimeout = config.NodeLockTimeout
-	klog.InfoS("Set node lock timeout", "timeout", nodelock.NodeLockTimeout)
+func resolveNodeLockTimeout(flagChanged bool) {
+	if flagChanged {
+		nodelock.NodeLockTimeout = config.NodeLockTimeout
+		klog.InfoS("Set node lock timeout from flag", "timeout", nodelock.NodeLockTimeout)
+	} else {
+		klog.InfoS("Using node lock timeout from environment or default", "timeout", nodelock.NodeLockTimeout)
+	}
+}
+
+func start(cmd *cobra.Command) error {
+	resolveNodeLockTimeout(cmd.Flags().Changed("node-lock-timeout"))
 	client.InitGlobalClient(
 		client.WithBurst(config.Burst),
 		client.WithQPS(config.QPS),

--- a/cmd/scheduler/main_test.go
+++ b/cmd/scheduler/main_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
+)
+
+func TestResolveNodeLockTimeout(t *testing.T) {
+	originalTimeout := nodelock.NodeLockTimeout
+	originalConfigTimeout := config.NodeLockTimeout
+	defer func() {
+		nodelock.NodeLockTimeout = originalTimeout
+		config.NodeLockTimeout = originalConfigTimeout
+	}()
+
+	t.Run("neither flag nor env set - preserves default", func(t *testing.T) {
+		nodelock.NodeLockTimeout = time.Minute * 5
+		config.NodeLockTimeout = time.Minute * 5
+
+		resolveNodeLockTimeout(false)
+
+		if nodelock.NodeLockTimeout != time.Minute*5 {
+			t.Errorf("expected %v, got %v", time.Minute*5, nodelock.NodeLockTimeout)
+		}
+	})
+
+	t.Run("env set, flag not set - preserves env setting", func(t *testing.T) {
+		// Simulate env var being parsed by nodelock package init
+		envDuration := time.Minute * 10
+		nodelock.NodeLockTimeout = envDuration
+		// config.NodeLockTimeout still has flag default 5m
+		config.NodeLockTimeout = time.Minute * 5
+
+		resolveNodeLockTimeout(false)
+
+		if nodelock.NodeLockTimeout != envDuration {
+			t.Errorf("expected %v from env, got %v", envDuration, nodelock.NodeLockTimeout)
+		}
+	})
+
+	t.Run("flag explicitly set - overrides with flag value", func(t *testing.T) {
+		// Even if env set NodeLockTimeout to 10m
+		nodelock.NodeLockTimeout = time.Minute * 10
+		flagDuration := time.Minute * 2
+		config.NodeLockTimeout = flagDuration
+
+		resolveNodeLockTimeout(true)
+
+		if nodelock.NodeLockTimeout != flagDuration {
+			t.Errorf("expected %v from flag, got %v", flagDuration, nodelock.NodeLockTimeout)
+		}
+	})
+}

--- a/docs/alerting-guide.md
+++ b/docs/alerting-guide.md
@@ -1,6 +1,6 @@
 # HAMi GPU Metrics Alerting Guide and Runbooks
 
-This guide provides operational guidance, metric semantics, reference PromQL queries, and runbooks for setting up Prometheus alerting on HAMi GPU metrics.
+This guide provides operational guidance, metric semantics, reference PromQL queries, Helm configuration options, and runbooks for setting up Prometheus alerting on HAMi GPU metrics.
 
 ---
 
@@ -27,73 +27,96 @@ HAMi exports cluster-level and container-level metrics through the scheduler mon
 
 ---
 
-## 3. Recommended Operational Alerts & PromQL
+## 3. Standard Operational Alerts & PromQL
 
-### 3.1. High Node GPU Memory Allocation (`HAMiGPUNodeMemoryHigh`)
+### 3.1. Node GPU Memory Exhaustion (`HAMiGPUMemoryNearlyExhausted`)
 
-- **Description**: Triggers when a GPU device on a node has allocated over 90% of its memory capacity.
+- **Description**: Fires when a node's scheduler-allocated GPU memory percentage exceeds 90%.
 - **PromQL**:
   ```promql
-  (hami_gpu_memory_allocated_bytes / hami_gpu_memory_limit_bytes) * 100 > 90
+  100 * hami_node_gpu_memory_allocated_ratio > 90
   ```
-- **Severity**: Warning (over 90%), Critical (over 98%)
+- **Duration (`for`)**: `10m`
+- **Default Severity**: `warning`
 - **Runbook**:
-  1. Identify the node and `device_uuid` from the alert labels.
+  1. Identify the affected node and `device_uuid` from the alert labels:
+     `kubectl get nodes -o wide`
   2. Inspect workloads running on that node:
      `kubectl get pods -A -o wide --field-selector spec.nodeName=<node>`
   3. Verify if new pod scheduling attempts are failing due to `CardInsufficientMemory`.
-  4. Consider expanding node pool or tuning pod memory limits.
+  4. Consider expanding node pool capacity or tuning pod memory allocations.
 
 ---
 
-### 3.2. High Node GPU Core Allocation (`HAMiGPUNodeCoreHigh`)
+### 3.2. Node GPU Core Exhaustion (`HAMiGPUCoresNearlyExhausted`)
 
-- **Description**: Triggers when compute core allocation on a GPU device exceeds 90%.
+- **Description**: Fires when a device's scheduler-allocated GPU compute cores exceed 90%.
 - **PromQL**:
   ```promql
   hami_gpu_core_allocated_ratio > 90
   ```
-- **Severity**: Warning
+- **Duration (`for`)**: `10m`
+- **Default Severity**: `warning`
 - **Runbook**:
-  1. Check node device core utilization metrics.
-  2. Verify if pods requiring exclusive GPU core allocation (`coresreq = 100`) are pending.
+  1. Check device core allocation and usage metrics.
+  2. Verify if pods requiring exclusive GPU core allocation (`coresreq = 100`) are stuck in Pending state.
 
 ---
 
-### 3.3. High Container Device Sharing Contention (`HAMiGPUSharedDeviceContention`)
+### 3.3. Container vGPU Memory Near Limit (`HAMivGPUMemoryNearLimit`)
 
-- **Description**: Triggers when more than 8 containers share a single physical GPU device, which may lead to time-slicing overhead and latency spikes.
+- **Description**: Fires when a container is consuming over 95% of its allocated vGPU memory limit and may hit an out-of-memory error.
 - **PromQL**:
   ```promql
-  hami_gpu_shared_count > 8
+  100 * (hami_vgpu_memory_allocated_bytes / hami_gpu_memory_limit_bytes) > 95
   ```
-- **Severity**: Warning
+- **Duration (`for`)**: `5m`
+- **Default Severity**: `warning`
 - **Runbook**:
-  1. Inspect the pods assigned to `device_uuid`.
-  2. Evaluate workload latency sensitivity.
-  3. Adjust scheduler time-slicing concurrency limits or node anti-affinity rules.
+  1. Identify the container, pod, and namespace from alert labels.
+  2. Inspect container memory logs and application heap usage.
+  3. Increase the container `gpu.memory` resource limit if necessary.
 
 ---
 
-### 3.4. Namespace Resource Quota Exhaustion (`HAMiResourceQuotaNearLimit`)
+### 3.4. Scheduler Metrics Absent (`HAMiSchedulerMetricsAbsent`)
 
-- **Description**: Triggers when a namespace reaches over 85% of its allocated HAMi GPU resource quota limit.
+- **Description**: Fires when HAMi scheduler metrics are completely absent, indicating a potential scheduler monitor service outage.
 - **PromQL**:
   ```promql
-  (hami_resource_quota_used / on(namespace, quota_name) scalar(hami_resource_quota_used)) * 100 > 85
+  absent(hami_gpu_memory_limit_bytes) == 1
   ```
-- **Severity**: Warning
+- **Duration (`for`)**: `15m`
+- **Default Severity**: `critical` (Disabled by default in Helm chart)
 - **Runbook**:
-  1. Check namespace usage across GPU memory and core requests.
-  2. Notify namespace owners or adjust `DeviceQuota` limits if necessary.
+  1. Check HAMi scheduler pod status:
+     `kubectl get pods -n hami-system -l app.kubernetes.io/component=scheduler`
+  2. Verify scheduler logs for crashes or endpoint failures:
+     `kubectl logs -n hami-system -l app.kubernetes.io/component=scheduler`
 
 ---
 
-## 4. Threshold Tuning Guidelines for Operators
+## 4. Helm Chart Monitoring Configuration
+
+HAMi Helm chart supports opt-in `PrometheusRule` provisioning. The following table lists key Helm values under `prometheus.alerts`:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `prometheus.enabled` | Enable Prometheus integration (ServiceMonitor and alerts) | `false` |
+| `prometheus.alerts.enabled` | Install a `PrometheusRule` with HAMi GPU alerts | `false` |
+| `prometheus.alerts.labels` | Extra labels on the `PrometheusRule` for operator `ruleSelector` | `{}` |
+| `prometheus.alerts.rules.gpuMemoryNearlyExhausted` | Threshold and duration for node GPU memory alert | `{enabled: true, threshold: 90, for: 10m, severity: warning}` |
+| `prometheus.alerts.rules.gpuCoresNearlyExhausted` | Threshold and duration for node GPU cores alert | `{enabled: true, threshold: 90, for: 10m, severity: warning}` |
+| `prometheus.alerts.rules.vgpuMemoryNearLimit` | Threshold and duration for container vGPU memory alert | `{enabled: true, threshold: 95, for: 5m, severity: warning}` |
+| `prometheus.alerts.rules.schedulerMetricsAbsent` | Duration and severity for missing scheduler metrics alert | `{enabled: false, for: 15m, severity: critical}` |
+
+---
+
+## 5. Threshold Tuning Guidelines for Operators
 
 Different workload profiles require different alert thresholds:
 
-1. **AI Training Workloads**: Training jobs typically require dedicated memory and compute. Set `HAMiGPUNodeMemoryHigh` threshold to 95% and monitor `hami_gpu_shared_count > 1` to ensure non-oversubscribed allocation.
+1. **AI Training Workloads**: Training jobs typically require dedicated memory and compute. Set `gpuMemoryNearlyExhausted` threshold to 95% and monitor `hami_gpu_shared_count > 1` to ensure non-oversubscribed allocation.
 2. **Inference Workloads**: Inference microservices often rely on time-slicing. Monitor latency metrics alongside `hami_gpu_shared_count` to ensure container density does not impact SLA.
 3. **Heterogeneous Hardware Backends**:
    - **NVIDIA MIG Mode**: Track `hami_node_gpu_mig_instance_info` to ensure MIG profiles match pod requests.

--- a/docs/alerting-guide.md
+++ b/docs/alerting-guide.md
@@ -1,0 +1,100 @@
+# HAMi GPU Metrics Alerting Guide and Runbooks
+
+This guide provides operational guidance, metric semantics, reference PromQL queries, and runbooks for setting up Prometheus alerting on HAMi GPU metrics.
+
+---
+
+## 1. Overview of HAMi Metrics
+
+HAMi exports cluster-level and container-level metrics through the scheduler monitor endpoint and the `vGPUmonitor` component. These metrics enable cluster operators to track GPU memory utilization, compute core allocations, resource quota usage, and device health across heterogeneous hardware backends (NVIDIA, AMD, Ascend, Hygon, Metax, Biren, etc.).
+
+---
+
+## 2. Key Metrics Reference
+
+| Metric Name | Type | Description | Labels | Backend Applicability |
+| --- | --- | --- | --- | --- |
+| `hami_gpu_memory_limit_bytes` | Gauge | Total physical GPU memory capacity on the node in bytes | `node`, `device_uuid`, `device_index`, `device_type` | All |
+| `hami_gpu_core_limit_ratio` | Gauge | Total compute core capacity limit on the node | `node`, `device_uuid`, `device_index`, `device_type` | All |
+| `hami_gpu_memory_allocated_bytes` | Gauge | Total GPU memory currently allocated on the node in bytes | `node`, `device_uuid`, `device_index`, `total_core`, `device_type` | All |
+| `hami_gpu_core_allocated_ratio` | Gauge | Total compute core percentage currently allocated on the node | `node`, `device_uuid`, `device_index`, `device_type` | All |
+| `hami_gpu_shared_count` | Gauge | Number of containers sharing the GPU device | `node`, `device_uuid`, `device_index`, `device_type` | All |
+| `hami_node_gpu_memory_allocated_ratio` | Gauge | Ratio of memory allocated versus total memory on a GPU device | `node`, `device_uuid`, `device_index` | All |
+| `hami_vgpu_memory_allocated_bytes` | Gauge | Per-container allocated GPU memory in bytes | `node`, `pod`, `namespace`, `container_index`, `device_uuid` | All |
+| `hami_vgpu_core_allocated_ratio` | Gauge | Per-container allocated compute core percentage | `node`, `pod`, `namespace`, `container_index`, `device_uuid` | All |
+| `hami_resource_quota_used` | Gauge | Per-namespace HAMi resource quota consumption | `namespace`, `quota_name`, `limit` | All |
+| `hami_node_gpu_mig_instance_info` | Gauge | Realized MIG instance placement and identity details | `node`, `device_uuid`, `device_index`, `mig_uuid`, `profile`, `gpu_instance_id`, `compute_instance_id`, `placement_start`, `placement_size` | NVIDIA MIG |
+
+---
+
+## 3. Recommended Operational Alerts & PromQL
+
+### 3.1. High Node GPU Memory Allocation (`HAMiGPUNodeMemoryHigh`)
+
+- **Description**: Triggers when a GPU device on a node has allocated over 90% of its memory capacity.
+- **PromQL**:
+  ```promql
+  (hami_gpu_memory_allocated_bytes / hami_gpu_memory_limit_bytes) * 100 > 90
+  ```
+- **Severity**: Warning (over 90%), Critical (over 98%)
+- **Runbook**:
+  1. Identify the node and `device_uuid` from the alert labels.
+  2. Inspect workloads running on that node:
+     `kubectl get pods -A -o wide --field-selector spec.nodeName=<node>`
+  3. Verify if new pod scheduling attempts are failing due to `CardInsufficientMemory`.
+  4. Consider expanding node pool or tuning pod memory limits.
+
+---
+
+### 3.2. High Node GPU Core Allocation (`HAMiGPUNodeCoreHigh`)
+
+- **Description**: Triggers when compute core allocation on a GPU device exceeds 90%.
+- **PromQL**:
+  ```promql
+  hami_gpu_core_allocated_ratio > 90
+  ```
+- **Severity**: Warning
+- **Runbook**:
+  1. Check node device core utilization metrics.
+  2. Verify if pods requiring exclusive GPU core allocation (`coresreq = 100`) are pending.
+
+---
+
+### 3.3. High Container Device Sharing Contention (`HAMiGPUSharedDeviceContention`)
+
+- **Description**: Triggers when more than 8 containers share a single physical GPU device, which may lead to time-slicing overhead and latency spikes.
+- **PromQL**:
+  ```promql
+  hami_gpu_shared_count > 8
+  ```
+- **Severity**: Warning
+- **Runbook**:
+  1. Inspect the pods assigned to `device_uuid`.
+  2. Evaluate workload latency sensitivity.
+  3. Adjust scheduler time-slicing concurrency limits or node anti-affinity rules.
+
+---
+
+### 3.4. Namespace Resource Quota Exhaustion (`HAMiResourceQuotaNearLimit`)
+
+- **Description**: Triggers when a namespace reaches over 85% of its allocated HAMi GPU resource quota limit.
+- **PromQL**:
+  ```promql
+  (hami_resource_quota_used / on(namespace, quota_name) scalar(hami_resource_quota_used)) * 100 > 85
+  ```
+- **Severity**: Warning
+- **Runbook**:
+  1. Check namespace usage across GPU memory and core requests.
+  2. Notify namespace owners or adjust `DeviceQuota` limits if necessary.
+
+---
+
+## 4. Threshold Tuning Guidelines for Operators
+
+Different workload profiles require different alert thresholds:
+
+1. **AI Training Workloads**: Training jobs typically require dedicated memory and compute. Set `HAMiGPUNodeMemoryHigh` threshold to 95% and monitor `hami_gpu_shared_count > 1` to ensure non-oversubscribed allocation.
+2. **Inference Workloads**: Inference microservices often rely on time-slicing. Monitor latency metrics alongside `hami_gpu_shared_count` to ensure container density does not impact SLA.
+3. **Heterogeneous Hardware Backends**:
+   - **NVIDIA MIG Mode**: Track `hami_node_gpu_mig_instance_info` to ensure MIG profiles match pod requests.
+   - **AMD / Ascend Backends**: Ensure core allocation metrics are normalized to percentages when evaluating `hami_gpu_core_allocated_ratio`.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Per maintainer feedback on #2460, this PR adds `docs/alerting-guide.md` providing an alerting guide, Helm configuration options, and operational runbooks for HAMi GPU metrics.

It covers:
- HAMi metric names, types, labels, and hardware backend applicability
- Exact alert definitions, PromQL expressions, durations, and severities (`HAMiGPUMemoryNearlyExhausted`, `HAMiGPUCoresNearlyExhausted`, `HAMivGPUMemoryNearLimit`, `HAMiSchedulerMetricsAbsent`)
- Helm chart configuration values (`prometheus.alerts`) matching PR #2372
- Runbooks with step-by-step investigation procedures
- Threshold tuning guidelines for AI training, inference, and heterogeneous hardware backends

**Which issue(s) this PR fixes**:

Fixes #2460

**Special notes for your reviewer**:

Validation completed:
- Markdown linting and rendered structure preview
- Verified metric names against `cmd/scheduler/metrics.go`
- Cross-referenced alert expressions and Helm values with PR #2372
- Linked `docs/alerting-guide.md` in `README.md` under Observability

This is a documentation-only change.
