### PR TITLE
feat(scheduler): bound Filter's per-node goroutine fan-out

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -69,7 +69,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.SchedulerName, "scheduler-name", "", "the name to be added to pod.spec.schedulerName if not empty")
 	rootCmd.Flags().StringVar(&config.NodeSchedulerPolicy, "node-scheduler-policy", util.NodeSchedulerPolicyBinpack.String(), "node scheduler policy")
 	rootCmd.Flags().StringVar(&device.GPUSchedulerPolicy, "gpu-scheduler-policy", util.GPUSchedulerPolicySpread.String(), "GPU scheduler policy")
-	rootCmd.Flags().IntVar(&config.FilterParallelism, "filter-parallelism", 0, "maximum number of candidate nodes scored concurrently during Filter (0 means runtime.GOMAXPROCS)")
+	rootCmd.Flags().IntVar(&config.FilterParallelism, "filter-parallelism", 0, "maximum number of candidate nodes scored concurrently during Filter (zero or negative means runtime.GOMAXPROCS)")
 	rootCmd.Flags().StringVar(&config.MetricsBindAddress, "metrics-bind-address", ":9395", "The TCP address that the scheduler should bind to for serving prometheus metrics(e.g. 127.0.0.1:9395, :9395)")
 	rootCmd.Flags().StringToStringVar(&config.NodeLabelSelector, "node-label-selector", nil, "key=value pairs separated by commas")
 

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -69,6 +69,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.SchedulerName, "scheduler-name", "", "the name to be added to pod.spec.schedulerName if not empty")
 	rootCmd.Flags().StringVar(&config.NodeSchedulerPolicy, "node-scheduler-policy", util.NodeSchedulerPolicyBinpack.String(), "node scheduler policy")
 	rootCmd.Flags().StringVar(&device.GPUSchedulerPolicy, "gpu-scheduler-policy", util.GPUSchedulerPolicySpread.String(), "GPU scheduler policy")
+	rootCmd.Flags().IntVar(&config.FilterParallelism, "filter-parallelism", 0, "maximum number of candidate nodes scored concurrently during Filter (0 means runtime.GOMAXPROCS)")
 	rootCmd.Flags().StringVar(&config.MetricsBindAddress, "metrics-bind-address", ":9395", "The TCP address that the scheduler should bind to for serving prometheus metrics(e.g. 127.0.0.1:9395, :9395)")
 	rootCmd.Flags().StringToStringVar(&config.NodeLabelSelector, "node-label-selector", nil, "key=value pairs separated by commas")
 

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -64,6 +64,13 @@ var (
 	// another PodGroup member. Zero disables retry (fail-fast).
 	NodeLockRetryTimeout time.Duration
 
+	// FilterParallelism bounds how many candidate nodes Filter scores
+	// concurrently. Scoring a node deep-copies its whole NodeUsage, so an
+	// unbounded goroutine per node makes peak memory grow with cluster size
+	// inside a synchronous extender call. Zero or negative selects
+	// runtime.GOMAXPROCS.
+	FilterParallelism int
+
 	// If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it, default value is true.
 	ForceOverwriteDefaultScheduler bool
 

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -417,7 +417,21 @@ func filterWorkerCount(nodeCount int) int {
 
 // runNodeWorkers calls fn once for every node, running at most workers of them
 // at a time. Callers must make fn safe for concurrent use.
+//
+// The worker count is normalised here rather than only in the caller: with no
+// worker no one ever receives from jobs, so a non-positive value handed in by
+// any future caller would block on the first send instead of failing. Such a
+// value falls back to runtime.GOMAXPROCS, the same meaning
+// config.FilterParallelism gives it, and an empty node set returns before any
+// goroutine is started.
 func runNodeWorkers(nodes map[string]*NodeUsage, workers int, fn func(nodeID string, node *NodeUsage)) {
+	if len(nodes) == 0 {
+		return
+	}
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+
 	type nodeJob struct {
 		nodeID string
 		node   *NodeUsage

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -17,6 +17,7 @@ package scheduler
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -399,6 +400,48 @@ func (s *Scheduler) recordFilteringFailures(task *corev1.Pod, failureReason map[
 	}
 }
 
+// filterWorkerCount reports how many nodes calcScoreWithOptions scores
+// concurrently. scoreNode deep-copies the whole NodeUsage once for the app
+// containers and once per non-sidecar init container, so one goroutine per
+// candidate node makes both the goroutine count and the concurrent copy
+// footprint grow with cluster size. config.FilterParallelism caps that;
+// zero or negative selects runtime.GOMAXPROCS. The result never exceeds
+// nodeCount, so clusters smaller than the cap keep the parallelism they had.
+func filterWorkerCount(nodeCount int) int {
+	workers := config.FilterParallelism
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	return min(workers, nodeCount)
+}
+
+// runNodeWorkers calls fn once for every node, running at most workers of them
+// at a time. Callers must make fn safe for concurrent use.
+func runNodeWorkers(nodes map[string]*NodeUsage, workers int, fn func(nodeID string, node *NodeUsage)) {
+	type nodeJob struct {
+		nodeID string
+		node   *NodeUsage
+	}
+	jobs := make(chan nodeJob)
+
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				fn(job.nodeID, job.node)
+			}
+		}()
+	}
+
+	for nodeID, node := range nodes {
+		jobs <- nodeJob{nodeID: nodeID, node: node}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
 func (s *Scheduler) calcScore(nodes *map[string]*NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, failedNodes map[string]string) (*policy.NodeScoreList, error) {
 	return s.calcScoreWithOptions(nodes, resourceReqs, task, failedNodes, true, false)
 }
@@ -415,42 +458,35 @@ func (s *Scheduler) calcScoreWithOptions(nodes *map[string]*NodeUsage, resourceR
 		NodeList: make([]*policy.NodeScore, 0),
 	}
 
-	wg := sync.WaitGroup{}
 	fitNodesMutex := sync.Mutex{}
 	failedNodesMutex := sync.Mutex{}
 	failureReason := make(map[string][]string)
 	errCh := make(chan error, len(*nodes))
 
-	for nodeID, node := range *nodes {
-		wg.Add(1)
-		go func(nodeID string, node *NodeUsage) {
-			defer wg.Done()
+	runNodeWorkers(*nodes, filterWorkerCount(len(*nodes)), func(nodeID string, node *NodeUsage) {
+		result := s.scoreNode(nodeID, node, resourceReqs, task, userNodePolicy, deviceScoringWeights)
 
-			result := s.scoreNode(nodeID, node, resourceReqs, task, userNodePolicy, deviceScoringWeights)
+		switch {
+		case result.err != nil:
+			failedNodesMutex.Lock()
+			failedNodes[nodeID] = result.reason
+			failedNodesMutex.Unlock()
+			errCh <- result.err
 
-			switch {
-			case result.err != nil:
-				failedNodesMutex.Lock()
-				failedNodes[nodeID] = result.reason
-				failedNodesMutex.Unlock()
-				errCh <- result.err
-
-			case result.score == nil:
-				failedNodesMutex.Lock()
-				failedNodes[nodeID] = result.reason
-				for reasonType := range common.ParseReason(result.reason) {
-					failureReason[reasonType] = append(failureReason[reasonType], nodeID)
-				}
-				failedNodesMutex.Unlock()
-
-			default:
-				fitNodesMutex.Lock()
-				res.NodeList = append(res.NodeList, result.score)
-				fitNodesMutex.Unlock()
+		case result.score == nil:
+			failedNodesMutex.Lock()
+			failedNodes[nodeID] = result.reason
+			for reasonType := range common.ParseReason(result.reason) {
+				failureReason[reasonType] = append(failureReason[reasonType], nodeID)
 			}
-		}(nodeID, node)
-	}
-	wg.Wait()
+			failedNodesMutex.Unlock()
+
+		default:
+			fitNodesMutex.Lock()
+			res.NodeList = append(res.NodeList, result.score)
+			fitNodesMutex.Unlock()
+		}
+	})
 	close(errCh)
 
 	if recordEvents && len(res.NodeList) == 0 {

--- a/pkg/scheduler/score_parallelism_test.go
+++ b/pkg/scheduler/score_parallelism_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+func TestFilterWorkerCount(t *testing.T) {
+	original := config.FilterParallelism
+	t.Cleanup(func() { config.FilterParallelism = original })
+
+	gomaxprocs := runtime.GOMAXPROCS(0)
+
+	tests := []struct {
+		name        string
+		parallelism int
+		nodeCount   int
+		want        int
+	}{
+		{
+			name:        "explicit parallelism below node count is honoured",
+			parallelism: 2,
+			nodeCount:   16,
+			want:        2,
+		},
+		{
+			name:        "worker count never exceeds the node count",
+			parallelism: 64,
+			nodeCount:   3,
+			want:        3,
+		},
+		{
+			name:        "zero falls back to GOMAXPROCS",
+			parallelism: 0,
+			nodeCount:   1024,
+			want:        gomaxprocs,
+		},
+		{
+			name:        "negative falls back to GOMAXPROCS",
+			parallelism: -1,
+			nodeCount:   1024,
+			want:        gomaxprocs,
+		},
+		{
+			name:        "no candidate nodes needs no workers",
+			parallelism: 8,
+			nodeCount:   0,
+			want:        0,
+		},
+		{
+			name:        "single node stays single worker",
+			parallelism: 8,
+			nodeCount:   1,
+			want:        1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.FilterParallelism = test.parallelism
+			assert.Equal(t, test.want, filterWorkerCount(test.nodeCount))
+		})
+	}
+}
+
+// TestRunNodeWorkersBoundsConcurrency is the regression guard for the bound
+// itself. The equivalence test below only proves the results are unchanged,
+// which stays true if the worker pool is reverted to one goroutine per node,
+// so this asserts the property the pool exists to provide: no more than
+// `workers` calls to fn are ever in flight at once.
+//
+// The upper-bound assertion is timing-independent — a correct pool can never
+// exceed the limit. The sleep only widens the window in which an unbounded
+// implementation would be caught overlapping.
+func TestRunNodeWorkersBoundsConcurrency(t *testing.T) {
+	const nodeCount = 32
+
+	nodes := make(map[string]*NodeUsage, nodeCount)
+	for i := range nodeCount {
+		name := "node" + strconv.Itoa(i)
+		nodes[name] = &NodeUsage{
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		}
+	}
+
+	for _, workers := range []int{1, 2, 4} {
+		t.Run("workers="+strconv.Itoa(workers), func(t *testing.T) {
+			var inFlight, peak atomic.Int64
+
+			visitMutex := sync.Mutex{}
+			visits := map[string]int{}
+
+			runNodeWorkers(nodes, workers, func(nodeID string, node *NodeUsage) {
+				current := inFlight.Add(1)
+				for {
+					observed := peak.Load()
+					if current <= observed || peak.CompareAndSwap(observed, current) {
+						break
+					}
+				}
+
+				time.Sleep(2 * time.Millisecond)
+
+				visitMutex.Lock()
+				visits[nodeID]++
+				visitMutex.Unlock()
+
+				inFlight.Add(-1)
+			})
+
+			assert.Assert(t, peak.Load() <= int64(workers),
+				"observed %d concurrent calls with a limit of %d", peak.Load(), workers)
+
+			if workers > 1 {
+				assert.Assert(t, peak.Load() > 1,
+					"expected concurrent execution with a limit of %d, observed %d", workers, peak.Load())
+			}
+
+			assert.Equal(t, nodeCount, len(visits))
+			for nodeID, count := range visits {
+				assert.Equal(t, 1, count, "node %s visited %d times", nodeID, count)
+			}
+		})
+	}
+}
+
+// TestRunNodeWorkersNoNodes covers the zero-worker path: filterWorkerCount
+// returns 0 for an empty cluster, so no goroutine is started and the send loop
+// never runs. It must return rather than deadlock.
+func TestRunNodeWorkersNoNodes(t *testing.T) {
+	called := atomic.Bool{}
+	runNodeWorkers(map[string]*NodeUsage{}, 0, func(string, *NodeUsage) {
+		called.Store(true)
+	})
+	assert.Equal(t, false, called.Load())
+}
+
+// parallelismTestContainer builds a container requesting one whole-card slice.
+func parallelismTestContainer(name string, memory int64) corev1.Container {
+	return corev1.Container{
+		Name: name,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"hami.io/gpu":      *resource.NewQuantity(1, resource.BinarySI),
+				"hami.io/gpucores": *resource.NewQuantity(10, resource.BinarySI),
+				"hami.io/gpumem":   *resource.NewQuantity(memory, resource.BinarySI),
+			},
+		},
+	}
+}
+
+// parallelismTestNodes builds nodeCount nodes carrying gpusPerNode devices each.
+// Node "node0" is deliberately given devices too small for the request so the
+// fixture exercises the fit path and the rejection path in the same run.
+func parallelismTestNodes(nodeCount, gpusPerNode int) *map[string]*NodeUsage {
+	nodes := make(map[string]*NodeUsage, nodeCount)
+	for i := range nodeCount {
+		name := "node" + strconv.Itoa(i)
+		k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+
+		totalmem := int32(8000)
+		if i == 0 {
+			totalmem = 10
+		}
+
+		lists := make([]*policy.DeviceListsScore, 0, gpusPerNode)
+		infos := make([]device.DeviceInfo, 0, gpusPerNode)
+		for g := range gpusPerNode {
+			id := name + "-gpu" + strconv.Itoa(g)
+			lists = append(lists, &policy.DeviceListsScore{
+				Device: &device.DeviceUsage{
+					ID:        id,
+					Index:     uint(g),
+					Count:     10,
+					Totalmem:  totalmem,
+					Totalcore: 100,
+					Numa:      g % 2,
+					Type:      nvidia.NvidiaGPUDevice,
+					Health:    true,
+				},
+			})
+			infos = append(infos, device.DeviceInfo{
+				ID:      id,
+				Index:   uint(g),
+				Count:   10,
+				Devmem:  totalmem,
+				Devcore: 100,
+				Type:    nvidia.NvidiaGPUDevice,
+				Health:  true,
+			})
+		}
+
+		nodes[name] = &NodeUsage{
+			Node: k8sNode,
+			NodeInfo: &device.NodeInfo{
+				ID:      name,
+				Node:    k8sNode,
+				Devices: map[string][]device.DeviceInfo{nvidia.NvidiaGPUDevice: infos},
+			},
+			Devices: policy.DeviceUsageList{
+				Policy:      util.GPUSchedulerPolicySpread.String(),
+				DeviceLists: lists,
+			},
+		}
+	}
+	return &nodes
+}
+
+// parallelismTestPod builds a pod with initCount init containers and one app
+// container, plus the matching per-container device requests.
+func parallelismTestPod(initCount int) (*corev1.Pod, device.PodDeviceRequests) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "parallelism", Namespace: "default"},
+	}
+	for i := range initCount {
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers,
+			parallelismTestContainer("init"+strconv.Itoa(i), 1000))
+	}
+	pod.Spec.Containers = append(pod.Spec.Containers,
+		parallelismTestContainer("app", 1000))
+
+	reqs := make(device.PodDeviceRequests, 0, initCount+1)
+	for range initCount + 1 {
+		reqs = append(reqs, device.ContainerDeviceRequests{
+			"hami.io/vgpu-devices-to-allocate": device.ContainerDeviceRequest{
+				Nums:     1,
+				Type:     nvidia.NvidiaGPUDevice,
+				Memreq:   1000,
+				Coresreq: 10,
+			},
+		})
+	}
+	return pod, reqs
+}
+
+// scoreOutcome is the order-independent view of one calcScoreWithOptions run.
+// NodeList order reflects goroutine completion order, so it is keyed by node
+// rather than compared as a slice.
+type scoreOutcome struct {
+	fit         map[string]device.PodDevices
+	scores      map[string]float32
+	failedNodes map[string]string
+}
+
+func runCalcScore(t *testing.T, parallelism, nodeCount, initCount int) scoreOutcome {
+	t.Helper()
+
+	config.FilterParallelism = parallelism
+	pod, reqs := parallelismTestPod(initCount)
+	nodes := parallelismTestNodes(nodeCount, 4)
+	failedNodes := map[string]string{}
+
+	res, err := (&Scheduler{}).calcScoreWithOptions(nodes, reqs, pod, failedNodes, false, false)
+	assert.NilError(t, err)
+
+	outcome := scoreOutcome{
+		fit:         map[string]device.PodDevices{},
+		scores:      map[string]float32{},
+		failedNodes: failedNodes,
+	}
+	for _, node := range res.NodeList {
+		outcome.fit[node.NodeID] = node.Devices
+		outcome.scores[node.NodeID] = node.Score
+	}
+	return outcome
+}
+
+// TestCalcScoreParallelismEquivalence is the equivalence check promised in
+// issue #2858: bounding the worker count changes only how the work is
+// scheduled, so every parallelism setting must produce the same fit set,
+// the same per-node allocations, the same scores and the same rejections.
+// Serial execution (parallelism 1) is the reference.
+func TestCalcScoreParallelismEquivalence(t *testing.T) {
+	original := config.FilterParallelism
+	t.Cleanup(func() { config.FilterParallelism = original })
+
+	const nodeCount = 12
+
+	for _, initCount := range []int{0, 3} {
+		t.Run("initContainers="+strconv.Itoa(initCount), func(t *testing.T) {
+			reference := runCalcScore(t, 1, nodeCount, initCount)
+
+			// The fixture must exercise both paths, otherwise the comparison
+			// below would pass on an empty result.
+			assert.Assert(t, len(reference.fit) > 0, "expected at least one fitting node")
+			assert.Assert(t, len(reference.failedNodes) > 0, "expected at least one rejected node")
+
+			for _, parallelism := range []int{2, 4, 64, 0, -1} {
+				t.Run("parallelism="+strconv.Itoa(parallelism), func(t *testing.T) {
+					got := runCalcScore(t, parallelism, nodeCount, initCount)
+					assert.DeepEqual(t, reference.fit, got.fit)
+					assert.DeepEqual(t, reference.scores, got.scores)
+					assert.DeepEqual(t, reference.failedNodes, got.failedNodes)
+				})
+			}
+		})
+	}
+}
+
+// TestCalcScoreParallelismNoCandidateNodes covers the zero-worker path: with
+// no candidate nodes no goroutine is started and the send loop never runs, so
+// the function must still return cleanly rather than deadlock.
+func TestCalcScoreParallelismNoCandidateNodes(t *testing.T) {
+	original := config.FilterParallelism
+	t.Cleanup(func() { config.FilterParallelism = original })
+	config.FilterParallelism = 8
+
+	pod, reqs := parallelismTestPod(0)
+	nodes := map[string]*NodeUsage{}
+	failedNodes := map[string]string{}
+
+	res, err := (&Scheduler{}).calcScoreWithOptions(&nodes, reqs, pod, failedNodes, false, false)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(res.NodeList))
+	assert.Equal(t, 0, len(failedNodes))
+}

--- a/pkg/scheduler/score_parallelism_test.go
+++ b/pkg/scheduler/score_parallelism_test.go
@@ -64,13 +64,15 @@ func TestFilterWorkerCount(t *testing.T) {
 			name:        "zero falls back to GOMAXPROCS",
 			parallelism: 0,
 			nodeCount:   1024,
-			want:        gomaxprocs,
+			// The node-count cap applies to the fallback too, so a host with
+			// more than 1024 CPUs is still capped at the candidate count.
+			want: min(gomaxprocs, 1024),
 		},
 		{
 			name:        "negative falls back to GOMAXPROCS",
 			parallelism: -1,
 			nodeCount:   1024,
-			want:        gomaxprocs,
+			want:        min(gomaxprocs, 1024),
 		},
 		{
 			name:        "no candidate nodes needs no workers",
@@ -94,6 +96,19 @@ func TestFilterWorkerCount(t *testing.T) {
 	}
 }
 
+// bareTestNodes builds nodeCount NodeUsage entries carrying nothing but a node
+// name. runNodeWorkers only fans the map out, so its tests need no devices.
+func bareTestNodes(nodeCount int) map[string]*NodeUsage {
+	nodes := make(map[string]*NodeUsage, nodeCount)
+	for i := range nodeCount {
+		name := "node" + strconv.Itoa(i)
+		nodes[name] = &NodeUsage{
+			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
+		}
+	}
+	return nodes
+}
+
 // TestRunNodeWorkersBoundsConcurrency is the regression guard for the bound
 // itself. The equivalence test below only proves the results are unchanged,
 // which stays true if the worker pool is reverted to one goroutine per node,
@@ -106,13 +121,7 @@ func TestFilterWorkerCount(t *testing.T) {
 func TestRunNodeWorkersBoundsConcurrency(t *testing.T) {
 	const nodeCount = 32
 
-	nodes := make(map[string]*NodeUsage, nodeCount)
-	for i := range nodeCount {
-		name := "node" + strconv.Itoa(i)
-		nodes[name] = &NodeUsage{
-			Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
-		}
-	}
+	nodes := bareTestNodes(nodeCount)
 
 	for _, workers := range []int{1, 2, 4} {
 		t.Run("workers="+strconv.Itoa(workers), func(t *testing.T) {
@@ -156,14 +165,72 @@ func TestRunNodeWorkersBoundsConcurrency(t *testing.T) {
 }
 
 // TestRunNodeWorkersNoNodes covers the zero-worker path: filterWorkerCount
-// returns 0 for an empty cluster, so no goroutine is started and the send loop
-// never runs. It must return rather than deadlock.
+// returns 0 for an empty cluster, so no goroutine is started and fn is never
+// called. It must return rather than deadlock.
 func TestRunNodeWorkersNoNodes(t *testing.T) {
 	called := atomic.Bool{}
 	runNodeWorkers(map[string]*NodeUsage{}, 0, func(string, *NodeUsage) {
 		called.Store(true)
 	})
 	assert.Equal(t, false, called.Load())
+}
+
+// TestRunNodeWorkersNonPositiveWorkers pins the guard inside runNodeWorkers.
+// Without it a non-positive worker count starts no worker, leaving the first
+// send on the unbuffered jobs channel with no receiver: the helper would hang
+// forever on a non-empty node set. Every node must still be visited exactly
+// once, under the GOMAXPROCS fallback bound.
+//
+// The test would hang rather than fail if the guard were removed, so it runs
+// the fan-out in a goroutine and fails on a timeout instead.
+func TestRunNodeWorkersNonPositiveWorkers(t *testing.T) {
+	const nodeCount = 16
+
+	for _, workers := range []int{0, -1} {
+		t.Run("workers="+strconv.Itoa(workers), func(t *testing.T) {
+			nodes := bareTestNodes(nodeCount)
+
+			var peak atomic.Int64
+			var inFlight atomic.Int64
+
+			visitMutex := sync.Mutex{}
+			visits := map[string]int{}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				runNodeWorkers(nodes, workers, func(nodeID string, node *NodeUsage) {
+					current := inFlight.Add(1)
+					for {
+						observed := peak.Load()
+						if current <= observed || peak.CompareAndSwap(observed, current) {
+							break
+						}
+					}
+
+					visitMutex.Lock()
+					visits[nodeID]++
+					visitMutex.Unlock()
+
+					inFlight.Add(-1)
+				})
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				t.Fatalf("runNodeWorkers blocked with workers=%d", workers)
+			}
+
+			assert.Equal(t, nodeCount, len(visits))
+			for nodeID, count := range visits {
+				assert.Equal(t, 1, count, "node %s visited %d times", nodeID, count)
+			}
+			assert.Assert(t, peak.Load() <= int64(runtime.GOMAXPROCS(0)),
+				"observed %d concurrent calls, expected at most GOMAXPROCS=%d",
+				peak.Load(), runtime.GOMAXPROCS(0))
+		})
+	}
 }
 
 // parallelismTestContainer builds a container requesting one whole-card slice.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`calcScoreWithOptions` spawned one goroutine per candidate node, and each call to `scoreNode` deep-copies the node's `NodeUsage` once per app/init container — so goroutine count and simultaneous copies both scaled with cluster size inside a synchronous extender call kube-scheduler blocks on.

This routes scoring through a worker pool bounded by a new `--filter-parallelism` flag, defaulting to `runtime.GOMAXPROCS` and capped at the node count (so small clusters keep existing parallelism, empty clusters spawn nothing). Scoring, aggregation, and the Filter response are unchanged.

**AI disclosure:**
I used AI assistance to verify the implementation and draft the PR description. I reviewed the implementation and final changes myself.



The changes are limited to the scheduler extender. No device allocation, device plugin, or in-container isolation code was modified. Therefore, the changes are covered by unit and mock testing in accordance with Contribution Gate 2.

**Which issue(s) this PR fixes**:
Fixes #2858

**Does this PR introduce a user-facing change?**:
```release-note
Add `--filter-parallelism` to the scheduler, bounding how many candidate nodes are scored concurrently during Filter. Defaults to `runtime.GOMAXPROCS`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a command-line option to control scheduler filtering parallelism.
- Scheduler filtering now supports bounded concurrent node scoring, with automatic CPU-based defaults and safeguards for small workloads.

## Bug Fixes
- Improved consistency and reliability of parallel node scoring across different parallelism settings, including empty workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->