### PR TITLE
fix(dashboard): use native node labels for host panels

### DIFF
--- a/dashboards/dashboard_test.go
+++ b/dashboards/dashboard_test.go
@@ -45,7 +45,10 @@ type panel struct {
 	} `json:"targets"`
 }
 
-func TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale(t *testing.T) {
+// loadDashboard reads and parses the importable HAMi dashboard fixture.
+func loadDashboard(t *testing.T) dashboard {
+	t.Helper()
+
 	data, err := os.ReadFile("hami-vgpu-dashboard.json")
 	if err != nil {
 		t.Fatalf("read dashboard: %v", err)
@@ -55,18 +58,57 @@ func TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale(t *testing.T) {
 	if err := json.Unmarshal(data, &d); err != nil {
 		t.Fatalf("parse dashboard: %v", err)
 	}
+	return d
+}
 
-	const title = "Node GPU memory allocated ratio"
-	var got *panel
+// findPanel returns the dashboard panel with the requested title.
+func findPanel(t *testing.T, d *dashboard, title string) *panel {
+	t.Helper()
+
 	for i := range d.Panels {
 		if d.Panels[i].Title == title {
-			got = &d.Panels[i]
-			break
+			return &d.Panels[i]
 		}
 	}
-	if got == nil {
-		t.Fatalf("panel %q not found", title)
+	t.Fatalf("panel %q not found", title)
+	return nil
+}
+
+// TestHostGPUPanelsUseNativeNodeLabel verifies host panels do not depend on scheduler series.
+func TestHostGPUPanelsUseNativeNodeLabel(t *testing.T) {
+	d := loadDashboard(t)
+	tests := []struct {
+		title string
+		expr  string
+	}{
+		{
+			title: "Host GPU memory used",
+			expr:  `hami_host_gpu_memory_used_bytes{node=~"$node"}`,
+		},
+		{
+			title: "Host GPU utilization",
+			expr:  `hami_host_gpu_utilization_ratio{node=~"$node"}`,
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := findPanel(t, &d, tt.title)
+			if len(got.Targets) != 1 {
+				t.Fatalf("panel %q has %d targets, want 1", tt.title, len(got.Targets))
+			}
+			if got.Targets[0].Expr != tt.expr {
+				t.Errorf("panel %q query = %q, want %q", tt.title, got.Targets[0].Expr, tt.expr)
+			}
+		})
+	}
+}
+
+// TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale verifies the metric's 0-1 display contract.
+func TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale(t *testing.T) {
+	d := loadDashboard(t)
+	const title = "Node GPU memory allocated ratio"
+	got := findPanel(t, &d, title)
 
 	if len(got.Targets) != 1 || got.Targets[0].Expr != `hami_node_gpu_memory_allocated_ratio{node=~"$node"}` {
 		t.Fatalf("panel %q must query the node memory allocation ratio directly", title)

--- a/dashboards/hami-vgpu-dashboard.json
+++ b/dashboards/hami-vgpu-dashboard.json
@@ -273,7 +273,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "hami_host_gpu_memory_used_bytes and on (device_uuid) hami_gpu_memory_limit_bytes{node=~\"$node\"}",
+          "expr": "hami_host_gpu_memory_used_bytes{node=~\"$node\"}",
           "legendFormat": "{{device_type}} idx{{device_index}} ({{device_uuid}})",
           "refId": "A"
         }
@@ -319,7 +319,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "hami_host_gpu_utilization_ratio and on (device_uuid) hami_gpu_memory_limit_bytes{node=~\"$node\"}",
+          "expr": "hami_host_gpu_utilization_ratio{node=~\"$node\"}",
           "legendFormat": "{{device_type}} idx{{device_index}} ({{device_uuid}})",
           "refId": "A"
         }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After #2580, the host GPU memory and utilization metrics include a native `node` label. The dashboard still filters these metrics through a `device_uuid` join with scheduler metrics.

This PR updates both host GPU panels to filter directly using their native `node` label. This prevents valid vGPUmonitor series from being removed when a matching scheduler series is unavailable.

A regression test verifies the query contract for both panels.

**Which issue(s) this PR fixes**:
Fixes #2843

**Special notes for your reviewer**:

Verified with:

- `make verify`
- `go test ./dashboards`
- `go test ./cmd/vGPUmonitor`

**Does this PR introduce a user-facing change?**:

Yes. The host GPU memory and utilization panels now use the metrics’ native node labels without requiring matching per-device scheduler series.

AI assistance disclosure: OpenAI Codex assisted with repository inspection, implementation, test preparation, and verification. I reviewed the changes and take responsibility for the contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host GPU memory and utilization dashboards to display native host metrics more reliably.
  * Removed an unnecessary filtering condition that could exclude valid host GPU data.
* **Tests**
  * Added coverage to verify host GPU panels use the expected native node metrics.
  * Streamlined dashboard fixture loading and panel validation in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->