### PR TITLE
ci: run CodeQL on every pull request

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,18 +9,8 @@ on:
   workflow_dispatch:
   push:
     branches: ["master","dev"]
-    paths-ignore:
-      - "**/*.json"
-      - "**/*.md"
-      - "**/*.txt"
-      - "**/*.yml"
   pull_request:
     branches: ["master","dev"]
-    paths-ignore:
-      - "**/*.json"
-      - "**/*.md"
-      - "**/*.txt"
-      - "**/*.yml"
   schedule:
     - cron: "0 4 * * 6"
 


### PR DESCRIPTION
/kind cleanup

The paths-ignore filters skipped CodeQL on pull requests that only touch yaml, markdown, json or txt files, so a share of merged pull requests carried no SAST run and the scorecard SAST check scored low. CodeQL now runs on every pull request and push.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated security analysis to run for all pushes and pull requests targeting the primary development branches.
  * Security checks now include changes to all file types, including documentation and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->