### PR TITLE
test(e2e): add scheduler policy E2E suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,7 @@ e2e-mig-test:
 .PHONY: e2e-mig-smoke-test
 e2e-mig-smoke-test:
 	./hack/e2e-mig-smoke-test.sh "${KUBE_CONF}"
+
+.PHONY: e2e-policy-test
+e2e-policy-test:
+	HAMI_E2E_REQUIRE_POLICY_TOPOLOGY=true bash ./hack/e2e-policy-test.sh "${KUBE_CONF}"

--- a/hack/e2e-policy-test.sh
+++ b/hack/e2e-policy-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2026 The HAMi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_CONF=${1:-"${HOME}/.kube/config"}
+export KUBE_CONF
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+
+if [ ! -f "${KUBE_CONF}" ]; then
+  echo "Error: kubeconfig file not found at ${KUBE_CONF}" >&2
+  exit 1
+fi
+
+if ! kubectl --kubeconfig "${KUBE_CONF}" get nodes >/dev/null; then
+  echo "Error: cannot reach Kubernetes API server via ${KUBE_CONF}" >&2
+  exit 1
+fi
+
+GINKGO_VERSION=$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+if [ -z "${GINKGO_VERSION}" ]; then
+  echo "Error: could not determine Ginkgo version from go.mod" >&2
+  exit 1
+fi
+
+go run "github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}" \
+  run -v --procs=1 ./test/e2e/policy/ -- --kubeconfig="${KUBE_CONF}"

--- a/test/e2e/pod/test_pod.go
+++ b/test/e2e/pod/test_pod.go
@@ -57,6 +57,10 @@ var _ = ginkgo.Describe("Pod E2E Tests", ginkgo.Ordered, func() {
 		ginkgo.By("Adding node labeling")
 		_, err = utils.AddNodeLabel(clientSet, nodeName, NodeLabelKey, NodeLabelValue)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for device-plugin to register healthy GPU devices")
+		err = utils.WaitForDevicePluginReady(clientSet, nodeName, 5*time.Minute, 2*time.Second)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "device-plugin did not become ready on node %s", nodeName)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/e2e/policy/test_policy.go
+++ b/test/e2e/policy/test_policy.go
@@ -1,0 +1,751 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+	"github.com/Project-HAMi/HAMi/test/utils"
+)
+
+const (
+	policyTestNamespacePrefix = "hami-policy-e2e-"
+	policyTestImage           = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0"
+	policyTestScheduler       = "hami-scheduler"
+	policyTestTimeout         = 5 * time.Minute
+	policyTestInterval        = 2 * time.Second
+
+	gpuResourceName       = corev1.ResourceName("nvidia.com/gpu")
+	gpuCoreResourceName   = corev1.ResourceName("nvidia.com/gpucores")
+	gpuMemoryPercentName  = corev1.ResourceName("nvidia.com/gpumem-percentage")
+	allocatedDevicesKey   = "hami.io/vgpu-devices-allocated"
+	schedulerComponentKey = "app.kubernetes.io/component"
+	schedulerComponent    = "hami-scheduler"
+	devicePluginComponent = "hami-device-plugin"
+	schedulerContainer    = "vgpu-scheduler-extender"
+)
+
+type gpuNode struct {
+	name string
+	gpus []device.DeviceInfo
+}
+
+func (n gpuNode) gpu(index int) string {
+	return n.gpus[index].ID
+}
+
+type policyFixture struct {
+	cluster   *policyCluster
+	client    kubernetes.Interface
+	namespace string
+	pods      []*corev1.Pod
+}
+
+type policyCluster struct {
+	client kubernetes.Interface
+}
+
+type policyMetricsTarget struct {
+	pod  string
+	port string
+}
+
+var _ = ginkgo.Describe("[policy] Scheduler policy E2E tests", ginkgo.Ordered, ginkgo.Serial, func() {
+	var (
+		cluster *policyCluster
+		nodes   []gpuNode
+	)
+
+	ginkgo.BeforeAll(func() {
+		cluster = newPolicyCluster()
+		ensureGPUNodeLabeled(cluster.client)
+
+		// The device-plugin may be Ready (probe passes) before it finishes
+		// registering GPU devices in the node annotation, and stale node-lock
+		// annotations or terminating pods from earlier suites may temporarily
+		// cause a node to be filtered out. Poll until at least one node passes
+		// all readiness checks so the specs can make informed skip/run decisions.
+		gomega.Eventually(func() []gpuNode {
+			nodes = registeredGPUNodes(cluster.client)
+			return nodes
+		}, policyTestTimeout, policyTestInterval).ShouldNot(gomega.BeEmpty(),
+			"timed out waiting for at least one node to register hami-core GPUs")
+	})
+
+	// This spec exercises the full schedule -> bind -> metrics -> release path
+	// using vGPU sharing on a single GPU, so it runs even on a single-GPU node
+	// (e.g. the Tesla P4 CI runner) while remaining valid on richer topologies.
+	ginkgo.It("shares one GPU across pods and releases capacity on delete", func() {
+		selected := requireNodes(nodes, 1, 1, "single-GPU vGPU sharing")
+		node := selected[0]
+		fixture := newPolicyFixture(cluster)
+
+		ginkgo.By("placing the first vGPU workload on the only GPU")
+		first := fixture.createPod("share-first", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0)},
+			cores:      30,
+			memoryPct:  30,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(first.Spec.NodeName).To(gomega.Equal(node.name))
+		gomega.Expect(allocatedGPU(first)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(first)
+
+		ginkgo.By("packing a second vGPU workload onto the same shared GPU")
+		second := fixture.createPod("share-second", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0)},
+			cores:      30,
+			memoryPct:  30,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(second)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(second)
+
+		ginkgo.By("releasing the first workload frees its share from the scheduler cache")
+		fixture.deletePod(first)
+
+		ginkgo.By("a replacement workload reuses the freed capacity on the same GPU")
+		third := fixture.createPod("share-third", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0)},
+			cores:      30,
+			memoryPct:  30,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(third)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(third)
+	})
+
+	ginkgo.It("places workloads according to node binpack and spread policies", func() {
+		selected := requireNodes(nodes, 2, 1, "node binpack and spread")
+
+		ginkgo.By("creating an unequal node utilization baseline")
+		fixture := newPolicyFixture(cluster)
+		seed := fixture.createPod("node-seed", podOptions{
+			nodes:      []string{selected[0].name},
+			gpuUUIDs:   []string{selected[0].gpu(0)},
+			cores:      60,
+			memoryPct:  40,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(seed.Spec.NodeName).To(gomega.Equal(selected[0].name))
+		cluster.waitForSchedulerCache(seed)
+
+		ginkgo.By("asserting node binpack selects the busier node")
+		binpack := fixture.createPod("node-binpack", podOptions{
+			nodes:      []string{selected[0].name, selected[1].name},
+			gpuUUIDs:   []string{selected[0].gpu(0), selected[1].gpu(0)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicySpread.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(binpack.Spec.NodeName).To(gomega.Equal(selected[0].name))
+		cluster.waitForSchedulerCache(binpack)
+
+		ginkgo.By("asserting node spread selects the less utilized node")
+		spread := fixture.createPod("node-spread", podOptions{
+			nodes:      []string{selected[0].name, selected[1].name},
+			gpuUUIDs:   []string{selected[0].gpu(0), selected[1].gpu(0)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicySpread.String(),
+			nodePolicy: util.NodeSchedulerPolicySpread.String(),
+		})
+		gomega.Expect(spread.Spec.NodeName).To(gomega.Equal(selected[1].name))
+	})
+
+	ginkgo.It("places workloads according to GPU binpack and spread policies", func() {
+		selected := requireNodes(nodes, 1, 2, "GPU binpack and spread")
+		node := selected[0]
+
+		ginkgo.By("creating an unequal GPU utilization baseline")
+		fixture := newPolicyFixture(cluster)
+		seed := fixture.createPod("gpu-seed", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0)},
+			cores:      60,
+			memoryPct:  40,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(seed)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(seed)
+
+		ginkgo.By("asserting GPU binpack selects the busier GPU")
+		binpack := fixture.createPod("gpu-binpack", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0), node.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(binpack)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(binpack)
+
+		ginkgo.By("asserting a comma-separated mutex policy excludes the busy GPU")
+		mutex := fixture.createPod("gpu-binpack-mutex", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0), node.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  "binpack,mutex",
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(mutex)).To(gomega.Equal(node.gpu(1)))
+		cluster.waitForSchedulerCache(mutex)
+
+		ginkgo.By("asserting GPU spread selects the less utilized GPU")
+		spread := fixture.createPod("gpu-spread", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0), node.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicySpread.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(spread)).To(gomega.Equal(node.gpu(1)))
+	})
+
+	ginkgo.It("honors combined node and GPU policy annotations", func() {
+		selected := requireNodes(nodes, 2, 2, "combined node and GPU policies")
+		low, high := selected[0], selected[1]
+		fixture := newPolicyFixture(cluster)
+
+		ginkgo.By("creating distinct baseline utilization on both nodes")
+		lowSeed := fixture.createPod("combined-low", podOptions{
+			nodes:      []string{low.name},
+			gpuUUIDs:   []string{low.gpu(0)},
+			cores:      20,
+			memoryPct:  20,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		highSeed := fixture.createPod("combined-high", podOptions{
+			nodes:      []string{high.name},
+			gpuUUIDs:   []string{high.gpu(0)},
+			cores:      60,
+			memoryPct:  60,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		cluster.waitForSchedulerCache(lowSeed)
+		cluster.waitForSchedulerCache(highSeed)
+
+		ginkgo.By("asserting binpack node and binpack GPU policy chains")
+		binpackBinpack := fixture.createPod("combined-binpack-binpack", podOptions{
+			nodes:      []string{low.name, high.name},
+			gpuUUIDs:   []string{low.gpu(0), low.gpu(1), high.gpu(0), high.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  "binpack,spread",
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(binpackBinpack.Spec.NodeName).To(gomega.Equal(high.name))
+		gomega.Expect(allocatedGPU(binpackBinpack)).To(gomega.Equal(high.gpu(0)))
+		cluster.waitForSchedulerCache(binpackBinpack)
+		fixture.deletePod(binpackBinpack)
+
+		ginkgo.By("asserting binpack node and spread GPU policy chains")
+		binpackSpread := fixture.createPod("combined-binpack-spread", podOptions{
+			nodes:      []string{low.name, high.name},
+			gpuUUIDs:   []string{low.gpu(0), low.gpu(1), high.gpu(0), high.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  "spread,binpack",
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(binpackSpread.Spec.NodeName).To(gomega.Equal(high.name))
+		gomega.Expect(allocatedGPU(binpackSpread)).To(gomega.Equal(high.gpu(1)))
+		cluster.waitForSchedulerCache(binpackSpread)
+		fixture.deletePod(binpackSpread)
+
+		ginkgo.By("asserting spread node and binpack GPU policy chains")
+		spreadBinpack := fixture.createPod("combined-spread-binpack", podOptions{
+			nodes:      []string{low.name, high.name},
+			gpuUUIDs:   []string{low.gpu(0), low.gpu(1), high.gpu(0), high.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  "binpack,spread",
+			nodePolicy: util.NodeSchedulerPolicySpread.String(),
+		})
+		gomega.Expect(spreadBinpack.Spec.NodeName).To(gomega.Equal(low.name))
+		gomega.Expect(allocatedGPU(spreadBinpack)).To(gomega.Equal(low.gpu(0)))
+		cluster.waitForSchedulerCache(spreadBinpack)
+		fixture.deletePod(spreadBinpack)
+
+		ginkgo.By("asserting spread node and spread GPU policy chains")
+		spreadSpread := fixture.createPod("combined-spread-spread", podOptions{
+			nodes:      []string{low.name, high.name},
+			gpuUUIDs:   []string{low.gpu(0), low.gpu(1), high.gpu(0), high.gpu(1)},
+			cores:      10,
+			memoryPct:  10,
+			gpuPolicy:  "spread,binpack",
+			nodePolicy: util.NodeSchedulerPolicySpread.String(),
+		})
+		gomega.Expect(spreadSpread.Spec.NodeName).To(gomega.Equal(low.name))
+		gomega.Expect(allocatedGPU(spreadSpread)).To(gomega.Equal(low.gpu(1)))
+	})
+
+	ginkgo.It("applies per-Pod device scoring weight overrides", func() {
+		selected := requireNodes(nodes, 1, 2, "per-Pod device scoring weights")
+		node := selected[0]
+		fixture := newPolicyFixture(cluster)
+
+		ginkgo.By("creating GPU utilization that default and memory-heavy weights rank differently")
+		coreSeed := fixture.createPod("weight-core", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0)},
+			cores:      60,
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		memorySeed := fixture.createPod("weight-memory", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(1)},
+			cores:      1,
+			memoryPct:  40,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		cluster.waitForSchedulerCache(coreSeed)
+		cluster.waitForSchedulerCache(memorySeed)
+
+		ginkgo.By("asserting default weights prefer the core-heavy GPU")
+		defaultWeights := fixture.createPod("weight-default", podOptions{
+			nodes:      []string{node.name},
+			gpuUUIDs:   []string{node.gpu(0), node.gpu(1)},
+			memoryPct:  10,
+			gpuPolicy:  util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy: util.NodeSchedulerPolicyBinpack.String(),
+		})
+		gomega.Expect(allocatedGPU(defaultWeights)).To(gomega.Equal(node.gpu(0)))
+		cluster.waitForSchedulerCache(defaultWeights)
+		fixture.deletePod(defaultWeights)
+
+		ginkgo.By("asserting memory-heavy weights prefer the memory-heavy GPU")
+		memoryWeighted := fixture.createPod("weight-memory-heavy", podOptions{
+			nodes:              []string{node.name},
+			gpuUUIDs:           []string{node.gpu(0), node.gpu(1)},
+			memoryPct:          10,
+			gpuPolicy:          util.GPUSchedulerPolicyBinpack.String(),
+			nodePolicy:         util.NodeSchedulerPolicyBinpack.String(),
+			deviceScoreWeights: "slot=1,core=1,memory=3",
+		})
+		gomega.Expect(allocatedGPU(memoryWeighted)).To(gomega.Equal(node.gpu(1)))
+	})
+})
+
+type podOptions struct {
+	nodes              []string
+	gpuUUIDs           []string
+	cores              int64
+	memoryPct          int64
+	nodePolicy         string
+	gpuPolicy          string
+	deviceScoreWeights string
+}
+
+func newPolicyFixture(cluster *policyCluster) *policyFixture {
+	client := cluster.client
+	namespace := fmt.Sprintf("%s%s", policyTestNamespacePrefix, utils.GetRandom())
+	_, err := client.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	fixture := &policyFixture{cluster: cluster, client: client, namespace: namespace}
+	ginkgo.DeferCleanup(fixture.cleanup)
+	return fixture
+}
+
+func (f *policyFixture) createPod(name string, options podOptions) *corev1.Pod {
+	pod := newPolicyPod(f.namespace, name, options)
+	_, err := f.client.CoreV1().Pods(f.namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	allocated := waitForAllocatedPod(f.client, f.namespace, pod.Name)
+	f.pods = append(f.pods, allocated)
+	return allocated
+}
+
+func (f *policyFixture) deletePod(pod *corev1.Pod) {
+	err := f.client.CoreV1().Pods(f.namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+	if !apierrors.IsNotFound(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	gomega.Eventually(func() bool {
+		_, err := f.client.CoreV1().Pods(f.namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue())
+
+	// The API object is gone, but the scheduler releases the pod's GPU/node
+	// usage asynchronously via an informer delete event. Wait for that release
+	// so a subsequent placement assertion does not observe stale utilization.
+	f.cluster.waitForSchedulerCacheRelease(pod)
+}
+
+func (f *policyFixture) cleanup() {
+	err := f.client.CoreV1().Namespaces().Delete(context.Background(), f.namespace, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	gomega.Eventually(func() bool {
+		_, err := f.client.CoreV1().Namespaces().Get(context.Background(), f.namespace, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue())
+
+	// Namespace deletion removes the pods from the API, but the scheduler's
+	// cache still counts their usage until the delete events are processed.
+	// Wait for release so the next It block starts from a clean cache.
+	for _, pod := range f.pods {
+		f.cluster.waitForSchedulerCacheRelease(pod)
+	}
+}
+
+func newPolicyCluster() *policyCluster {
+	return &policyCluster{client: utils.GetClientSet()}
+}
+
+// waitForSchedulerCache blocks until the scheduler's in-memory cache reflects
+// the pod's allocation (its resource-usage metric line has appeared on at least
+// one running scheduler replica).
+func (c *policyCluster) waitForSchedulerCache(pod *corev1.Pod) {
+	needle := schedulerCacheNeedle(pod)
+	gomega.Eventually(func() bool {
+		return strings.Contains(c.schedulerMetrics(), needle)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
+		"scheduler cache never reflected pod %s/%s", pod.Namespace, pod.Name)
+}
+
+// waitForSchedulerCacheRelease blocks until the scheduler's in-memory cache has
+// released the pod's allocation on every running scheduler replica, so freed
+// GPU/node resources are no longer counted against subsequent placements.
+func (c *policyCluster) waitForSchedulerCacheRelease(pod *corev1.Pod) {
+	needle := schedulerCacheNeedle(pod)
+	gomega.Eventually(func() bool {
+		return !strings.Contains(c.schedulerMetrics(), needle)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
+		"scheduler cache never released pod %s/%s", pod.Namespace, pod.Name)
+}
+
+func schedulerCacheNeedle(pod *corev1.Pod) string {
+	return fmt.Sprintf("namespace=\"%s\",node=\"%s\",pod=\"%s\"", pod.Namespace, pod.Spec.NodeName, pod.Name)
+}
+
+// schedulerMetricsTargets returns the metrics endpoint of every running
+// scheduler-extender replica. Scraping all replicas (rather than guessing the
+// leader) keeps the cache assertions correct under HA and across leader changes.
+func (c *policyCluster) schedulerMetricsTargets() []policyMetricsTarget {
+	pods, err := c.client.CoreV1().Pods(hamiNamespace()).List(context.Background(), metav1.ListOptions{
+		LabelSelector: schedulerComponentKey + "=" + schedulerComponent,
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	targets := make([]policyMetricsTarget, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, container := range pod.Spec.Containers {
+			if container.Name != schedulerContainer {
+				continue
+			}
+			for _, port := range container.Ports {
+				if port.Name == "metrics" {
+					targets = append(targets, policyMetricsTarget{pod: pod.Name, port: fmt.Sprint(port.ContainerPort)})
+				}
+			}
+		}
+	}
+	gomega.Expect(targets).NotTo(gomega.BeEmpty(), "no running HAMi scheduler metrics endpoint found")
+	return targets
+}
+
+// schedulerMetrics returns the concatenated /metrics output of every running
+// scheduler replica, re-resolving the endpoints on each call so leader changes
+// and replica restarts are tolerated.
+func (c *policyCluster) schedulerMetrics() string {
+	var builder strings.Builder
+	for _, target := range c.schedulerMetricsTargets() {
+		response := c.client.CoreV1().Pods(hamiNamespace()).ProxyGet("http", target.pod, target.port, "metrics", nil)
+		stream, err := response.Stream(context.Background())
+		if err != nil {
+			continue
+		}
+		metrics, err := io.ReadAll(stream)
+		stream.Close()
+		if err != nil {
+			continue
+		}
+		builder.Write(metrics)
+	}
+	return builder.String()
+}
+
+func newPolicyPod(namespace, name string, options podOptions) *corev1.Pod {
+	annotations := map[string]string{
+		nvidia.GPUUseUUID:                     strings.Join(options.gpuUUIDs, ","),
+		util.NodeSchedulerPolicyAnnotationKey: options.nodePolicy,
+		util.GPUSchedulerPolicyAnnotationKey:  options.gpuPolicy,
+	}
+	if options.deviceScoreWeights != "" {
+		annotations[util.DeviceScoringWeightsAnnotationKey] = options.deviceScoreWeights
+	}
+
+	limits := corev1.ResourceList{
+		gpuResourceName:      resource.MustParse("1"),
+		gpuMemoryPercentName: *resource.NewQuantity(options.memoryPct, resource.DecimalSI),
+	}
+	if options.cores > 0 {
+		limits[gpuCoreResourceName] = *resource.NewQuantity(options.cores, resource.DecimalSI)
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name + "-" + utils.GetRandom(),
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: policyTestScheduler,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchFields: []corev1.NodeSelectorRequirement{{
+								Key:      "metadata.name",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   options.nodes,
+							}},
+						}},
+					},
+				},
+			},
+			Containers: []corev1.Container{{
+				Name:      "cuda",
+				Image:     policyTestImage,
+				Command:   []string{"/bin/sh", "-c", "sleep 86400"},
+				Resources: corev1.ResourceRequirements{Limits: limits},
+			}},
+		},
+	}
+}
+
+func waitForAllocatedPod(client kubernetes.Interface, namespace, name string) *corev1.Pod {
+	var latest *corev1.Pod
+	gomega.Eventually(func(g gomega.Gomega) {
+		pod, err := client.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		latest = pod
+		g.Expect(pod.Spec.SchedulerName).To(gomega.Equal(policyTestScheduler))
+		g.Expect(pod.Spec.NodeName).NotTo(gomega.BeEmpty())
+		g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+		g.Expect(pod.Annotations[util.AssignedNodeAnnotations]).To(gomega.Equal(pod.Spec.NodeName))
+		g.Expect(pod.Annotations[util.DeviceBindPhase]).To(gomega.Equal(util.DeviceBindSuccess))
+		g.Expect(pod.Annotations[allocatedDevicesKey]).NotTo(gomega.BeEmpty())
+	}, policyTestTimeout, policyTestInterval).Should(gomega.Succeed())
+	return latest
+}
+
+func allocatedGPU(pod *corev1.Pod) string {
+	return allocatedGPUs(pod)[0]
+}
+
+func allocatedGPUs(pod *corev1.Pod) []string {
+	devices, err := device.DecodePodDevices(map[string]string{
+		nvidia.NvidiaGPUDevice: allocatedDevicesKey,
+	}, pod.Annotations)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// The encoded annotation carries a trailing separator, so the decode may
+	// yield an empty container entry after the real one. Keep only the
+	// containers that were actually allocated a device rather than depending
+	// on that separator quirk.
+	allocated := devices[nvidia.NvidiaGPUDevice]
+	containers := make([][]device.ContainerDevice, 0, len(allocated))
+	for _, container := range allocated {
+		if len(container) > 0 {
+			containers = append(containers, container)
+		}
+	}
+	gomega.Expect(containers).To(gomega.HaveLen(1), "expected exactly one allocated container")
+	gomega.Expect(containers[0]).To(gomega.HaveLen(1), "expected exactly one allocated GPU")
+
+	uuids := make([]string, 0, len(containers[0]))
+	for _, allocatedDevice := range containers[0] {
+		uuids = append(uuids, allocatedDevice.UUID)
+	}
+	return uuids
+}
+
+func registeredGPUNodes(client kubernetes.Interface) []gpuNode {
+	nodeList, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	registered := make([]gpuNode, 0)
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !nodeReady(node) || node.Spec.Unschedulable {
+			continue
+		}
+		if !hasReadyDevicePlugin(client, node.Name) {
+			continue
+		}
+
+		raw := node.Annotations[nvidia.RegisterAnnos]
+		devices, err := device.UnMarshalNodeDevices(raw)
+		if err != nil {
+			continue
+		}
+
+		gpus := make([]device.DeviceInfo, 0, len(devices))
+		for _, gpu := range devices {
+			if gpu != nil && gpu.Health && gpu.Mode == nvidia.HamiCoreMode && gpu.Count >= 2 && gpu.Devcore == 100 && gpu.Devmem > 0 {
+				gpus = append(gpus, *gpu)
+			}
+		}
+		if len(gpus) == 0 {
+			continue
+		}
+		sort.Slice(gpus, func(i, j int) bool {
+			return gpus[i].Index < gpus[j].Index
+		})
+		registered = append(registered, gpuNode{name: node.Name, gpus: gpus})
+	}
+
+	sort.Slice(registered, func(i, j int) bool {
+		return registered[i].name < registered[j].name
+	})
+	return registered
+}
+
+func requireNodes(nodes []gpuNode, count, minimumGPUs int, feature string) []gpuNode {
+	selected := make([]gpuNode, 0, count)
+	for _, node := range nodes {
+		if len(node.gpus) >= minimumGPUs {
+			selected = append(selected, node)
+		}
+		if len(selected) == count {
+			return selected
+		}
+	}
+
+	message := fmt.Sprintf("%s requires %d idle registered NVIDIA GPU node(s) with at least %d healthy hami-core GPU(s) each", feature, count, minimumGPUs)
+	if os.Getenv("HAMI_E2E_REQUIRE_POLICY_TOPOLOGY") == "true" {
+		gomega.Expect(selected).To(gomega.HaveLen(count), message)
+	}
+	ginkgo.Skip(message)
+	return nil
+}
+
+// ensureGPUNodeLabeled adds the gpu=on label (if missing) to the first GPU-capable
+// node and waits for the device-plugin DaemonSet pod to become Ready on that node.
+// This makes the policy suite independent of earlier test suites that may have
+// removed the label during their cleanup.
+func ensureGPUNodeLabeled(client kubernetes.Interface) {
+	clientSet, ok := client.(*kubernetes.Clientset)
+	if !ok {
+		// Non-standard client (e.g. fake in unit tests); skip labeling.
+		return
+	}
+
+	nodeName, err := utils.GetGPUNode(clientSet)
+	if err != nil {
+		// No GPU node discovered — requireNodes will skip later.
+		return
+	}
+
+	node, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	if node.Labels[utils.GPUNodeLabelKey] != utils.GPUNodeLabelValue {
+		ginkgo.By(fmt.Sprintf("labeling node %s with %s=%s for device-plugin scheduling", nodeName, utils.GPUNodeLabelKey, utils.GPUNodeLabelValue))
+		_, err = utils.AddNodeLabel(clientSet, nodeName, utils.GPUNodeLabelKey, utils.GPUNodeLabelValue)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	// Wait for the device-plugin pod to become Ready on this node.
+	gomega.Eventually(func() bool {
+		return hasReadyDevicePlugin(client, nodeName)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
+		"device-plugin did not become ready on node %s after labeling", nodeName)
+}
+
+func nodeReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func hasReadyDevicePlugin(client kubernetes.Interface, nodeName string) bool {
+	pods, err := client.CoreV1().Pods(hamiNamespace()).List(context.Background(), metav1.ListOptions{
+		LabelSelector: schedulerComponentKey + "=" + devicePluginComponent,
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return false
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == "device-plugin" && status.Ready {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hamiNamespace() string {
+	if namespace := os.Getenv("HAMI_NAMESPACE"); namespace != "" {
+		return namespace
+	}
+	return utils.GPUNameSpace
+}

--- a/test/e2e/policy/test_policy.go
+++ b/test/e2e/policy/test_policy.go
@@ -579,6 +579,17 @@ func waitForAllocatedPod(client kubernetes.Interface, namespace, name string) *c
 		pod, err := client.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		latest = pod
+
+		// Abort immediately on terminal pod phases — no amount of retrying
+		// will move a Failed or Succeeded pod back to Running.
+		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+			gomega.StopTrying(fmt.Sprintf(
+				"pod %s/%s reached terminal phase %s: %s",
+				namespace, name, pod.Status.Phase,
+				podTerminalReason(pod),
+			)).Now()
+		}
+
 		g.Expect(pod.Spec.SchedulerName).To(gomega.Equal(policyTestScheduler))
 		g.Expect(pod.Spec.NodeName).NotTo(gomega.BeEmpty())
 		g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
@@ -587,6 +598,29 @@ func waitForAllocatedPod(client kubernetes.Interface, namespace, name string) *c
 		g.Expect(pod.Annotations[allocatedDevicesKey]).NotTo(gomega.BeEmpty())
 	}, policyTestTimeout, policyTestInterval).Should(gomega.Succeed())
 	return latest
+}
+
+// podTerminalReason extracts a human-readable reason from a pod in a terminal
+// phase (Failed/Succeeded), checking container statuses for exit codes and OOM
+// signals so the E2E failure message is immediately actionable.
+func podTerminalReason(pod *corev1.Pod) string {
+	var reasons []string
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil {
+			t := cs.State.Terminated
+			reasons = append(reasons, fmt.Sprintf(
+				"container %q exited %d (reason=%s, message=%s)",
+				cs.Name, t.ExitCode, t.Reason, t.Message,
+			))
+		}
+	}
+	if pod.Status.Message != "" {
+		reasons = append(reasons, pod.Status.Message)
+	}
+	if len(reasons) == 0 {
+		return "(no additional detail)"
+	}
+	return strings.Join(reasons, "; ")
 }
 
 func allocatedGPU(pod *corev1.Pod) string {

--- a/test/e2e/policy/test_policy.go
+++ b/test/e2e/policy/test_policy.go
@@ -549,7 +549,11 @@ func newPolicyPod(namespace, name string, options podOptions) *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			SchedulerName: policyTestScheduler,
-			RestartPolicy: corev1.RestartPolicyNever,
+			// OnFailure lets kubelet retry if the container fails to start
+			// (e.g. during a transient device-plugin restart), avoiding a
+			// permanent Failed phase that would stall the test for its full
+			// timeout duration.
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -664,7 +668,7 @@ func registeredGPUNodes(client kubernetes.Interface) []gpuNode {
 		if !nodeReady(node) || node.Spec.Unschedulable {
 			continue
 		}
-		if !hasReadyDevicePlugin(client, node.Name) {
+		if !hasReadyDevicePlugin(client, node.Name) || hasTerminatingDevicePlugin(client, node.Name) {
 			continue
 		}
 
@@ -740,11 +744,14 @@ func ensureGPUNodeLabeled(client kubernetes.Interface) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	// Wait for the device-plugin pod to become Ready on this node.
+	// Wait for the device-plugin pod to become Ready on this node, with no
+	// terminating pods left from a previous DaemonSet revision (the label may
+	// have been briefly removed by an earlier suite's cleanup, causing the
+	// DaemonSet controller to terminate and recreate the device-plugin pod).
 	gomega.Eventually(func() bool {
-		return hasReadyDevicePlugin(client, nodeName)
+		return hasReadyDevicePlugin(client, nodeName) && !hasTerminatingDevicePlugin(client, nodeName)
 	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
-		"device-plugin did not become ready on node %s after labeling", nodeName)
+		"device-plugin did not become ready and stable on node %s after labeling", nodeName)
 
 	// Wait for the scheduler to recognize the node's GPU resources.
 	// After the device-plugin is ready, there's a delay before the scheduler
@@ -781,6 +788,26 @@ func hasReadyDevicePlugin(client kubernetes.Interface, nodeName string) bool {
 			if status.Name == "device-plugin" && status.Ready {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// hasTerminatingDevicePlugin returns true if any device-plugin pod on the given
+// node is being deleted. A terminating pod may still pass readiness checks
+// briefly, but kubelet's device-plugin gRPC registration will be removed once
+// the pod is fully gone, so scheduling through a terminating plugin is unsafe.
+func hasTerminatingDevicePlugin(client kubernetes.Interface, nodeName string) bool {
+	pods, err := client.CoreV1().Pods(hamiNamespace()).List(context.Background(), metav1.ListOptions{
+		LabelSelector: schedulerComponentKey + "=" + devicePluginComponent,
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return false
+	}
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil {
+			return true
 		}
 	}
 	return false

--- a/test/e2e/policy/test_policy.go
+++ b/test/e2e/policy/test_policy.go
@@ -711,6 +711,15 @@ func ensureGPUNodeLabeled(client kubernetes.Interface) {
 		return hasReadyDevicePlugin(client, nodeName)
 	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
 		"device-plugin did not become ready on node %s after labeling", nodeName)
+
+	// Wait for the scheduler to recognize the node's GPU resources.
+	// After the device-plugin is ready, there's a delay before the scheduler
+	// processes the node update and registers the node's GPU capacity.
+	ginkgo.By(fmt.Sprintf("waiting for scheduler to register GPU resources on node %s", nodeName))
+	gomega.Eventually(func() bool {
+		return schedulerCanScheduleGPU(client, nodeName)
+	}, policyTestTimeout, policyTestInterval).Should(gomega.BeTrue(),
+		"scheduler did not register GPU resources on node %s", nodeName)
 }
 
 func nodeReady(node *corev1.Node) bool {
@@ -741,6 +750,32 @@ func hasReadyDevicePlugin(client kubernetes.Interface, nodeName string) bool {
 		}
 	}
 	return false
+}
+
+// schedulerCanScheduleGPU checks if the scheduler can schedule a GPU pod on the node.
+// This verifies that the node has GPU resources registered and available.
+func schedulerCanScheduleGPU(client kubernetes.Interface, nodeName string) bool {
+	node, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	// Check if the node has GPU resources in its capacity
+	if _, ok := node.Status.Capacity[gpuResourceName]; !ok {
+		return false
+	}
+
+	// Check if the node has GPU resources in its allocatable
+	if _, ok := node.Status.Allocatable[gpuResourceName]; !ok {
+		return false
+	}
+
+	// Check if the node is not unschedulable
+	if node.Spec.Unschedulable {
+		return false
+	}
+
+	return true
 }
 
 func hamiNamespace() string {

--- a/test/e2e/policy/test_suite_test.go
+++ b/test/e2e/policy/test_suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/Project-HAMi/HAMi/test/utils"
+)
+
+func init() {
+	testing.Init()
+}
+
+func TestInit(t *testing.T) {
+	flag.Parse()
+	utils.DefaultKubeConfigPath()
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "HAMi Scheduler Policy E2E Test Suite")
+}

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -19,9 +19,12 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -99,4 +102,63 @@ func RemoveNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey string)
 		return nil, err
 	}
 	return result, nil
+}
+
+// WaitForDevicePluginReady polls until the HAMi device-plugin pod on the given
+// node is Running and Ready with no terminating pods from a previous revision,
+// and the node reports healthy GPU resources in its Allocatable capacity.
+// Call this after adding the gpu=on label and before creating GPU pods to avoid
+// "no healthy devices" admission errors from a device-plugin that hasn't
+// finished initializing.
+func WaitForDevicePluginReady(clientSet kubernetes.Interface, nodeName string, timeout, interval time.Duration) error {
+	namespace := GPUNameSpace
+	if ns := os.Getenv("HAMI_NAMESPACE"); ns != "" {
+		namespace = ns
+	}
+
+	return wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (bool, error) {
+		// Check device-plugin pods: need at least one Ready, none terminating.
+		pods, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/component=" + HamiDevicePlugin,
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil {
+			return false, nil
+		}
+
+		hasReady := false
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.DeletionTimestamp != nil {
+				// A terminating device-plugin pod may still pass readiness
+				// checks briefly; wait for it to be fully removed.
+				return false, nil
+			}
+			if pod.Status.Phase != v1.PodRunning {
+				continue
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Name == "device-plugin" && cs.Ready {
+					hasReady = true
+				}
+			}
+		}
+		if !hasReady {
+			return false, nil
+		}
+
+		// Verify the node reports healthy GPU resources (kubelet only
+		// populates Allocatable after the device-plugin registers healthy
+		// devices via its ListAndWatch stream).
+		node, err := clientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		gpuAlloc, ok := node.Status.Allocatable[v1.ResourceName("nvidia.com/gpu")]
+		if !ok || gpuAlloc.Value() <= 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
 }

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +59,6 @@ func UpdateNode(clientSet *kubernetes.Clientset, node *v1.Node) (*v1.Node, error
 		return nil, err
 	}
 
-	time.Sleep(time.Second * 30)
 	return updatedNode, nil
 }
 
@@ -81,7 +79,6 @@ func AddNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey, labelValu
 	if err != nil {
 		return nil, err
 	}
-	time.Sleep(time.Second * 30)
 	return result, nil
 }
 
@@ -101,6 +98,5 @@ func RemoveNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey string)
 	if err != nil {
 		return nil, err
 	}
-	time.Sleep(time.Second * 30)
 	return result, nil
 }

--- a/test/utils/node.go
+++ b/test/utils/node.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -64,28 +65,42 @@ func UpdateNode(clientSet *kubernetes.Clientset, node *v1.Node) (*v1.Node, error
 }
 
 func AddNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey, labelValue string) (*v1.Node, error) {
-	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	var result *v1.Node
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		node.Labels[labelKey] = labelValue
+		result, err = clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	if node.Labels == nil {
-		node.Labels = make(map[string]string)
-	}
-	node.Labels[labelKey] = labelValue
-
-	return UpdateNode(clientSet, node)
+	time.Sleep(time.Second * 30)
+	return result, nil
 }
 
 func RemoveNodeLabel(clientSet *kubernetes.Clientset, nodeName, labelKey string) (*v1.Node, error) {
-	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	var result *v1.Node
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if node.Labels != nil {
+			delete(node.Labels, labelKey)
+		}
+		result, err = clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	if node.Labels != nil {
-		delete(node.Labels, labelKey)
-	}
-
-	return UpdateNode(clientSet, node)
+	time.Sleep(time.Second * 30)
+	return result, nil
 }


### PR DESCRIPTION

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
  Adds a Ginkgo E2E suite asserting deterministic placement for HAMi's scheduler policies: node/GPU `binpack` & `spread`, comma-separated policy chains (incl. mutex), and per-Pod device scoring weight overrides. Run via `make e2e-policy-test`.

  The suite waits on the scheduler cache (via /metrics) so assertions never see stale utilization — pods are confirmed released from every replica after cleanup, metrics are scraped from all scheduler replicas (HA/leader-change safe), and allocation decoding tolerates the trailing-separator quirk of EncodePodSingleDevice.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

  Developed with AI assistance (Claude Code), per CONTRIBUTING.md. Requires a GPU cluster with ≥2 idle hami-core GPUs; skips otherwise. Not wired into CI — on-demand target only.

**Does this PR introduce a user-facing change?**:

NO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for scheduler policies, including GPU sharing and release, binpacking, spreading, combined policies, mutex policies, and per-Pod device scoring.
  * Added Kubernetes-based scenarios to validate policy behavior and resource allocation.

* **Tests**
  * Added a dedicated command and test suite for running policy end-to-end tests.
  * Added checks for Kubernetes connectivity, scheduler synchronization, GPU allocation, and eligible-node handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->