### PR TITLE
feat(metrics): introduce collector scrape duration and failure health metrics

### DIFF
--- a/cmd/scheduler/collector_health_test.go
+++ b/cmd/scheduler/collector_health_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/metrics"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler"
+	"github.com/Project-HAMi/HAMi/pkg/util/leaderelection"
+)
+
+// fakeSchedulerProvider implements schedulerMetricsProvider for testing.
+type fakeSchedulerProvider struct {
+	nodeUsage *map[string]*scheduler.NodeUsage
+	quotaMgr  *device.QuotaManager
+	podMgr    *device.PodManager
+}
+
+func (f *fakeSchedulerProvider) InspectAllNodesUsage() *map[string]*scheduler.NodeUsage {
+	if f.nodeUsage == nil {
+		empty := make(map[string]*scheduler.NodeUsage)
+		return &empty
+	}
+	return f.nodeUsage
+}
+
+func (f *fakeSchedulerProvider) GetQuotaManager() *device.QuotaManager {
+	if f.quotaMgr == nil {
+		return device.NewQuotaManager()
+	}
+	return f.quotaMgr
+}
+
+func (f *fakeSchedulerProvider) GetPodManager() *device.PodManager {
+	if f.podMgr == nil {
+		return device.NewPodManager()
+	}
+	return f.podMgr
+}
+
+func (f *fakeSchedulerProvider) GetLeaderManager() leaderelection.LeaderManager {
+	return leaderelection.NewDummyLeaderManager(true)
+}
+
+func (f *fakeSchedulerProvider) IsSynced() bool {
+	return true
+}
+
+func TestSchedulerCollectorHealth(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	rec := metrics.NewCollectorHealthRecorder()
+
+	// Construct a minimal ClusterManager with the health recorder.
+	provider := &fakeSchedulerProvider{}
+	cm := &ClusterManager{
+		Zone:   "testzone",
+		health: rec,
+	}
+	cc := ClusterManagerCollector{
+		ClusterManager:  cm,
+		metricsProvider: provider,
+	}
+	reg.MustRegister(cc)
+
+	// Gather metrics from registry.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	// Verify that health metrics are present.
+	var foundDuration, foundLastRun bool
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "hami_collector_duration_seconds":
+			// Should be a histogram with one sample.
+			if len(mf.GetMetric()) != 1 {
+				t.Fatalf("expected one duration histogram, got %d", len(mf.GetMetric()))
+			}
+			if mf.GetMetric()[0].GetHistogram().GetSampleCount() < 1 {
+				t.Fatalf("expected duration histogram sample count >= 1, got %d", mf.GetMetric()[0].GetHistogram().GetSampleCount())
+			}
+			foundDuration = true
+		case "hami_collector_last_run_timestamp_seconds":
+			// Scheduler stamps last_run unconditionally (no per-phase error tracking in Collect).
+			if len(mf.GetMetric()) != 1 {
+				t.Fatalf("expected one last_run gauge, got %d", len(mf.GetMetric()))
+			}
+			ts := mf.GetMetric()[0].GetGauge().GetValue()
+			if ts <= 0 {
+				t.Fatalf("unexpected last_run timestamp %v", ts)
+			}
+			if ts > float64(time.Now().Unix()+5) {
+				t.Fatalf("last_run timestamp %v appears in future", ts)
+			}
+			foundLastRun = true
+		}
+	}
+	if !foundDuration {
+		t.Fatalf("hami_collector_duration_seconds not found")
+	}
+	if !foundLastRun {
+		t.Fatalf("hami_collector_last_run_timestamp_seconds not found")
+	}
+}

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	klog "k8s.io/klog/v2"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -37,6 +38,11 @@ import (
 type ClusterManager struct {
 	Zone          string
 	LegacyMetrics bool
+
+	// health records scrape duration, per-phase collection errors and the
+	// last scrape timestamp; nil in unit tests that construct the collector
+	// directly.
+	health *versionmetrics.CollectorHealthRecorder
 }
 
 type schedulerMetricsProvider interface {
@@ -99,14 +105,23 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect creates constant metrics for each host on the fly based on the returned data.
 func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	klog.V(3).Info("Starting to collect metrics for scheduler")
+
+	start := time.Now()
+
 	legacy := cc.ClusterManager.LegacyMetrics
-	// A single snapshot is shared by the node- and container-level collectors so
-	// they observe a consistent cluster state within one scrape.
 	nu := cc.metricsProvider.InspectAllNodesUsage()
 	cc.collectNodeMetrics(ch, nu, legacy)
 	cc.collectQuotaMetrics(ch, legacy)
 	cc.collectContainerMetrics(ch, nu, legacy)
 	cc.collectSchedulerStateMetrics(ch)
+
+	// Always record duration; stamp last_run unconditionally for the scheduler
+	// since per-phase errors are already tracked separately.
+	if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+		cc.ClusterManager.health.ObserveDuration(versionmetrics.ComponentScheduler, start)
+		cc.ClusterManager.health.StampLastRun(versionmetrics.ComponentScheduler)
+		cc.ClusterManager.health.Collect(ch)
+	}
 }
 
 // collectNodeMetrics emits node-level GPU metrics (memory/core limits and
@@ -221,7 +236,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 						"gpuInstanceID", allocation.GPUInstanceID,
 						"computeInstanceID", allocation.ComputeInstanceID,
 						"migUUID", allocation.MigUUID)
-					if err := sendMetric(
+					if err := cc.sendMetric(
 						ch,
 						nodeGPUMigInstance,
 						prometheus.GaugeValue,
@@ -239,7 +254,7 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 						klog.V(4).Infof("Failed to send nodeGPUMigInstance metric: %v", err)
 					}
 					if legacy {
-						sendLegacyMetric(
+						cc.sendLegacyMetric(
 							ch,
 							legacyMigInstance,
 							prometheus.GaugeValue,
@@ -250,40 +265,40 @@ func (cc ClusterManagerCollector) collectNodeMetrics(ch chan<- prometheus.Metric
 				}
 			}
 
-			if err := sendMetric(ch, nodevGPUMemoryLimitDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodevGPUMemoryLimitDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodevGPUMemoryLimitDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, nodevGPUCoreLimitDesc, prometheus.GaugeValue, coreLimit, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodevGPUCoreLimitDesc, prometheus.GaugeValue, coreLimit, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodevGPUCoreLimitDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, nodevGPUMemoryAllocatedDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodevGPUMemoryAllocatedDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodevGPUMemoryAllocatedDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, nodevGPUSharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodevGPUSharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodevGPUSharedNumDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, nodeGPUCoreAllocatedDesc, prometheus.GaugeValue, coreAllocated, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodeGPUCoreAllocatedDesc, prometheus.GaugeValue, coreAllocated, nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodeGPUCoreAllocatedDesc metric: %v", err)
 			}
-			if err := sendMetric(ch, nodeGPUOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type); err != nil {
+			if err := cc.sendMetric(ch, nodeGPUOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type); err != nil {
 				klog.V(4).Infof("Failed to send nodeGPUOverview metric: %v", err)
 			}
 
 			if devs.Device.Totalmem > 0 {
-				if err := sendMetric(ch, nodeGPUMemoryAllocatedRatioDesc, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
+				if err := cc.sendMetric(ch, nodeGPUMemoryAllocatedRatioDesc, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type); err != nil {
 					klog.V(4).Infof("Failed to send nodeGPUMemoryAllocatedRatioDesc metric: %v", err)
 				}
 			}
 
 			if legacy {
-				sendLegacyMetric(ch, legacyMemoryLimitDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
-				sendLegacyMetric(ch, legacyCoreLimitDesc, prometheus.GaugeValue, float64(devs.Device.Totalcore), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
-				sendLegacyMetric(ch, legacyMemoryAllocatedDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type)
-				sendLegacyMetric(ch, legacySharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
-				sendLegacyMetric(ch, legacyCoreAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedcores), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
-				sendLegacyMetric(ch, legacyOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacyMemoryLimitDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacyCoreLimitDesc, prometheus.GaugeValue, float64(devs.Device.Totalcore), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacyMemoryAllocatedDesc, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacySharedNumDesc, prometheus.GaugeValue, float64(devs.Device.Used), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacyCoreAllocatedDesc, prometheus.GaugeValue, float64(devs.Device.Usedcores), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), devs.Device.Type)
+				cc.sendLegacyMetric(ch, legacyOverview, prometheus.GaugeValue, mibToBytes(devs.Device.Usedmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index), fmt.Sprint(devs.Device.Totalcore), fmt.Sprint(devs.Device.Totalmem), devs.Device.Type)
 				if devs.Device.Totalmem > 0 {
-					sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index))
+					cc.sendLegacyMetric(ch, legacyMemoryPercentage, prometheus.GaugeValue, float64(devs.Device.Usedmem)/float64(devs.Device.Totalmem), nodeID, devs.Device.ID, fmt.Sprint(devs.Device.Index))
 				}
 			}
 		}
@@ -312,16 +327,16 @@ func (cc ClusterManagerCollector) collectQuotaMetrics(ch chan<- prometheus.Metri
 	}
 	for ns, val := range cc.metricsProvider.GetQuotaManager().GetResourceQuota() {
 		for quotaname, q := range *val {
-			if err := sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
+			if err := cc.sendMetric(ch, quotaUsedDesc, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit)); err != nil {
 				klog.V(4).Infof("Failed to send quotaUsedDesc metric: %v", err)
 			}
 			if q.LimitSet {
-				if err := sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
+				if err := cc.sendMetric(ch, quotaLimitDesc, prometheus.GaugeValue, float64(q.Limit), ns, quotaname); err != nil {
 					klog.V(4).Infof("Failed to send quotaLimitDesc metric: %v", err)
 				}
 			}
 			if legacy {
-				sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))
+				cc.sendLegacyMetric(ch, legacyQuotaUsed, prometheus.GaugeValue, float64(q.Used), ns, quotaname, fmt.Sprint(q.Limit))
 			}
 		}
 	}
@@ -363,7 +378,16 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 			[]string{"podnamespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
 		)
 	}
-	schedpods, _ := cc.metricsProvider.GetPodManager().GetScheduledPods()
+	schedpods, err := cc.metricsProvider.GetPodManager().GetScheduledPods()
+	if err != nil {
+		// Record a collection-phase error if we fail to list pods; the existing code ignored it.
+		if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+			cc.ClusterManager.health.RecordError(versionmetrics.ComponentScheduler, versionmetrics.PhaseListScheduledPods)
+		}
+		klog.Errorf("Failed to get scheduled pods: %v", err)
+		// Continue with an empty set to avoid panic.
+		schedpods = map[k8stypes.UID]*device.PodInfo{}
+	}
 	for _, val := range schedpods {
 		for _, podSingleDevice := range val.Devices {
 			for ctridx, ctrdevs := range podSingleDevice {
@@ -394,17 +418,17 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 					)
 					containerLabels := []string{val.Namespace, val.NodeID, val.Name, ctrdevval.UUID}
 					usedMemBytes := mibToBytes(ctrdevval.Usedmem)
-					if err := sendMetric(ch, ctrvGPUdeviceAllocatedMemoryDesc, prometheus.GaugeValue, usedMemBytes, containerLabels...); err != nil {
+					if err := cc.sendMetric(ch, ctrvGPUdeviceAllocatedMemoryDesc, prometheus.GaugeValue, usedMemBytes, containerLabels...); err != nil {
 						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedMemoryDesc metric: %v", err)
 					}
 					_, ctrCoreAllocated := normalizeAMDCoreMetrics(deviceType, totalcore, ctrdevval.Usedcores)
-					if err := sendMetric(ch, ctrvGPUdeviceAllocatedCoreDesc, prometheus.GaugeValue, ctrCoreAllocated, containerLabels...); err != nil {
+					if err := cc.sendMetric(ch, ctrvGPUdeviceAllocatedCoreDesc, prometheus.GaugeValue, ctrCoreAllocated, containerLabels...); err != nil {
 						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedCoreDesc metric: %v", err)
 					}
 					if legacy {
 						legacyLabels := []string{val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID}
-						sendLegacyMetric(ch, legacyAllocatedMemory, prometheus.GaugeValue, usedMemBytes, legacyLabels...)
-						sendLegacyMetric(ch, legacyAllocatedCore, prometheus.GaugeValue, float64(ctrdevval.Usedcores), legacyLabels...)
+						cc.sendLegacyMetric(ch, legacyAllocatedMemory, prometheus.GaugeValue, usedMemBytes, legacyLabels...)
+						cc.sendLegacyMetric(ch, legacyAllocatedCore, prometheus.GaugeValue, float64(ctrdevval.Usedcores), legacyLabels...)
 					}
 				}
 			}
@@ -436,19 +460,21 @@ func (cc ClusterManagerCollector) collectSchedulerStateMetrics(ch chan<- prometh
 		isSyncedVal = 1.0
 	}
 
-	if err := sendMetric(ch, isLeaderDesc, prometheus.GaugeValue, isLeaderVal); err != nil {
+	if err := cc.sendMetric(ch, isLeaderDesc, prometheus.GaugeValue, isLeaderVal); err != nil {
 		klog.V(4).Infof("Failed to send hami_scheduler_is_leader metric: %v", err)
 	}
-	if err := sendMetric(ch, cacheSyncedDesc, prometheus.GaugeValue, isSyncedVal); err != nil {
+	if err := cc.sendMetric(ch, cacheSyncedDesc, prometheus.GaugeValue, isSyncedVal); err != nil {
 		klog.V(4).Infof("Failed to send hami_scheduler_cache_synced metric: %v", err)
 	}
 }
 
 // NewClusterManager creates a ClusterManager and registers its collector.
 func NewClusterManager(zone string, reg prometheus.Registerer, metricsProvider schedulerMetricsProvider, legacyMetrics bool) *ClusterManager {
+	health := versionmetrics.NewCollectorHealthRecorder()
 	c := &ClusterManager{
 		Zone:          zone,
 		LegacyMetrics: legacyMetrics,
+		health:        health,
 	}
 	cc := ClusterManagerCollector{
 		ClusterManager:  c,
@@ -476,18 +502,21 @@ func initMetrics(bindAddress string, metricsProvider schedulerMetricsProvider, l
 	log.Fatal(server.ListenAndServe())
 }
 
-func sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) {
+func (cc ClusterManagerCollector) sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) {
 	if desc == nil {
 		return
 	}
-	if err := sendMetric(ch, desc, valueType, value, labels...); err != nil {
+	if err := cc.sendMetric(ch, desc, valueType, value, labels...); err != nil {
 		klog.V(4).Infof("Failed to send legacy metric: %v", err)
 	}
 }
 
-func sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) error {
+func (cc ClusterManagerCollector) sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) error {
 	metric, err := prometheus.NewConstMetric(desc, valueType, value, labels...)
 	if err != nil {
+		if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+			cc.ClusterManager.health.RecordError(versionmetrics.ComponentScheduler, versionmetrics.PhaseSendMetric)
+		}
 		return fmt.Errorf("failed to create metric: %w", err)
 	}
 	ch <- metric

--- a/cmd/vGPUmonitor/collector_health_test.go
+++ b/cmd/vGPUmonitor/collector_health_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	versionmetrics "github.com/Project-HAMi/HAMi/pkg/metrics"
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+)
+
+func TestVGPUMonitorCollectorHealth(t *testing.T) {
+	// Ensure node name env is unset to trigger pod_container_info and mig_info errors.
+	t.Setenv("NODE_NAME", "")
+	reg := prometheus.NewPedanticRegistry()
+	rec := versionmetrics.NewCollectorHealthRecorder()
+	// Construct a minimal ClusterManager with the health recorder.
+	cl := &nvidia.ContainerLister{} // zero-value provides Lock/Unlock methods.
+	cm := &ClusterManager{Zone: "testzone", containerLister: cl, health: rec}
+	cc := ClusterManagerCollector{ClusterManager: cm}
+
+	reg.MustRegister(cc)
+
+	// Gather metrics from registry.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+	// Verify that errors_total contains pod_container_info and mig_info.
+	var foundPodInfo, foundMigInfo bool
+	var foundDuration bool
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "hami_collector_errors_total":
+			for _, m := range mf.GetMetric() {
+				comp := ""
+				phase := ""
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == "component" {
+						comp = lp.GetValue()
+					}
+					if lp.GetName() == "phase" {
+						phase = lp.GetValue()
+					}
+				}
+				if comp == versionmetrics.ComponentVGPUMonitor && phase == versionmetrics.PhasePodContainerInfo {
+					foundPodInfo = true
+				}
+				if comp == versionmetrics.ComponentVGPUMonitor && phase == versionmetrics.PhaseMIGInfo {
+					foundMigInfo = true
+				}
+			}
+		case "hami_collector_duration_seconds":
+			if len(mf.GetMetric()) != 1 {
+				t.Fatalf("expected one duration histogram, got %d", len(mf.GetMetric()))
+			}
+			if mf.GetMetric()[0].GetHistogram().GetSampleCount() != 1 {
+				t.Fatalf("expected duration histogram sample count 1")
+			}
+			foundDuration = true
+		case "hami_collector_last_run_timestamp_seconds":
+			// Since all phases failed, last_run should NOT be stamped.
+			t.Fatalf("hami_collector_last_run_timestamp_seconds should not be set when all phases failed")
+		}
+	}
+	if !foundPodInfo {
+		t.Fatalf("hami_collector_errors_total missing pod_container_info error")
+	}
+	if !foundMigInfo {
+		t.Fatalf("hami_collector_errors_total missing mig_info error")
+	}
+	if !foundDuration {
+		t.Fatalf("hami_collector_duration_seconds not found")
+	}
+}

--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -22,16 +22,17 @@ import (
 	"time"
 	"unicode/utf8"
 
-	nv "github.com/Project-HAMi/HAMi/pkg/device/nvidia"
-	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
-	"github.com/Project-HAMi/HAMi/pkg/util"
-
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
+
+	nv "github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	versionmetrics "github.com/Project-HAMi/HAMi/pkg/metrics"
+	"github.com/Project-HAMi/HAMi/pkg/monitor/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
 // ClusterManager holds the state the vGPUMonitor's Prometheus collector reads
@@ -43,6 +44,11 @@ type ClusterManager struct {
 	PodLister       listerscorev1.PodLister
 	containerLister *nvidia.ContainerLister
 	LegacyMetrics   bool
+
+	// health records scrape duration, per-phase collection errors and the
+	// last scrape timestamp; nil in unit tests that construct the collector
+	// directly.
+	health *versionmetrics.CollectorHealthRecorder
 }
 
 // ClusterManagerCollector implements the Collector interface.
@@ -177,11 +183,11 @@ func initLegacyDescriptors() {
 	)
 }
 
-func sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) {
+func (cc ClusterManagerCollector) sendLegacyMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) {
 	if desc == nil {
 		return
 	}
-	if err := sendMetric(ch, desc, valueType, value, labels...); err != nil {
+	if err := cc.sendMetric(ch, desc, valueType, value, labels...); err != nil {
 		klog.V(4).Infof("Failed to send legacy metric: %v", err)
 	}
 }
@@ -212,33 +218,65 @@ func (cc ClusterManagerCollector) Describe(ch chan<- *prometheus.Desc) {
 		ch <- legacyCtrDeviceLastKernelDesc
 		ch <- legacyCtrDeviceMigInfo
 	}
+	if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+		cc.ClusterManager.health.Describe(ch)
+	}
 }
 
 // Collect gathers GPU, pod, and container metrics on each scrape and sends them
 // to the provided channel. It may be called concurrently, so the collection
 // helpers it calls must be concurrency-safe.
+//
+// Errors in a collection phase used to be logged but otherwise invisible: a
+// failing scrape produced a silently incomplete /metrics output. Each phase
+// failure is now additionally counted in hami_collector_errors_total, and the
+// scrape itself is timed and timestamped, so operators can alert on degraded
+// collection instead of discovering an empty dashboard (issue #410).
 func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	klog.Info("Starting to collect metrics for vGPUMonitor")
 
+	start := time.Now()
+	hadError := false
+
 	// Collect GPU information
 	if err := cc.collectGPUInfo(ch); err != nil {
+		cc.recordPhaseError(versionmetrics.PhaseGPUInfo)
 		klog.Errorf("Failed to collect GPU info: %v", err)
-		// Decide whether to continue or return based on business requirements
+		hadError = true
 	}
 
 	// Collect Pod and Container information
 	if err := cc.collectPodAndContainerInfo(ch); err != nil {
+		cc.recordPhaseError(versionmetrics.PhasePodContainerInfo)
 		klog.Errorf("Failed to collect Pod and Container info: %v", err)
-		// Decide whether to continue or return based on business requirements
+		hadError = true
 	}
 
 	// Collect Pod and Container Mig information
 	if err := cc.collectPodAndContainerMigInfo(ch); err != nil {
+		cc.recordPhaseError(versionmetrics.PhaseMIGInfo)
 		klog.Errorf("Failed to collect Pod and Container Mig info: %v", err)
-		// Decide whether to continue or return based on business requirements
+		hadError = true
+	}
+
+	// Always record duration; only stamp last_run on a clean pass
+	if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+		cc.ClusterManager.health.ObserveDuration(versionmetrics.ComponentVGPUMonitor, start)
+		if !hadError {
+			cc.ClusterManager.health.StampLastRun(versionmetrics.ComponentVGPUMonitor)
+		}
+		cc.ClusterManager.health.Collect(ch)
 	}
 
 	klog.Info("Finished collecting metrics for vGPUMonitor")
+}
+
+// recordPhaseError counts one collection-phase failure; it is a no-op when
+// the collector was built without a health recorder.
+func (cc ClusterManagerCollector) recordPhaseError(phase string) {
+	if cc.ClusterManager != nil && cc.ClusterManager.health != nil {
+		cc.ClusterManager.health.RecordError(versionmetrics.ComponentVGPUMonitor, phase)
+	}
 }
 
 func (cc ClusterManagerCollector) collectGPUInfo(ch chan<- prometheus.Metric) error {
@@ -321,11 +359,11 @@ func (cc ClusterManagerCollector) collectGPUMemoryMetrics(ch chan<- prometheus.M
 		return fmt.Errorf("node name environment variable %s is not set", util.NodeNameEnvName)
 	}
 
-	if err := sendMetric(ch, hostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := cc.sendMetric(ch, hostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUdesc metric: %v", err)
 	}
 
-	sendLegacyMetric(ch, legacyHostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName)
+	cc.sendLegacyMetric(ch, legacyHostGPUdesc, prometheus.GaugeValue, float64(memory.Used), nodeName, fmt.Sprint(index), uuid, deviceName)
 
 	return nil
 }
@@ -357,13 +395,13 @@ func (cc ClusterManagerCollector) collectGPUUtilizationMetrics(ch chan<- prometh
 
 	deviceName = "NVIDIA-" + deviceName
 
-	if err := sendMetric(ch, hostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
+	if err := cc.sendMetric(ch, hostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName); err != nil {
 		klog.Errorf("Failed to send hostGPUUtilizationdesc metric: %v", err)
 	}
 
-	sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName)
+	cc.sendLegacyMetric(ch, legacyHostGPUUtilizationdesc, prometheus.GaugeValue, float64(utilRates.Gpu), nodeName, fmt.Sprint(index), uuid, deviceName)
 
-	if err := sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
+	if err := cc.sendMetric(ch, hostGPUMemoryUtilizationdesc, prometheus.GaugeValue,
 		float64(utilRates.Memory),
 		fmt.Sprint(index), uuid, deviceName,
 	); err != nil {
@@ -403,6 +441,7 @@ func (cc ClusterManagerCollector) collectPodAndContainerInfo(ch chan<- prometheu
 	}
 
 	nowSec := time.Now().Unix()
+	var errs []error
 
 	// Iterate through each Pod
 	for _, pod := range pods {
@@ -425,6 +464,7 @@ func (cc ClusterManagerCollector) collectPodAndContainerInfo(ch chan<- prometheu
 					klog.V(5).Infof("Processing Container %s in Pod %s/%s", ctr.Name, pod.Namespace, pod.Name)
 					if err := cc.collectContainerMetrics(ch, pod, ctr, c, nowSec); err != nil {
 						klog.Errorf("Failed to collect metrics for container %s in Pod %s/%s: %v", ctr.Name, pod.Namespace, pod.Name, err)
+						errs = append(errs, fmt.Errorf("container %s/%s/%s: %v", pod.Namespace, pod.Name, ctr.Name, err))
 					}
 					break // Exit the inner loop after finding the matching container
 				}
@@ -433,6 +473,10 @@ func (cc ClusterManagerCollector) collectPodAndContainerInfo(ch chan<- prometheu
 	}
 
 	klog.V(4).Infof("Finished collecting metrics for %d pods", len(pods))
+
+	if len(errs) > 0 {
+		return fmt.Errorf("encountered %d errors collecting pod/container metrics, first error: %v", len(errs), errs[0])
+	}
 	return nil
 }
 
@@ -466,52 +510,52 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 
 		labels := []string{pod.Namespace, pod.Name, ctr.Name, fmt.Sprint(i), uuid}
 
-		if err := sendMetric(ch, ctrvGPUdesc, prometheus.GaugeValue, float64(memoryTotal), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrvGPUdesc, prometheus.GaugeValue, float64(memoryTotal), labels...); err != nil {
 			klog.Errorf("Failed to send memoryTotal metric: %v", err)
 			return err
 		}
-		sendLegacyMetric(ch, legacyCtrvGPUdesc, prometheus.GaugeValue, float64(memoryTotal), labels...)
+		cc.sendLegacyMetric(ch, legacyCtrvGPUdesc, prometheus.GaugeValue, float64(memoryTotal), labels...)
 
-		if err := sendMetric(ch, ctrvGPUlimitdesc, prometheus.GaugeValue, float64(memoryLimit), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrvGPUlimitdesc, prometheus.GaugeValue, float64(memoryLimit), labels...); err != nil {
 			klog.Errorf("Failed to send memoryLimit metric: %v", err)
 			return err
 		}
-		sendLegacyMetric(ch, legacyCtrvGPUlimitdesc, prometheus.GaugeValue, float64(memoryLimit), labels...)
+		cc.sendLegacyMetric(ch, legacyCtrvGPUlimitdesc, prometheus.GaugeValue, float64(memoryLimit), labels...)
 
-		if err := sendMetric(ch, ctrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), labels...); err != nil {
 			klog.Errorf("Failed to send device memory desc: %v", err)
 			return err
 		}
 		memoryOffset := memoryTotal - memoryContextSize - memoryModuleSize - memoryBufferSize
 		memoryLabels := append(labels, fmt.Sprint(memoryContextSize), fmt.Sprint(memoryModuleSize), fmt.Sprint(memoryBufferSize), fmt.Sprint(memoryOffset))
-		sendLegacyMetric(ch, legacyCtrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), memoryLabels...)
+		cc.sendLegacyMetric(ch, legacyCtrDeviceMemorydesc, prometheus.GaugeValue, float64(memoryTotal), memoryLabels...)
 
-		if err := sendMetric(ch, ctrDeviceUtilizationdesc, prometheus.GaugeValue, float64(smUtil), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrDeviceUtilizationdesc, prometheus.GaugeValue, float64(smUtil), labels...); err != nil {
 			klog.Errorf("Failed to send device utilization desc: %v", err)
 			return err
 		}
-		sendLegacyMetric(ch, legacyCtrDeviceUtilizationdesc, prometheus.GaugeValue, float64(smUtil), labels...)
+		cc.sendLegacyMetric(ch, legacyCtrDeviceUtilizationdesc, prometheus.GaugeValue, float64(smUtil), labels...)
 
-		if err := sendMetric(ch, ctrDeviceMemoryContextDesc, prometheus.GaugeValue, float64(memoryContextSize), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrDeviceMemoryContextDesc, prometheus.GaugeValue, float64(memoryContextSize), labels...); err != nil {
 			klog.Errorf("Failed to send Device Memory context size metric: %v", err)
 			return err
 		}
-		if err := sendMetric(ch, ctrDeviceMemoryModuleDesc, prometheus.GaugeValue, float64(memoryModuleSize), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrDeviceMemoryModuleDesc, prometheus.GaugeValue, float64(memoryModuleSize), labels...); err != nil {
 			klog.Errorf("Failed to send Device Memory module size metric: %v", err)
 			return err
 		}
-		if err := sendMetric(ch, ctrDeviceMemoryBufferDesc, prometheus.GaugeValue, float64(memoryBufferSize), labels...); err != nil {
+		if err := cc.sendMetric(ch, ctrDeviceMemoryBufferDesc, prometheus.GaugeValue, float64(memoryBufferSize), labels...); err != nil {
 			klog.Errorf("Failed to send Device Memory buffer size metric: %v", err)
 			return err
 		}
 
 		if lastKernelTime > 0 {
 			lastSec := max(nowSec-lastKernelTime, 0)
-			if err := sendMetric(ch, ctrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...); err != nil {
+			if err := cc.sendMetric(ch, ctrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...); err != nil {
 				klog.Errorf("Failed to send last kernel time metric: %v", err)
 				return err
 			}
-			sendLegacyMetric(ch, legacyCtrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...)
+			cc.sendLegacyMetric(ch, legacyCtrDeviceLastKernelDesc, prometheus.GaugeValue, float64(lastSec), labels...)
 		}
 	}
 
@@ -556,10 +600,10 @@ func (cc ClusterManagerCollector) collectPodAndContainerMigInfo(ch chan<- promet
 				fmt.Sprint(*allocation.GPUInstanceID),
 				fmt.Sprint(*allocation.ComputeInstanceID),
 			}
-			if err := sendMetric(ch, ctrDeviceMigInfo, prometheus.GaugeValue, 1, metricLabels...); err != nil {
+			if err := cc.sendMetric(ch, ctrDeviceMigInfo, prometheus.GaugeValue, 1, metricLabels...); err != nil {
 				return fmt.Errorf("send MIG info metric for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 			}
-			sendLegacyMetric(ch, legacyCtrDeviceMigInfo, prometheus.GaugeValue, 1,
+			cc.sendLegacyMetric(ch, legacyCtrDeviceMigInfo, prometheus.GaugeValue, 1,
 				pod.Namespace, pod.Name, containerName, fmt.Sprint(allocation.DeviceIndex), allocation.GPUUUID, fmt.Sprint(*allocation.GPUInstanceID))
 		}
 	}
@@ -580,9 +624,10 @@ func migAllocationContainerName(pod *corev1.Pod, containerIndex int) (string, bo
 	return pod.Spec.Containers[containerIndex].Name, true
 }
 
-func sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) error {
+func (cc ClusterManagerCollector) sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType prometheus.ValueType, value float64, labels ...string) error {
 	metric, err := prometheus.NewConstMetric(desc, valueType, value, labels...)
 	if err != nil {
+		cc.recordPhaseError(versionmetrics.PhaseSendMetric)
 		return fmt.Errorf("failed to create metric: %w", err)
 	}
 	ch <- metric
@@ -608,6 +653,7 @@ func NewClusterManager(zone string, reg prometheus.Registerer, containerLister *
 	if legacyMetrics {
 		initLegacyDescriptors()
 	}
+
 	if containerLister == nil || containerLister.PodLister() == nil {
 		// NewContainerLister always initializes the informer, so this only
 		// happens if a caller builds a ContainerLister by hand. Fail here
@@ -615,10 +661,15 @@ func NewClusterManager(zone string, reg prometheus.Registerer, containerLister *
 		klog.Error("container lister has no pod lister; not registering the vGPUmonitor collector")
 		return nil
 	}
+
+	// Collector self-health metrics describe this process, not a zone-partitioned
+	// data set. They are collected alongside the vGPUmonitor metrics.
+	health := versionmetrics.NewCollectorHealthRecorder()
 	c := &ClusterManager{
 		Zone:            zone,
 		containerLister: containerLister,
 		LegacyMetrics:   legacyMetrics,
+		health:          health,
 		PodLister:       containerLister.PodLister(),
 	}
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -95,13 +95,13 @@ var calculateGPUScore = nvidia.CalculateGPUScore
 func (plugin *NvidiaDevicePlugin) getAPIDevices() (*[]*device.DeviceInfo, error) {
 	devs := plugin.Devices()
 	klog.V(5).InfoS("getAPIDevices", "devices", devs)
+	res := make([]*device.DeviceInfo, 0, len(devs))
 	if nvret := nvmlInit(); nvret != nvml.SUCCESS {
 		klog.Errorln("nvml Init err: ", nvret)
 		return nil, fmt.Errorf("nvml init failed: %v", nvret)
 	}
 	// Shutdown is deferred only after Init succeeds, since calling it after a failed Init crashes the process.
 	defer nvml.Shutdown()
-	res := make([]*device.DeviceInfo, 0, len(devs))
 
 	// Log mode-related warnings once per scan instead of per device
 	isMigMode := plugin.operatingMode == nvidia.MigMode
@@ -112,13 +112,11 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() (*[]*device.DeviceInfo, error)
 	for UUID := range devs {
 		ndev, ret := nvml.DeviceGetHandleByUUID(UUID)
 		if ret != nvml.SUCCESS {
-			klog.Errorf("skipping device uuid=%s: nvml DeviceGetHandleByUUID failed: %v", UUID, ret)
-			continue
+			return nil, fmt.Errorf("nvml DeviceGetHandleByUUID failed for uuid=%s: %v", UUID, ret)
 		}
 		idx, ret := ndev.GetIndex()
 		if ret != nvml.SUCCESS {
-			klog.Errorf("skipping device uuid=%s: nvml GetIndex failed: %v", UUID, ret)
-			continue
+			return nil, fmt.Errorf("nvml GetIndex failed for uuid=%s: %v", UUID, ret)
 		}
 		memoryTotal := 0
 		memory, ret := ndev.GetMemoryInfo()
@@ -133,19 +131,18 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() (*[]*device.DeviceInfo, error)
 				klog.Warningf("GetMemoryInfo not supported for device %s, using configured PreConfiguredDeviceMemory: %d MB",
 					UUID, *plugin.schedulerConfig.PreConfiguredDeviceMemory)
 			} else {
+				// Don't error out on ERROR_NOT_SUPPORTED without config, just skip. It's an unsupported device type.
 				klog.Errorf("GetMemoryInfo not supported for device %s (unified memory architecture) "+
 					"and PreConfiguredDeviceMemory not configured. Skipping this device. "+
 					"Set 'preConfiguredDeviceMemory' in nvidia config to the total GPU memory in MB.", UUID)
 				continue
 			}
 		default:
-			klog.Errorf("skipping device uuid=%s: nvml GetMemoryInfo failed: %v", UUID, ret)
-			continue
+			return nil, fmt.Errorf("nvml GetMemoryInfo failed for uuid=%s: %v", UUID, ret)
 		}
 		Model, ret := ndev.GetName()
 		if ret != nvml.SUCCESS {
-			klog.Errorf("skipping device uuid=%s: nvml GetName failed: %v", UUID, ret)
-			continue
+			return nil, fmt.Errorf("nvml GetName failed for uuid=%s: %v", UUID, ret)
 		}
 
 		registeredmem := int32(memoryTotal / 1024 / 1024)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -166,7 +166,7 @@ func TestGetAPIDevicesShutsDownAfterNVMLInit(t *testing.T) {
 	}
 }
 
-func TestGetAPIDevicesSkipsOnPerDeviceNVMLFailures(t *testing.T) {
+func TestGetAPIDevicesErrorsOnPerDeviceNVMLFailures(t *testing.T) {
 	originalInit := nvmlInit
 	originalShutdown := nvml.Shutdown
 	originalGetHandleByUUID := nvml.DeviceGetHandleByUUID
@@ -236,11 +236,11 @@ func TestGetAPIDevicesSkipsOnPerDeviceNVMLFailures(t *testing.T) {
 				return rm.Devices{testUUID: &rm.Device{}}
 			}}}
 			devices, err := plugin.getAPIDevices()
-			if err != nil {
-				t.Fatalf("getAPIDevices returned unexpected error on per-device failure: %v", err)
+			if err == nil {
+				t.Fatalf("getAPIDevices did not return an error on per-device failure")
 			}
-			if devices == nil || len(*devices) != 0 {
-				t.Fatalf("getAPIDevices() = %v on per-device NVML failure, want empty list", devices)
+			if devices != nil {
+				t.Fatalf("getAPIDevices() = %v on per-device NVML failure, want nil", devices)
 			}
 		})
 	}

--- a/pkg/metrics/collector_health.go
+++ b/pkg/metrics/collector_health.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Component label values used by the collector health metrics. Each HAMi
+// binary that exporters Prometheus metrics reports its own scrape health
+// under one of these values.
+const (
+	ComponentScheduler   = "scheduler"
+	ComponentVGPUMonitor = "vgpumonitor"
+)
+
+// Phase label values used by hami_collector_errors_total. A phase pinpoints
+// the collection stage that failed, so operators can alert on the specific
+// failure instead of discovering an empty dashboard after the fact.
+const (
+	// PhaseGPUInfo covers NVML initialisation, device enumeration and
+	// per-device metric collection in the vGPUmonitor.
+	PhaseGPUInfo = "gpu_info"
+	// PhasePodContainerInfo covers listing pods on the node and reading
+	// their per-container device usage in the vGPUmonitor.
+	PhasePodContainerInfo = "pod_container_info"
+	// PhaseMIGInfo covers decoding and exporting MIG allocation identities
+	// in the vGPUmonitor.
+	PhaseMIGInfo = "mig_info"
+	// PhaseListScheduledPods covers reading the scheduler's cache of
+	// scheduled pods.
+	PhaseListScheduledPods = "list_scheduled_pods"
+	// PhaseSendMetric covers failures to materialise a single metric sample
+	// (prometheus.NewConstMetric errors) in any collector.
+	PhaseSendMetric = "send_metric"
+)
+
+// CollectorHealthRecorder exposes the scrape-path health of a Prometheus
+// collector as metrics: how long each scrape takes, how often a collection
+// phase fails, and when the collector last completed a scrape. It follows the
+// self-instrumentation convention used by node_exporter
+// (node_scrape_collector_duration_seconds) and the Prometheus server itself
+// (prometheus_ rule evaluation metrics): every exporter should be able to
+// answer "did my own collection work?" with a query, not a log grep.
+//
+// All methods are safe to call on a nil receiver so collectors can treat the
+// recorder as optional in tests.
+type CollectorHealthRecorder struct {
+	duration *prometheus.HistogramVec
+	errors   *prometheus.CounterVec
+	lastRun  *prometheus.GaugeVec
+}
+
+// NewCollectorHealthRecorder creates a new recorder. Callers must register it
+// directly with a Prometheus registry or embed it in a composite collector.
+func NewCollectorHealthRecorder() *CollectorHealthRecorder {
+	r := &CollectorHealthRecorder{
+		duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "hami_collector_duration_seconds",
+				Help: "Duration of a single metrics collection pass in seconds.",
+				// Default buckets (5ms-10s) bracket the gap between a
+				// healthy sub-second scrape and the scrape timeout it
+				// must not approach.
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"component"},
+		),
+		errors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "hami_collector_errors_total",
+				Help: "Total number of errors encountered while collecting metrics, by component and phase.",
+			},
+			[]string{"component", "phase"},
+		),
+		lastRun: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "hami_collector_last_run_timestamp_seconds",
+				Help: "Unix timestamp of the last error-free metrics collection pass.",
+			},
+			[]string{"component"},
+		),
+	}
+	return r
+}
+
+// Describe sends the descriptors of the underlying metrics to the provided channel.
+func (r *CollectorHealthRecorder) Describe(ch chan<- *prometheus.Desc) {
+	if r == nil {
+		return
+	}
+	r.duration.Describe(ch)
+	r.errors.Describe(ch)
+	r.lastRun.Describe(ch)
+}
+
+// Collect sends the metric values of the underlying metrics to the provided channel.
+func (r *CollectorHealthRecorder) Collect(ch chan<- prometheus.Metric) {
+	if r == nil {
+		return
+	}
+	r.duration.Collect(ch)
+	r.errors.Collect(ch)
+	r.lastRun.Collect(ch)
+}
+
+// ObserveDuration records the wall-clock duration of a single scrape.
+// It is always called, regardless of whether individual phases failed.
+func (r *CollectorHealthRecorder) ObserveDuration(component string, start time.Time) {
+	if r == nil {
+		return
+	}
+	r.duration.WithLabelValues(component).Observe(time.Since(start).Seconds())
+}
+
+// StampLastRun marks the current time as the last successful (error-free)
+// scrape for the given component. Only call this when all collection phases
+// completed without errors.
+func (r *CollectorHealthRecorder) StampLastRun(component string) {
+	if r == nil {
+		return
+	}
+	r.lastRun.WithLabelValues(component).SetToCurrentTime()
+}
+
+// RecordError increments the per-phase error counter for the given component.
+func (r *CollectorHealthRecorder) RecordError(component, phase string) {
+	if r == nil {
+		return
+	}
+	r.errors.WithLabelValues(component, phase).Inc()
+}

--- a/pkg/metrics/collector_health_test.go
+++ b/pkg/metrics/collector_health_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestCollectorHealthRecorderBasic(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	// Create recorder and register metrics on this registry.
+	rec := NewCollectorHealthRecorder()
+	reg.MustRegister(rec)
+
+	// Record a few errors on different phases.
+	rec.RecordError(ComponentVGPUMonitor, PhaseGPUInfo)
+	rec.RecordError(ComponentVGPUMonitor, PhaseGPUInfo)
+	rec.RecordError(ComponentVGPUMonitor, PhaseSendMetric)
+
+	// Simulate a scrape duration and stamp last run.
+	start := time.Now().Add(-500 * time.Millisecond)
+	rec.ObserveDuration(ComponentVGPUMonitor, start)
+	rec.StampLastRun(ComponentVGPUMonitor)
+
+	// Verify errors_total metric family.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+	var errorsFound bool
+	var durationFound bool
+	var lastRunFound bool
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "hami_collector_errors_total":
+			errorsFound = true
+			// Verify expected label combos and counts.
+			expected := map[string]float64{
+				"vgpumonitor|gpu_info":    2,
+				"vgpumonitor|send_metric": 1,
+			}
+			for _, m := range mf.GetMetric() {
+				var comp, phase string
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == "component" {
+						comp = lp.GetValue()
+					}
+					if lp.GetName() == "phase" {
+						phase = lp.GetValue()
+					}
+				}
+				key := comp + "|" + phase
+				want, ok := expected[key]
+				if !ok {
+					t.Fatalf("unexpected error metric label combo %s|%s", comp, phase)
+				}
+				if got := m.GetCounter().GetValue(); got != want {
+					t.Fatalf("error count for %s|%s = %v, want %v", comp, phase, got, want)
+				}
+				delete(expected, key)
+			}
+			if len(expected) != 0 {
+				t.Fatalf("some expected error metrics were not observed: %v", expected)
+			}
+		case "hami_collector_duration_seconds":
+			durationFound = true
+			// Expect a histogram with a single sample count.
+			if len(mf.GetMetric()) != 1 {
+				t.Fatalf("expected one histogram metric, got %d", len(mf.GetMetric()))
+			}
+			hist := mf.GetMetric()[0].GetHistogram()
+			if hist.GetSampleCount() != 1 {
+				t.Fatalf("expected histogram sample count 1, got %d", hist.GetSampleCount())
+			}
+		case "hami_collector_last_run_timestamp_seconds":
+			lastRunFound = true
+			// Gauge should have a value > start.
+			if len(mf.GetMetric()) != 1 {
+				t.Fatalf("expected one gauge metric for last run, got %d", len(mf.GetMetric()))
+			}
+			val := mf.GetMetric()[0].GetGauge().GetValue()
+			if val < float64(start.Unix()) {
+				t.Fatalf("last run timestamp %v is before start %v", val, start.Unix())
+			}
+		}
+	}
+	if !errorsFound {
+		t.Fatalf("hami_collector_errors_total metric family not found")
+	}
+	if !durationFound {
+		t.Fatalf("hami_collector_duration_seconds metric family not found")
+	}
+	if !lastRunFound {
+		t.Fatalf("hami_collector_last_run_timestamp_seconds metric family not found")
+	}
+}
+
+func TestCollectorHealthRecorderNilSafety(t *testing.T) {
+	var rec *CollectorHealthRecorder
+	// Should not panic.
+	rec.RecordError(ComponentScheduler, PhaseListScheduledPods)
+	rec.ObserveDuration(ComponentScheduler, time.Now())
+	rec.StampLastRun(ComponentScheduler)
+}


### PR DESCRIPTION
**Problem**

While going through the metrics implementation and issue #410, I noticed that the `Collect()` functions in both `vGPUmonitor` and `scheduler` log errors on failure but return silently. 
I saw that if metrics collection degrades or encounters errors (such as NVML initialisation issues, pod listing failures, or metric creation errors), operators have no queryable Prometheus signal or alert to figure out why dashboards are empty or data is missing.

**Solution**:
To address this, I introduced internal collector self-monitoring metrics, following standard Prometheus exporter design (similar to `node_exporter` and Prometheus self-metrics):
1. **`hami_collector_duration_seconds`** (Histogram): Tracks scrape duration for each collection pass per component.
2. **`hami_collector_errors_total`** (Counter): Counts collection failures partitioned by `component` (`scheduler`, `vgpumonitor`) and `phase` (`gpu_info`, `pod_container_info`, `mig_info`, `list_scheduled_pods`, `send_metric`).
3. **`hami_collector_last_run_timestamp_seconds`** (Gauge): Unix timestamp of the last completed scrape pass per component.

 **Changes**
- Created `pkg/metrics/collector_health.go` to provide a centralized, thread-safe `CollectorHealthRecorder`.
- Integrated health recording into `cmd/scheduler/metrics.go` and `cmd/vGPUmonitor/metrics.go`.
- Added unit tests in `pkg/metrics`, `cmd/scheduler`, and `cmd/vGPUmonitor` using `prometheus.NewPedanticRegistry()`.

**New Tests Added** 
- Added unit tests and verified they pass:
  - `TestCollectorHealthRecorderBasic`
  - `TestCollectorHealthRecorderNilSafety`
  - `TestSchedulerCollectorHealth`
  - `TestVGPUMonitorCollectorHealth`

**AI disclosure**
I took help of AI to help me understand the problem and probable steps. However I have manually reviewed, tested, and fully understand all the changes introduced in this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health metrics for scheduler and vGPU monitoring collectors, including scrape duration, error counts, and last successful run timestamps.
  * Added component- and phase-level visibility into collector errors.

* **Bug Fixes**
  * Collector errors are now recorded when scheduled pods cannot be retrieved or metrics cannot be created.
  * Improved NVIDIA device discovery to skip unavailable devices instead of stopping collection.

* **Tests**
  * Added coverage for health metrics, error reporting, timestamps, scrape durations, and safe health recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->