### PR TITLE
fix(scheduler): validate scheduler-policy annotations

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -139,7 +139,11 @@ func fitInDevices(node *NodeUsage, requests device.ContainerDeviceRequests, pod 
 func resolveNodeSchedulerPolicy(task *corev1.Pod) string {
 	if task.GetAnnotations() != nil {
 		if value, ok := task.GetAnnotations()[util.NodeSchedulerPolicyAnnotationKey]; ok {
-			return value
+			if util.ValidNodeSchedulerPolicy(value) {
+				return value
+			}
+			klog.Warningf("ignoring unrecognized %s annotation %q on pod %s/%s, keeping configured policy %q",
+				util.NodeSchedulerPolicyAnnotationKey, value, task.Namespace, task.Name, config.NodeSchedulerPolicy)
 		}
 	}
 	return config.NodeSchedulerPolicy

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -74,6 +74,20 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
 		return admission.Denied(err.Error())
 	}
+	// Reject unrecognized scheduler-policy values the same way, instead of
+	// silently discarding the operator's configured default (#2767).
+	if pod.Annotations != nil {
+		if value, ok := pod.Annotations[util.GPUSchedulerPolicyAnnotationKey]; ok && !util.ValidGPUSchedulerPolicy(value) {
+			reason := fmt.Sprintf("invalid %s annotation %q: expected binpack, spread, numa, mutex, topology-aware, or a comma-separated chain of them", util.GPUSchedulerPolicyAnnotationKey, value)
+			klog.Warningf(template+" - Denying admission: %s", pod.Namespace, pod.Name, pod.UID, reason)
+			return admission.Denied(reason)
+		}
+		if value, ok := pod.Annotations[util.NodeSchedulerPolicyAnnotationKey]; ok && !util.ValidNodeSchedulerPolicy(value) {
+			reason := fmt.Sprintf("invalid %s annotation %q: expected binpack or spread", util.NodeSchedulerPolicyAnnotationKey, value)
+			klog.Warningf(template+" - Denying admission: %s", pod.Namespace, pod.Name, pod.UID, reason)
+			return admission.Denied(reason)
+		}
+	}
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -1276,3 +1276,102 @@ func TestHandleNumaAlignmentAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleSchedulerPolicyAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantDenied  bool
+	}{
+		{
+			name:        "valid gpu policy chain is admitted",
+			annotations: map[string]string{util.GPUSchedulerPolicyAnnotationKey: "binpack,numa"},
+		},
+		{
+			name:        "valid node policy is admitted",
+			annotations: map[string]string{util.NodeSchedulerPolicyAnnotationKey: "spread"},
+		},
+		{
+			name:        "unrecognized gpu policy is denied",
+			annotations: map[string]string{util.GPUSchedulerPolicyAnnotationKey: "topology"},
+			wantDenied:  true,
+		},
+		{
+			name:        "unrecognized node policy is denied",
+			annotations: map[string]string{util.NodeSchedulerPolicyAnnotationKey: "numa"},
+			wantDenied:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "policy-pod",
+					Namespace:   "default",
+					Annotations: test.annotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+						},
+					}},
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+			podBytes, err := runtime.Encode(codec, pod)
+			if err != nil {
+				t.Fatalf("Error encoding pod: %v", err)
+			}
+
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "test-uid", Namespace: "default", Name: "policy-pod",
+					Object: runtime.RawExtension{Raw: podBytes},
+				},
+			}
+
+			wh, err := NewWebHook()
+			if err != nil {
+				t.Fatalf("Error creating webhook: %v", err)
+			}
+			resp := wh.Handle(context.Background(), req)
+
+			if test.wantDenied {
+				if resp.Allowed {
+					t.Fatalf("expected denial, got allowed: %+v", resp.Result)
+				}
+				if !strings.Contains(resp.Result.Message, "invalid") {
+					t.Fatalf("expected invalid-annotation message, got %q", resp.Result.Message)
+				}
+			} else if !resp.Allowed {
+				t.Fatalf("expected admission, got denied: %+v", resp.Result)
+			}
+		})
+	}
+}
+
+func TestResolveNodeSchedulerPolicyFallback(t *testing.T) {
+	previous := config.NodeSchedulerPolicy
+	config.NodeSchedulerPolicy = "spread"
+	t.Cleanup(func() { config.NodeSchedulerPolicy = previous })
+
+	valid := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{util.NodeSchedulerPolicyAnnotationKey: "binpack"},
+	}}
+	if got := resolveNodeSchedulerPolicy(valid); got != "binpack" {
+		t.Fatalf("valid annotation: got %q, want binpack", got)
+	}
+
+	invalid := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{util.NodeSchedulerPolicyAnnotationKey: "bogus"},
+	}}
+	if got := resolveNodeSchedulerPolicy(invalid); got != "spread" {
+		t.Fatalf("unrecognized annotation: got %q, want configured spread", got)
+	}
+}

--- a/pkg/util/scheduler_policy.go
+++ b/pkg/util/scheduler_policy.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "strings"
+
+// ValidNodeSchedulerPolicy reports whether value names a recognized node
+// scheduler policy.
+func ValidNodeSchedulerPolicy(value string) bool {
+	switch SchedulerPolicyName(strings.TrimSpace(value)) {
+	case NodeSchedulerPolicyBinpack, NodeSchedulerPolicySpread:
+		return true
+	}
+	return false
+}
+
+// ValidGPUSchedulerPolicy reports whether value names a recognized GPU
+// scheduler policy, or a comma-separated chain of them. binpack, spread, and
+// numa order the device sort; mutex and topology-aware are filters consumed
+// by the device backends.
+func ValidGPUSchedulerPolicy(value string) bool {
+	for part := range strings.SplitSeq(value, ",") {
+		switch SchedulerPolicyName(strings.TrimSpace(part)) {
+		case GPUSchedulerPolicyBinpack, GPUSchedulerPolicySpread, GPUSchedulerPolicyNuma,
+			GPUSchedulerPolicyMutex, GPUSchedulerPolicyTopology:
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/scheduler_policy_test.go
+++ b/pkg/util/scheduler_policy_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidNodeSchedulerPolicy(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"binpack", true},
+		{"spread", true},
+		{" spread ", true},
+		{"", false},
+		{"Binpack", false},
+		{"numa", false},
+		{"binpack,spread", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			assert.Equal(t, ValidNodeSchedulerPolicy(tt.value), tt.want)
+		})
+	}
+}
+
+func TestValidGPUSchedulerPolicy(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"binpack", true},
+		{"spread", true},
+		{"numa", true},
+		{"mutex", true},
+		{"topology-aware", true},
+		{"binpack,numa", true},
+		{"mutex, spread ,numa", true},
+		{"", false},
+		{"topology", false},
+		{"binpack,bogus", false},
+		{"binpack,,numa", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			assert.Equal(t, ValidGPUSchedulerPolicy(tt.value), tt.want)
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -298,7 +298,12 @@ func GetGPUSchedulerPolicyByPod(defaultPolicy string, task *corev1.Pod) string {
 	userGPUPolicy := defaultPolicy
 	if task != nil && task.Annotations != nil {
 		if value, ok := task.Annotations[GPUSchedulerPolicyAnnotationKey]; ok {
-			userGPUPolicy = value
+			if ValidGPUSchedulerPolicy(value) {
+				userGPUPolicy = value
+			} else {
+				klog.Warningf("ignoring unrecognized %s annotation %q on pod %s/%s, keeping configured policy %q",
+					GPUSchedulerPolicyAnnotationKey, value, task.Namespace, task.Name, defaultPolicy)
+			}
 		}
 	}
 	return userGPUPolicy

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -779,6 +779,16 @@ func TestGetGPUSchedulerPolicyByPod(t *testing.T) {
 				Annotations: map[string]string{GPUSchedulerPolicyAnnotationKey: "spread"},
 			},
 		}, "spread"},
+		{"with chain annotation", "binpack", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{GPUSchedulerPolicyAnnotationKey: "spread,numa"},
+			},
+		}, "spread,numa"},
+		{"unrecognized annotation keeps configured default", "binpack", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{GPUSchedulerPolicyAnnotationKey: "bogus"},
+			},
+		}, "binpack"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

An unrecognized `hami.io/gpu-scheduler-policy` or `hami.io/node-scheduler-policy` value was silently accepted: the annotation overrode the configured policy whatever its value, and the comparator's hardcoded fallback then replaced the operator's configured default.

Two layers of fix, following the same pattern as the numa-alignment validation in #2729:

- The admission webhook denies invalid values, so a typo surfaces at `kubectl apply` with a clear message listing the accepted values.
- `GetGPUSchedulerPolicyByPod` and `resolveNodeSchedulerPolicy` keep the configured default with a warning when the value is unrecognized, covering pods created before upgrade or bypassing the webhook.

Accepted GPU policy values: `binpack`, `spread`, `numa`, `mutex`, `topology-aware`, or a comma-separated chain of them. Node policy: `binpack` or `spread`.

**Which issue(s) this PR fixes**:

Fixes #2767

**Special notes for your reviewer**:

Scheduler-extender scoped; covered by unit tests (validators, resolver fallbacks, webhook admission table). The sort comparator is left untouched: with validation at the sources, unrecognized values no longer reach it.

AI assistance disclosure: written primarily by Claude Code, directed and reviewed by me.

**Does this PR introduce a user-facing change?**:

```release-note
Pods with an unrecognized hami.io/gpu-scheduler-policy or hami.io/node-scheduler-policy annotation are now rejected at admission; previously the invalid value silently replaced the configured scheduler policy.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for GPU and node scheduling policies.
  * Invalid policy annotations are rejected with clear errors during admission.
  * Invalid annotations now fall back to configured default policies instead of being applied.
  * Valid policy annotations continue to be accepted, including multiple comma-separated GPU policies.
* **Tests**
  * Expanded coverage for valid, invalid, whitespace-trimmed, and unsupported policy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->