### PR TITLE
fix(ascend): gate 910C module pair allocation on SuperPod

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -174,6 +174,9 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 			}
 		}
 	}
+	// count, not reqNum: the 910C SuperPod rewrite to 2 is HAMi's module
+	// packaging rule, not a multi device request, and #2005 added 910C vNPU
+	// templates so a single device fractional request stays schedulable.
 	if count.Value() > 1 && !isHAMiCore {
 		if trimMem != dev.config.MemoryAllocatable {
 			return true, errors.New("vNPU not supported for multiple devices")
@@ -464,6 +467,10 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		klog.V(4).Infof("all devices have NetworkID. device CommonWord %s", npu.CommonWord())
 		needTopology = true
 	}
+	// Full module pair allocation only applies to SuperPod deployments, the
+	// same gate MutateAdmission uses. Split mode carves vNPUs out of single
+	// devices and must not be forced onto whole physical cards.
+	pair910C := k.Type == Ascend910CType && originReq > 1 && npu.config.SuperPod
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
@@ -547,7 +554,7 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		}
 		if k.Nums > 0 {
 			klog.V(5).InfoS("find fit device", "pod", klog.KObj(pod), "device", dev.ID)
-			if !needTopology && (k.Type != Ascend910CType || originReq <= 1) {
+			if !needTopology && !pair910C {
 				k.Nums--
 			}
 			tmpDevs[k.Type] = append(tmpDevs[k.Type], device.ContainerDevice{
@@ -559,13 +566,13 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 				CustomInfo: dev.CustomInfo,
 			})
 		}
-		if k.Nums == 0 && !needTopology && (k.Type != Ascend910CType || originReq <= 1) {
+		if k.Nums == 0 && !needTopology && !pair910C {
 			klog.V(4).InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
 			return true, tmpDevs, ""
 		}
 	}
 
-	if k.Type == Ascend910CType && originReq > 1 {
+	if pair910C {
 		// Ascend 910C requires full module-pair allocation (2 NPUs per physical card).
 		combination := npu.computeBestCombination910C(nodeInfo, int(originReq), tmpDevs[k.Type])
 		if len(combination) != int(originReq) {

--- a/pkg/device/ascend/device_910c_pairing_test.go
+++ b/pkg/device/ascend/device_910c_pairing_test.go
@@ -29,7 +29,7 @@ import (
 
 // TestAscend910C_FitPartialAllocationBug tests rejection when partial cards cannot fulfill the request.
 func TestAscend910C_FitPartialAllocationBug(t *testing.T) {
-	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType, SuperPod: true}}
 	nodeInfo := &device.NodeInfo{
 		Node: &corev1.Node{},
 		Devices: map[string][]device.DeviceInfo{
@@ -65,7 +65,7 @@ func TestAscend910C_FitPartialAllocationBug(t *testing.T) {
 
 // TestAscend910C_FitExactCountBypassBug tests pairing validation when candidate count matches originReq.
 func TestAscend910C_FitExactCountBypassBug(t *testing.T) {
-	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType, SuperPod: true}}
 	nodeInfo := &device.NodeInfo{
 		Node: &corev1.Node{},
 		Devices: map[string][]device.DeviceInfo{
@@ -95,7 +95,7 @@ func TestAscend910C_FitExactCountBypassBug(t *testing.T) {
 
 // TestAscend910C_FitFullPairSucceeds tests successful allocation for full module pairs.
 func TestAscend910C_FitFullPairSucceeds(t *testing.T) {
-	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType, SuperPod: true}}
 	nodeInfo := &device.NodeInfo{
 		Node: &corev1.Node{},
 		Devices: map[string][]device.DeviceInfo{
@@ -122,7 +122,7 @@ func TestAscend910C_FitFullPairSucceeds(t *testing.T) {
 
 // TestAscend910C_FitWithoutNetworkID_ValidatesPairing tests pairing validation when NetworkID is missing.
 func TestAscend910C_FitWithoutNetworkID_ValidatesPairing(t *testing.T) {
-	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType, SuperPod: true}}
 	nodeInfo := &device.NodeInfo{
 		Node: &corev1.Node{},
 		Devices: map[string][]device.DeviceInfo{
@@ -163,7 +163,7 @@ func TestAscend910C_FitWithoutNetworkID_ValidatesPairing(t *testing.T) {
 
 // TestComputeBestCombination910C_NoFullPairsReturnsEmpty tests empty combination when no candidate NPUs form a full module.
 func TestComputeBestCombination910C_NoFullPairsReturnsEmpty(t *testing.T) {
-	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType, SuperPod: true}}
 	nodeInfo := &device.NodeInfo{
 		Node: &corev1.Node{},
 		Devices: map[string][]device.DeviceInfo{

--- a/pkg/device/ascend/device_910c_superpod_test.go
+++ b/pkg/device/ascend/device_910c_superpod_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ascend
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+// Module pair allocation was introduced for SuperPod environments (#1610), and
+// #2005 added the SuperPod gate to MutateAdmission but not to Fit. In split
+// mode an odd request therefore passed admission and was then rejected on every
+// node, because the pair combination selects whole cards and returns more
+// devices than requested.
+func TestAscend910C_FitSplitModeOddRequestSchedulable(t *testing.T) {
+	dev := &Devices{config: VNPUConfig{CommonWord: Ascend910CType}}
+	devices := make([]*device.DeviceUsage, 0, 8)
+	for i := range 8 {
+		devices = append(devices, &device.DeviceUsage{
+			ID:        fmt.Sprintf("npu-%d", i),
+			Index:     uint(i),
+			Count:     100,
+			Totalmem:  65536,
+			Totalcore: 100,
+			Health:    true,
+		})
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", Annotations: map[string]string{}}}
+	request := device.ContainerDeviceRequest{Nums: 3, Type: Ascend910CType, Memreq: 16384, Coresreq: 20}
+
+	fit, tmpDevs, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true, reason)
+	assert.Equal(t, len(tmpDevs[Ascend910CType]), 3)
+}

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2528,6 +2528,7 @@ func TestDevices_Fit_910C(t *testing.T) {
   memoryCapacity: 65536
   aiCore: 20
   aiCPU: 7
+  superPod: true
 `
 
 	var config []VNPUConfig


### PR DESCRIPTION
/kind bug

Module pair allocation was added for SuperPod environments in #1610, and #2005 introduced the `superPod` config flag but gated only `MutateAdmission` on it, leaving `Fit` forcing pairing for every 910C request larger than one. In split mode an odd request therefore passed admission and was then rejected on every node, because the pair combination selects whole cards and returns more devices than requested, so such pods stayed Pending forever.

Does this PR introduce a user-facing change?:

release-note:
Fixed Ascend 910C scheduling in non-SuperPod deployments, where an odd device request passed admission and then failed to schedule on every node.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ascend 910C multi-device scheduling to correctly account for effective device requests.
  * Ensured multi-device requests use topology-aware pairing only when SuperPod mode is enabled.
  * Improved scheduling of split-mode requests, including odd device counts.

* **Tests**
  * Added regression coverage for successful three-device allocation across healthy Ascend 910C devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->