### PR TITLE
[kind/bug] Restore model-aware scheduling for Cambricon MLU devices

### DIFF
--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -42,11 +42,14 @@ import (
 const (
 	CambriconMLUDevice     = "MLU"
 	CambriconMLUCommonWord = "MLU"
-	MluMemSplitLimit       = "CAMBRICON_SPLIT_MEMS"
-	MluMemSplitIndex       = "CAMBRICON_SPLIT_VISIBLE_DEVICES"
-	MluMemSplitEnable      = "CAMBRICON_SPLIT_ENABLE"
-	MLUInUse               = "cambricon.com/use-mlutype"
-	MLUNoUse               = "cambricon.com/nouse-mlutype"
+	// MLUModelLabel is published by cambricon-k8s-device-plugin when node label
+	// reporting is enabled.
+	MLUModelLabel     = "Model"
+	MluMemSplitLimit  = "CAMBRICON_SPLIT_MEMS"
+	MluMemSplitIndex  = "CAMBRICON_SPLIT_VISIBLE_DEVICES"
+	MluMemSplitEnable = "CAMBRICON_SPLIT_ENABLE"
+	MLUInUse          = "cambricon.com/use-mlutype"
+	MLUNoUse          = "cambricon.com/nouse-mlutype"
 	// MLUUseUUID annotation specifies a comma-separated list of MLU UUIDs to use.
 	MLUUseUUID = "cambricon.com/use-gpuuuid"
 	// MLUNoUseUUID annotation specifies a comma-separated list of MLU UUIDs to exclude.
@@ -214,6 +217,10 @@ func (dev *CambriconDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo
 		return []*device.DeviceInfo{}, fmt.Errorf("device not found %s", MLUResourceCores)
 	}
 	memoryTotal, _ := n.Status.Capacity.Name(corev1.ResourceName(MLUResourceMemory), resource.DecimalSI).AsInt64()
+	mluType := strings.TrimSpace(n.Labels[MLUModelLabel])
+	if mluType == "" {
+		mluType = CambriconMLUDevice
+	}
 	for int64(i)*100 < cards {
 		nodedevices = append(nodedevices, &device.DeviceInfo{
 			Index:        uint(i),
@@ -221,7 +228,7 @@ func (dev *CambriconDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo
 			Count:        100,
 			Devmem:       int32(memoryTotal * MemoryFactor * 100 / cards),
 			Devcore:      100,
-			Type:         CambriconMLUDevice,
+			Type:         mluType,
 			Numa:         0,
 			Health:       true,
 			DeviceVendor: CambriconMLUCommonWord,
@@ -242,7 +249,12 @@ func (dev *CambriconDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 
 func (dev *CambriconDevices) checkType(annos map[string]string, d device.DeviceUsage, n device.ContainerDeviceRequest) (bool, bool, bool) {
 	if strings.Compare(n.Type, CambriconMLUDevice) == 0 {
-		return true, true, false
+		model := strings.TrimSpace(d.Type)
+		constrained := strings.TrimSpace(annos[MLUInUse]) != "" || strings.TrimSpace(annos[MLUNoUse]) != ""
+		if constrained && (model == "" || strings.EqualFold(model, CambriconMLUDevice)) {
+			return true, false, false
+		}
+		return true, device.CheckType(annos, d.Type, MLUInUse, MLUNoUse), false
 	}
 	return false, false, false
 }

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -42,8 +42,9 @@ import (
 const (
 	CambriconMLUDevice     = "MLU"
 	CambriconMLUCommonWord = "MLU"
-	// MLUModelLabel is published by cambricon-k8s-device-plugin when node label
-	// reporting is enabled.
+	// MLUModelLabel is published by cambricon-k8s-device-plugin v2.0.20 and later
+	// when --node-label is enabled. See:
+	// https://github.com/Cambricon/cambricon-k8s-device-plugin/blob/v2.0.20/device-plugin/README.md#mlu-device-label-management
 	MLUModelLabel     = "Model"
 	MluMemSplitLimit  = "CAMBRICON_SPLIT_MEMS"
 	MluMemSplitIndex  = "CAMBRICON_SPLIT_VISIBLE_DEVICES"
@@ -218,7 +219,7 @@ func (dev *CambriconDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo
 	}
 	memoryTotal, _ := n.Status.Capacity.Name(corev1.ResourceName(MLUResourceMemory), resource.DecimalSI).AsInt64()
 	mluType := strings.TrimSpace(n.Labels[MLUModelLabel])
-	if mluType == "" {
+	if !strings.Contains(strings.ToUpper(mluType), CambriconMLUDevice) {
 		mluType = CambriconMLUDevice
 	}
 	for int64(i)*100 < cards {

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -105,6 +105,36 @@ func Test_GetNodeDevices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "model label without MLU keeps the device schedulable",
+			args: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						MLUModelLabel: "370-X4",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Capacity: corev1.ResourceList{
+						"cambricon.com/mlu.smlu.vcore":   *resource.NewQuantity(1, resource.DecimalSI),
+						"cambricon.com/mlu.smlu.vmemory": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+				},
+			},
+			want: []*device.DeviceInfo{
+				{
+					Index:        0,
+					ID:           "test-cambricon-mlu-0",
+					Count:        int32(100),
+					Devmem:       int32(25600),
+					Devcore:      int32(100),
+					Type:         CambriconMLUDevice,
+					Numa:         0,
+					Health:       true,
+					DeviceVendor: CambriconMLUCommonWord,
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -75,6 +75,36 @@ func Test_GetNodeDevices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "device plugin model label supplies the real MLU model",
+			args: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						MLUModelLabel: "MLU370-X4",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Capacity: corev1.ResourceList{
+						"cambricon.com/mlu.smlu.vcore":   *resource.NewQuantity(1, resource.DecimalSI),
+						"cambricon.com/mlu.smlu.vmemory": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+				},
+			},
+			want: []*device.DeviceInfo{
+				{
+					Index:        0,
+					ID:           "test-cambricon-mlu-0",
+					Count:        int32(100),
+					Devmem:       int32(25600),
+					Devcore:      int32(100),
+					Type:         "MLU370-X4",
+					Numa:         0,
+					Health:       true,
+					DeviceVendor: CambriconMLUCommonWord,
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -193,6 +223,160 @@ func Test_checkType(t *testing.T) {
 				},
 			},
 			want1: false,
+			want2: false,
+		},
+		{
+			name: "use-mlutype allows the listed model",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: "MLU370"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "use-mlutype rejects a non-listed model",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: "MLU590"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			name: "nouse-mlutype excludes the listed model",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUNoUse: "MLU370"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			name: "nouse-mlutype ignores a non-listed model",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUNoUse: "MLU590"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "empty use-mlutype does not block scheduling",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: ""},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "whitespace nouse-mlutype does not block scheduling",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUNoUse: "   "},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "comma-separated use-mlutype matches one entry",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: "MLU290,MLU370"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "comma-separated use-mlutype matches no entry",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: "MLU290,MLU590"},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			name: "missing model annotations keep default behavior",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{},
+				d:     device.DeviceUsage{Type: "MLU370-X4"},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: true,
+		},
+		{
+			name: "use-mlutype rejects a device whose model is unknown",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUInUse: "MLU370"},
+				d:     device.DeviceUsage{Type: CambriconMLUDevice},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
+			want2: false,
+		},
+		{
+			name: "nouse-mlutype rejects a device whose model is unknown",
+			args: struct {
+				annos map[string]string
+				d     device.DeviceUsage
+				n     device.ContainerDeviceRequest
+			}{
+				annos: map[string]string{MLUNoUse: "MLU370"},
+				d:     device.DeviceUsage{Type: CambriconMLUDevice},
+				n:     device.ContainerDeviceRequest{Type: CambriconMLUDevice},
+			},
+			want1: true,
 			want2: false,
 		},
 	}
@@ -1271,6 +1455,118 @@ func TestDevices_Fit(t *testing.T) {
 			wantLen:    0,
 			wantDevIDs: []string{},
 			wantReason: "1/1 CardNotHealth",
+		},
+		{
+			name: "model-aware fit: use-mlutype selects the matching model",
+			devices: []*device.DeviceUsage{{
+				ID:        "dev-0",
+				Index:     0,
+				Used:      0,
+				Count:     100,
+				Usedmem:   0,
+				Totalmem:  128,
+				Totalcore: 100,
+				Usedcores: 0,
+				Numa:      0,
+				Type:      "MLU370-X4",
+				Health:    true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums:             1,
+				Memreq:           64,
+				MemPercentagereq: 0,
+				Coresreq:         50,
+				Type:             CambriconMLUDevice,
+			},
+			annos:      map[string]string{MLUInUse: "MLU370"},
+			wantFit:    true,
+			wantLen:    1,
+			wantDevIDs: []string{"dev-0"},
+			wantReason: "",
+		},
+		{
+			name: "model-aware fit fail: use-mlutype excludes a non-listed model",
+			devices: []*device.DeviceUsage{{
+				ID:        "dev-0",
+				Index:     0,
+				Used:      0,
+				Count:     100,
+				Usedmem:   0,
+				Totalmem:  128,
+				Totalcore: 100,
+				Usedcores: 0,
+				Numa:      0,
+				Type:      "MLU370-X4",
+				Health:    true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums:             1,
+				Memreq:           64,
+				MemPercentagereq: 0,
+				Coresreq:         50,
+				Type:             CambriconMLUDevice,
+			},
+			annos:      map[string]string{MLUInUse: "MLU590"},
+			wantFit:    false,
+			wantLen:    0,
+			wantDevIDs: []string{},
+			wantReason: "1/1 CardTypeMismatch",
+		},
+		{
+			name: "model-aware fit fail: nouse-mlutype excludes the listed model",
+			devices: []*device.DeviceUsage{{
+				ID:        "dev-0",
+				Index:     0,
+				Used:      0,
+				Count:     100,
+				Usedmem:   0,
+				Totalmem:  128,
+				Totalcore: 100,
+				Usedcores: 0,
+				Numa:      0,
+				Type:      "MLU370-X4",
+				Health:    true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums:             1,
+				Memreq:           64,
+				MemPercentagereq: 0,
+				Coresreq:         50,
+				Type:             CambriconMLUDevice,
+			},
+			annos:      map[string]string{MLUNoUse: "MLU370"},
+			wantFit:    false,
+			wantLen:    0,
+			wantDevIDs: []string{},
+			wantReason: "1/1 CardTypeMismatch",
+		},
+		{
+			name: "model-aware fit: empty use-mlutype does not block scheduling",
+			devices: []*device.DeviceUsage{{
+				ID:        "dev-0",
+				Index:     0,
+				Used:      0,
+				Count:     100,
+				Usedmem:   0,
+				Totalmem:  128,
+				Totalcore: 100,
+				Usedcores: 0,
+				Numa:      0,
+				Type:      "MLU370-X4",
+				Health:    true,
+			}},
+			request: device.ContainerDeviceRequest{
+				Nums:             1,
+				Memreq:           64,
+				MemPercentagereq: 0,
+				Coresreq:         50,
+				Type:             CambriconMLUDevice,
+			},
+			annos:      map[string]string{MLUInUse: ""},
+			wantFit:    true,
+			wantLen:    1,
+			wantDevIDs: []string{"dev-0"},
+			wantReason: "",
 		},
 	}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR fixes Cambricon MLU model-aware scheduling.

HAMi defines the following pod annotations:

- `cambricon.com/use-mlutype`
- `cambricon.com/nouse-mlutype`

Previously, the Cambricon scheduler did not use these annotations. Every Cambricon device was recorded with the generic type `MLU`. Therefore, HAMi could not distinguish models such as `MLU370-X4` and `MLU590`.

This could allow a pod to be scheduled on an MLU model that it did not request or explicitly excluded.

This PR:

- Reads the MLU model from the node's `Model` label.
- Stores the real model in the HAMi device information when the label contains `MLU`.
- Falls back to the generic `MLU` type when the label is missing, empty, or does not contain `MLU`.
- Uses the existing `device.CheckType` helper to check the model annotations.
- Allows devices that match `use-mlutype`.
- Rejects devices that match `nouse-mlutype`.
- Preserves existing scheduling behavior when no model constraint is provided.
- Rejects constrained requests when the device model cannot be verified.

### Behavior before this fix

```text
Node label: Model=MLU370-X4
              |
              v
HAMi records Type="MLU"
              |
              v
Model annotations are ignored
              |
              v
Any healthy MLU may be selected
```

### Behavior after this fix

```text
Node label: Model=MLU370-X4
              |
              v
HAMi records Type="MLU370-X4"
              |
              v
Check the pod's model annotations
          /               \
         /                 \
Model is allowed       Model is excluded
       |                       |
       v                       v
Schedule device           Reject device
```

### Behavior when the model label is missing or invalid

```text
Model label contains "MLU" -> Use the real model
Model label is missing     -> Fall back to "MLU"
Model label lacks "MLU"    -> Fall back to "MLU"

No model constraint        -> Preserve existing scheduling behavior
Model constraint set       -> Reject the device because its model cannot be verified
```

This change only affects Cambricon model filtering in the scheduler. It does not change device resource counts, memory accounting, core accounting, allocation annotations, or other accelerator backends.

**Which issue(s) this PR fixes**:

Fixes #2774

**Special notes for your reviewer**:

Cambricon device-plugin `v2.0.20` introduced automatic MLU node labels. It publishes the bare `Model` label when `--node-label` is enabled:

- [Cambricon device-plugin v2.0.20 documentation](https://github.com/Cambricon/cambricon-k8s-device-plugin/blob/v2.0.20/device-plugin/README.md#mlu-device-label-management)
- [Cambricon device-plugin v2.0.20 label definition](https://github.com/Cambricon/cambricon-k8s-device-plugin/blob/v2.0.20/device-plugin/pkg/nodeLabel/nodelabel.go#L26-L31)

The implementation reuses the existing `device.CheckType` helper used by other device backends.

Validation completed:

- `go test -count=1 ./pkg/device/cambricon` — PASS
- `go test -race -count=1 ./pkg/device/cambricon` — PASS
- `make test` — PASS
- `make verify` — PASS
- `make build` — PASS
- `make tidy` — PASS with no module-file changes

Physical Cambricon MLU hardware was not tested because this change is limited to scheduler logic and is covered by unit and mock tests.

AI assistance disclosure:

I used OpenAI Codex to help analyze the code, implement and review the fix and tests, darfting this pull request description. I reviewed the changes and take responsibility for the contribution. 

Does this PR introduce a user-facing change?**:

```release-note
Cambricon scheduling now honors the `cambricon.com/use-mlutype` and `cambricon.com/nouse-mlutype` annotations. Pods using these annotations may remain pending on nodes whose `Model` label is missing or does not contain `MLU`. Cambricon device-plugin v2.0.20 and later can publish this label when `--node-label` is enabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cambricon devices now identify their specific model from node labels when available.
  * Device selection supports model-specific allow and deny rules, including case-insensitive matching and multiple model values.

* **Bug Fixes**
  * Improved fallback behavior when model information is missing, empty, or unsupported.
  * Corrected device-fit decisions for constrained workloads using model-specific requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->