### PR TITLE
fix(amd): keep allocation annotations decodable for empty registered types

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -333,14 +333,21 @@ func (amddevice *AMDDevices) Fit(devices []*device.DeviceUsage, request device.C
 
 		if k.Nums > 0 {
 			k.Nums--
+			// Keep the map keyed by the logical AMD device type, but retain the
+			// registered product type in the allocation annotation. Consumers of
+			// the annotation (for example workload GPU reporting) need the latter
+			// to identify the actual AMD model. The registered type comes from an
+			// external node annotation and can be empty; DecodeContainerDevices
+			// rejects an empty type, so fall back to the logical type to keep
+			// the allocation annotation readable.
+			allocType := dev.Type
+			if allocType == "" {
+				allocType = k.Type
+			}
 			tmpDevs[k.Type] = append(tmpDevs[k.Type], device.ContainerDevice{
-				Idx:  int(dev.Index),
-				UUID: dev.ID,
-				// Keep the map keyed by the logical AMD device type, but retain the
-				// registered product type in the allocation annotation. Consumers of
-				// the annotation (for example workload GPU reporting) need the latter
-				// to identify the actual AMD model.
-				Type:      dev.Type,
+				Idx:       int(dev.Index),
+				UUID:      dev.ID,
+				Type:      allocType,
 				Usedmem:   memReq,
 				Usedcores: coreReq,
 			})

--- a/pkg/device/amd/device_alloctype_test.go
+++ b/pkg/device/amd/device_alloctype_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amd
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+// The registered device type is taken verbatim from the external
+// hami.io/node-amd-register annotation and can be empty. Since
+// DecodeContainerDevices rejects an empty type, an allocation carrying it
+// would be unreadable to the scheduler and the pod's usage would be dropped.
+func Test_Fit_EmptyRegisteredTypeStaysDecodable(t *testing.T) {
+	dev := &AMDDevices{}
+	devices := []*device.DeviceUsage{{
+		ID:        "GPU-amd-0",
+		Index:     0,
+		Count:     10,
+		Totalmem:  8192,
+		Totalcore: 100,
+		Type:      "",
+		Health:    true,
+	}}
+	request := device.ContainerDeviceRequest{
+		Nums:     1,
+		Type:     AMDDevice,
+		Memreq:   4096,
+		Coresreq: 100,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	fit, tmpDevs, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true, reason)
+	assert.Equal(t, tmpDevs[AMDDevice][0].Type, AMDDevice)
+
+	encoded := device.EncodeContainerDevices(tmpDevs[AMDDevice])
+	decoded, err := device.DecodeContainerDevices(encoded)
+	assert.NilError(t, err)
+	assert.Equal(t, decoded[0].UUID, "GPU-amd-0")
+	assert.Equal(t, decoded[0].Type, AMDDevice)
+}
+
+// A non empty registered product type is still passed through unchanged.
+func Test_Fit_RegisteredProductTypePreserved(t *testing.T) {
+	dev := &AMDDevices{}
+	devices := []*device.DeviceUsage{{
+		ID:        "GPU-amd-0",
+		Index:     0,
+		Count:     10,
+		Totalmem:  8192,
+		Totalcore: 100,
+		Type:      "AMD Instinct MI300X",
+		Health:    true,
+	}}
+	request := device.ContainerDeviceRequest{
+		Nums:     1,
+		Type:     AMDDevice,
+		Memreq:   4096,
+		Coresreq: 100,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	fit, tmpDevs, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true, reason)
+	assert.Equal(t, tmpDevs[AMDDevice][0].Type, "AMD Instinct MI300X")
+}


### PR DESCRIPTION
/kind bug

The AMD backend writes the registered product type into the allocation annotation so consumers can identify the model. That type is read verbatim from the external node registration annotation and can be empty, and since the decoder rejects an empty type field the scheduler could no longer read the pod allocation and silently dropped its device usage. The backend now falls back to the logical AMD type when the registered type is empty.