### PR TITLE
webhook: validate device-scoring-weights at admission

### DIFF
--- a/docs/develop/scheduler-policy.md
+++ b/docs/develop/scheduler-policy.md
@@ -199,5 +199,6 @@ checks remain unchanged.
 When the annotation is absent, all three weights default to `1`, preserving
 the existing scheduling behavior. When present, the annotation must specify
 all three non-negative integer weights, and at least one weight must be
-positive. Invalid annotations prevent the Pod from being scheduled until the
-annotation is corrected.
+positive. When the admission webhook is enabled, invalid annotations are
+rejected when the Pod is created. The scheduler also validates the annotation
+so invalid values cannot be used when admission validation is unavailable.

--- a/docs/develop/scheduler-policy.md
+++ b/docs/develop/scheduler-policy.md
@@ -200,5 +200,6 @@ When the annotation is absent, all three weights default to `1`, preserving
 the existing scheduling behavior. When present, the annotation must specify
 all three non-negative integer weights, and at least one weight must be
 positive. When the admission webhook is enabled, invalid annotations are
-rejected when the Pod is created. The scheduler also validates the annotation
-so invalid values cannot be used when admission validation is unavailable.
+rejected when a Pod requesting a HAMi-managed resource is created. The
+scheduler also validates the annotation so invalid values cannot be used when
+admission validation is unavailable.

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -74,6 +74,13 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
 		return admission.Denied(err.Error())
 	}
+	// Validate device-scoring weights at admission so malformed workload input
+	// is reported before scheduling. The scheduler retains the same validation
+	// as a defense-in-depth check.
+	if _, err := util.GetDeviceScoringWeightsByPod(pod); err != nil {
+		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
+		return admission.Denied(err.Error())
+	}
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false

--- a/pkg/scheduler/webhook.go
+++ b/pkg/scheduler/webhook.go
@@ -74,13 +74,6 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
 		return admission.Denied(err.Error())
 	}
-	// Validate device-scoring weights at admission so malformed workload input
-	// is reported before scheduling. The scheduler retains the same validation
-	// as a defense-in-depth check.
-	if _, err := util.GetDeviceScoringWeightsByPod(pod); err != nil {
-		klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
-		return admission.Denied(err.Error())
-	}
 	klog.V(5).Infof(template, pod.Namespace, pod.Name, pod.UID)
 	privilegedName, hasPrivileged := privilegedContainerName(pod)
 	hasResource := false
@@ -108,6 +101,15 @@ func (h *webhook) Handle(_ context.Context, req admission.Request) admission.Res
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
 			hasResource = hasResource || found
+		}
+	}
+	// Validate device-scoring weights for HAMi workloads so malformed input is
+	// reported before scheduling. The scheduler retains the same validation as
+	// a defense-in-depth check.
+	if hasResource {
+		if _, err := util.GetDeviceScoringWeightsByPod(pod); err != nil {
+			klog.Warningf(template+" - Denying admission: %v", pod.Namespace, pod.Name, pod.UID, err)
+			return admission.Denied(err.Error())
 		}
 	}
 	if hasPrivileged && hasResource {

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -1278,16 +1278,24 @@ func TestHandleNumaAlignmentAnnotation(t *testing.T) {
 }
 
 func TestHandleDeviceScoringWeightsAnnotation(t *testing.T) {
+	nvidiaDevice, ok := device.GetDevices()[nvidia.NvidiaGPUDevice]
+	if !ok {
+		t.Fatal("NVIDIA device is not registered")
+	}
+	resourceName := corev1.ResourceName(nvidiaDevice.GetResourceNames().ResourceCountName)
+
 	tests := []struct {
 		name              string
 		annotationPresent bool
 		value             string
+		hasResource       bool
 		wantDenied        bool
 	}{
-		{name: "missing annotation is admitted", wantDenied: false},
-		{name: "valid weights are admitted", annotationPresent: true, value: "slot=1,core=1,memory=3", wantDenied: false},
-		{name: "missing dimension is denied", annotationPresent: true, value: "slot=1,core=1", wantDenied: true},
-		{name: "non-integer weight is denied", annotationPresent: true, value: "slot=1,core=high,memory=3", wantDenied: true},
+		{name: "missing annotation is admitted", hasResource: true, wantDenied: false},
+		{name: "valid weights with HAMi resource are admitted", annotationPresent: true, value: "slot=1,core=1,memory=3", hasResource: true, wantDenied: false},
+		{name: "missing dimension with HAMi resource is denied", annotationPresent: true, value: "slot=1,core=1", hasResource: true, wantDenied: true},
+		{name: "non-integer weight with HAMi resource is denied", annotationPresent: true, value: "slot=1,core=high,memory=3", hasResource: true, wantDenied: true},
+		{name: "invalid weights without HAMi resource are admitted", annotationPresent: true, value: "slot=1,core=1", wantDenied: false},
 	}
 
 	for _, test := range tests {
@@ -1296,20 +1304,19 @@ func TestHandleDeviceScoringWeightsAnnotation(t *testing.T) {
 			if test.annotationPresent {
 				annotations = map[string]string{util.DeviceScoringWeightsAnnotationKey: test.value}
 			}
+			container := corev1.Container{Name: "container1"}
+			if test.hasResource {
+				container.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{resourceName: resource.MustParse("1")},
+				}
+			}
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "weights-pod",
 					Namespace:   "default",
 					Annotations: annotations,
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: "container1",
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
-						},
-					}},
-				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{container}},
 			}
 
 			scheme := runtime.NewScheme()

--- a/pkg/scheduler/webhook_test.go
+++ b/pkg/scheduler/webhook_test.go
@@ -1276,3 +1276,73 @@ func TestHandleNumaAlignmentAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleDeviceScoringWeightsAnnotation(t *testing.T) {
+	tests := []struct {
+		name              string
+		annotationPresent bool
+		value             string
+		wantDenied        bool
+	}{
+		{name: "missing annotation is admitted", wantDenied: false},
+		{name: "valid weights are admitted", annotationPresent: true, value: "slot=1,core=1,memory=3", wantDenied: false},
+		{name: "missing dimension is denied", annotationPresent: true, value: "slot=1,core=1", wantDenied: true},
+		{name: "non-integer weight is denied", annotationPresent: true, value: "slot=1,core=high,memory=3", wantDenied: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var annotations map[string]string
+			if test.annotationPresent {
+				annotations = map[string]string{util.DeviceScoringWeightsAnnotationKey: test.value}
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "weights-pod",
+					Namespace:   "default",
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container1",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+						},
+					}},
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			codec := serializer.NewCodecFactory(scheme).LegacyCodec(corev1.SchemeGroupVersion)
+			podBytes, err := runtime.Encode(codec, pod)
+			if err != nil {
+				t.Fatalf("Error encoding pod: %v", err)
+			}
+
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "test-uid", Namespace: "default", Name: "weights-pod",
+					Object: runtime.RawExtension{Raw: podBytes},
+				},
+			}
+
+			wh, err := NewWebHook()
+			if err != nil {
+				t.Fatalf("Error creating webhook: %v", err)
+			}
+			resp := wh.Handle(context.Background(), req)
+
+			if test.wantDenied {
+				if resp.Allowed {
+					t.Fatalf("expected denial, got allowed: %+v", resp.Result)
+				}
+				if !strings.Contains(resp.Result.Message, "invalid") {
+					t.Fatalf("expected invalid-annotation message, got %q", resp.Result.Message)
+				}
+			} else if !resp.Allowed {
+				t.Fatalf("expected admission, got denied: %+v", resp.Result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

This PR validates the `hami.io/device-scoring-weights` annotation in the HAMi admission webhook.

Previously, an invalid value was accepted when the Pod was created. The scheduler found the error later, causing the Pod to remain Pending.

After this change, the webhook rejects an invalid value immediately and returns the existing parser error. Valid values and Pods without the annotation continue to be accepted.

The existing schedule-time validation remains as a safety check when admission validation is unavailable.

```text
Before

Create Pod
    |
    v
Webhook accepts invalid value
    |
    v
Scheduler finds the error
    |
    v
Pod remains Pending


After

Create Pod
    |
    v
Webhook checks the value
    |
    +---- Valid or missing ----> Pod is accepted
    |
    +---- Invalid ------------> Pod is rejected immediately
                                 with a clear error
```

**Which issue(s) this PR fixes**:

Fixes #2826

**Special notes for your reviewer**:

The implementation reuses `GetDeviceScoringWeightsByPod`; no new parser or validation rules were added.

The change does not affect device allocation, scoring calculations, resource accounting, or other device backends.

The scheduler-policy documentation was updated to explain admission validation and the retained schedule-time safety check.

AI assistance disclosure:

I used AI Assistance to review and refine the webhook change, update tests and documentation and run validation. I reviewed the final implementation and understand the changes.

**Does this PR introduce a user-facing change?**:

Yes. When the admission webhook is enabled, Pods with an invalid `hami.io/device-scoring-weights` annotation are rejected during creation instead of failing later during scheduling. Valid and missing annotations keep their existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid device-scoring weight annotations are now rejected during admission only for Pods requesting HAMi-managed resources.
  - Pods without HAMi-managed resources are no longer rejected because of these annotations.
  - Scheduler validation continues when admission validation is unavailable, helping prevent invalid configurations from remaining unschedulable.
  - Valid and missing annotations continue to be accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->