### PR TITLE
re-check ResourceQuota in Fit() to close admission-vs-schedule race

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -276,6 +276,45 @@ func (dev *AMDDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, 
 	return nil
 }
 
+// fitQuota resolves the pod's hypothetical total usage (this candidate device
+// plus whatever is already tentatively allocated) and checks it against the
+// namespace ResourceQuota. This closes the same admission-time gap the nvidia
+// and cambricon backends already guard against: fitResourceQuota enforces
+// ResourceQuota when the pod is admitted, but namespace usage is only
+// recorded once a pod actually schedules, so a burst of concurrent pods can
+// pass admission and then jointly exceed the quota by the time each reaches
+// Filter. Re-checking here, against the same resolved memory/core values Fit
+// is about to allocate, closes that window.
+func fitQuota(pod *corev1.Pod, tmpDevs map[string]device.ContainerDevices, allocated *device.PodDevices, ns string, devUUID string, memreq int64, coresreq int64) bool {
+	hypo := device.PodDevices{}
+	if allocated != nil {
+		for devType, podSingle := range *allocated {
+			hypo[devType] = append(device.PodSingleDevice{}, podSingle...)
+		}
+	}
+	cur := append(device.ContainerDevices{}, tmpDevs[AMDDevice]...)
+	cur = append(cur, device.ContainerDevice{
+		UUID:      devUUID,
+		Type:      AMDDevice,
+		Usedmem:   int32(memreq),
+		Usedcores: int32(coresreq),
+	})
+	hypo[AMDDevice] = append(hypo[AMDDevice], cur)
+
+	var mem, core int64
+	for _, ctrDevs := range device.CollapseInitContainerUsage(pod, hypo)[AMDDevice] {
+		for _, val := range ctrDevs {
+			mem += int64(val.Usedmem)
+			core += int64(val.Usedcores)
+		}
+	}
+
+	// AMD does not scale the memory value read off the container spec (see
+	// GenerateResourceRequests), so it reports a zero MemoryFactor like the
+	// other unscaled backends and no scaling is applied here either.
+	return device.GetLocalCache().FitQuota(ns, mem, 0, core, AMDDevice)
+}
+
 func (amddevice *AMDDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeinfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
@@ -340,6 +379,11 @@ func (amddevice *AMDDevices) Fit(devices []*device.DeviceUsage, request device.C
 		if dev.Totalcore-dev.Usedcores < coreReq {
 			reason[common.CardInsufficientCore]++
 			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device total core", dev.Totalcore, "device used core", dev.Usedcores, "request cores", coreReq)
+			continue
+		}
+		if !fitQuota(pod, tmpDevs, allocated, pod.Namespace, dev.ID, int64(memReq), int64(coreReq)) {
+			reason[common.ResourceQuotaNotFit]++
+			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memReq, "coresreq", coreReq)
 			continue
 		}
 

--- a/pkg/device/amd/device_test.go
+++ b/pkg/device/amd/device_test.go
@@ -476,6 +476,108 @@ func TestDevices_Fit(t *testing.T) {
 	})
 }
 
+// TestDevices_Fit_ResourceQuota closes the same admission-vs-schedule race
+// already guarded against in nvidia and cambricon (see
+// https://github.com/Project-HAMi/HAMi/issues/2829): fitResourceQuota only
+// enforces ResourceQuota once, at admission time, while namespace usage is
+// recorded when a pod actually schedules. Concurrent pods can pass admission
+// and then jointly exceed the quota by the time each reaches Filter. This
+// asserts Fit re-checks the namespace ResourceQuota against the resolved
+// memory/core values it is about to allocate, and denies a request that
+// would push usage over the limit even though the device itself has room.
+func TestDevices_Fit_ResourceQuota(t *testing.T) {
+	newQuotaManager := func(t *testing.T, ns string, hard corev1.ResourceList) {
+		qm := device.NewQuotaManager()
+		quota := &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "amd-quota", Namespace: ns},
+			Spec:       corev1.ResourceQuotaSpec{Hard: hard},
+		}
+		qm.AddQuota(quota)
+		t.Cleanup(func() { qm.DelQuota(quota) })
+	}
+
+	t.Run("memory request exceeding namespace quota is denied", func(t *testing.T) {
+		dev := InitAMDGPUDevice(AMDConfig{
+			ResourceCountName:  "amd.com/gpu",
+			ResourceMemoryName: "amd.com/gpu-mem",
+			ResourceCoreName:   "amd.com/gpu-core-pct",
+		})
+		device.DevicesMap = map[string]device.Devices{AMDDevice: dev}
+
+		ns := "amd-quota-test-ns"
+		newQuotaManager(t, ns, corev1.ResourceList{
+			corev1.ResourceName("limits.amd.com/gpu-mem"): resource.MustParse("100"),
+		})
+
+		devices := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Used: 0, Count: 1,
+			Usedmem: 0, Totalmem: 4096, Totalcore: 100, Usedcores: 0,
+			Type: AMDDevice, Health: true,
+		}}
+		req := device.ContainerDeviceRequest{Nums: 1, Type: AMDDevice, Memreq: 200, Coresreq: 10}
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+
+		ok, _, reason := dev.Fit(devices, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+		assert.Equal(t, false, ok)
+		assert.Assert(t, strings.Contains(reason, common.ResourceQuotaNotFit))
+	})
+
+	t.Run("core request exceeding namespace quota is denied", func(t *testing.T) {
+		dev := InitAMDGPUDevice(AMDConfig{
+			ResourceCountName:  "amd.com/gpu",
+			ResourceMemoryName: "amd.com/gpu-mem",
+			ResourceCoreName:   "amd.com/gpu-core-pct",
+		})
+		device.DevicesMap = map[string]device.Devices{AMDDevice: dev}
+
+		ns := "amd-quota-test-ns-cores"
+		newQuotaManager(t, ns, corev1.ResourceList{
+			corev1.ResourceName("limits.amd.com/gpu-core-pct"): resource.MustParse("50"),
+		})
+
+		devices := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Used: 0, Count: 1,
+			Usedmem: 0, Totalmem: 4096, Totalcore: 100, Usedcores: 0,
+			Type: AMDDevice, Health: true,
+		}}
+		// Coresreq of 60% resolves to a coreReq of 60 (out of Totalcore=100),
+		// which alone exceeds the 50-core quota even though device capacity
+		// has room for it.
+		req := device.ContainerDeviceRequest{Nums: 1, Type: AMDDevice, Memreq: 100, Coresreq: 60}
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+
+		ok, _, reason := dev.Fit(devices, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+		assert.Equal(t, false, ok)
+		assert.Assert(t, strings.Contains(reason, common.ResourceQuotaNotFit))
+	})
+
+	t.Run("request within namespace quota is admitted", func(t *testing.T) {
+		dev := InitAMDGPUDevice(AMDConfig{
+			ResourceCountName:  "amd.com/gpu",
+			ResourceMemoryName: "amd.com/gpu-mem",
+			ResourceCoreName:   "amd.com/gpu-core-pct",
+		})
+		device.DevicesMap = map[string]device.Devices{AMDDevice: dev}
+
+		ns := "amd-quota-test-ns-ok"
+		newQuotaManager(t, ns, corev1.ResourceList{
+			corev1.ResourceName("limits.amd.com/gpu-mem"): resource.MustParse("1000"),
+		})
+
+		devices := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Used: 0, Count: 1,
+			Usedmem: 0, Totalmem: 4096, Totalcore: 100, Usedcores: 0,
+			Type: AMDDevice, Health: true,
+		}}
+		req := device.ContainerDeviceRequest{Nums: 1, Type: AMDDevice, Memreq: 200, Coresreq: 10}
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+
+		ok, _, reason := dev.Fit(devices, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "", reason)
+	})
+}
+
 func TestCheckAMDType(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
What this PR does

## Kind: feature (kind/feature)


Closes the ResourceQuota TOCTOU (admission-vs-schedule race) gap in the AMD backend's `Fit()`, per #2829 — one of the 11 backends currently missing this check (nvidia and cambricon already have it; cambricon's fix, #2536, is the precedent this PR follows).

`fitResourceQuota` enforces `ResourceQuota` once, at admission time, via the scheduler webhook. Namespace usage is only recorded once a pod actually schedules, so concurrent pod creation can pass admission and then jointly exceed the quota by the time each pod reaches `Filter`. This adds a package-local `fitQuota()` re-check inside AMD's `Fit()`, resolving the pod's hypothetical total usage (already-tentatively-allocated devices + the candidate device) against the namespace `ResourceQuota` before allocating.

AMD does not scale the memory value read off the container spec (unlike cambricon's 256x factor), so it reports `memoryFactor=0`, matching the convention documented on `device.ResourceNames.MemoryFactor` for unscaled backends.

## Scope

Per #2829's acceptance criteria, this PR touches **only the AMD backend** — no other backend is modified. The remaining 10 backends (ascend, awsneuron, biren, enflame, hygon, iluvatar, kunlun, metax, mthreads, vastai) will each get their own separate PR.

## Changes

- `pkg/device/amd/device.go` — added `fitQuota()` helper, wired into `Fit()` after the existing memory/core capacity checks
- `pkg/device/amd/device_test.go` — added `TestDevices_Fit_ResourceQuota` covering: memory request exceeding namespace quota (denied), core request exceeding namespace quota (denied), request within quota (admitted)

## Testing

- `go build ./pkg/device/amd/...` — passes
- `go vet ./pkg/device/amd/...` — clean
- `gofmt -l` — no diffs
- `go test ./pkg/device/... -short --race -count=1` — all 15 device packages pass, no regressions

## AI Assistance Disclosure
Per CONTRIBUTING.md, this PR was developed with AI assistance (Claude Code) for research and initial implementation. I reviewed and validated all changes myself and can explain the design and any line if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AMD device scheduling now checks namespace memory and core quotas before admitting allocations.
  * Requests that exceed configured quotas are rejected with an appropriate quota error.
  * Requests within quota limits continue to be admitted normally.

* **Tests**
  * Added coverage for AMD scheduling scenarios that exceed or remain within resource quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->