### PR TITLE
fix(vGPUmonitor): gracefully skip GPU utilization metrics when unsupported

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -338,6 +338,10 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 	}
 
 	utilRates, nvret := hdev.GetUtilizationRates()
+	if nvret == nvml.ERROR_NOT_SUPPORTED {
+		klog.V(3).Infof("GPU utilization metrics not supported for device %d, skipping", index)
+		return nil
+	}
 	if nvret != nvml.SUCCESS {
 		return fmt.Errorf("nvml GetUtilizationRates err: %s", nvml.ErrorString(nvret))
 	}

--- a/cmd/vGPUmonitor/metrics_test.go
+++ b/cmd/vGPUmonitor/metrics_test.go
@@ -214,3 +214,32 @@ func TestCollectMemoryControllerUtilizationValue(t *testing.T) {
 		t.Fatalf("expected memory controller utilization metric with value %v", wantMemory)
 	}
 }
+
+func TestHostGPUMetricsNotSupportedGracefullySkipped(t *testing.T) {
+	t.Setenv(util.NodeNameEnvName, "test-node")
+
+	mockDev := &nvmlmock.Device{
+		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+			return nvml.Memory{}, nvml.ERROR_NOT_SUPPORTED
+		},
+		GetUtilizationRatesFunc: func() (nvml.Utilization, nvml.Return) {
+			return nvml.Utilization{}, nvml.ERROR_NOT_SUPPORTED
+		},
+	}
+
+	cc := ClusterManagerCollector{}
+	ch := make(chan prometheus.Metric, 10)
+
+	if err := cc.collectGPUMemoryMetrics(ch, mockDev, 0); err != nil {
+		t.Errorf("expected collectGPUMemoryMetrics to return nil on ERROR_NOT_SUPPORTED, got: %v", err)
+	}
+
+	if err := cc.collectGPUUtilizationMetrics(ch, mockDev, 0); err != nil {
+		t.Errorf("expected collectGPUUtilizationMetrics to return nil on ERROR_NOT_SUPPORTED, got: %v", err)
+	}
+
+	close(ch)
+	if count := len(ch); count != 0 {
+		t.Errorf("expected 0 metrics emitted for unsupported device, got: %d", count)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**: In `cmd/vGPUmonitor/metrics.go`, `collectGPUMemoryMetrics` gracefully handles unsupported devices by checking `nvml.ERROR_NOT_SUPPORTED` and returning `nil`.

However, `collectGPUUtilizationMetrics` lacked this check and returned an error on `nvml.ERROR_NOT_SUPPORTED`, causing `vGPUmonitor` to log an error on every scrape when running on GPUs/vGPU profiles where utilization rate queries are unsupported.

Added `nvret == nvml.ERROR_NOT_SUPPORTED` check in `collectGPUUtilizationMetrics` to log an info message and skip, matching `collectGPUMemoryMetrics`.

**Which issue(s) this PR fixes**:
Fixes #2797 

**Special notes for your reviewer**: None

AI disclosure: Antigravity was used to audit.

**Does this PR introduce a user-facing change?**:
```release-note
fix(vGPUmonitor): gracefully skip GPU utilization metrics when unsupported by NVML
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU monitoring when utilization data isn’t supported by the device.
  * Monitoring now continues without errors while omitting unavailable utilization metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->