### PR TITLE
fix(kunlun): make topology selection independent of device slice order

### DIFF
--- a/pkg/device/kunlun/topo.go
+++ b/pkg/device/kunlun/topo.go
@@ -220,6 +220,15 @@ func devicepick(devices []*device.DeviceUsage, start int, request device.Contain
 }
 
 func graghSelect(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, fitFn FitFn) []int {
+	// Wing classification and devicepick read topology from slice positions,
+	// but the scheduler sorts devices by score before calling Fit. Restore
+	// index order on a copy so position math matches the physical layout.
+	sorted := make([]*device.DeviceUsage, len(devices))
+	copy(sorted, devices)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Index < sorted[j].Index
+	})
+	devices = sorted
 	count := int(request.Nums)
 	leftwing := 0
 	rightwing := 0

--- a/pkg/device/kunlun/topo_order_test.go
+++ b/pkg/device/kunlun/topo_order_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kunlun
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+// The scheduler sorts the device slice by score before Fit runs, so
+// graghSelect cannot assume devices arrive in index order. With XPU 7 used
+// and the slice rotated to score order, position based wing math previously
+// picked {3,4,5,6}, a set that crosses both wings and is not a valid
+// interconnect group.
+func TestGraghSelect_ScoreSortedInputMatchesIndexOrder(t *testing.T) {
+	ordered := newDevices(7)
+	want := graghSelect(ordered, req(4), fitAvailable)
+
+	scrambled := []*device.DeviceUsage{
+		ordered[7], ordered[0], ordered[1], ordered[2],
+		ordered[3], ordered[4], ordered[5], ordered[6],
+	}
+	got := graghSelect(scrambled, req(4), fitAvailable)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selection depends on slice order: got %v from score sorted input, want %v", got, want)
+	}
+	if !reflect.DeepEqual(want, []int{0, 1, 2, 3}) {
+		t.Fatalf("expected the free left wing {0,1,2,3}, got %v", want)
+	}
+}
+
+// The caller's slice must not be reordered as a side effect.
+func TestGraghSelect_DoesNotMutateCallerSlice(t *testing.T) {
+	ordered := newDevices()
+	scrambled := []*device.DeviceUsage{
+		ordered[4], ordered[5], ordered[6], ordered[7],
+		ordered[0], ordered[1], ordered[2], ordered[3],
+	}
+	snapshot := make([]*device.DeviceUsage, len(scrambled))
+	copy(snapshot, scrambled)
+
+	graghSelect(scrambled, req(2), fitAvailable)
+
+	if !reflect.DeepEqual(scrambled, snapshot) {
+		t.Fatal("graghSelect reordered the caller's slice")
+	}
+}


### PR DESCRIPTION
/kind bug

graghSelect reads topology from slice positions, but the scheduler sorts devices by score before Fit runs. A used XPU that sorts to the front shifts both wings and the picker can return a set that crosses wings and is not a valid interconnect group. Sorting a copy by index restores the physical layout.
