### PR TITLE
chore: add new linters to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,14 +13,29 @@ linters:
   default: none
   enable:
     - asciicheck
+    - depguard
+    - exptostd
     - forcetypeassert
     - godot
+    - govet
+    - intrange
+    - iotamixing
     - misspell
     - modernize
+    - nilnesserr
+    - recvcheck
     - staticcheck
+    - testifylint
+    - unconvert
   settings:
     dupl:
       threshold: 800
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: use standard library errors or k8s.io/klog/v2
     errcheck:
       check-type-assertions: true
       check-blank: true

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -678,7 +678,7 @@ func (npudev *Devices) computeBestCombination910C(nodeInfo *device.NodeInfo, req
 	indexToDevice := make(map[int]device.ContainerDevice)
 	var npuIndices []int
 	for _, dev := range containerDevices {
-		idx := int(dev.Idx)
+		idx := dev.Idx
 		indexToDevice[idx] = dev
 		npuIndices = append(npuIndices, idx)
 	}

--- a/pkg/device/cambricon/device_test.go
+++ b/pkg/device/cambricon/device_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -81,7 +82,7 @@ func Test_GetNodeDevices(t *testing.T) {
 			dev := CambriconDevices{}
 			result, err := dev.GetNodeDevices(test.args)
 			if err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			for k, v := range test.want {
 				assert.Equal(t, v, result[k])
@@ -129,7 +130,7 @@ func Test_MutateAdmission(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dev := CambriconDevices{}
 			result, _ := dev.MutateAdmission(&test.args.ctr, &test.args.pod)
-			assert.Equal(t, result, test.want)
+			assert.Equal(t, test.want, result)
 		})
 	}
 }
@@ -414,7 +415,7 @@ func Test_PatchAnnotations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dev := CambriconDevices{}
 			result := dev.PatchAnnotations(&corev1.Pod{}, &test.args.annoinput, test.args.pd)
-			assert.Equal(t, len(test.want), len(result), "Expected length of result to match want")
+			assert.Len(t, result, len(test.want), "Expected length of result to match want")
 			for k, v := range test.want {
 				assert.Equal(t, v, result[k], "pod add annotation key [%s], values is [%s]", k, result[k])
 			}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -566,7 +566,7 @@ func GetDevicesUUIDList(infos []*DeviceInfo) []string {
 // Deprecated: dynamic NVIDIA MIG constructs candidates from MigProfiles.
 func PlatternMIG(n *MigInUse, templates []Geometry, templateIdx int) {
 	for _, value := range templates[templateIdx] {
-		for count := int32(0); count < value.Count; count++ {
+		for range value.Count {
 			n.Index = int32(templateIdx)
 			n.UsageList = append(n.UsageList, MigTemplateUsage{Name: value.Name, Memory: value.Memory, Core: value.Core})
 		}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -591,8 +591,8 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 				Nums:             int32(n),
 				Type:             NvidiaGPUDevice,
 				Memreq:           int32(memnum),
-				MemPercentagereq: int32(mempnum),
-				Coresreq:         int32(corenum),
+				MemPercentagereq: mempnum,
+				Coresreq:         corenum,
 			}
 		}
 	}
@@ -959,7 +959,7 @@ func computeBestCombination(nodeInfo *device.NodeInfo, combinations []device.Con
 	for _, partition := range combinations {
 		totalScore := 0
 
-		for i := 0; i < len(partition)-1; i++ {
+		for i := range len(partition) - 1 {
 			dev1 := partition[i]
 			scoreMapDev1 := deviceScoreMap[dev1.UUID]
 			for z := i + 1; z < len(partition); z++ {

--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -156,9 +157,9 @@ func TestGetScheduledPods(t *testing.T) {
 
 	scheduledPods, err := podManager.GetScheduledPods()
 
-	assert.NoError(t, err, "GetScheduledPods should not return an error")
+	require.NoError(t, err, "GetScheduledPods should not return an error")
 	assert.NotNil(t, scheduledPods, "The result should not be nil")
-	assert.Equal(t, 2, len(scheduledPods), "The number of scheduled pods should be 2")
+	assert.Len(t, scheduledPods, 2, "The number of scheduled pods should be 2")
 
 	expectedPods := map[k8stypes.UID]*PodInfo{
 		pod1.UID: pod1,
@@ -361,7 +362,7 @@ func TestListPodsUID(t *testing.T) {
 	podManager := NewPodManager()
 
 	uids, err := podManager.ListPodsUID()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, uids, "expected no pods when the manager is empty")
 
 	pod1 := &corev1.Pod{
@@ -382,7 +383,7 @@ func TestListPodsUID(t *testing.T) {
 	podManager.AddPod(pod2, "node2", PodDevices{"device2": {{}}})
 
 	uids, err = podManager.ListPodsUID()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, uids, 2, "expected one entry per tracked pod")
 
 	gotUIDs := make(map[k8stypes.UID]bool, len(uids))
@@ -581,7 +582,7 @@ func TestPodDevicesDeepCopy(t *testing.T) {
 
 	_, exists := original["AMD"]
 	assert.False(t, exists, "original should not have AMD key")
-	assert.Equal(t, original["NVIDIA"][0][0].UUID, "GPU-0")
+	assert.Equal(t, "GPU-0", original["NVIDIA"][0][0].UUID)
 }
 
 func TestPodSingleDeviceDeepCopy(t *testing.T) {
@@ -602,7 +603,7 @@ func TestPodSingleDeviceDeepCopy(t *testing.T) {
 	// 2. Mutating the copy must not affect the original.
 	copy[0][0].UUID = "mutated-gpu"
 
-	assert.Equal(t, original[0][0].UUID, "GPU-0")
+	assert.Equal(t, "GPU-0", original[0][0].UUID)
 }
 
 func TestContainerDevicesDeepCopy(t *testing.T) {
@@ -619,7 +620,7 @@ func TestContainerDevicesDeepCopy(t *testing.T) {
 	// 2. Mutating the copy must not affect the original.
 	copy[0].UUID = "mutated-gpu"
 
-	assert.Equal(t, original[0].UUID, "GPU-0")
+	assert.Equal(t, "GPU-0", original[0].UUID)
 }
 
 func TestContainerDeviceDeepCopy(t *testing.T) {
@@ -641,7 +642,7 @@ func TestContainerDeviceDeepCopy(t *testing.T) {
 	copy.UUID = "mutated-gpu"
 	copy.CustomInfo["key2"] = "value2"
 
-	assert.Equal(t, original.UUID, "GPU-0")
+	assert.Equal(t, "GPU-0", original.UUID)
 	_, exists := original.CustomInfo["key2"]
 	assert.False(t, exists, "original CustomInfo should not have key2")
 }
@@ -739,7 +740,7 @@ func TestGetScheduledPodsReturnsDetachedEntries(t *testing.T) {
 	})
 
 	scheduled, err := pm.GetScheduledPods()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	scheduled["detach-uid"].Devices["NVIDIA"][0][0].Usedmem = 999
 	scheduled["detach-uid"].NodeID = "tampered"
 

--- a/pkg/scheduler/event_test.go
+++ b/pkg/scheduler/event_test.go
@@ -106,13 +106,13 @@ func TestRecordScheduleBindingResultEvent(t *testing.T) {
 				}
 				event := events.Items[0]
 				if test.schedulerErr != nil {
-					assert.Equal(t, event.Type, corev1.EventTypeWarning)
+					assert.Equal(t, corev1.EventTypeWarning, event.Type)
 				} else {
-					assert.Equal(t, event.Type, corev1.EventTypeNormal)
+					assert.Equal(t, corev1.EventTypeNormal, event.Type)
 				}
 			} else {
 				events, _ = fakeClient.CoreV1().Events(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
-				assert.Equal(t, len(events.Items), 0)
+				assert.Empty(t, events.Items)
 			}
 		})
 	}
@@ -193,13 +193,13 @@ func TestRecordScheduleFilterResultEvent(t *testing.T) {
 				}
 				event := events.Items[0]
 				if test.schedulerErr != nil {
-					assert.Equal(t, event.Type, corev1.EventTypeWarning)
+					assert.Equal(t, corev1.EventTypeWarning, event.Type)
 				} else {
-					assert.Equal(t, event.Type, corev1.EventTypeNormal)
+					assert.Equal(t, corev1.EventTypeNormal, event.Type)
 				}
 			} else {
 				events, _ = fakeClient.CoreV1().Events(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
-				assert.Equal(t, len(events.Items), 0)
+				assert.Empty(t, events.Items)
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1857,7 +1857,7 @@ func TestRegisterHealthReconciliationOnDiscoveryError_Recovery(t *testing.T) {
 	require.NoError(t, err)
 	cachedDevs, ok := nodeInfo.Devices["mock-vendor"]
 	assert.Equal(t, true, ok, "cached mock-vendor devices should be preserved despite transient discovery error")
-	require.Equal(t, 1, len(cachedDevs))
+	require.Len(t, cachedDevs, 1)
 	assert.Equal(t, "MOCK-0", cachedDevs[0].ID, "cached device ID MOCK-0 should remain unchanged")
 
 	// Cycle 2: Vendor recovers — GetNodeDevices succeeds and returns updated device (MOCK-RECOVERED).
@@ -1884,7 +1884,7 @@ func TestRegisterHealthReconciliationOnDiscoveryError_Recovery(t *testing.T) {
 	require.NoError(t, err)
 	cachedDevs, ok = nodeInfo.Devices["mock-vendor"]
 	assert.Equal(t, true, ok, "mock-vendor devices should be present after recovery")
-	require.Equal(t, 1, len(cachedDevs))
+	require.Len(t, cachedDevs, 1)
 	// Cycle 3: Vendor subsequently reports zero devices successfully.
 	// Verify zero-device cleanup removes stale cached vendor entry (scheduler.go:509-516).
 	mockDev.getNodeErr = nil
@@ -2588,7 +2588,7 @@ func TestFilterTemplateNodesDoesNotTouchSchedulingCaches(t *testing.T) {
 
 	pods, err := s.podManager.ListPodsUID()
 	require.NoError(t, err)
-	require.Len(t, pods, 0)
+	require.Empty(t, pods)
 
 	quotas := s.quotaManager.GetResourceQuota()
 	require.Contains(t, quotas, "default")
@@ -2996,7 +2996,7 @@ func Test_Bind_DelPodOnGetPodFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "not found")
 
 	podsAfter, _ := s.podManager.ListPodsUID()
-	require.Len(t, podsAfter, 0)
+	require.Empty(t, podsAfter)
 }
 
 func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
@@ -3051,7 +3051,7 @@ func Test_Bind_DelPodOnGetNodeFailure(t *testing.T) {
 	require.Contains(t, res.Error, "not found")
 
 	podsAfter, _ := s.podManager.ListPodsUID()
-	require.Len(t, podsAfter, 0)
+	require.Empty(t, podsAfter)
 }
 
 type bindLockMockDevice struct {

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -212,7 +212,7 @@ func TestClientRealNodePerformance(t *testing.T) {
 				t.Logf("Using node %s for testing", nodeName)
 			}
 			start := time.Now()
-			for i := 0; i < tt.updates; i++ {
+			for i := range tt.updates {
 				labelValue := fmt.Sprintf("perf-test-value-%d", i)
 				node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add 9 new linters to improve code quality:
- depguard, exptostd, intrange, iotamixing, nilnesserr, recvcheck, testifylint, unconvert, govet

Fix issues found by new linters:
- Convert for loops to Go 1.22+ integer range syntax
- Fix testify assertions (assert.Len, require.NoError, etc.)
- Remove unnecessary type conversions

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
All tests pass. Lint passes with 0 issues.

**Does this PR introduce a user-facing change?**:
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Enhanced automated code checks to identify more potential issues and discourage nonstandard error handling.
  * Improved validation of device, scheduler, and pod behavior through clearer, more reliable test assertions.

* **Maintenance**
  * Simplified internal iteration and type handling without changing user-visible behavior.
  * Improved consistency and readability across device management and scheduling components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->