### PR TITLE
fix(nvidia): honor enableGetPreferredAllocation in GetDevicePluginOptions

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -598,7 +598,7 @@ func (plugin *NvidiaDevicePlugin) Register(kubeletSocket string) error {
 // GetDevicePluginOptions returns the values of the optional settings for this plugin
 func (plugin *NvidiaDevicePlugin) GetDevicePluginOptions(context.Context, *kubeletdevicepluginv1beta1.Empty) (*kubeletdevicepluginv1beta1.DevicePluginOptions, error) {
 	options := &kubeletdevicepluginv1beta1.DevicePluginOptions{
-		GetPreferredAllocationAvailable: true,
+		GetPreferredAllocationAvailable: enableGetPreferredAllocation,
 	}
 	return options, nil
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -262,12 +262,33 @@ func TestSelectPreferredDeviceIDsFromAnnotatedDevicesErrorsWhenAnnotatedUUIDMiss
 	require.Contains(t, err.Error(), "GPU-03f69c50-207a-2038-9b45-23cac89cb67c")
 }
 
-func TestGetDevicePluginOptionsEnablesPreferredAllocation(t *testing.T) {
-	plugin := &NvidiaDevicePlugin{}
+// TestGetDevicePluginOptionsHonorsEnableGetPreferredAllocation is a regression
+// test for issue #2844: GetDevicePluginOptions must reflect the configured
+// enableGetPreferredAllocation value, not unconditionally report true.
+func TestGetDevicePluginOptionsHonorsEnableGetPreferredAllocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "enabled=true reports true", enabled: true},
+		{name: "enabled=false reports false", enabled: false},
+	}
 
-	options, err := plugin.GetDevicePluginOptions(context.Background(), &kubeletdevicepluginv1beta1.Empty{})
-	require.NoError(t, err)
-	require.True(t, options.GetPreferredAllocationAvailable)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Save and restore the package-level variable used by both
+			// Register() and GetDevicePluginOptions().
+			original := enableGetPreferredAllocation
+			enableGetPreferredAllocation = tc.enabled
+			defer func() { enableGetPreferredAllocation = original }()
+
+			plugin := &NvidiaDevicePlugin{}
+			options, err := plugin.GetDevicePluginOptions(context.Background(), &kubeletdevicepluginv1beta1.Empty{})
+			require.NoError(t, err)
+			require.Equal(t, tc.enabled, options.GetPreferredAllocationAvailable,
+				"GetDevicePluginOptions must reflect enableGetPreferredAllocation=%v", tc.enabled)
+		})
+	}
 }
 
 func TestGetPreferredAllocationAlignsWithAnnotatedDevices(t *testing.T) {


### PR DESCRIPTION
## Description

Fix the NVIDIA device plugin to honor `enableGetPreferredAllocation` when reporting `GetDevicePluginOptions()`.

Previously, `Register()` correctly used the configured `enableGetPreferredAllocation` value, while `GetDevicePluginOptions()` unconditionally reported `GetPreferredAllocationAvailable: true`. This could result in inconsistent capability reporting when preferred allocation was disabled.

## What changed

- Updated `GetDevicePluginOptions()` to use the existing `enableGetPreferredAllocation` configuration value.
- Added table-driven regression coverage for both enabled and disabled configurations.
- Kept `Register()` and `GetDevicePluginOptions()` aligned to the same source of truth.
- No constructor changes, new abstractions, or unrelated refactoring.

## Expected behavior

| `enableGetPreferredAllocation` | `Register()` | `GetDevicePluginOptions()` |
|---|---|---|
| `true` | `true` | `true` |
| `false` | `false` | `false` |

## Testing

- `gofmt` — passed
- `git diff --check` — passed
- License/import verification — passed
- Targeted NVIDIA plugin tests — blocked locally by Linux-only NVIDIA/container dependencies on Windows
- Full Go test/race validation — requires Linux CI
- `golangci-lint` — `pkg/device-plugin` is excluded by the repository configuration

## AI Disclosure

AI assistance was used during development to inspect the codebase, analyze the reported capability inconsistency, and review the implementation and test approach.

The final changes were manually verified against the existing HAMi configuration flow and kept minimal and focused on this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device-plugin capability reporting now accurately reflects whether preferred allocation is enabled in configuration.

* **Tests**
  * Added regression coverage for both enabled and disabled preferred-allocation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->