### PR TITLE
feat(nvidia): score MIG placements and add backtracking fallback.

### DIFF
--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -586,25 +587,44 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 }
 
 func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *device.PodDevices, request device.ContainerDeviceRequest, toAllocate device.ContainerDevices, devusage *device.DeviceUsage) bool {
-	if devusage.Mode == MigMode {
-		occupied := occupiedMigPlacements(devusage.MigAllocationsInUse)
-		for _, existing := range toAllocate {
-			if existing.UUID != devusage.ID {
-				continue
-			}
-			_, placement, ok := selectMigCandidate(devusage.MigProfiles, occupied, existing.Usedmem)
-			if !ok {
-				return false
-			}
-			occupied = append(occupied, placement)
-		}
-		_, _, ok := selectMigCandidate(devusage.MigProfiles, occupied, request.Memreq)
-		return ok
+	if devusage.Mode != MigMode {
+		return true
 	}
-	return true
+	occupied := occupiedMigPlacements(devusage.MigAllocationsInUse)
+	// Plan every slice of this container on this card together; reject only when no layout exists.
+	memories := queuedMigMemories(toAllocate, devusage.ID)
+	memories = append(memories, request.Memreq)
+	if _, _, ok := planMigAllocations(devusage.MigProfiles, occupied, memories); ok {
+		return true
+	}
+	// Fall back to the sequential path, which may upgrade a request to a larger profile.
+	for _, existing := range toAllocate {
+		if existing.UUID != devusage.ID {
+			continue
+		}
+		_, placement, ok := selectMigCandidate(devusage.MigProfiles, occupied, existing.Usedmem)
+		if !ok {
+			return false
+		}
+		occupied = append(occupied, placement)
+	}
+	_, _, ok := selectMigCandidate(devusage.MigProfiles, occupied, request.Memreq)
+	return ok
 }
 
-func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlacement, memory int32) (device.MigProfile, device.MigPlacement, bool) {
+// queuedMigMemories returns the memory requests already queued for this container on the given card.
+func queuedMigMemories(toAllocate device.ContainerDevices, uuid string) []int32 {
+	memories := make([]int32, 0, len(toAllocate)+1)
+	for _, existing := range toAllocate {
+		if existing.UUID == uuid {
+			memories = append(memories, existing.Usedmem)
+		}
+	}
+	return memories
+}
+
+// migProfilesByMemory returns the profiles ordered smallest first.
+func migProfilesByMemory(profiles []device.MigProfile) []device.MigProfile {
 	candidates := append([]device.MigProfile(nil), profiles...)
 	sort.SliceStable(candidates, func(i, j int) bool {
 		if candidates[i].MemoryMB != candidates[j].MemoryMB {
@@ -612,7 +632,22 @@ func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlace
 		}
 		return candidates[i].SliceCount < candidates[j].SliceCount
 	})
-	for _, profile := range candidates {
+	return candidates
+}
+
+// migProfileForMemory returns the smallest profile whose memory covers the request.
+func migProfileForMemory(profiles []device.MigProfile, memory int32) (device.MigProfile, bool) {
+	for _, profile := range migProfilesByMemory(profiles) {
+		if profile.MemoryMB >= memory {
+			return profile, true
+		}
+	}
+	return device.MigProfile{}, false
+}
+
+// selectMigCandidate picks the smallest covering profile that still has a free placement, and its best placement.
+func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlacement, memory int32) (device.MigProfile, device.MigPlacement, bool) {
+	for _, profile := range migProfilesByMemory(profiles) {
 		if profile.MemoryMB < memory {
 			continue
 		}
@@ -624,13 +659,103 @@ func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlace
 	return device.MigProfile{}, device.MigPlacement{}, false
 }
 
+// planMigAllocations maps each request to its smallest covering profile and places them all jointly.
+// The returned slices are aligned with memories.
+func planMigAllocations(profiles []device.MigProfile, occupied []device.MigPlacement, memories []int32) ([]device.MigProfile, []device.MigPlacement, bool) {
+	chosen := make([]device.MigProfile, len(memories))
+	requested := make([]string, len(memories))
+	for i, memory := range memories {
+		profile, ok := migProfileForMemory(profiles, memory)
+		if !ok {
+			return nil, nil, false
+		}
+		chosen[i] = profile
+		requested[i] = profile.Name
+	}
+	placements, ok := placeMigProfiles(profiles, occupied, requested)
+	if !ok {
+		return nil, nil, false
+	}
+	return chosen, placements, true
+}
+
+// recordMigPlans stores the jointly planned profile and placement on each tentative slice so AddResourceUsage commits that layout.
+// Slices on a card with no joint plan have any stale plan removed.
+func recordMigPlans(devices []*device.DeviceUsage, tentative device.ContainerDevices) {
+	usageByID := make(map[string]*device.DeviceUsage, len(devices))
+	for _, dev := range devices {
+		if dev.Mode == MigMode {
+			usageByID[dev.ID] = dev
+		}
+	}
+	grouped := make(map[string][]int)
+	order := make([]string, 0, len(tentative))
+	for idx, ctr := range tentative {
+		if _, ok := usageByID[ctr.UUID]; !ok {
+			continue
+		}
+		if _, seen := grouped[ctr.UUID]; !seen {
+			order = append(order, ctr.UUID)
+		}
+		grouped[ctr.UUID] = append(grouped[ctr.UUID], idx)
+	}
+	for _, id := range order {
+		indices := grouped[id]
+		usage := usageByID[id]
+		memories := make([]int32, len(indices))
+		for i, idx := range indices {
+			memories[i] = tentative[idx].Usedmem
+		}
+		profiles, placements, ok := planMigAllocations(usage.MigProfiles, occupiedMigPlacements(usage.MigAllocationsInUse), memories)
+		for i, idx := range indices {
+			ctr := &tentative[idx]
+			if !ok {
+				if ctr.CustomInfo != nil {
+					delete(ctr.CustomInfo, MigProfileCustomInfo)
+					delete(ctr.CustomInfo, MigPlacementCustomInfo)
+				}
+				continue
+			}
+			if ctr.CustomInfo == nil {
+				ctr.CustomInfo = make(map[string]any)
+			}
+			ctr.CustomInfo[MigProfileCustomInfo] = profiles[i].Name
+			ctr.CustomInfo[MigPlacementCustomInfo] = placements[i]
+		}
+	}
+}
+
+// plannedMigAllocation returns the plan recorded on ctr if it is still legal and conflict-free.
+func plannedMigAllocation(profiles []device.MigProfile, occupied []device.MigPlacement, ctr *device.ContainerDevice) (device.MigProfile, device.MigPlacement, bool) {
+	if ctr.CustomInfo == nil {
+		return device.MigProfile{}, device.MigPlacement{}, false
+	}
+	name, nameOK := ctr.CustomInfo[MigProfileCustomInfo].(string)
+	placement, placementOK := ctr.CustomInfo[MigPlacementCustomInfo].(device.MigPlacement)
+	if !nameOK || !placementOK {
+		return device.MigProfile{}, device.MigPlacement{}, false
+	}
+	profile, ok := findMigProfile(profiles, name)
+	if !ok || profile.MemoryMB < ctr.Usedmem {
+		return device.MigProfile{}, device.MigPlacement{}, false
+	}
+	if !slices.Contains(profile.Placements, placement) || migPlacementConflicts(placement, occupied) {
+		return device.MigProfile{}, device.MigPlacement{}, false
+	}
+	return profile, placement, true
+}
+
 func (dev *NvidiaGPUDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
 	return 0
 }
 
 func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
 	if n.Mode == MigMode {
-		profile, placement, ok := selectMigCandidate(n.MigProfiles, occupiedMigPlacements(n.MigAllocationsInUse), ctr.Usedmem)
+		occupied := occupiedMigPlacements(n.MigAllocationsInUse)
+		profile, placement, ok := plannedMigAllocation(n.MigProfiles, occupied, ctr)
+		if !ok {
+			profile, placement, ok = selectMigCandidate(n.MigProfiles, occupied, ctr.Usedmem)
+		}
 		if !ok {
 			return errors.New("MIG profile and placement allocation failed")
 		}
@@ -827,6 +952,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 		}
 		if k.Nums == 0 && !needTopology {
 			klog.V(4).InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
+			recordMigPlans(devices, tmpDevs[k.Type])
 			return true, tmpDevs, ""
 		}
 		if dev.Mode == "mig" {
@@ -836,6 +962,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 	if needTopology {
 		if len(tmpDevs[k.Type]) == int(originReq) {
 			klog.V(5).InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
+			recordMigPlans(devices, tmpDevs[k.Type])
 			return true, tmpDevs, ""
 		}
 		if len(tmpDevs[k.Type]) > int(originReq) {
@@ -857,6 +984,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 				tmpDevs[k.Type] = combination
 				klog.V(5).InfoS("device allocate success", "pod", klog.KObj(pod), "best device combination", tmpDevs)
 			}
+			recordMigPlans(devices, tmpDevs[k.Type])
 			return true, tmpDevs, ""
 		}
 	}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -587,29 +587,29 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 }
 
 func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *device.PodDevices, request device.ContainerDeviceRequest, toAllocate device.ContainerDevices, devusage *device.DeviceUsage) bool {
-	if devusage.Mode != MigMode {
-		return true
-	}
-	occupied := occupiedMigPlacements(devusage.MigAllocationsInUse)
-	// Plan every slice of this container on this card together; reject only when no layout exists.
-	memories := queuedMigMemories(toAllocate, devusage.ID)
-	memories = append(memories, request.Memreq)
-	if _, _, ok := planMigAllocations(devusage.MigProfiles, occupied, memories); ok {
-		return true
-	}
-	// Fall back to the sequential path, which may upgrade a request to a larger profile.
-	for _, existing := range toAllocate {
-		if existing.UUID != devusage.ID {
-			continue
+	if devusage.Mode == MigMode {
+		occupied := occupiedMigPlacements(devusage.MigAllocationsInUse)
+		// Plan every slice of this container on this card together; reject only when no layout exists.
+		memories := queuedMigMemories(toAllocate, devusage.ID)
+		memories = append(memories, request.Memreq)
+		if _, _, ok := planMigAllocations(devusage.MigProfiles, occupied, memories); ok {
+			return true
 		}
-		_, placement, ok := selectMigCandidate(devusage.MigProfiles, occupied, existing.Usedmem)
-		if !ok {
-			return false
+		// Fall back to the sequential path, which may upgrade a request to a larger profile.
+		for _, existing := range toAllocate {
+			if existing.UUID != devusage.ID {
+				continue
+			}
+			_, placement, ok := selectMigCandidate(devusage.MigProfiles, occupied, existing.Usedmem)
+			if !ok {
+				return false
+			}
+			occupied = append(occupied, placement)
 		}
-		occupied = append(occupied, placement)
+		_, _, ok := selectMigCandidate(devusage.MigProfiles, occupied, request.Memreq)
+		return ok
 	}
-	_, _, ok := selectMigCandidate(devusage.MigProfiles, occupied, request.Memreq)
-	return ok
+	return true
 }
 
 // queuedMigMemories returns the memory requests already queued for this container on the given card.

--- a/pkg/device/nvidia/mig_capability_test.go
+++ b/pkg/device/nvidia/mig_capability_test.go
@@ -108,3 +108,79 @@ func TestFitUsesEffectivePercentageMemoryForMigPlacement(t *testing.T) {
 		t.Fatal("25 percent memory request should not fit when only a 1g placement remains")
 	}
 }
+
+func TestCustomFilterPlansSlicesOfOneContainerJointly(t *testing.T) {
+	dev := &NvidiaGPUDevices{}
+	usage := &device.DeviceUsage{
+		ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles(),
+		MigAllocationsInUse: []device.MigAllocation{{Profile: "1g.5gb", Placement: device.MigPlacement{Start: 6, Size: 1}}},
+	}
+	// The 5GB slice is queued first; placed sequentially it would take the
+	// 3g's last legal span. Planned jointly, the 3g goes first.
+	queued := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000}}
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, usage) {
+		t.Fatal("5GB + 20GB should fit next to a running 1g at slot 6 when planned together")
+	}
+	empty := &device.DeviceUsage{ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles()}
+	queued = device.ContainerDevices{{UUID: "GPU-a", Usedmem: 10000}, {UUID: "GPU-a", Usedmem: 10000}}
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, empty) {
+		t.Fatal("10GB + 10GB + 20GB should fill an empty A100")
+	}
+}
+
+func TestAddResourceUsageCommitsRecordedPlan(t *testing.T) {
+	dev := &NvidiaGPUDevices{}
+	usage := &device.DeviceUsage{
+		ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles(),
+		MigAllocationsInUse: []device.MigAllocation{{Profile: "1g.5gb", Placement: device.MigPlacement{Start: 6, Size: 1}}},
+	}
+	tentative := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000}, {UUID: "GPU-a", Usedmem: 20000}}
+	recordMigPlans([]*device.DeviceUsage{usage}, tentative)
+	for i := range tentative {
+		if err := dev.AddResourceUsage(nil, usage, &tentative[i]); err != nil {
+			t.Fatalf("commit slice %d: %v", i, err)
+		}
+	}
+	if tentative[0].CustomInfo[MigProfileCustomInfo] != "1g.5gb" || tentative[0].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 4, Size: 1}) {
+		t.Fatalf("first slice = %+v, want 1g.5gb at slot 4", tentative[0].CustomInfo)
+	}
+	if tentative[1].CustomInfo[MigProfileCustomInfo] != "3g.20gb" || tentative[1].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 0, Size: 4}) {
+		t.Fatalf("second slice = %+v, want 3g.20gb at slot 0", tentative[1].CustomInfo)
+	}
+	if len(usage.MigAllocationsInUse) != 3 || usage.Used != 2 || usage.Usedmem != 5120+20480 {
+		t.Fatalf("usage after commit = %+v", usage)
+	}
+}
+
+func TestAddResourceUsageIgnoresStalePlan(t *testing.T) {
+	dev := &NvidiaGPUDevices{}
+	usage := &device.DeviceUsage{
+		ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles(),
+		MigAllocationsInUse: []device.MigAllocation{{Profile: "1g.5gb", Placement: device.MigPlacement{Start: 0, Size: 1}}},
+	}
+	ctr := &device.ContainerDevice{UUID: "GPU-a", Usedmem: 5000, CustomInfo: map[string]any{
+		MigProfileCustomInfo:   "1g.5gb",
+		MigPlacementCustomInfo: device.MigPlacement{Start: 0, Size: 1},
+	}}
+	if err := dev.AddResourceUsage(nil, usage, ctr); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if ctr.CustomInfo[MigPlacementCustomInfo] == (device.MigPlacement{Start: 0, Size: 1}) {
+		t.Fatal("stale placement was committed on top of a running instance")
+	}
+}
+
+func TestRecordMigPlansClearsStalePlanWhenInfeasible(t *testing.T) {
+	usage := &device.DeviceUsage{
+		ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles(),
+		MigAllocationsInUse: []device.MigAllocation{
+			{Profile: "3g.20gb", Placement: device.MigPlacement{Start: 0, Size: 4}},
+			{Profile: "3g.20gb", Placement: device.MigPlacement{Start: 4, Size: 4}},
+		},
+	}
+	tentative := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000, CustomInfo: map[string]any{MigProfileCustomInfo: "1g.5gb"}}}
+	recordMigPlans([]*device.DeviceUsage{usage}, tentative)
+	if _, ok := tentative[0].CustomInfo[MigProfileCustomInfo]; ok {
+		t.Fatal("stale plan key should have been removed")
+	}
+}

--- a/pkg/device/nvidia/mig_capability_test.go
+++ b/pkg/device/nvidia/mig_capability_test.go
@@ -141,8 +141,8 @@ func TestAddResourceUsageCommitsRecordedPlan(t *testing.T) {
 			t.Fatalf("commit slice %d: %v", i, err)
 		}
 	}
-	if tentative[0].CustomInfo[MigProfileCustomInfo] != "1g.5gb" || tentative[0].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 4, Size: 1}) {
-		t.Fatalf("first slice = %+v, want 1g.5gb at slot 4", tentative[0].CustomInfo)
+	if tentative[0].CustomInfo[MigProfileCustomInfo] != "1g.5gb" || tentative[0].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 5, Size: 1}) {
+		t.Fatalf("first slice = %+v, want 1g.5gb at slot 5", tentative[0].CustomInfo)
 	}
 	if tentative[1].CustomInfo[MigProfileCustomInfo] != "3g.20gb" || tentative[1].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 0, Size: 4}) {
 		t.Fatalf("second slice = %+v, want 3g.20gb at slot 0", tentative[1].CustomInfo)

--- a/pkg/device/nvidia/mig_topology.go
+++ b/pkg/device/nvidia/mig_topology.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 )
 
+const migSearchBudget = 4096
+
 // migRegion is a half-open range [start, end) of memory slices.
 type migRegion struct {
 	start uint32
@@ -85,13 +87,34 @@ func migReservedRegion(profiles []device.MigProfile, regions []migRegion) int {
 // migLayout is the placement geometry of one card, derived once per request
 // from the profile table the device plugin reports.
 type migLayout struct {
-	regions  []migRegion
-	reserved int
+	sliceCount int
+	regions    []migRegion
+	reserved   int
 }
 
 func newMigLayout(profiles []device.MigProfile) migLayout {
-	regions := migRegions(profiles, migSliceCount(profiles))
-	return migLayout{regions: regions, reserved: migReservedRegion(profiles, regions)}
+	sliceCount := migSliceCount(profiles)
+	regions := migRegions(profiles, sliceCount)
+	return migLayout{sliceCount: sliceCount, regions: regions, reserved: migReservedRegion(profiles, regions)}
+}
+
+// freeSliceCount counts the slices of the card that no occupied placement covers.
+func (l migLayout) freeSliceCount(occupied []device.MigPlacement) int {
+	used := make([]bool, l.sliceCount)
+	for _, p := range occupied {
+		for slice := p.Start; slice < p.Start+p.Size; slice++ {
+			if int(slice) < l.sliceCount {
+				used[slice] = true
+			}
+		}
+	}
+	free := 0
+	for _, taken := range used {
+		if !taken {
+			free++
+		}
+	}
+	return free
 }
 
 // migPlacementScore ranks one candidate placement; fields are compared in order.
@@ -166,26 +189,53 @@ func (l migLayout) rank(occupied []device.MigPlacement, profile device.MigProfil
 	return ranked
 }
 
-// place assigns every requested profile, pickiest first, without revisiting a
-// choice. result[i] belongs to requested[i]. It fails as soon as one profile
-// has no free placement, leaving the card untouched.
+// place assigns every requested profile without overlap. result[i] belongs to
+// requested[i]. The ranked greedy path is tried first: pickiest request first,
+// best-scored placement first. Only when that path fails, although the free
+// slices could hold the request, does it backtrack over the same ranked
+// candidates within migSearchBudget, so a valid layout is never rejected just
+// because the greedy choice filled the wrong half first. When the greedy path
+// succeeds the result is exactly the greedy result.
 func (l migLayout) place(occupied []device.MigPlacement, requested []device.MigProfile) ([]device.MigPlacement, bool) {
+	needed := 0
+	for _, profile := range requested {
+		needed += int(migProfileFootprint(profile))
+	}
+	if needed > l.freeSliceCount(occupied) {
+		return nil, false
+	}
 	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
 	used = append(used, occupied...)
 	result := make([]device.MigPlacement, len(requested))
 	placed := make([]bool, len(requested))
-	for range requested {
+	budget := migSearchBudget
+	var search func(remaining int) bool
+	search = func(remaining int) bool {
+		if remaining == 0 {
+			return true
+		}
 		idx := nextMigRequest(used, requested, placed)
 		if idx < 0 {
-			return nil, false
+			return false
 		}
-		ranked := l.rank(used, requested[idx])
-		if len(ranked) == 0 {
-			return nil, false
-		}
-		result[idx] = ranked[0]
-		used = append(used, ranked[0])
 		placed[idx] = true
+		for _, candidate := range l.rank(used, requested[idx]) {
+			if budget == 0 {
+				break
+			}
+			budget--
+			used = append(used, candidate)
+			result[idx] = candidate
+			if search(remaining - 1) {
+				return true
+			}
+			used = used[:len(used)-1]
+		}
+		placed[idx] = false
+		return false
+	}
+	if !search(len(requested)) {
+		return nil, false
 	}
 	return result, true
 }

--- a/pkg/device/nvidia/mig_topology.go
+++ b/pkg/device/nvidia/mig_topology.go
@@ -18,24 +18,40 @@ package nvidia
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 )
 
-func preferHighMigPlacement(profile string) bool {
-	return strings.HasPrefix(profile, "1g.") || strings.HasPrefix(profile, "3g.")
+// migPlacementScore ranks one candidate placement; fields are compared in order.
+type migPlacementScore struct {
+	largestFreeRun int    // longest run of free slices left after placing
+	survivors      int    // legal placements of every profile still free after placing
+	start          uint32 // lower start wins ties
 }
 
-func orderedMigPlacements(profile string, placements []device.MigPlacement) []device.MigPlacement {
-	ordered := append([]device.MigPlacement(nil), placements...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if preferHighMigPlacement(profile) {
-			return ordered[i].Start > ordered[j].Start
+// betterMigPlacement reports whether a should be preferred over b.
+func betterMigPlacement(a, b migPlacementScore) bool {
+	if a.largestFreeRun != b.largestFreeRun {
+		return a.largestFreeRun > b.largestFreeRun
+	}
+	if a.survivors != b.survivors {
+		return a.survivors > b.survivors
+	}
+	return a.start < b.start
+}
+
+func migPlacementsOverlap(a, b device.MigPlacement) bool {
+	return a.Start < b.Start+b.Size && b.Start < a.Start+a.Size
+}
+
+// migPlacementConflicts reports whether candidate overlaps any occupied placement.
+func migPlacementConflicts(candidate device.MigPlacement, occupied []device.MigPlacement) bool {
+	for _, existing := range occupied {
+		if migPlacementsOverlap(candidate, existing) {
+			return true
 		}
-		return ordered[i].Start < ordered[j].Start
-	})
-	return ordered
+	}
+	return false
 }
 
 func findMigProfile(profiles []device.MigProfile, name string) (device.MigProfile, bool) {
@@ -55,78 +71,230 @@ func occupiedMigPlacements(allocations []device.MigAllocation) []device.MigPlace
 	return out
 }
 
+// migSliceCount is the furthest slice any reported placement reaches (8 on A100, 4 on A30).
+func migSliceCount(profiles []device.MigProfile) int {
+	count := 0
+	for _, profile := range profiles {
+		for _, placement := range profile.Placements {
+			if end := int(placement.Start + placement.Size); end > count {
+				count = end
+			}
+		}
+	}
+	return count
+}
+
+// freeMigPlacements returns the placements of profile that overlap nothing in occupied.
+func freeMigPlacements(profile device.MigProfile, occupied []device.MigPlacement) []device.MigPlacement {
+	free := make([]device.MigPlacement, 0, len(profile.Placements))
+	for _, candidate := range profile.Placements {
+		if !migPlacementConflicts(candidate, occupied) {
+			free = append(free, candidate)
+		}
+	}
+	return free
+}
+
+// largestFreeMigRun returns the longest run of consecutive free slices.
+func largestFreeMigRun(sliceCount int, occupied []device.MigPlacement) int {
+	if sliceCount <= 0 {
+		return 0
+	}
+	used := make([]bool, sliceCount)
+	for _, placement := range occupied {
+		for slice := placement.Start; slice < placement.Start+placement.Size; slice++ {
+			if int(slice) < sliceCount {
+				used[slice] = true
+			}
+		}
+	}
+	best, current := 0, 0
+	for _, taken := range used {
+		if taken {
+			current = 0
+			continue
+		}
+		current++
+		if current > best {
+			best = current
+		}
+	}
+	return best
+}
+
+// survivingMigPlacements counts the free legal placements across every profile.
+func survivingMigPlacements(profiles []device.MigProfile, occupied []device.MigPlacement) int {
+	total := 0
+	for _, profile := range profiles {
+		total += len(freeMigPlacements(profile, occupied))
+	}
+	return total
+}
+
+// scoreMigPlacement scores the card as it would look with candidate added.
+func scoreMigPlacement(profiles []device.MigProfile, sliceCount int, occupied []device.MigPlacement, candidate device.MigPlacement) migPlacementScore {
+	after := make([]device.MigPlacement, 0, len(occupied)+1)
+	after = append(after, occupied...)
+	after = append(after, candidate)
+	return migPlacementScore{
+		largestFreeRun: largestFreeMigRun(sliceCount, after),
+		survivors:      survivingMigPlacements(profiles, after),
+		start:          candidate.Start,
+	}
+}
+
+// rankedMigPlacements returns the free placements of profile, best score first.
+func rankedMigPlacements(profiles []device.MigProfile, occupied []device.MigPlacement, profile device.MigProfile) []device.MigPlacement {
+	candidates := freeMigPlacements(profile, occupied)
+	if len(candidates) < 2 {
+		return candidates
+	}
+	sliceCount := migSliceCount(profiles)
+	scores := make([]migPlacementScore, len(candidates))
+	for i, candidate := range candidates {
+		scores[i] = scoreMigPlacement(profiles, sliceCount, occupied, candidate)
+	}
+	order := make([]int, len(candidates))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		return betterMigPlacement(scores[order[i]], scores[order[j]])
+	})
+	ranked := make([]device.MigPlacement, len(candidates))
+	for i, idx := range order {
+		ranked[i] = candidates[idx]
+	}
+	return ranked
+}
+
+// selectMigPlacement picks the best free placement for one instance of profileName.
 func selectMigPlacement(profiles []device.MigProfile, occupied []device.MigPlacement, profileName string) (device.MigPlacement, bool) {
 	profile, ok := findMigProfile(profiles, profileName)
 	if !ok {
 		return device.MigPlacement{}, false
 	}
-	for _, candidate := range orderedMigPlacements(profileName, profile.Placements) {
-		conflict := false
-		for _, existing := range occupied {
-			if migPlacementsOverlap(candidate, existing) {
-				conflict = true
-				break
-			}
-		}
-		if !conflict {
-			return candidate, true
-		}
+	ranked := rankedMigPlacements(profiles, occupied, profile)
+	if len(ranked) == 0 {
+		return device.MigPlacement{}, false
 	}
-	return device.MigPlacement{}, false
+	return ranked[0], true
 }
 
-func migPlacementsOverlap(a, b device.MigPlacement) bool {
-	return a.Start < b.Start+b.Size && b.Start < a.Start+a.Size
+// migProfileFootprint is the number of slices one instance occupies.
+func migProfileFootprint(profile device.MigProfile) uint32 {
+	if len(profile.Placements) == 0 {
+		return 0
+	}
+	return profile.Placements[0].Size
 }
 
-// canPlaceMigProfiles determines whether every requested profile can be
-// assigned one of the profile-specific placements reported by NVML without
-// overlapping an already-running or newly-selected instance.
-func canPlaceMigProfiles(capabilities []device.MigProfile, occupied []device.MigPlacement, requested []string) bool {
-	if len(requested) == 0 {
-		return true
-	}
-	placements := make(map[string][]device.MigPlacement, len(capabilities))
-	for _, profile := range capabilities {
-		placements[profile.Name] = profile.Placements
-	}
-	ordered := append([]string(nil), requested...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		left, right := placements[ordered[i]], placements[ordered[j]]
-		if len(left) != len(right) {
-			return len(left) < len(right)
+// resolveMigRequests looks up every requested name; an unknown name fails the request.
+func resolveMigRequests(profiles []device.MigProfile, requested []string) ([]device.MigProfile, bool) {
+	resolved := make([]device.MigProfile, len(requested))
+	for i, name := range requested {
+		profile, ok := findMigProfile(profiles, name)
+		if !ok {
+			return nil, false
 		}
-		if len(left) == 0 {
-			return false
-		}
-		return left[0].Size > right[0].Size
-	})
+		resolved[i] = profile
+	}
+	return resolved, true
+}
 
-	used := append([]device.MigPlacement(nil), occupied...)
-	var place func(int) bool
-	place = func(idx int) bool {
-		if idx == len(ordered) {
+// nextMigRequest picks the unplaced request with the fewest free placements,
+// then the larger footprint, then the name. It returns -1 once all are placed.
+func nextMigRequest(occupied []device.MigPlacement, requested []device.MigProfile, placed []bool) int {
+	best := -1
+	bestFree := 0
+	bestSize := uint32(0)
+	for idx, profile := range requested {
+		if placed[idx] {
+			continue
+		}
+		free := len(freeMigPlacements(profile, occupied))
+		size := migProfileFootprint(profile)
+		switch {
+		case best == -1,
+			free < bestFree,
+			free == bestFree && size > bestSize,
+			free == bestFree && size == bestSize && profile.Name < requested[best].Name:
+			best, bestFree, bestSize = idx, free, size
+		}
+	}
+	return best
+}
+
+// greedyPlaceMigProfiles places requests pickiest first, best score first, never revisiting a choice.
+func greedyPlaceMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
+	resolved, ok := resolveMigRequests(profiles, requested)
+	if !ok {
+		return nil, false
+	}
+	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
+	used = append(used, occupied...)
+	result := make([]device.MigPlacement, len(requested))
+	placed := make([]bool, len(requested))
+	for range requested {
+		idx := nextMigRequest(used, resolved, placed)
+		ranked := rankedMigPlacements(profiles, used, resolved[idx])
+		if len(ranked) == 0 {
+			return nil, false
+		}
+		result[idx] = ranked[0]
+		used = append(used, ranked[0])
+		placed[idx] = true
+	}
+	return result, true
+}
+
+// backtrackMigProfiles searches every assignment, trying candidates best score first.
+func backtrackMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
+	resolved, ok := resolveMigRequests(profiles, requested)
+	if !ok {
+		return nil, false
+	}
+	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
+	used = append(used, occupied...)
+	result := make([]device.MigPlacement, len(requested))
+	placed := make([]bool, len(requested))
+	var place func(remaining int) bool
+	place = func(remaining int) bool {
+		if remaining == 0 {
 			return true
 		}
-		candidates := orderedMigPlacements(ordered[idx], placements[ordered[idx]])
-		for _, candidate := range candidates {
-			conflict := false
-			for _, existing := range used {
-				if migPlacementsOverlap(candidate, existing) {
-					conflict = true
-					break
-				}
-			}
-			if conflict {
-				continue
-			}
+		idx := nextMigRequest(used, resolved, placed)
+		placed[idx] = true
+		for _, candidate := range rankedMigPlacements(profiles, used, resolved[idx]) {
 			used = append(used, candidate)
-			if place(idx + 1) {
+			result[idx] = candidate
+			if place(remaining - 1) {
 				return true
 			}
 			used = used[:len(used)-1]
 		}
+		placed[idx] = false
 		return false
 	}
-	return place(0)
+	if !place(len(requested)) {
+		return nil, false
+	}
+	return result, true
+}
+
+// placeMigProfiles runs the greedy pass, then backtracking if it fails. result[i] belongs to requested[i].
+func placeMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
+	if len(requested) == 0 {
+		return nil, true
+	}
+	if placements, ok := greedyPlaceMigProfiles(profiles, occupied, requested); ok {
+		return placements, true
+	}
+	return backtrackMigProfiles(profiles, occupied, requested)
+}
+
+// canPlaceMigProfiles reports whether every requested profile can be placed without overlap.
+func canPlaceMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) bool {
+	_, ok := placeMigProfiles(profiles, occupied, requested)
+	return ok
 }

--- a/pkg/device/nvidia/mig_topology.go
+++ b/pkg/device/nvidia/mig_topology.go
@@ -22,137 +22,135 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 )
 
+// migRegion is a half-open range [start, end) of memory slices.
+type migRegion struct {
+	start uint32
+	end   uint32
+}
+
+func (r migRegion) size() uint32 {
+	return r.end - r.start
+}
+
+// contains reports whether p lies entirely inside the region.
+func (r migRegion) contains(p device.MigPlacement) bool {
+	return p.Size > 0 && p.Start >= r.start && p.Start+p.Size <= r.end
+}
+
+// free reports whether nothing in occupied touches the region.
+func (r migRegion) free(occupied []device.MigPlacement) bool {
+	return !migPlacementConflicts(device.MigPlacement{Start: r.start, Size: r.size()}, occupied)
+}
+
+// migRegions splits the card at the midpoint. If any placement other than the
+// full-card one straddles the midpoint, the whole card is a single region and
+// scoring degrades to first-fit rather than misplacing on an unknown table.
+func migRegions(profiles []device.MigProfile, sliceCount int) []migRegion {
+	whole := []migRegion{{start: 0, end: uint32(sliceCount)}}
+	if sliceCount < 2 {
+		return whole
+	}
+	mid := uint32(sliceCount / 2)
+	for _, profile := range profiles {
+		for _, p := range profile.Placements {
+			if p.Size == 0 || p.Size >= uint32(sliceCount) {
+				continue
+			}
+			if p.Start < mid && p.Start+p.Size > mid {
+				return whole
+			}
+		}
+	}
+	return []migRegion{{start: 0, end: mid}, {start: mid, end: uint32(sliceCount)}}
+}
+
+func migReservedRegion(profiles []device.MigProfile, regions []migRegion) int {
+	reserved, best := 0, -1
+	for i, region := range regions {
+		count := 0
+		for _, profile := range profiles {
+			for _, p := range profile.Placements {
+				if region.contains(p) {
+					count++
+				}
+			}
+		}
+		if best < 0 || count <= best {
+			reserved, best = i, count
+		}
+	}
+	return reserved
+}
+
+// migLayout is the placement geometry of one card, derived once per request
+// from the profile table the device plugin reports.
+type migLayout struct {
+	regions  []migRegion
+	reserved int
+}
+
+func newMigLayout(profiles []device.MigProfile) migLayout {
+	regions := migRegions(profiles, migSliceCount(profiles))
+	return migLayout{regions: regions, reserved: migReservedRegion(profiles, regions)}
+}
+
 // migPlacementScore ranks one candidate placement; fields are compared in order.
 type migPlacementScore struct {
-	largestFreeRun int    // longest run of free slices left after placing
-	survivors      int    // legal placements of every profile still free after placing
-	start          uint32 // lower start wins ties
+	emptyRegions int
+	zoneMismatch int
+	edgeDistance uint32
+	start        uint32
 }
 
 // betterMigPlacement reports whether a should be preferred over b.
 func betterMigPlacement(a, b migPlacementScore) bool {
-	if a.largestFreeRun != b.largestFreeRun {
-		return a.largestFreeRun > b.largestFreeRun
+	if a.emptyRegions != b.emptyRegions {
+		return a.emptyRegions > b.emptyRegions
 	}
-	if a.survivors != b.survivors {
-		return a.survivors > b.survivors
+	if a.zoneMismatch != b.zoneMismatch {
+		return a.zoneMismatch < b.zoneMismatch
+	}
+	if a.edgeDistance != b.edgeDistance {
+		return a.edgeDistance > b.edgeDistance
 	}
 	return a.start < b.start
 }
 
-func migPlacementsOverlap(a, b device.MigPlacement) bool {
-	return a.Start < b.Start+b.Size && b.Start < a.Start+a.Size
-}
-
-// migPlacementConflicts reports whether candidate overlaps any occupied placement.
-func migPlacementConflicts(candidate device.MigPlacement, occupied []device.MigPlacement) bool {
-	for _, existing := range occupied {
-		if migPlacementsOverlap(candidate, existing) {
-			return true
-		}
-	}
-	return false
-}
-
-func findMigProfile(profiles []device.MigProfile, name string) (device.MigProfile, bool) {
-	for _, profile := range profiles {
-		if profile.Name == name {
-			return profile, true
-		}
-	}
-	return device.MigProfile{}, false
-}
-
-func occupiedMigPlacements(allocations []device.MigAllocation) []device.MigPlacement {
-	out := make([]device.MigPlacement, 0, len(allocations))
-	for _, allocation := range allocations {
-		out = append(out, allocation.Placement)
-	}
-	return out
-}
-
-// migSliceCount is the furthest slice any reported placement reaches (8 on A100, 4 on A30).
-func migSliceCount(profiles []device.MigProfile) int {
-	count := 0
-	for _, profile := range profiles {
-		for _, placement := range profile.Placements {
-			if end := int(placement.Start + placement.Size); end > count {
-				count = end
-			}
-		}
-	}
-	return count
-}
-
-// freeMigPlacements returns the placements of profile that overlap nothing in occupied.
-func freeMigPlacements(profile device.MigProfile, occupied []device.MigPlacement) []device.MigPlacement {
-	free := make([]device.MigPlacement, 0, len(profile.Placements))
-	for _, candidate := range profile.Placements {
-		if !migPlacementConflicts(candidate, occupied) {
-			free = append(free, candidate)
-		}
-	}
-	return free
-}
-
-// largestFreeMigRun returns the longest run of consecutive free slices.
-func largestFreeMigRun(sliceCount int, occupied []device.MigPlacement) int {
-	if sliceCount <= 0 {
-		return 0
-	}
-	used := make([]bool, sliceCount)
-	for _, placement := range occupied {
-		for slice := placement.Start; slice < placement.Start+placement.Size; slice++ {
-			if int(slice) < sliceCount {
-				used[slice] = true
-			}
-		}
-	}
-	best, current := 0, 0
-	for _, taken := range used {
-		if taken {
-			current = 0
-			continue
-		}
-		current++
-		if current > best {
-			best = current
-		}
-	}
-	return best
-}
-
-// survivingMigPlacements counts the free legal placements across every profile.
-func survivingMigPlacements(profiles []device.MigProfile, occupied []device.MigPlacement) int {
-	total := 0
-	for _, profile := range profiles {
-		total += len(freeMigPlacements(profile, occupied))
-	}
-	return total
-}
-
-// scoreMigPlacement scores the card as it would look with candidate added.
-func scoreMigPlacement(profiles []device.MigProfile, sliceCount int, occupied []device.MigPlacement, candidate device.MigPlacement) migPlacementScore {
+// score rates the card as it would look with candidate added.
+func (l migLayout) score(occupied []device.MigPlacement, candidate device.MigPlacement) migPlacementScore {
 	after := make([]device.MigPlacement, 0, len(occupied)+1)
 	after = append(after, occupied...)
 	after = append(after, candidate)
-	return migPlacementScore{
-		largestFreeRun: largestFreeMigRun(sliceCount, after),
-		survivors:      survivingMigPlacements(profiles, after),
-		start:          candidate.Start,
+	score := migPlacementScore{start: candidate.Start}
+	for i, region := range l.regions {
+		if region.free(after) {
+			score.emptyRegions++
+		}
+		if len(l.regions) < 2 || !region.contains(candidate) {
+			continue
+		}
+		if (candidate.Size == region.size()) != (i == l.reserved) {
+			score.zoneMismatch = 1
+		}
+		if i == 0 {
+			score.edgeDistance = region.end - (candidate.Start + candidate.Size)
+		} else {
+			score.edgeDistance = candidate.Start - region.start
+		}
 	}
+	return score
 }
 
-// rankedMigPlacements returns the free placements of profile, best score first.
-func rankedMigPlacements(profiles []device.MigProfile, occupied []device.MigPlacement, profile device.MigProfile) []device.MigPlacement {
+// rank returns the free placements of profile, best score first. The order is
+// deterministic: equal scores keep the order of the reported placement table.
+func (l migLayout) rank(occupied []device.MigPlacement, profile device.MigProfile) []device.MigPlacement {
 	candidates := freeMigPlacements(profile, occupied)
 	if len(candidates) < 2 {
 		return candidates
 	}
-	sliceCount := migSliceCount(profiles)
 	scores := make([]migPlacementScore, len(candidates))
 	for i, candidate := range candidates {
-		scores[i] = scoreMigPlacement(profiles, sliceCount, occupied, candidate)
+		scores[i] = l.score(occupied, candidate)
 	}
 	order := make([]int, len(candidates))
 	for i := range order {
@@ -168,13 +166,111 @@ func rankedMigPlacements(profiles []device.MigProfile, occupied []device.MigPlac
 	return ranked
 }
 
+// place assigns every requested profile, pickiest first, without revisiting a
+// choice. result[i] belongs to requested[i]. It fails as soon as one profile
+// has no free placement, leaving the card untouched.
+func (l migLayout) place(occupied []device.MigPlacement, requested []device.MigProfile) ([]device.MigPlacement, bool) {
+	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
+	used = append(used, occupied...)
+	result := make([]device.MigPlacement, len(requested))
+	placed := make([]bool, len(requested))
+	for range requested {
+		idx := nextMigRequest(used, requested, placed)
+		if idx < 0 {
+			return nil, false
+		}
+		ranked := l.rank(used, requested[idx])
+		if len(ranked) == 0 {
+			return nil, false
+		}
+		result[idx] = ranked[0]
+		used = append(used, ranked[0])
+		placed[idx] = true
+	}
+	return result, true
+}
+
+// migPlacementsOverlap reports whether two placements share a slice. A
+// zero-width placement occupies nothing and never overlaps.
+func migPlacementsOverlap(a, b device.MigPlacement) bool {
+	if a.Size == 0 || b.Size == 0 {
+		return false
+	}
+	return a.Start < b.Start+b.Size && b.Start < a.Start+a.Size
+}
+
+// migPlacementConflicts reports whether candidate overlaps any occupied placement.
+func migPlacementConflicts(candidate device.MigPlacement, occupied []device.MigPlacement) bool {
+	for _, existing := range occupied {
+		if migPlacementsOverlap(candidate, existing) {
+			return true
+		}
+	}
+	return false
+}
+
+// findMigProfile returns the first profile with the given name.
+func findMigProfile(profiles []device.MigProfile, name string) (device.MigProfile, bool) {
+	for _, profile := range profiles {
+		if profile.Name == name {
+			return profile, true
+		}
+	}
+	return device.MigProfile{}, false
+}
+
+// occupiedMigPlacements extracts the placements held by running allocations.
+func occupiedMigPlacements(allocations []device.MigAllocation) []device.MigPlacement {
+	out := make([]device.MigPlacement, 0, len(allocations))
+	for _, allocation := range allocations {
+		out = append(out, allocation.Placement)
+	}
+	return out
+}
+
+// migSliceCount is the furthest slice any reported placement reaches (8 on A100, 4 on A30).
+func migSliceCount(profiles []device.MigProfile) int {
+	count := 0
+	for _, profile := range profiles {
+		for _, placement := range profile.Placements {
+			if placement.Size == 0 {
+				continue
+			}
+			if end := int(placement.Start + placement.Size); end > count {
+				count = end
+			}
+		}
+	}
+	return count
+}
+
+// freeMigPlacements returns the placements of profile that overlap nothing in
+// occupied. Zero-width entries are malformed table rows, not slots, and are skipped.
+func freeMigPlacements(profile device.MigProfile, occupied []device.MigPlacement) []device.MigPlacement {
+	free := make([]device.MigPlacement, 0, len(profile.Placements))
+	for _, candidate := range profile.Placements {
+		if candidate.Size == 0 {
+			continue
+		}
+		if !migPlacementConflicts(candidate, occupied) {
+			free = append(free, candidate)
+		}
+	}
+	return free
+}
+
+// rankedMigPlacements returns the free placements of profile, best score first.
+func rankedMigPlacements(profiles []device.MigProfile, occupied []device.MigPlacement, profile device.MigProfile) []device.MigPlacement {
+	return newMigLayout(profiles).rank(occupied, profile)
+}
+
 // selectMigPlacement picks the best free placement for one instance of profileName.
 func selectMigPlacement(profiles []device.MigProfile, occupied []device.MigPlacement, profileName string) (device.MigPlacement, bool) {
 	profile, ok := findMigProfile(profiles, profileName)
 	if !ok {
 		return device.MigPlacement{}, false
 	}
-	ranked := rankedMigPlacements(profiles, occupied, profile)
+	ranked := newMigLayout(profiles).rank(occupied, profile)
 	if len(ranked) == 0 {
 		return device.MigPlacement{}, false
 	}
@@ -183,10 +279,13 @@ func selectMigPlacement(profiles []device.MigProfile, occupied []device.MigPlace
 
 // migProfileFootprint is the number of slices one instance occupies.
 func migProfileFootprint(profile device.MigProfile) uint32 {
-	if len(profile.Placements) == 0 {
-		return 0
+	footprint := uint32(0)
+	for _, placement := range profile.Placements {
+		if placement.Size > footprint {
+			footprint = placement.Size
+		}
 	}
-	return profile.Placements[0].Size
+	return footprint
 }
 
 // resolveMigRequests looks up every requested name; an unknown name fails the request.
@@ -225,72 +324,15 @@ func nextMigRequest(occupied []device.MigPlacement, requested []device.MigProfil
 	return best
 }
 
-// greedyPlaceMigProfiles places requests pickiest first, best score first, never revisiting a choice.
-func greedyPlaceMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
-	resolved, ok := resolveMigRequests(profiles, requested)
-	if !ok {
-		return nil, false
-	}
-	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
-	used = append(used, occupied...)
-	result := make([]device.MigPlacement, len(requested))
-	placed := make([]bool, len(requested))
-	for range requested {
-		idx := nextMigRequest(used, resolved, placed)
-		ranked := rankedMigPlacements(profiles, used, resolved[idx])
-		if len(ranked) == 0 {
-			return nil, false
-		}
-		result[idx] = ranked[0]
-		used = append(used, ranked[0])
-		placed[idx] = true
-	}
-	return result, true
-}
-
-// backtrackMigProfiles searches every assignment, trying candidates best score first.
-func backtrackMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
-	resolved, ok := resolveMigRequests(profiles, requested)
-	if !ok {
-		return nil, false
-	}
-	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
-	used = append(used, occupied...)
-	result := make([]device.MigPlacement, len(requested))
-	placed := make([]bool, len(requested))
-	var place func(remaining int) bool
-	place = func(remaining int) bool {
-		if remaining == 0 {
-			return true
-		}
-		idx := nextMigRequest(used, resolved, placed)
-		placed[idx] = true
-		for _, candidate := range rankedMigPlacements(profiles, used, resolved[idx]) {
-			used = append(used, candidate)
-			result[idx] = candidate
-			if place(remaining - 1) {
-				return true
-			}
-			used = used[:len(used)-1]
-		}
-		placed[idx] = false
-		return false
-	}
-	if !place(len(requested)) {
-		return nil, false
-	}
-	return result, true
-}
-
-// placeMigProfiles runs the greedy pass, then backtracking if it fails. result[i] belongs to requested[i].
 func placeMigProfiles(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) ([]device.MigPlacement, bool) {
 	if len(requested) == 0 {
 		return nil, true
 	}
-	if placements, ok := greedyPlaceMigProfiles(profiles, occupied, requested); ok {
-		return placements, true
+	resolved, ok := resolveMigRequests(profiles, requested)
+	if !ok {
+		return nil, false
 	}
-	return backtrackMigProfiles(profiles, occupied, requested)
+	return newMigLayout(profiles).place(occupied, resolved)
 }
 
 // canPlaceMigProfiles reports whether every requested profile can be placed without overlap.

--- a/pkg/device/nvidia/mig_topology.go
+++ b/pkg/device/nvidia/mig_topology.go
@@ -44,15 +44,18 @@ func (r migRegion) free(occupied []device.MigPlacement) bool {
 	return !migPlacementConflicts(device.MigPlacement{Start: r.start, Size: r.size()}, occupied)
 }
 
-// migRegions splits the card at the midpoint. If any placement other than the
-// full-card one straddles the midpoint, the whole card is a single region and
-// scoring degrades to first-fit rather than misplacing on an unknown table.
+// migRegions splits the card into two halves. The midpoint rounds up because
+// the table ends where the furthest allowed placement ends: an A100 allowlist
+// without 3g or 7g reaches slot 6 only, yet the card is still eight slices
+// wide with its halves at 4. If any placement other than the full-card one
+// straddles the midpoint, the whole card is a single region and scoring
+// degrades to first-fit rather than misplacing on an unknown table.
 func migRegions(profiles []device.MigProfile, sliceCount int) []migRegion {
 	whole := []migRegion{{start: 0, end: uint32(sliceCount)}}
 	if sliceCount < 2 {
 		return whole
 	}
-	mid := uint32(sliceCount / 2)
+	mid := uint32((sliceCount + 1) / 2)
 	for _, profile := range profiles {
 		for _, p := range profile.Placements {
 			if p.Size == 0 || p.Size >= uint32(sliceCount) {
@@ -115,6 +118,44 @@ func (l migLayout) freeSliceCount(occupied []device.MigPlacement) int {
 		}
 	}
 	return free
+}
+
+// fits rejects a request before any search when it cannot be satisfied: the
+// footprints exceed the free slices, or a placement table is requested more
+// times than it has free placements. Profiles that share a table, such as the
+// media-extension variant of a 1g, are counted together.
+func (l migLayout) fits(occupied []device.MigPlacement, requested []device.MigProfile) bool {
+	needed := 0
+	for _, profile := range requested {
+		needed += int(migProfileFootprint(profile))
+	}
+	if needed > l.freeSliceCount(occupied) {
+		return false
+	}
+	for _, profile := range requested {
+		demand := 0
+		for _, other := range requested {
+			if sameMigPlacements(profile.Placements, other.Placements) {
+				demand++
+			}
+		}
+		if demand > len(freeMigPlacements(profile, occupied)) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameMigPlacements(a, b []device.MigPlacement) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // migPlacementScore ranks one candidate placement; fields are compared in order.
@@ -190,34 +231,37 @@ func (l migLayout) rank(occupied []device.MigPlacement, profile device.MigProfil
 }
 
 // place assigns every requested profile without overlap. result[i] belongs to
-// requested[i]. The ranked greedy path is tried first: pickiest request first,
-// best-scored placement first. Only when that path fails, although the free
-// slices could hold the request, does it backtrack over the same ranked
-// candidates within migSearchBudget, so a valid layout is never rejected just
-// because the greedy choice filled the wrong half first. When the greedy path
-// succeeds the result is exactly the greedy result.
+// requested[i]. Requests are placed pickiest first, best-scored placement
+// first; when that greedy path succeeds the result is exactly the greedy
+// result. When it fails although fits allowed the request, the same ranked
+// candidates are searched by backtracking, so the greedy choice filling the
+// wrong half first does not by itself reject the request. Every level checks
+// fits for the requests still unplaced, so a run of identical requests that
+// can no longer fit is rejected once rather than in every order. The search
+// tries at most migSearchBudget candidates in total and rejects the request
+// once the budget is spent; on the supported placement tables the exhaustive
+// search never comes near it.
 func (l migLayout) place(occupied []device.MigPlacement, requested []device.MigProfile) ([]device.MigPlacement, bool) {
-	needed := 0
-	for _, profile := range requested {
-		needed += int(migProfileFootprint(profile))
-	}
-	if needed > l.freeSliceCount(occupied) {
-		return nil, false
-	}
 	used := make([]device.MigPlacement, 0, len(occupied)+len(requested))
 	used = append(used, occupied...)
 	result := make([]device.MigPlacement, len(requested))
 	placed := make([]bool, len(requested))
 	budget := migSearchBudget
-	var search func(remaining int) bool
-	search = func(remaining int) bool {
-		if remaining == 0 {
+	var search func() bool
+	search = func() bool {
+		remaining := make([]device.MigProfile, 0, len(requested))
+		for i, profile := range requested {
+			if !placed[i] {
+				remaining = append(remaining, profile)
+			}
+		}
+		if len(remaining) == 0 {
 			return true
 		}
-		idx := nextMigRequest(used, requested, placed)
-		if idx < 0 {
+		if !l.fits(used, remaining) {
 			return false
 		}
+		idx := nextMigRequest(used, requested, placed)
 		placed[idx] = true
 		for _, candidate := range l.rank(used, requested[idx]) {
 			if budget == 0 {
@@ -226,7 +270,7 @@ func (l migLayout) place(occupied []device.MigPlacement, requested []device.MigP
 			budget--
 			used = append(used, candidate)
 			result[idx] = candidate
-			if search(remaining - 1) {
+			if search() {
 				return true
 			}
 			used = used[:len(used)-1]
@@ -234,7 +278,7 @@ func (l migLayout) place(occupied []device.MigPlacement, requested []device.MigP
 		placed[idx] = false
 		return false
 	}
-	if !search(len(requested)) {
+	if !search() {
 		return nil, false
 	}
 	return result, true

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/device"
 )
 
-// a100TopologyProfiles is the A100-40GB allowlist: eight memory slices, seven compute slices.
+// a100TopologyProfiles is the A100-40GB table with 4g allowed: eight memory slices, seven compute slices.
 func a100TopologyProfiles() []device.MigProfile {
 	return []device.MigProfile{
 		{Name: "1g.5gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 4, Size: 1}, {Start: 5, Size: 1}, {Start: 6, Size: 1}}},
 		{Name: "2g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}},
 		{Name: "3g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}},
+		{Name: "4g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}}},
 		{Name: "7g.40gb", Placements: []device.MigPlacement{{Start: 0, Size: 8}}},
 	}
 }

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -17,17 +17,40 @@ limitations under the License.
 package nvidia
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 )
 
-func TestCanPlaceMigProfilesA100(t *testing.T) {
-	allowed := []device.MigProfile{
+// a100TopologyProfiles is the A100-40GB allowlist: eight memory slices, seven compute slices.
+func a100TopologyProfiles() []device.MigProfile {
+	return []device.MigProfile{
 		{Name: "1g.5gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 4, Size: 1}, {Start: 5, Size: 1}, {Start: 6, Size: 1}}},
 		{Name: "2g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}},
 		{Name: "3g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}},
+		{Name: "7g.40gb", Placements: []device.MigPlacement{{Start: 0, Size: 8}}},
 	}
+}
+
+// a100WithTwoSliceProfile adds 1g.10gb, the only small profile that can reach slice 7.
+func a100WithTwoSliceProfile() []device.MigProfile {
+	return append(a100TopologyProfiles(), device.MigProfile{
+		Name: "1g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}, {Start: 6, Size: 2}},
+	})
+}
+
+// a30TopologyProfiles has four memory slices and four compute slices.
+func a30TopologyProfiles() []device.MigProfile {
+	return []device.MigProfile{
+		{Name: "1g.6gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}}},
+		{Name: "2g.12gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}}},
+		{Name: "4g.24gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}}},
+	}
+}
+
+func TestCanPlaceMigProfilesA100(t *testing.T) {
+	allowed := a100TopologyProfiles()
 
 	if !canPlaceMigProfiles(allowed, nil, []string{"3g.20gb", "2g.10gb", "1g.5gb", "1g.5gb"}) {
 		t.Fatal("A100 all-balanced geometry should be feasible")
@@ -41,28 +64,186 @@ func TestCanPlaceMigProfilesA100(t *testing.T) {
 	if canPlaceMigProfiles(allowed, []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}, []string{"2g.10gb"}) {
 		t.Fatal("fourth 2g placement should be rejected")
 	}
+	if canPlaceMigProfiles(allowed, nil, []string{"1g.5gb", "9g.unknown"}) {
+		t.Fatal("unknown profile names must not be placeable")
+	}
+}
+
+// sequentialPlacements places profiles one at a time, as pods arrive, and returns the chosen starts.
+func sequentialPlacements(t *testing.T, allowed []device.MigProfile, occupied []device.MigPlacement, profiles []string) []uint32 {
+	t.Helper()
+	starts := make([]uint32, 0, len(profiles))
+	for _, profile := range profiles {
+		placement, ok := selectMigPlacement(allowed, occupied, profile)
+		if !ok {
+			t.Fatalf("profile %s could not be placed with occupied=%+v", profile, occupied)
+		}
+		starts = append(starts, placement.Start)
+		occupied = append(occupied, placement)
+	}
+	return starts
 }
 
 func TestSelectMigPlacementUsesBalancedPacking(t *testing.T) {
-	allowed := []device.MigProfile{
-		{Name: "1g.5gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 4, Size: 1}, {Start: 5, Size: 1}, {Start: 6, Size: 1}}},
-		{Name: "2g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}},
-		{Name: "3g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}},
+	// 3g takes the top half so both 2g spans stay open; 2g then takes the lowest span.
+	got := sequentialPlacements(t, a100TopologyProfiles(), nil, []string{"3g.20gb", "2g.10gb", "1g.5gb", "1g.5gb"})
+	want := []uint32{4, 0, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("balanced packing starts = %v, want %v", got, want)
 	}
-	occupied := []device.MigPlacement{}
-	for _, tc := range []struct {
-		profile string
-		start   uint32
+}
+
+func TestSelectMigPlacementKeepsLargestFreeRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		occupied []device.MigPlacement
+		arrivals []string
+		want     []uint32
 	}{
-		{profile: "3g.20gb", start: 4},
-		{profile: "2g.10gb", start: 0},
-		{profile: "1g.5gb", start: 3},
-		{profile: "1g.5gb", start: 2},
-	} {
-		placement, ok := selectMigPlacement(allowed, occupied, tc.profile)
-		if !ok || placement.Start != tc.start {
-			t.Fatalf("profile %s placement = %+v, %v; want start %d", tc.profile, placement, ok, tc.start)
+		{
+			// Small requests fill from the bottom instead of eating the top slices a 3g needs.
+			name:     "repeated 1g",
+			arrivals: []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"},
+			want:     []uint32{0, 1, 2, 3},
+		},
+		{
+			// The order that fragments the card under first-fit now fits completely.
+			name:     "mixed small then large",
+			arrivals: []string{"1g.5gb", "1g.5gb", "2g.10gb", "3g.20gb"},
+			want:     []uint32{0, 1, 2, 4},
+		},
+		{
+			// A lone 3g goes to the top so two 2g spans stay open instead of one.
+			name:     "single 3g prefers the top half",
+			arrivals: []string{"3g.20gb", "2g.10gb", "2g.10gb"},
+			want:     []uint32{4, 0, 2},
+		},
+		{
+			// A running 1g at slot 6 rules out the top 3g span; the new 1g must not take slot 0 too.
+			name:     "existing instance blocks one 3g span",
+			occupied: []device.MigPlacement{{Start: 6, Size: 1}},
+			arrivals: []string{"1g.5gb", "3g.20gb"},
+			want:     []uint32{5, 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sequentialPlacements(t, a100TopologyProfiles(), tc.occupied, tc.arrivals)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("starts = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectMigPlacementRejectsWhenNothingFree(t *testing.T) {
+	occupied := []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}
+	if _, ok := selectMigPlacement(a100TopologyProfiles(), occupied, "1g.5gb"); ok {
+		t.Fatal("1g must not be placed on a fully occupied card")
+	}
+	if _, ok := selectMigPlacement(a100TopologyProfiles(), nil, "9g.unknown"); ok {
+		t.Fatal("unknown profile must not be placed")
+	}
+}
+
+func TestPlaceMigProfilesPlacesPickiestFirst(t *testing.T) {
+	// Listing the 1g first must not let it take the 3g's last span.
+	occupied := []device.MigPlacement{{Start: 6, Size: 1}}
+	got, ok := placeMigProfiles(a100TopologyProfiles(), occupied, []string{"1g.5gb", "3g.20gb"})
+	if !ok {
+		t.Fatal("1g + 3g should fit next to a running 1g at slot 6")
+	}
+	want := []device.MigPlacement{{Start: 4, Size: 1}, {Start: 0, Size: 4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placements = %+v, want %+v", got, want)
+	}
+}
+
+func TestPlaceMigProfilesBreaksTiesWithLookahead(t *testing.T) {
+	// Both 3g spans leave a run of four; only the top one keeps both 2g spans alive.
+	got, ok := placeMigProfiles(a100TopologyProfiles(), nil, []string{"2g.10gb", "2g.10gb", "3g.20gb"})
+	if !ok {
+		t.Fatal("3g + 2g + 2g should fill an empty A100")
+	}
+	want := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placements = %+v, want %+v", got, want)
+	}
+}
+
+func TestPlaceMigProfilesIsDeterministic(t *testing.T) {
+	requested := []string{"1g.5gb", "2g.10gb", "1g.5gb", "3g.20gb"}
+	first, ok := placeMigProfiles(a100TopologyProfiles(), nil, requested)
+	if !ok {
+		t.Fatal("request should fit an empty A100")
+	}
+	for i := range 20 {
+		again, ok := placeMigProfiles(a100TopologyProfiles(), nil, requested)
+		if !ok || !reflect.DeepEqual(again, first) {
+			t.Fatalf("run %d produced %+v, want %+v", i, again, first)
 		}
-		occupied = append(occupied, placement)
+	}
+}
+
+func TestPlaceMigProfilesFallsBackToBacktracking(t *testing.T) {
+	// Greedy parks the 1g.10gb at 2-3 for the longer free run, leaving only slots 5 and 6 for three 1g.5gb.
+	// Backtracking finds the only working layout: 1g.10gb at 6-7.
+	allowed := a100WithTwoSliceProfile()
+	occupied := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 4, Size: 1}}
+	requested := []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.10gb"}
+
+	if _, ok := greedyPlaceMigProfiles(allowed, occupied, requested); ok {
+		t.Fatal("greedy pass was expected to fail on this layout")
+	}
+	got, ok := placeMigProfiles(allowed, occupied, requested)
+	if !ok {
+		t.Fatal("backtracking should find the layout with 1g.10gb at slot 6")
+	}
+	if got[3] != (device.MigPlacement{Start: 6, Size: 2}) {
+		t.Fatalf("1g.10gb placed at %+v, want start 6", got[3])
+	}
+	seen := map[uint32]bool{}
+	for i := range 3 {
+		if got[i].Size != 1 || seen[got[i].Start] {
+			t.Fatalf("1g.5gb placements = %+v, want three distinct single slices", got[:3])
+		}
+		seen[got[i].Start] = true
+	}
+	if !seen[2] || !seen[3] || !seen[5] {
+		t.Fatalf("1g.5gb placements = %+v, want slots 2, 3 and 5", got[:3])
+	}
+}
+
+func TestPlaceMigProfilesReportsInfeasible(t *testing.T) {
+	allowed := a100TopologyProfiles()
+	// Two 3g instances leave no legal slice for anything.
+	if _, ok := placeMigProfiles(allowed, []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}, []string{"1g.5gb"}); ok {
+		t.Fatal("full card must reject a 1g")
+	}
+	// Eight compute slices are more than the card has.
+	if _, ok := placeMigProfiles(allowed, nil, []string{"3g.20gb", "3g.20gb", "1g.5gb"}); ok {
+		t.Fatal("two 3g plus a 1g must not fit an A100")
+	}
+	if got, ok := placeMigProfiles(allowed, nil, nil); !ok || len(got) != 0 {
+		t.Fatalf("empty request = %+v, %v; want empty success", got, ok)
+	}
+}
+
+func TestPlaceMigProfilesUsesReportedGeometry(t *testing.T) {
+	// A30 has four memory slices; the slice count and every start come from the placements.
+	allowed := a30TopologyProfiles()
+	if count := migSliceCount(allowed); count != 4 {
+		t.Fatalf("A30 slice count = %d, want 4", count)
+	}
+	got := sequentialPlacements(t, allowed, nil, []string{"1g.6gb", "2g.12gb", "1g.6gb"})
+	want := []uint32{0, 2, 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("A30 starts = %v, want %v", got, want)
+	}
+	if _, ok := placeMigProfiles(allowed, nil, []string{"4g.24gb", "1g.6gb"}); ok {
+		t.Fatal("4g fills an A30; nothing else may be placed with it")
+	}
+	if _, ok := placeMigProfiles(allowed, nil, []string{"2g.12gb", "1g.6gb", "1g.6gb"}); !ok {
+		t.Fatal("2g + 1g + 1g should fill an A30")
 	}
 }

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -33,19 +33,172 @@ func a100TopologyProfiles() []device.MigProfile {
 	}
 }
 
-// a100WithTwoSliceProfile adds 1g.10gb, the only small profile that can reach slice 7.
-func a100WithTwoSliceProfile() []device.MigProfile {
-	return append(a100TopologyProfiles(), device.MigProfile{
-		Name: "1g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}, {Start: 6, Size: 2}},
-	})
-}
-
 // a30TopologyProfiles has four memory slices and four compute slices.
 func a30TopologyProfiles() []device.MigProfile {
 	return []device.MigProfile{
 		{Name: "1g.6gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}}},
 		{Name: "2g.12gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}}},
 		{Name: "4g.24gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}}},
+	}
+}
+
+// h100TopologyProfiles is the full table NVIDIA reports for H100-80GB, including
+// the media-extension 1g, the double-memory 1g and the 4g.
+func h100TopologyProfiles() []device.MigProfile {
+	single := []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 4, Size: 1}, {Start: 5, Size: 1}, {Start: 6, Size: 1}}
+	double := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}, {Start: 6, Size: 2}}
+	return []device.MigProfile{
+		{Name: "1g.10gb", Placements: single},
+		{Name: "1g.10gb+me", Placements: single},
+		{Name: "1g.20gb", Placements: double},
+		{Name: "2g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}},
+		{Name: "3g.40gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}},
+		{Name: "4g.40gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}}},
+		{Name: "7g.80gb", Placements: []device.MigPlacement{{Start: 0, Size: 8}}},
+	}
+}
+
+// straddlingProfiles has a placement across the midpoint, so the halves are not independent.
+func straddlingProfiles() []device.MigProfile {
+	return []device.MigProfile{
+		{Name: "1g", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}}},
+		{Name: "2g", Placements: []device.MigPlacement{{Start: 1, Size: 2}}},
+	}
+}
+
+// sequentialPlacements places profiles one at a time, as pods arrive, and returns the chosen starts.
+func sequentialPlacements(t *testing.T, allowed []device.MigProfile, occupied []device.MigPlacement, profiles []string) []uint32 {
+	t.Helper()
+	starts := make([]uint32, 0, len(profiles))
+	for _, profile := range profiles {
+		placement, ok := selectMigPlacement(allowed, occupied, profile)
+		if !ok {
+			t.Fatalf("profile %s could not be placed with occupied=%+v", profile, occupied)
+		}
+		starts = append(starts, placement.Start)
+		occupied = append(occupied, placement)
+	}
+	return starts
+}
+
+func TestMigSliceCountComesFromPlacements(t *testing.T) {
+	if got := migSliceCount(a100TopologyProfiles()); got != 8 {
+		t.Fatalf("A100 slice count = %d, want 8", got)
+	}
+	if got := migSliceCount(a30TopologyProfiles()); got != 4 {
+		t.Fatalf("A30 slice count = %d, want 4", got)
+	}
+	if got := migSliceCount(nil); got != 0 {
+		t.Fatalf("empty table slice count = %d, want 0", got)
+	}
+	// A zero-width row must not stretch the card.
+	malformed := []device.MigProfile{{Name: "x", Placements: []device.MigPlacement{{Start: 20, Size: 0}, {Start: 0, Size: 1}}}}
+	if got := migSliceCount(malformed); got != 1 {
+		t.Fatalf("malformed table slice count = %d, want 1", got)
+	}
+}
+
+func TestMigRegionsSplitTheCardInHalves(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []device.MigProfile
+		want     []migRegion
+	}{
+		{name: "A100", profiles: a100TopologyProfiles(), want: []migRegion{{start: 0, end: 4}, {start: 4, end: 8}}},
+		{name: "A30", profiles: a30TopologyProfiles(), want: []migRegion{{start: 0, end: 2}, {start: 2, end: 4}}},
+		{name: "H100 with 4g and double-memory 1g", profiles: h100TopologyProfiles(), want: []migRegion{{start: 0, end: 4}, {start: 4, end: 8}}},
+		{name: "straddling placement keeps one region", profiles: straddlingProfiles(), want: []migRegion{{start: 0, end: 4}}},
+		{name: "no placements", profiles: nil, want: []migRegion{{start: 0, end: 0}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := migRegions(tc.profiles, migSliceCount(tc.profiles))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("regions = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMigReservedRegionIsTheUpperHalf(t *testing.T) {
+	// A100 and H100: [4,8) holds fewer placements than [0,4). A30: both halves tie, so the upper one wins.
+	for _, tc := range []struct {
+		name     string
+		profiles []device.MigProfile
+	}{
+		{name: "A100", profiles: a100TopologyProfiles()},
+		{name: "A30", profiles: a30TopologyProfiles()},
+		{name: "H100", profiles: h100TopologyProfiles()},
+	} {
+		regions := migRegions(tc.profiles, migSliceCount(tc.profiles))
+		if got := migReservedRegion(tc.profiles, regions); got != 1 {
+			t.Fatalf("%s reserved region = %d, want 1", tc.name, got)
+		}
+	}
+	single := straddlingProfiles()
+	if got := migReservedRegion(single, migRegions(single, migSliceCount(single))); got != 0 {
+		t.Fatalf("single-region reserved index = %d, want 0", got)
+	}
+}
+
+func TestBetterMigPlacementComparesFieldsInOrder(t *testing.T) {
+	same := migPlacementScore{emptyRegions: 1, zoneMismatch: 0, edgeDistance: 1, start: 4}
+	tests := []struct {
+		name string
+		a, b migPlacementScore
+		want bool
+	}{
+		{name: "an untouched half beats everything", a: migPlacementScore{emptyRegions: 1, zoneMismatch: 1}, b: migPlacementScore{emptyRegions: 0, edgeDistance: 3}, want: true},
+		{name: "the matching zone beats the outer edge", a: migPlacementScore{zoneMismatch: 0, start: 6}, b: migPlacementScore{zoneMismatch: 1, edgeDistance: 3}, want: true},
+		{name: "the outer edge beats a lower start", a: migPlacementScore{edgeDistance: 2, start: 6}, b: migPlacementScore{edgeDistance: 0, start: 4}, want: true},
+		{name: "lower start breaks the tie", a: migPlacementScore{start: 0}, b: migPlacementScore{start: 1}, want: true},
+		{name: "equal scores are not better", a: same, b: same, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := betterMigPlacement(tc.a, tc.b); got != tc.want {
+				t.Fatalf("betterMigPlacement(%+v, %+v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindMigProfileReturnsTheFirstMatch(t *testing.T) {
+	profiles := []device.MigProfile{
+		{Name: "1g", Placements: []device.MigPlacement{{Start: 0, Size: 1}}},
+		{Name: "1g", Placements: []device.MigPlacement{{Start: 5, Size: 1}}},
+	}
+	got, ok := findMigProfile(profiles, "1g")
+	if !ok || got.Placements[0].Start != 0 {
+		t.Fatalf("findMigProfile = %+v, %v; want the first 1g entry", got, ok)
+	}
+	if _, ok := findMigProfile(profiles, "9g"); ok {
+		t.Fatal("unknown profile must not be found")
+	}
+}
+
+func TestMigProfileFootprintIsTheLargestPlacement(t *testing.T) {
+	if got := migProfileFootprint(device.MigProfile{Name: "empty"}); got != 0 {
+		t.Fatalf("footprint of a profile without placements = %d, want 0", got)
+	}
+	mixed := device.MigProfile{Name: "x", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 0, Size: 2}}}
+	if got := migProfileFootprint(mixed); got != 2 {
+		t.Fatalf("footprint = %d, want 2", got)
+	}
+}
+
+func TestOccupiedMigPlacementsFollowsAllocationOrder(t *testing.T) {
+	allocations := []device.MigAllocation{
+		{Placement: device.MigPlacement{Start: 4, Size: 4}},
+		{Placement: device.MigPlacement{Start: 0, Size: 1}},
+	}
+	got := occupiedMigPlacements(allocations)
+	want := []device.MigPlacement{{Start: 4, Size: 4}, {Start: 0, Size: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("occupied = %+v, want %+v", got, want)
+	}
+	if got := occupiedMigPlacements(nil); len(got) != 0 {
+		t.Fatalf("occupied of no allocations = %+v, want empty", got)
 	}
 }
 
@@ -69,23 +222,8 @@ func TestCanPlaceMigProfilesA100(t *testing.T) {
 	}
 }
 
-// sequentialPlacements places profiles one at a time, as pods arrive, and returns the chosen starts.
-func sequentialPlacements(t *testing.T, allowed []device.MigProfile, occupied []device.MigPlacement, profiles []string) []uint32 {
-	t.Helper()
-	starts := make([]uint32, 0, len(profiles))
-	for _, profile := range profiles {
-		placement, ok := selectMigPlacement(allowed, occupied, profile)
-		if !ok {
-			t.Fatalf("profile %s could not be placed with occupied=%+v", profile, occupied)
-		}
-		starts = append(starts, placement.Start)
-		occupied = append(occupied, placement)
-	}
-	return starts
-}
-
 func TestSelectMigPlacementUsesBalancedPacking(t *testing.T) {
-	// 3g takes the top half so both 2g spans stay open; 2g then takes the lowest span.
+	// 3g takes the reserved upper half so both 2g spans stay open; 2g then takes the lowest span (NVIDIA config 9).
 	got := sequentialPlacements(t, a100TopologyProfiles(), nil, []string{"3g.20gb", "2g.10gb", "1g.5gb", "1g.5gb"})
 	want := []uint32{4, 0, 2, 3}
 	if !reflect.DeepEqual(got, want) {
@@ -93,7 +231,7 @@ func TestSelectMigPlacementUsesBalancedPacking(t *testing.T) {
 	}
 }
 
-func TestSelectMigPlacementKeepsLargestFreeRun(t *testing.T) {
+func TestSelectMigPlacementPacksEachHalfSeparately(t *testing.T) {
 	tests := []struct {
 		name     string
 		occupied []device.MigPlacement
@@ -101,29 +239,64 @@ func TestSelectMigPlacementKeepsLargestFreeRun(t *testing.T) {
 		want     []uint32
 	}{
 		{
-			// Small requests fill from the bottom instead of eating the top slices a 3g needs.
+			// Small requests fill the lower half from slot 0 instead of eating the upper half a 3g needs (config 11 path).
 			name:     "repeated 1g",
 			arrivals: []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"},
 			want:     []uint32{0, 1, 2, 3},
 		},
 		{
-			// The order that fragments the card under first-fit now fits completely.
+			// Once the lower half is full, the upper half fills from its outer edge (config 19).
+			name:     "seven 1g",
+			arrivals: []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"},
+			want:     []uint32{0, 1, 2, 3, 6, 5, 4},
+		},
+		{
+			// The order that fragments the card under first-fit now fits completely (config 10).
 			name:     "mixed small then large",
 			arrivals: []string{"1g.5gb", "1g.5gb", "2g.10gb", "3g.20gb"},
 			want:     []uint32{0, 1, 2, 4},
 		},
 		{
-			// A lone 3g goes to the top so two 2g spans stay open instead of one.
-			name:     "single 3g prefers the top half",
+			// A lone 3g goes to the reserved upper half so two 2g spans stay open instead of one (config 8).
+			name:     "single 3g prefers the upper half",
 			arrivals: []string{"3g.20gb", "2g.10gb", "2g.10gb"},
 			want:     []uint32{4, 0, 2},
 		},
 		{
-			// A running 1g at slot 6 rules out the top 3g span; the new 1g must not take slot 0 too.
+			// The second 3g takes the only span left (config 5).
+			name:     "two 3g",
+			arrivals: []string{"3g.20gb", "3g.20gb"},
+			want:     []uint32{4, 0},
+		},
+		{
+			// A 3g arriving after a 1g still has its half; the next 1g keeps packing below (config 11 path).
+			name:     "1g then 3g then 1g",
+			occupied: nil,
+			arrivals: []string{"1g.5gb", "3g.20gb", "1g.5gb"},
+			want:     []uint32{0, 4, 1},
+		},
+		{
+			// Three 2g and a 1g land exactly as NVIDIA config 12.
+			name:     "three 2g then 1g",
+			arrivals: []string{"2g.10gb", "2g.10gb", "2g.10gb", "1g.5gb"},
+			want:     []uint32{0, 2, 4, 6},
+		},
+		{
+			// A running 1g at slot 6 already spoils the upper half; the new 1g joins it there,
+			// next to the outer edge, and leaves the lower half whole for the 3g.
 			name:     "existing instance blocks one 3g span",
 			occupied: []device.MigPlacement{{Start: 6, Size: 1}},
 			arrivals: []string{"1g.5gb", "3g.20gb"},
 			want:     []uint32{5, 0},
+		},
+		{
+			// With both halves already touched, small requests keep packing the lower half:
+			// the 1g takes slot 1 rather than spoiling the upper 2g span, and the 2g still
+			// finds [2,4) below, so the span at slot 4 survives for a later request.
+			name:     "both halves touched",
+			occupied: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 6, Size: 1}},
+			arrivals: []string{"1g.5gb", "2g.10gb"},
+			want:     []uint32{1, 2},
 		},
 	}
 	for _, tc := range tests {
@@ -136,6 +309,82 @@ func TestSelectMigPlacementKeepsLargestFreeRun(t *testing.T) {
 	}
 }
 
+func TestSelectMigPlacementHandlesTheFullH100Table(t *testing.T) {
+	tests := []struct {
+		name     string
+		arrivals []string
+		want     []uint32
+	}{
+		{
+			// Double-memory 1g packs the lower half first and then uses [6,8), the only
+			// way to reach slice 7 without a 3g.
+			name:     "four double-memory 1g",
+			arrivals: []string{"1g.20gb", "1g.20gb", "1g.20gb", "1g.20gb"},
+			want:     []uint32{0, 2, 6, 4},
+		},
+		{
+			// 3g in the reserved half, everything else packed below: all eight slices used.
+			name:     "3g with mixed small profiles",
+			arrivals: []string{"3g.40gb", "1g.20gb", "1g.10gb", "1g.10gb"},
+			want:     []uint32{4, 0, 2, 3},
+		},
+		{
+			// The media-extension variant shares the plain 1g placements.
+			name:     "media extension variant",
+			arrivals: []string{"1g.10gb+me", "1g.10gb"},
+			want:     []uint32{0, 1},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sequentialPlacements(t, h100TopologyProfiles(), nil, tc.arrivals)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("starts = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlaceMigProfilesHandles4gWhenRequestedTogether(t *testing.T) {
+	allowed := h100TopologyProfiles()
+	// The 4g only fits the lower half; it is placed first because it is the pickiest,
+	// and the 1g then takes the upper half from its outer edge.
+	got, ok := placeMigProfiles(allowed, nil, []string{"1g.10gb", "4g.40gb"})
+	if !ok {
+		t.Fatal("1g + 4g should fit an empty H100")
+	}
+	want := []device.MigPlacement{{Start: 6, Size: 1}, {Start: 0, Size: 4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placements = %+v, want %+v", got, want)
+	}
+	got, ok = placeMigProfiles(allowed, nil, []string{"4g.40gb", "3g.40gb"})
+	if !ok {
+		t.Fatal("4g + 3g should fill an empty H100")
+	}
+	want = []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placements = %+v, want %+v", got, want)
+	}
+}
+
+func TestSelectMigPlacementFallsBackToFirstFit(t *testing.T) {
+	// Without independent halves the score reduces to the lowest free start.
+	got := sequentialPlacements(t, straddlingProfiles(), nil, []string{"1g", "1g", "1g"})
+	want := []uint32{0, 1, 2}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("first-fit starts = %v, want %v", got, want)
+	}
+}
+
+func TestSelectMigPlacementIgnoresMalformedOccupiedEntries(t *testing.T) {
+	// A zero-width entry occupies nothing and an entry past the card touches nothing.
+	occupied := []device.MigPlacement{{Start: 0, Size: 0}, {Start: 8, Size: 2}}
+	got, ok := selectMigPlacement(a100TopologyProfiles(), occupied, "1g.5gb")
+	if !ok || got.Start != 0 || got.Size != 1 {
+		t.Fatalf("placement = %+v, %v; want slot 0", got, ok)
+	}
+}
+
 func TestSelectMigPlacementRejectsWhenNothingFree(t *testing.T) {
 	occupied := []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}
 	if _, ok := selectMigPlacement(a100TopologyProfiles(), occupied, "1g.5gb"); ok {
@@ -144,28 +393,81 @@ func TestSelectMigPlacementRejectsWhenNothingFree(t *testing.T) {
 	if _, ok := selectMigPlacement(a100TopologyProfiles(), nil, "9g.unknown"); ok {
 		t.Fatal("unknown profile must not be placed")
 	}
+	malformed := []device.MigProfile{
+		{Name: "no-placements"},
+		{Name: "zero-width", Placements: []device.MigPlacement{{Start: 0, Size: 0}}},
+	}
+	if _, ok := selectMigPlacement(malformed, nil, "no-placements"); ok {
+		t.Fatal("a profile without placements must not be placed")
+	}
+	if _, ok := selectMigPlacement(malformed, nil, "zero-width"); ok {
+		t.Fatal("a zero-width placement must not be handed out")
+	}
+}
+
+func TestNextMigRequestOrdersByScarcity(t *testing.T) {
+	allowed := a100TopologyProfiles()
+	requested, ok := resolveMigRequests(allowed, []string{"1g.5gb", "2g.10gb", "3g.20gb"})
+	if !ok {
+		t.Fatal("known names must resolve")
+	}
+	if got := nextMigRequest(nil, requested, []bool{false, false, false}); got != 2 {
+		t.Fatalf("first pick = %d, want the 3g (2)", got)
+	}
+	if got := nextMigRequest(nil, requested, []bool{false, false, true}); got != 1 {
+		t.Fatalf("second pick = %d, want the 2g (1)", got)
+	}
+	if got := nextMigRequest(nil, requested, []bool{true, true, true}); got != -1 {
+		t.Fatalf("pick with everything placed = %d, want -1", got)
+	}
+
+	// With slots 1 and 2 taken, 2g and 3g both have a single free span; the larger footprint goes first.
+	tied, _ := resolveMigRequests(allowed, []string{"2g.10gb", "3g.20gb"})
+	occupied := []device.MigPlacement{{Start: 1, Size: 1}, {Start: 2, Size: 1}}
+	if got := nextMigRequest(occupied, tied, []bool{false, false}); got != 1 {
+		t.Fatalf("tied pick = %d, want the 3g (1)", got)
+	}
+
+	// Identical requests keep their listed order.
+	twins, _ := resolveMigRequests(allowed, []string{"1g.5gb", "1g.5gb"})
+	if got := nextMigRequest(nil, twins, []bool{false, false}); got != 0 {
+		t.Fatalf("twin pick = %d, want 0", got)
+	}
 }
 
 func TestPlaceMigProfilesPlacesPickiestFirst(t *testing.T) {
-	// Listing the 1g first must not let it take the 3g's last span.
+	// Listing the 1g first must not let it take the 3g's last span. The 1g then
+	// fills the upper half from its outer edge, so slot 5 rather than slot 4.
 	occupied := []device.MigPlacement{{Start: 6, Size: 1}}
 	got, ok := placeMigProfiles(a100TopologyProfiles(), occupied, []string{"1g.5gb", "3g.20gb"})
 	if !ok {
 		t.Fatal("1g + 3g should fit next to a running 1g at slot 6")
 	}
-	want := []device.MigPlacement{{Start: 4, Size: 1}, {Start: 0, Size: 4}}
+	want := []device.MigPlacement{{Start: 5, Size: 1}, {Start: 0, Size: 4}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("placements = %+v, want %+v", got, want)
 	}
 }
 
-func TestPlaceMigProfilesBreaksTiesWithLookahead(t *testing.T) {
-	// Both 3g spans leave a run of four; only the top one keeps both 2g spans alive.
+func TestPlaceMigProfilesKeepsLargeProfilesInReservedHalf(t *testing.T) {
+	// Both 3g spans are legal; the upper one is the reserved half, so both 2g spans below stay alive (config 8).
 	got, ok := placeMigProfiles(a100TopologyProfiles(), nil, []string{"2g.10gb", "2g.10gb", "3g.20gb"})
 	if !ok {
 		t.Fatal("3g + 2g + 2g should fill an empty A100")
 	}
 	want := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("placements = %+v, want %+v", got, want)
+	}
+}
+
+func TestPlaceMigProfilesResultFollowsRequestOrder(t *testing.T) {
+	// Placement order is pickiest first, but result[i] must still belong to requested[i].
+	got, ok := placeMigProfiles(a100TopologyProfiles(), nil, []string{"1g.5gb", "3g.20gb", "2g.10gb", "1g.5gb"})
+	if !ok {
+		t.Fatal("1g + 3g + 2g + 1g should fill an empty A100")
+	}
+	want := []device.MigPlacement{{Start: 2, Size: 1}, {Start: 4, Size: 4}, {Start: 0, Size: 2}, {Start: 3, Size: 1}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("placements = %+v, want %+v", got, want)
 	}
@@ -185,32 +487,20 @@ func TestPlaceMigProfilesIsDeterministic(t *testing.T) {
 	}
 }
 
-func TestPlaceMigProfilesFallsBackToBacktracking(t *testing.T) {
-	// Greedy parks the 1g.10gb at 2-3 for the longer free run, leaving only slots 5 and 6 for three 1g.5gb.
-	// Backtracking finds the only working layout: 1g.10gb at 6-7.
-	allowed := a100WithTwoSliceProfile()
-	occupied := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 4, Size: 1}}
-	requested := []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.10gb"}
-
-	if _, ok := greedyPlaceMigProfiles(allowed, occupied, requested); ok {
-		t.Fatal("greedy pass was expected to fail on this layout")
+func TestPlaceMigProfilesHandlesTheFullCardProfile(t *testing.T) {
+	allowed := a100TopologyProfiles()
+	got, ok := placeMigProfiles(allowed, nil, []string{"7g.40gb"})
+	if !ok || !reflect.DeepEqual(got, []device.MigPlacement{{Start: 0, Size: 8}}) {
+		t.Fatalf("7g on an empty card = %+v, %v; want slot 0 size 8", got, ok)
 	}
-	got, ok := placeMigProfiles(allowed, occupied, requested)
-	if !ok {
-		t.Fatal("backtracking should find the layout with 1g.10gb at slot 6")
+	if _, ok := placeMigProfiles(allowed, nil, []string{"7g.40gb", "1g.5gb"}); ok {
+		t.Fatal("nothing fits next to a 7g")
 	}
-	if got[3] != (device.MigPlacement{Start: 6, Size: 2}) {
-		t.Fatalf("1g.10gb placed at %+v, want start 6", got[3])
+	if _, ok := placeMigProfiles(allowed, nil, []string{"1g.5gb", "7g.40gb"}); ok {
+		t.Fatal("the 7g is placed first regardless of listing order and must still fail")
 	}
-	seen := map[uint32]bool{}
-	for i := range 3 {
-		if got[i].Size != 1 || seen[got[i].Start] {
-			t.Fatalf("1g.5gb placements = %+v, want three distinct single slices", got[:3])
-		}
-		seen[got[i].Start] = true
-	}
-	if !seen[2] || !seen[3] || !seen[5] {
-		t.Fatalf("1g.5gb placements = %+v, want slots 2, 3 and 5", got[:3])
+	if _, ok := placeMigProfiles(allowed, []device.MigPlacement{{Start: 6, Size: 1}}, []string{"7g.40gb"}); ok {
+		t.Fatal("a 7g must not be placed on a card with any running instance")
 	}
 }
 
@@ -224,6 +514,10 @@ func TestPlaceMigProfilesReportsInfeasible(t *testing.T) {
 	if _, ok := placeMigProfiles(allowed, nil, []string{"3g.20gb", "3g.20gb", "1g.5gb"}); ok {
 		t.Fatal("two 3g plus a 1g must not fit an A100")
 	}
+	// 2+2+2+1+1 adds up to eight slices, but slice 7 is only reachable by a 3g.
+	if _, ok := placeMigProfiles(allowed, nil, []string{"2g.10gb", "2g.10gb", "2g.10gb", "1g.5gb", "1g.5gb"}); ok {
+		t.Fatal("three 2g plus two 1g must not fit an A100")
+	}
 	if got, ok := placeMigProfiles(allowed, nil, nil); !ok || len(got) != 0 {
 		t.Fatalf("empty request = %+v, %v; want empty success", got, ok)
 	}
@@ -232,9 +526,6 @@ func TestPlaceMigProfilesReportsInfeasible(t *testing.T) {
 func TestPlaceMigProfilesUsesReportedGeometry(t *testing.T) {
 	// A30 has four memory slices; the slice count and every start come from the placements.
 	allowed := a30TopologyProfiles()
-	if count := migSliceCount(allowed); count != 4 {
-		t.Fatalf("A30 slice count = %d, want 4", count)
-	}
 	got := sequentialPlacements(t, allowed, nil, []string{"1g.6gb", "2g.12gb", "1g.6gb"})
 	want := []uint32{0, 2, 1}
 	if !reflect.DeepEqual(got, want) {
@@ -245,5 +536,10 @@ func TestPlaceMigProfilesUsesReportedGeometry(t *testing.T) {
 	}
 	if _, ok := placeMigProfiles(allowed, nil, []string{"2g.12gb", "1g.6gb", "1g.6gb"}); !ok {
 		t.Fatal("2g + 1g + 1g should fill an A30")
+	}
+	// A 2g fills a whole A30 half, so it is treated like a 3g on A100 and goes to the reserved half first.
+	pair, ok := placeMigProfiles(allowed, nil, []string{"2g.12gb", "2g.12gb"})
+	if !ok || !reflect.DeepEqual(pair, []device.MigPlacement{{Start: 2, Size: 2}, {Start: 0, Size: 2}}) {
+		t.Fatalf("two 2g on an A30 = %+v, %v; want slots 2 then 0", pair, ok)
 	}
 }

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -18,6 +18,7 @@ package nvidia
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -622,5 +623,189 @@ func TestPlaceMigProfilesUsesReportedGeometry(t *testing.T) {
 	pair, ok := placeMigProfiles(allowed, nil, []string{"2g.12gb", "2g.12gb"})
 	if !ok || !reflect.DeepEqual(pair, []device.MigPlacement{{Start: 2, Size: 2}, {Start: 0, Size: 2}}) {
 		t.Fatalf("two 2g on an A30 = %+v, %v; want slots 2 then 0", pair, ok)
+	}
+}
+
+// migDistinctPlacements returns every distinct placement in the table, in table order.
+func migDistinctPlacements(profiles []device.MigProfile) []device.MigPlacement {
+	seen := map[device.MigPlacement]bool{}
+	var out []device.MigPlacement
+	for _, profile := range profiles {
+		for _, p := range profile.Placements {
+			if p.Size == 0 || seen[p] {
+				continue
+			}
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// realizableMigOccupancies enumerates every set of non-overlapping placements
+// the table allows, which is every state a card can be in.
+func realizableMigOccupancies(profiles []device.MigProfile) [][]device.MigPlacement {
+	placements := migDistinctPlacements(profiles)
+	var out [][]device.MigPlacement
+	var walk func(i int, chosen []device.MigPlacement)
+	walk = func(i int, chosen []device.MigPlacement) {
+		if i == len(placements) {
+			out = append(out, append([]device.MigPlacement(nil), chosen...))
+			return
+		}
+		walk(i+1, chosen)
+		if !migPlacementConflicts(placements[i], chosen) {
+			walk(i+1, append(chosen, placements[i]))
+		}
+	}
+	walk(0, nil)
+	return out
+}
+
+// migRequestMultisets enumerates every request whose footprints fit in
+// maxSlices, as name lists in table order.
+func migRequestMultisets(profiles []device.MigProfile, maxSlices int) [][]string {
+	var out [][]string
+	var walk func(i int, remaining int, names []string)
+	walk = func(i int, remaining int, names []string) {
+		if i == len(profiles) {
+			out = append(out, append([]string(nil), names...))
+			return
+		}
+		footprint := int(migProfileFootprint(profiles[i]))
+		for count := 0; count*footprint <= remaining; count++ {
+			next := names
+			for range count {
+				next = append(next, profiles[i].Name)
+			}
+			walk(i+1, remaining-count*footprint, next)
+		}
+	}
+	walk(0, maxSlices, nil)
+	return out
+}
+
+func migPlacementMask(p device.MigPlacement) int {
+	return ((1 << p.Size) - 1) << p.Start
+}
+
+// migLayoutExists decides, independently of the scoring heuristics, whether
+// some non-overlapping assignment of the requested profiles exists.
+func migLayoutExists(profiles []device.MigProfile, occupied []device.MigPlacement, requested []string) bool {
+	resolved, ok := resolveMigRequests(profiles, requested)
+	if !ok {
+		return false
+	}
+	start := 0
+	for _, p := range occupied {
+		start |= migPlacementMask(p)
+	}
+	memo := map[[2]int]bool{}
+	var solve func(mask int, i int) bool
+	solve = func(mask int, i int) bool {
+		if i == len(resolved) {
+			return true
+		}
+		key := [2]int{mask, i}
+		if found, seen := memo[key]; seen {
+			return found
+		}
+		found := false
+		for _, p := range resolved[i].Placements {
+			if p.Size == 0 {
+				continue
+			}
+			if m := migPlacementMask(p); mask&m == 0 && solve(mask|m, i+1) {
+				found = true
+				break
+			}
+		}
+		memo[key] = found
+		return found
+	}
+	return solve(start, 0)
+}
+
+func assertValidMigLayout(t *testing.T, requested []device.MigProfile, occupied, got []device.MigPlacement) {
+	t.Helper()
+	if len(got) != len(requested) {
+		t.Fatalf("got %d placements for %d requests", len(got), len(requested))
+	}
+	used := append([]device.MigPlacement(nil), occupied...)
+	for i, p := range got {
+		if !slices.Contains(requested[i].Placements, p) {
+			t.Fatalf("result[%d] = %+v is not a placement of %s", i, p, requested[i].Name)
+		}
+		if migPlacementConflicts(p, used) {
+			t.Fatalf("result[%d] = %+v overlaps occupied=%+v", i, p, used)
+		}
+		used = append(used, p)
+	}
+}
+
+// TestPlaceMigProfilesMatchesExhaustiveSearch checks, for every state a card
+// can be in and every request that fits its free slices, that place succeeds
+// exactly when a layout exists and that what it returns is legal.
+func TestPlaceMigProfilesMatchesExhaustiveSearch(t *testing.T) {
+	tables := []struct {
+		name     string
+		profiles []device.MigProfile
+	}{
+		{name: "A100 allowlist", profiles: a100TopologyProfiles()},
+		{name: "A100 allowlist without slot 7", profiles: a100NoSlotSevenProfiles()},
+		{name: "A30", profiles: a30TopologyProfiles()},
+		{name: "H100 full table", profiles: h100TopologyProfiles()},
+	}
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			layout := newMigLayout(table.profiles)
+			cases := 0
+			for _, occupied := range realizableMigOccupancies(table.profiles) {
+				for _, requested := range migRequestMultisets(table.profiles, layout.freeSliceCount(occupied)) {
+					if len(requested) == 0 {
+						continue
+					}
+					cases++
+					got, ok := placeMigProfiles(table.profiles, occupied, requested)
+					if want := migLayoutExists(table.profiles, occupied, requested); ok != want {
+						t.Fatalf("occupied=%+v requested=%v: placed=%v, layout exists=%v", occupied, requested, ok, want)
+					}
+					if ok {
+						resolved, _ := resolveMigRequests(table.profiles, requested)
+						assertValidMigLayout(t, resolved, occupied, got)
+					}
+				}
+			}
+			t.Logf("%d occupancy/request combinations", cases)
+		})
+	}
+}
+
+// BenchmarkPlaceMigProfilesWorstFit is the largest search a feasible request
+// causes on the supported tables: the 1g.20gb must take slot 6, which is ranked
+// last, so its three lower placements are each tried and rejected first.
+func BenchmarkPlaceMigProfilesWorstFit(b *testing.B) {
+	profiles := h100TopologyProfiles()
+	requested := []string{"1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.20gb"}
+	b.ReportAllocs()
+	for range b.N {
+		if _, ok := placeMigProfiles(profiles, nil, requested); !ok {
+			b.Fatal("six 1g.10gb and a 1g.20gb should fit an empty H100")
+		}
+	}
+}
+
+// BenchmarkPlaceMigProfilesWorstRejection is the largest search a rejection
+// causes on the supported tables: three 2g.10gb and two 1g.5gb fit the slice
+// count, but the 2g placements cover slots 0-5 and only slot 6 is left for
+// the 1g pair.
+func BenchmarkPlaceMigProfilesWorstRejection(b *testing.B) {
+	profiles := a100TopologyProfiles()
+	requested := []string{"1g.5gb", "1g.5gb", "2g.10gb", "2g.10gb", "2g.10gb"}
+	b.ReportAllocs()
+	for range b.N {
+		if _, ok := placeMigProfiles(profiles, nil, requested); ok {
+			b.Fatal("two 1g.5gb and three 2g.10gb must not fit an A100")
+		}
 	}
 }

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -367,6 +367,46 @@ func TestPlaceMigProfilesHandles4gWhenRequestedTogether(t *testing.T) {
 	}
 }
 
+func TestPlaceMigProfilesBacktracksWhenGreedyFails(t *testing.T) {
+	t.Run("review counterexample", func(t *testing.T) {
+		// a:[0,1),[4,5) and b:[0,1),[1,2). The greedy path takes a at 0 and strands the
+		// second b; the only valid layout is a at 4 with both b placements.
+		profiles := []device.MigProfile{
+			{Name: "a", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 4, Size: 1}}},
+			{Name: "b", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}}},
+		}
+		got, ok := placeMigProfiles(profiles, nil, []string{"a", "b", "b"})
+		if !ok {
+			t.Fatal("a + b + b has a valid layout and must be placed")
+		}
+		want := []device.MigPlacement{{Start: 4, Size: 1}, {Start: 0, Size: 1}, {Start: 1, Size: 1}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("placements = %+v, want %+v", got, want)
+		}
+	})
+	t.Run("H100 double-memory 1g with four 1g", func(t *testing.T) {
+		// The greedy path packs both 1g.20gb into the lower half and leaves only three 1g
+		// slots. The search moves the second 1g.20gb to [6,8), the only way to use slice 7.
+		got, ok := placeMigProfiles(h100TopologyProfiles(), nil, []string{"1g.20gb", "1g.20gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb"})
+		if !ok {
+			t.Fatal("2 x 1g.20gb + 4 x 1g.10gb fills an H100 and must be placed")
+		}
+		want := []device.MigPlacement{{Start: 0, Size: 2}, {Start: 6, Size: 2}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 5, Size: 1}, {Start: 4, Size: 1}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("placements = %+v, want %+v", got, want)
+		}
+	})
+}
+
+func TestPlaceMigProfilesGivesUpWithinBudget(t *testing.T) {
+	// Eight 1g add up to eight slices, but slice 7 is unreachable by a 1g, so no layout
+	// exists. The search must report that within its budget instead of running unbounded.
+	requested := []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"}
+	if _, ok := placeMigProfiles(a100TopologyProfiles(), nil, requested); ok {
+		t.Fatal("eight 1g must not fit an A100")
+	}
+}
+
 func TestSelectMigPlacementFallsBackToFirstFit(t *testing.T) {
 	// Without independent halves the score reduces to the lowest free start.
 	got := sequentialPlacements(t, straddlingProfiles(), nil, []string{"1g", "1g", "1g"})

--- a/pkg/device/nvidia/mig_topology_test.go
+++ b/pkg/device/nvidia/mig_topology_test.go
@@ -33,6 +33,15 @@ func a100TopologyProfiles() []device.MigProfile {
 	}
 }
 
+// a100NoSlotSevenProfiles is an A100 allowlist where no profile reaches slot 7, so the table ends at 7.
+func a100NoSlotSevenProfiles() []device.MigProfile {
+	return []device.MigProfile{
+		{Name: "1g.5gb", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}, {Start: 4, Size: 1}, {Start: 5, Size: 1}, {Start: 6, Size: 1}}},
+		{Name: "2g.10gb", Placements: []device.MigPlacement{{Start: 0, Size: 2}, {Start: 2, Size: 2}, {Start: 4, Size: 2}}},
+		{Name: "4g.20gb", Placements: []device.MigPlacement{{Start: 0, Size: 4}}},
+	}
+}
+
 // a30TopologyProfiles has four memory slices and four compute slices.
 func a30TopologyProfiles() []device.MigProfile {
 	return []device.MigProfile{
@@ -63,6 +72,20 @@ func straddlingProfiles() []device.MigProfile {
 	return []device.MigProfile{
 		{Name: "1g", Placements: []device.MigPlacement{{Start: 0, Size: 1}, {Start: 1, Size: 1}, {Start: 2, Size: 1}, {Start: 3, Size: 1}}},
 		{Name: "2g", Placements: []device.MigPlacement{{Start: 1, Size: 2}}},
+	}
+}
+
+// slidingWindowProfiles is a synthetic table of two-slice placements offset by
+// one slot each, so every placement overlaps its neighbours. The tail placement
+// stretches the card to a final slot no window can reach.
+func slidingWindowProfiles(slots int) []device.MigProfile {
+	windows := make([]device.MigPlacement, 0, slots-2)
+	for start := range slots - 2 {
+		windows = append(windows, device.MigPlacement{Start: uint32(start), Size: 2})
+	}
+	return []device.MigProfile{
+		{Name: "window", Placements: windows},
+		{Name: "tail", Placements: []device.MigPlacement{{Start: uint32(slots - 2), Size: 2}}},
 	}
 }
 
@@ -105,6 +128,8 @@ func TestMigRegionsSplitTheCardInHalves(t *testing.T) {
 		want     []migRegion
 	}{
 		{name: "A100", profiles: a100TopologyProfiles(), want: []migRegion{{start: 0, end: 4}, {start: 4, end: 8}}},
+		// The allowlist ends at slot 7, but the halves still meet at 4.
+		{name: "A100 allowlist without slot 7", profiles: a100NoSlotSevenProfiles(), want: []migRegion{{start: 0, end: 4}, {start: 4, end: 7}}},
 		{name: "A30", profiles: a30TopologyProfiles(), want: []migRegion{{start: 0, end: 2}, {start: 2, end: 4}}},
 		{name: "H100 with 4g and double-memory 1g", profiles: h100TopologyProfiles(), want: []migRegion{{start: 0, end: 4}, {start: 4, end: 8}}},
 		{name: "straddling placement keeps one region", profiles: straddlingProfiles(), want: []migRegion{{start: 0, end: 4}}},
@@ -121,12 +146,14 @@ func TestMigRegionsSplitTheCardInHalves(t *testing.T) {
 }
 
 func TestMigReservedRegionIsTheUpperHalf(t *testing.T) {
-	// A100 and H100: [4,8) holds fewer placements than [0,4). A30: both halves tie, so the upper one wins.
+	// A100 and H100: [4,8) holds fewer placements than [0,4), and so does [4,7) when the
+	// allowlist ends at slot 7. A30: both halves tie, so the upper one wins.
 	for _, tc := range []struct {
 		name     string
 		profiles []device.MigProfile
 	}{
 		{name: "A100", profiles: a100TopologyProfiles()},
+		{name: "A100 allowlist without slot 7", profiles: a100NoSlotSevenProfiles()},
 		{name: "A30", profiles: a30TopologyProfiles()},
 		{name: "H100", profiles: h100TopologyProfiles()},
 	} {
@@ -399,11 +426,14 @@ func TestPlaceMigProfilesBacktracksWhenGreedyFails(t *testing.T) {
 }
 
 func TestPlaceMigProfilesGivesUpWithinBudget(t *testing.T) {
-	// Eight 1g add up to eight slices, but slice 7 is unreachable by a 1g, so no layout
-	// exists. The search must report that within its budget instead of running unbounded.
-	requested := []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"}
-	if _, ok := placeMigProfiles(a100TopologyProfiles(), nil, requested); ok {
-		t.Fatal("eight 1g must not fit an A100")
+	// Sixteen slots and eight requests for the sliding window: the slice count and the
+	// placement count both allow the request, but only seven windows fit without
+	// overlap, and identical requests make the search retry every order. Unbounded,
+	// it visits about 66,000 candidates; the budget stops it at migSearchBudget and
+	// reports that no layout exists.
+	requested := []string{"window", "window", "window", "window", "window", "window", "window", "window"}
+	if _, ok := placeMigProfiles(slidingWindowProfiles(16), nil, requested); ok {
+		t.Fatal("eight windows must not fit fifteen usable slots")
 	}
 }
 
@@ -557,6 +587,17 @@ func TestPlaceMigProfilesReportsInfeasible(t *testing.T) {
 	// 2+2+2+1+1 adds up to eight slices, but slice 7 is only reachable by a 3g.
 	if _, ok := placeMigProfiles(allowed, nil, []string{"2g.10gb", "2g.10gb", "2g.10gb", "1g.5gb", "1g.5gb"}); ok {
 		t.Fatal("three 2g plus two 1g must not fit an A100")
+	}
+	// Eight 1g add up to eight slices, but only seven 1g placements exist, so the
+	// request is rejected before any search.
+	if _, ok := placeMigProfiles(allowed, nil, []string{"1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb", "1g.5gb"}); ok {
+		t.Fatal("eight 1g must not fit an A100")
+	}
+	// The media-extension 1g shares the plain 1g placements, so both names count
+	// against the same seven placements.
+	h100 := h100TopologyProfiles()
+	if _, ok := placeMigProfiles(h100, nil, []string{"1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb", "1g.10gb+me", "1g.10gb+me"}); ok {
+		t.Fatal("six 1g.10gb plus two 1g.10gb+me must not fit an H100")
 	}
 	if got, ok := placeMigProfiles(allowed, nil, nil); !ok || len(got) != 0 {
 		t.Fatalf("empty request = %+v, %v; want empty success", got, ok)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
Before this PR MIG  takes the first free slot based on the profile name example :- 1g and 3g scan from the top, the rest from the bottom, and it never look back what is left.
This PR changes check Whenever a container asks for several slices on one card, the profile with the fewest free positions is placed first. Each and every candidate position is scored by the largest free run it leaves, after then by how many legal placements survive.
**Which issue(s) this PR fixes**:
Fixes #2831 
AI Disclosure :- This pr is used AI for understanding the code  , optimizing the code quality and writing comment (for increasing the readblity )and writing the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved NVIDIA MIG allocation by planning multiple slices on the same GPU together.
  - Selects suitable profiles and conflict-free placements to use GPU capacity more efficiently.
  - Makes placement decisions that better preserve capacity in fragmented layouts.
  - Retains valid allocation plans through resource updates.

- **Bug Fixes**
  - Added fallback handling when joint MIG planning is unavailable.
  - Prevents stale or conflicting allocation plans from being committed.
  - Improves reliability when requested MIG slices cannot be placed together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->