### PR TITLE
Add nil node checks to PatchNodeAnnotations and RemoveNodeAnnotation

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -137,6 +137,13 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 }
 
 func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
+	c := client.GetClient()
+	if c == nil {
+		return fmt.Errorf("kubernetes client is not initialized")
+	}
 	type patchMetadata struct {
 		Annotations map[string]string `json:"annotations,omitempty"`
 	}
@@ -151,7 +158,7 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 	if err != nil {
 		return err
 	}
-	_, err = client.GetClient().CoreV1().Nodes().
+	_, err = c.CoreV1().Nodes().
 		Patch(context.Background(), node.Name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infoln("annotations=", annotations)
@@ -259,6 +266,9 @@ func MarkAnnotationsToDelete(devType string, nn string) error {
 }
 
 func RemoveNodeAnnotation(node *corev1.Node, annotationKeys ...string) error {
+	if node == nil {
+		return fmt.Errorf("node is nil")
+	}
 	annos := make(map[string]any, len(annotationKeys))
 	for _, key := range annotationKeys {
 		annos[key] = nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -977,3 +977,62 @@ func TestAllNonSidecarInitContainersSucceeded(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchNodeAnnotations_NilNode(t *testing.T) {
+	err := PatchNodeAnnotations(nil, map[string]string{"hami.io/test": "bar"})
+	assert.ErrorContains(t, err, "node is nil")
+}
+
+func TestPatchNodeAnnotations_ValidNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+	client.KubeClient = fake.NewClientset(node)
+
+	err := PatchNodeAnnotations(node, map[string]string{"hami.io/test": "bar"})
+	assert.NilError(t, err)
+
+	updated, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "test-node", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, "bar", updated.Annotations["hami.io/test"])
+}
+
+func TestRemoveNodeAnnotation_NilNode(t *testing.T) {
+	err := RemoveNodeAnnotation(nil, "hami.io/test")
+	assert.ErrorContains(t, err, "node is nil")
+}
+
+func TestRemoveNodeAnnotation_ValidNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Annotations: map[string]string{
+				"hami.io/test": "bar",
+			},
+		},
+	}
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+	client.KubeClient = fake.NewClientset(node)
+
+	err := RemoveNodeAnnotation(node, "hami.io/test")
+	assert.NilError(t, err)
+
+	updated, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "test-node", metav1.GetOptions{})
+	assert.NilError(t, err)
+	_, hasAnno := updated.Annotations["hami.io/test"]
+	assert.Assert(t, !hasAnno)
+}
+
+func TestPatchNodeAnnotations_NilClient(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+	client.KubeClient = nil
+	err := PatchNodeAnnotations(node, map[string]string{"hami.io/test": "bar"})
+	assert.ErrorContains(t, err, "kubernetes client is not initialized")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `pkg/util/util.go`, both `PatchNodeAnnotations` and `RemoveNodeAnnotation` directly accessed `node.Name` without checking if `node` was `nil`. If passed a `nil` node pointer (for instance when `GetNode` fails or returns `nil`), calling either function resulted in an unhandled runtime panic (`invalid memory address or nil pointer dereference`).

This PR adds defensive `nil` checks to both functions so they return a clean error (`fmt.Errorf("node is nil")`) instead of panicking, matching the pattern in `PatchPodAnnotations`.

**Which issue(s) this PR fixes**:
Fixes #2791 

**Special notes for your reviewer**:

- Includes unit tests in `pkg/util/util_test.go`.
- `go test -v ./pkg/util/...` passes cleanly.

**Does this PR introduce a user-facing change?**:

No

---

This PR was written with the assistance of Antigravity AI. I have reviewed all changes and understand the content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when updating or removing node annotations.
  * Clear errors are now returned when a node is missing.
  * Annotation updates now report an error when the Kubernetes client is unavailable, helping prevent invalid requests.

* **Tests**
  * Added coverage for nil-node error handling, unavailable-client validation, and successful annotation operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->