### PR TITLE
fix(scheduler): validate NUMA refit quota with container positions

### DIFF
--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -241,7 +241,7 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 	maps.Copy(hypothetical, allocated)
 	hypothetical[req.DeviceType] = refitted
 	var quotaMem, quotaCores int64
-	for _, ctrDevs := range device.CollapseInitContainerUsage(pod, hypothetical)[req.DeviceType] {
+	for _, ctrDevs := range effectivePodDeviceUsage(pod, hypothetical, pi.InitContainerResourceReleased)[req.DeviceType] {
 		for _, d := range ctrDevs {
 			quotaMem += int64(d.Usedmem)
 			quotaCores += int64(d.Usedcores)
@@ -283,10 +283,7 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 		// init-container usage has been released, collapsing again would
 		// re-inflate the reservation back to the init peak, the same hazard
 		// PodManager.AddPod guards against on a re-add.
-		effective := device.CollapseInitContainerUsage(pod, rawDevices)
-		if pi.InitContainerResourceReleased {
-			effective = device.SteadyStateDeviceUsage(pod, rawDevices)
-		}
+		effective := effectivePodDeviceUsage(pod, rawDevices, pi.InitContainerResourceReleased)
 		if _, ok := s.podManager.ReplacePodDevices(key, effective); ok {
 			s.quotaManager.AddUsage(pod, effective)
 		} else {
@@ -303,6 +300,16 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 	klog.InfoS(message, "pod", klog.KObj(pod), "node", req.NodeName)
 	s.recordNumaRefitResultEvent(pod, message, nil)
 	return device.NumaRefitResponse{Succeeded: true, ContainerDevices: device.EncodeContainerDevices(newDevices)}
+}
+
+// effectivePodDeviceUsage mirrors the accounting shape stored by PodManager.
+// Non-sidecar init-container usage is part of the phase peak until the
+// informer records its release, and excluded from steady-state usage after it.
+func effectivePodDeviceUsage(pod *corev1.Pod, raw device.PodDevices, initReleased bool) device.PodDevices {
+	if initReleased {
+		return device.SteadyStateDeviceUsage(pod, raw)
+	}
+	return device.CollapseInitContainerUsage(pod, raw)
 }
 
 // replaceContainerDeviceEntry swaps one container's entry inside an encoded

--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -89,7 +89,8 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 	if len(req.AllowedDeviceUUIDs) > maxAllowedDeviceUUIDs {
 		return numaRefitFailure(nil, "refit request carries %d allowed devices, limit is %d", len(req.AllowedDeviceUUIDs), maxAllowedDeviceUUIDs)
 	}
-	if _, ok := device.GetDevices()[req.DeviceType]; !ok {
+	refitDevice, ok := device.GetDevices()[req.DeviceType]
+	if !ok {
 		return numaRefitFailure(nil, "unknown device type %q", req.DeviceType)
 	}
 	// HAMi's type matching is substring based, so a refit for one type could
@@ -229,6 +230,27 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 		return failWithQuotaRestore("restricted fit selected %d container sets, want %d with %d devices", len(selected), seeded+1, len(current))
 	}
 	newDevices := selected[seeded]
+
+	// The restricted fit seeds only non-empty, non-target allocations, so its
+	// quota check cannot preserve the container indexes used to distinguish init
+	// and app usage. Validate the selected devices in the original annotation
+	// layout before changing annotations or cached accounting.
+	refitted := append(device.PodSingleDevice{}, allocatedSingle...)
+	refitted[req.ContainerIndex] = newDevices
+	hypothetical := make(device.PodDevices, len(allocated))
+	maps.Copy(hypothetical, allocated)
+	hypothetical[req.DeviceType] = refitted
+	var quotaMem, quotaCores int64
+	for _, ctrDevs := range device.CollapseInitContainerUsage(pod, hypothetical)[req.DeviceType] {
+		for _, d := range ctrDevs {
+			quotaMem += int64(d.Usedmem)
+			quotaCores += int64(d.Usedcores)
+		}
+	}
+	resourceNames := refitDevice.GetResourceNames()
+	if !s.quotaManager.FitQuota(pod.Namespace, quotaMem, resourceNames.MemoryFactor, quotaCores, req.DeviceType) {
+		return failWithQuotaRestore("refit would exceed the %s resource quota in namespace %s", req.DeviceType, pod.Namespace)
+	}
 
 	// Patch both annotations by replacing only this container's entry inside
 	// the current raw values: entries Allocate already consumed stay blank,

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -478,7 +479,6 @@ func TestRefitNumaAllocationKeepsShrunkAccounting(t *testing.T) {
 			{ID: "GPU-b", Count: 10, Devmem: 40000, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
 		}},
 	})
-
 	initDevices := device.ContainerDevices{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}}
 	appDevices := device.ContainerDevices{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}}
 	reserved := device.PodSingleDevice{initDevices, appDevices}
@@ -524,4 +524,124 @@ func TestRefitNumaAllocationKeepsShrunkAccounting(t *testing.T) {
 		}
 	}
 	assert.Equal(t, total, int32(20000))
+}
+
+// initRefitFixture builds a scheduler tracking one pod whose PodDevices span an
+// init container (index 0) and two app containers (indices 1 and 2), each
+// reserving 5000 of GPU-a. With numInit=1, CollapseInitContainerUsage folds the
+// init container into the peak and sums the two app containers, so the effective
+// GPU-a usage is max(5000, 5000+5000) = 10000 - the value tracked in memory and
+// counted against the namespace gpumem quota, which is capped at gpumemLimit.
+// GPU-b (NUMA 0) is the refit target.
+func initRefitFixture(t *testing.T, gpumemLimit int64) (*Scheduler, *corev1.Pod, string) {
+	t.Helper()
+	nodes := newNodeManager()
+	nodes.addNode(refitNode, &device.NodeInfo{
+		ID: refitNode, Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: refitNode}},
+		Devices: map[string][]device.DeviceInfo{nvidia.NvidiaGPUDevice: {
+			{ID: "GPU-a", Count: 10, Devmem: 40000, Devcore: 100, Numa: 1, Type: nvidia.NvidiaGPUDevice, Health: true},
+			{ID: "GPU-b", Count: 10, Devmem: 40000, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
+		}},
+	})
+
+	// One raw entry per container position: init container first, then the two
+	// app containers. The annotations keep this per-container layout; in-memory
+	// accounting keeps the collapsed aggregate.
+	raw := device.PodSingleDevice{
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 5000, Usedcores: 10}},
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 5000, Usedcores: 10}},
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 5000, Usedcores: 10}},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: refitPodUID, Name: refitPodName, Namespace: "default",
+			Annotations: map[string]string{
+				device.InRequestDevices[nvidia.NvidiaGPUDevice]: device.EncodePodSingleDevice(raw),
+				device.SupportDevices[nvidia.NvidiaGPUDevice]:   device.EncodePodSingleDevice(raw),
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init-0"}},
+			Containers:     []corev1.Container{{Name: "app-0"}, {Name: "app-1"}},
+		},
+	}
+
+	collapsed := device.CollapseInitContainerUsage(pod, device.PodDevices{nvidia.NvidiaGPUDevice: raw})
+	pods := device.NewPodManager()
+	pods.AddPod(pod, refitNode, collapsed)
+
+	s := &Scheduler{nodeManager: nodes, podManager: pods, quotaManager: device.NewQuotaManager()}
+	oldQuotas := s.quotaManager.Quotas
+	s.quotaManager.Quotas = map[string]*device.DeviceQuota{}
+	t.Cleanup(func() { s.quotaManager.Quotas = oldQuotas })
+
+	resourceNames := device.GetDevices()[nvidia.NvidiaGPUDevice].GetResourceNames()
+	s.quotaManager.AddQuota(&corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace},
+		Spec: corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{
+			corev1.ResourceName("limits." + resourceNames.ResourceMemoryName): *resource.NewQuantity(gpumemLimit, resource.DecimalSI),
+		}},
+	})
+	// Seed the namespace usage with the pod's current effective total (10000),
+	// as the scheduler cache does before a refit.
+	s.quotaManager.AddUsage(pod, collapsed)
+	return s, pod, resourceNames.ResourceMemoryName
+}
+
+// TestRefitNumaAllocationInitContainerRefitRejectedOverQuota is the regression
+// for the NUMA refit quota undercount. Moving the init container (index 0) off
+// GPU-a leaves the two app containers summing to 10000 on GPU-a and adds 5000 on
+// GPU-b, a positionally-correct effective total of 15000. Under a 12000 gpumem
+// quota the refit must be refused. Before the fix, the restricted fit's quota
+// gate evaluated a compacted device list that misclassified an app container as
+// the init container, undercounted to 10000, admitted the refit, and recorded
+// 15000 against the 12000 limit.
+func TestRefitNumaAllocationInitContainerRefitRejectedOverQuota(t *testing.T) {
+	s, _, memoryResource := initRefitFixture(t, 12000)
+	_, calls := stubRefitPatch(t, nil)
+
+	// refitTestRequestFor targets ContainerIndex 0 - here the init container.
+	response := s.RefitNumaAllocation(refitTestRequestFor("GPU-b"))
+
+	assert.Equal(t, response.Succeeded, false)
+	assert.Assert(t, strings.Contains(response.FailureReason, "quota"), "reason: %s", response.FailureReason)
+	// A failed quota check changes neither the annotations (no patch)...
+	assert.Equal(t, *calls, 0)
+	// ...nor the in-memory reservation...
+	assert.Equal(t, trackedUUID(t, s), "GPU-a")
+	// ...nor the recorded namespace usage, which stays at the pre-refit total.
+	dq := s.quotaManager.GetResourceQuota()["default"]
+	assert.Equal(t, (*dq)[memoryResource].Used, int64(10000))
+}
+
+// TestRefitNumaAllocationInitContainerRefitRecordsCollapsedUsage is the positive
+// counterpart: the same init-container refit fits under a 20000 quota, and the
+// rebuilt reservation records the positionally-correct 15000 total - GPU-a keeps
+// the two app containers (10000) and GPU-b carries the refitted init container
+// (5000) - proving the added quota gate matches the usage AddUsage records.
+func TestRefitNumaAllocationInitContainerRefitRecordsCollapsedUsage(t *testing.T) {
+	s, _, memoryResource := initRefitFixture(t, 20000)
+	captured, calls := stubRefitPatch(t, nil)
+
+	response := s.RefitNumaAllocation(refitTestRequestFor("GPU-b"))
+
+	assert.Equal(t, response.Succeeded, true, "refit failed: %s", response.FailureReason)
+	assert.Equal(t, *calls, 1)
+	// The moved init container records GPU-b in both annotations.
+	for _, key := range []string{device.InRequestDevices[nvidia.NvidiaGPUDevice], device.SupportDevices[nvidia.NvidiaGPUDevice]} {
+		assert.Assert(t, strings.Contains(captured[key], "GPU-b"), "annotation %s: %q", key, captured[key])
+	}
+	// Collapsed accounting: GPU-a holds the two app containers, GPU-b the init.
+	pi, _ := s.podManager.GetPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: refitPodUID}})
+	collapsed := pi.Devices[nvidia.NvidiaGPUDevice]
+	assert.Equal(t, len(collapsed), 1)
+	byUUID := map[string]device.ContainerDevice{}
+	for _, d := range collapsed[0] {
+		byUUID[d.UUID] = d
+	}
+	assert.Equal(t, byUUID["GPU-a"].Usedmem, int32(10000))
+	assert.Equal(t, byUUID["GPU-b"].Usedmem, int32(5000))
+	// Namespace usage reflects the true 15000 total, not the undercounted 10000.
+	dq := s.quotaManager.GetResourceQuota()["default"]
+	assert.Equal(t, (*dq)[memoryResource].Used, int64(15000))
 }

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 const (
@@ -468,6 +470,8 @@ func TestRefitNumaAllocationHeterogeneousReservation(t *testing.T) {
 	assert.Equal(t, *calls, 0)
 }
 
+// TestRefitNumaAllocationKeepsShrunkAccounting verifies that a later refit
+// cannot restore a completed init container's peak reservation.
 func TestRefitNumaAllocationKeepsShrunkAccounting(t *testing.T) {
 	// A pod whose init-container usage was already released must not have its
 	// reservation re-inflated back to the init peak by a later refit.
@@ -524,6 +528,138 @@ func TestRefitNumaAllocationKeepsShrunkAccounting(t *testing.T) {
 		}
 	}
 	assert.Equal(t, total, int32(20000))
+}
+
+// TestEffectivePodDeviceUsageHonorsInitRelease verifies that quota validation
+// and committed accounting select the same phase-aware usage shape.
+func TestEffectivePodDeviceUsageHonorsInitRelease(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		InitContainers: []corev1.Container{{Name: "init"}},
+		Containers:     []corev1.Container{{Name: "main"}},
+	}}
+	raw := device.PodDevices{nvidia.NvidiaGPUDevice: {
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+	}}
+
+	beforeRelease := effectivePodDeviceUsage(pod, raw, false)[nvidia.NvidiaGPUDevice][0][0]
+	afterRelease := effectivePodDeviceUsage(pod, raw, true)[nvidia.NvidiaGPUDevice][0][0]
+
+	assert.Equal(t, beforeRelease.Usedmem, int32(30000))
+	assert.Equal(t, beforeRelease.Usedcores, int32(60))
+	assert.Equal(t, afterRelease.Usedmem, int32(20000))
+	assert.Equal(t, afterRelease.Usedcores, int32(30))
+}
+
+// TestRefitNumaAllocationSerializesInitRelease verifies that the informer
+// cannot replace quota and reservations while a refit uses its earlier snapshot.
+func TestRefitNumaAllocationSerializesInitRelease(t *testing.T) {
+	nodes := newNodeManager()
+	nodes.addNode(refitNode, &device.NodeInfo{
+		ID: refitNode, Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: refitNode}},
+		Devices: map[string][]device.DeviceInfo{nvidia.NvidiaGPUDevice: {
+			{ID: "GPU-a", Count: 10, Devmem: 40000, Devcore: 100, Numa: 1, Type: nvidia.NvidiaGPUDevice, Health: true},
+			{ID: "GPU-b", Count: 10, Devmem: 40000, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
+		}},
+	})
+
+	raw := device.PodDevices{nvidia.NvidiaGPUDevice: {
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+		{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+	}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: refitPodUID, Name: refitPodName, Namespace: "default",
+			Annotations: map[string]string{
+				util.AssignedNodeAnnotations:                    refitNode,
+				device.InRequestDevices[nvidia.NvidiaGPUDevice]: device.EncodePodSingleDevice(raw[nvidia.NvidiaGPUDevice]),
+				device.SupportDevices[nvidia.NvidiaGPUDevice]:   device.EncodePodSingleDevice(raw[nvidia.NvidiaGPUDevice]),
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init"}},
+			Containers:     []corev1.Container{{Name: "main"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	collapsed := device.CollapseInitContainerUsage(pod, raw)
+	pods := device.NewPodManager()
+	pods.AddPod(pod, refitNode, collapsed)
+	s := &Scheduler{nodeManager: nodes, podManager: pods, quotaManager: device.NewQuotaManager()}
+	oldQuotas := s.quotaManager.Quotas
+	s.quotaManager.Quotas = map[string]*device.DeviceQuota{}
+	t.Cleanup(func() { s.quotaManager.Quotas = oldQuotas })
+	s.quotaManager.AddUsage(pod, collapsed)
+
+	patchStarted := make(chan struct{})
+	releasePatch := make(chan struct{})
+	previousPatch := patchPodAnnotations
+	patchPodAnnotations = func(_ *corev1.Pod, _ map[string]string) error {
+		close(patchStarted)
+		<-releasePatch
+		return errors.New("conflict")
+	}
+	t.Cleanup(func() { patchPodAnnotations = previousPatch })
+
+	request := refitTestRequestFor("GPU-b")
+	request.ContainerIndex = 1
+	request.ContainerName = "main"
+	refitDone := make(chan device.NumaRefitResponse, 1)
+	go func() { refitDone <- s.RefitNumaAllocation(request) }()
+	select {
+	case <-patchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("refit did not reach the annotation patch")
+	}
+
+	updatedPod := pod.DeepCopy()
+	updatedPod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+		Name: "init",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+		},
+	}}
+	updateStarted := make(chan struct{})
+	updateDone := make(chan struct{})
+	go func() {
+		close(updateStarted)
+		s.onUpdatePod(pod, updatedPod)
+		close(updateDone)
+	}()
+	<-updateStarted
+
+	updateInterleaved := false
+	select {
+	case <-updateDone:
+		updateInterleaved = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releasePatch)
+
+	var response device.NumaRefitResponse
+	select {
+	case response = <-refitDone:
+	case <-time.After(time.Second):
+		t.Fatal("refit did not finish after the patch was released")
+	}
+	select {
+	case <-updateDone:
+	case <-time.After(time.Second):
+		t.Fatal("pod update did not finish after the refit released allocLock")
+	}
+
+	assert.Equal(t, updateInterleaved, false, "init-release accounting changed while the refit held allocLock")
+	assert.Equal(t, response.Succeeded, false)
+	assert.Assert(t, strings.Contains(response.FailureReason, "conflict"), "reason: %s", response.FailureReason)
+	pi, ok := s.podManager.GetPod(pod)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, pi.InitContainerResourceReleased, true)
+	steady := pi.Devices[nvidia.NvidiaGPUDevice][0][0]
+	assert.Equal(t, steady.UUID, "GPU-a")
+	assert.Equal(t, steady.Usedmem, int32(20000))
+	resourceNames := device.GetDevices()[nvidia.NvidiaGPUDevice].GetResourceNames()
+	dq := s.quotaManager.GetResourceQuota()[pod.Namespace]
+	assert.Equal(t, (*dq)[resourceNames.ResourceMemoryName].Used, int64(20000))
 }
 
 // initRefitFixture builds a scheduler tracking one pod whose PodDevices span an

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -80,11 +80,11 @@ type Scheduler struct {
 	lock   sync.RWMutex
 	synced atomic.Bool
 
-	// allocLock serializes reservation mutations between Filter and the
-	// NUMA refit (RefitNumaAllocation). kube-scheduler already serializes
-	// Filter calls per scheduling cycle, so in the common path this adds no
-	// contention; it exists so a refit cannot interleave with Filter's
-	// take-fit-readd span and observe or produce half-applied accounting.
+	// allocLock serializes reservation mutations between Filter, the NUMA
+	// refit (RefitNumaAllocation), and pod updates that release init-container
+	// usage. kube-scheduler already serializes Filter calls per scheduling
+	// cycle, so in the common path this adds no contention; it exists so these
+	// paths cannot observe or produce half-applied accounting.
 	allocLock sync.Mutex
 }
 
@@ -209,6 +209,13 @@ func (s *Scheduler) onUpdatePod(oldObj, newObj any) {
 		s.podManager.UpdatePod(newPod)
 		return
 	}
+
+	// RefitNumaAllocation reads the release flag, devices, and quota as one
+	// accounting snapshot. Keep the normal update and the one-time init-usage
+	// transition in the same critical section so a refit cannot commit from a
+	// stale pre-release snapshot after this handler records steady-state usage.
+	s.allocLock.Lock()
+	defer s.allocLock.Unlock()
 
 	pi, exists := s.podManager.GetPod(newPod)
 	if !exists {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes ResourceQuota accounting during a NUMA device refit.

The restricted fit can temporarily remove empty and target container entries. This changes container positions and may cause an application container to be counted as an init container. As a result, the quota check can report less GPU usage than the final allocation uses.

This PR preserves the original container positions when validating the new allocation. If the correct usage exceeds the namespace quota, the refit is rejected before pod annotations or scheduler accounting are changed.

### Behavior

```text
Before

Original allocation:
[init: GPU-A] [app: GPU-A] [app: GPU-A]
                         |
                         v
Compacted quota input:
[app: GPU-A] [new init: GPU-B]
                         |
                         v
Incorrect quota usage: 10000


After

Original positions preserved:
[init: GPU-B] [app: GPU-A] [app: GPU-A]
                         |
                         v
Correct collapsed usage:
GPU-A applications: 10000
GPU-B init:          5000
                         |
                         v
Correct quota usage: 15000
```

A refit within the quota continues normally. A rejected refit leaves the existing annotations, device reservation, and quota usage unchanged.

**Which issue(s) this PR fixes**:

Fixes #2828

**Special notes for your reviewer**:

Regression tests cover:

- Rejecting a refit when the correctly calculated usage exceeds the quota.
- Keeping annotations, cached allocation, and quota usage unchanged after rejection.
- Allowing a refit when the resulting usage fits within the quota.
- Recording the correct collapsed usage after a successful refit.

AI assistance disclosure:

I used AI Assistance  to help review the final code  and refine the PR description. 
**Does this PR introduce a user-facing change?**:

```release-note
Fixed NUMA refit quota validation so init and application container usage is counted using the correct container positions.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NUMA allocation refits for workloads with init containers.
  * Preserved per-container device allocation annotations during refits.
  * Enforced device-specific namespace memory quotas before applying allocation changes.
  * Prevented over-quota refits from modifying annotations or recorded usage.
  * Correctly collapsed init-container usage into total device accounting after release.
  * Serialized allocation updates to prevent inconsistent resource accounting.
  * Added a timeout to allocation annotation updates to prevent stalled operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->