### PR TITLE
fix(dashboard): align node GPU memory ratio scale

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -134,7 +134,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 		"GPU overview on a certain node",
 		[]string{"node", "device_uuid", "device_index", "device_cores", "device_memory_limit", "device_type"}, nil,
 	)
-	nodeGPUMemoryPercentage := prometheus.NewDesc(
+	nodeGPUMemoryAllocatedRatioDesc := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
 		"GPU memory allocated ratio on a certain GPU (0-1)",
 		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
@@ -261,8 +261,8 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 			}
 
 			if devs.Device.Totalmem > 0 {
-				if err := sendMetric(ch, nodeGPUMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
-					klog.V(4).Infof("Failed to send nodeGPUMemoryPercentage metric: %v", err)
+				if err := sendMetric(ch, nodeGPUMemoryAllocatedRatioDesc, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+					klog.V(4).Infof("Failed to send nodeGPUMemoryAllocatedRatioDesc metric: %v", err)
 				}
 			}
 

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -136,7 +136,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 	)
 	nodeGPUMemoryPercentage := prometheus.NewDesc(
 		"hami_node_gpu_memory_allocated_ratio",
-		"GPU Memory Allocated Percentage on a certain GPU",
+		"GPU memory allocated ratio on a certain GPU (0-1)",
 		[]string{"node", "device_uuid", "device_index", "device_type"}, nil,
 	)
 	nodeGPUMigInstance := prometheus.NewDesc(

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -359,7 +359,7 @@ func TestClusterManagerCollectorSkipsMemoryRatioWithNonPositiveTotalMemory(t *te
 hami_gpu_core_limit_ratio{device_index="0",device_type="AWSNeuron",device_uuid="zero-memory",node="node-1"} 2
 hami_gpu_core_limit_ratio{device_index="1",device_type="test-device",device_uuid="negative-memory",node="node-1"} 2
 hami_gpu_core_limit_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 2
-# HELP hami_node_gpu_memory_allocated_ratio GPU Memory Allocated Percentage on a certain GPU
+# HELP hami_node_gpu_memory_allocated_ratio GPU memory allocated ratio on a certain GPU (0-1)
 # TYPE hami_node_gpu_memory_allocated_ratio gauge
 hami_node_gpu_memory_allocated_ratio{device_index="2",device_type="NVIDIA",device_uuid="normal-memory",node="node-1"} 0.25
 # HELP nodeGPUMemoryPercentage GPU Memory Allocated Percentage on a certain GPU

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -65,12 +65,13 @@ on the metrics port; the scheduler and the vGPU monitor each expose a subset):
 | `hami_gpu_memory_allocated_bytes` | scheduler | GPU memory allocated to pods. |
 | `hami_gpu_core_allocated_ratio` | scheduler | Allocated compute cores (0-100). |
 | `hami_gpu_shared_count` | scheduler | Containers sharing a device. |
-| `hami_node_gpu_memory_allocated_ratio` | scheduler | Per-node memory allocated (0-100). |
+| `hami_node_gpu_memory_allocated_ratio` | scheduler | Per-node memory allocated as a ratio (0-1). |
 | `hami_host_gpu_memory_used_bytes` | vGPU monitor | Real memory in use per device. |
 | `hami_host_gpu_utilization_ratio` | vGPU monitor | Physical GPU utilization (0-100). |
 | `hami_vgpu_memory_used_bytes` | vGPU monitor | Per-container vGPU memory used. |
 | `hami_vgpu_memory_limit_bytes` | vGPU monitor | Per-container vGPU memory limit. |
 | `hami_container_device_utilization_ratio` | vGPU monitor | Per-container utilization (0-100). |
 
-> Utilization and allocation-ratio metrics are reported on a 0-100 scale, so the
-> percentage panels display them directly without rescaling.
+> Utilization and core-allocation metrics are reported on a 0-100 scale. The
+> node memory-allocation ratio is reported on a 0-1 scale and uses Grafana's
+> fraction-to-percent unit.

--- a/dashboards/dashboard_test.go
+++ b/dashboards/dashboard_test.go
@@ -1,0 +1,72 @@
+package dashboards
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type dashboard struct {
+	Panels []panel `json:"panels"`
+}
+
+type panel struct {
+	Title       string `json:"title"`
+	FieldConfig struct {
+		Defaults struct {
+			Min        *float64 `json:"min"`
+			Max        *float64 `json:"max"`
+			Unit       string   `json:"unit"`
+			Thresholds struct {
+				Steps []struct {
+					Value *float64 `json:"value"`
+				} `json:"steps"`
+			} `json:"thresholds"`
+		} `json:"defaults"`
+	} `json:"fieldConfig"`
+	Targets []struct {
+		Expr string `json:"expr"`
+	} `json:"targets"`
+}
+
+func TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale(t *testing.T) {
+	data, err := os.ReadFile("hami-vgpu-dashboard.json")
+	if err != nil {
+		t.Fatalf("read dashboard: %v", err)
+	}
+
+	var d dashboard
+	if err := json.Unmarshal(data, &d); err != nil {
+		t.Fatalf("parse dashboard: %v", err)
+	}
+
+	const title = "Node GPU memory allocated ratio"
+	var got *panel
+	for i := range d.Panels {
+		if d.Panels[i].Title == title {
+			got = &d.Panels[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("panel %q not found", title)
+	}
+
+	if len(got.Targets) != 1 || got.Targets[0].Expr != `hami_node_gpu_memory_allocated_ratio{node=~"$node"}` {
+		t.Fatalf("panel %q must query the node memory allocation ratio directly", title)
+	}
+	if got.FieldConfig.Defaults.Unit != "percentunit" {
+		t.Errorf("unit = %q, want percentunit for a 0-1 ratio", got.FieldConfig.Defaults.Unit)
+	}
+	if got.FieldConfig.Defaults.Min == nil || *got.FieldConfig.Defaults.Min != 0 {
+		t.Errorf("min = %v, want 0", got.FieldConfig.Defaults.Min)
+	}
+	if got.FieldConfig.Defaults.Max == nil || *got.FieldConfig.Defaults.Max != 1 {
+		t.Errorf("max = %v, want 1", got.FieldConfig.Defaults.Max)
+	}
+	for _, step := range got.FieldConfig.Defaults.Thresholds.Steps {
+		if step.Value != nil && (*step.Value < 0 || *step.Value > 1) {
+			t.Errorf("threshold %v is outside the metric's 0-1 scale", *step.Value)
+		}
+	}
+}

--- a/dashboards/dashboard_test.go
+++ b/dashboards/dashboard_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dashboards
 
 import (

--- a/dashboards/hami-vgpu-dashboard.json
+++ b/dashboards/hami-vgpu-dashboard.json
@@ -417,17 +417,17 @@
             "thresholdsStyle": { "mode": "dashed" }
           },
           "mappings": [],
-          "max": 100,
+          "max": 1,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 75 },
-              { "color": "red", "value": 90 }
+              { "color": "yellow", "value": 0.75 },
+              { "color": "red", "value": 0.9 }
             ]
           },
-          "unit": "percent"
+          "unit": "percentunit"
         },
         "overrides": []
       },


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The scheduler exports `hami_node_gpu_memory_allocated_ratio` on a 0-1 scale,
while its Grafana panel used a 0-100 unit, maximum, and thresholds. This PR
aligns the dashboard with the exported scale, clarifies the metric description,
and adds a regression test for the panel contract.

**Which issue(s) this PR fixes**:
Fixes #

Related to #2126.

**Special notes for your reviewer**:

Verified with `go test ./dashboards ./cmd/scheduler`.

AI assistance disclosure: OpenAI Codex assisted with repository inspection,
test drafting, and PR preparation. I reviewed the implementation and test
results and take responsibility for the contribution.

**Does this PR introduce a user-facing change?**:

Yes. The node GPU memory allocation panel now displays the scheduler's 0-1
ratio using the correct percentage scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the GPU memory allocation ratio metric description to clarify that values range from 0 to 1.
  - Updated the Grafana panel to display fractional values correctly, with 0–1 bounds, percentage formatting, and appropriate thresholds.

- **Documentation**
  - Clarified metric scales and explained that Grafana converts ratio values to percentages.

- **Tests**
  - Added validation to ensure the dashboard uses the correct metric, units, range, and thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
