### PR TITLE
fix(scheduler): use phase-aware accounting during NUMA refit

### DIFF
--- a/pkg/device/numa_refit.go
+++ b/pkg/device/numa_refit.go
@@ -38,8 +38,9 @@ type NumaRefitRequest struct {
 	// scheduler can cross-check the index against the Pod spec and refuse a
 	// mismatched request.
 	ContainerName string `json:"containerName,omitempty"`
-	// DeviceType is the device vendor type the refit applies to, for
-	// example "NVIDIA".
+	// DeviceType is the device vendor type the refit applies to. The scheduler
+	// currently accepts "NVIDIA" only; other registered types are rejected
+	// until their allocation-specific accounting is supported.
 	DeviceType string `json:"deviceType"`
 	// AllowedDeviceUUIDs lists the physical device IDs kubelet can still
 	// satisfy the allocation from. The refit must select among these only.

--- a/pkg/scheduler/numa_refit.go
+++ b/pkg/scheduler/numa_refit.go
@@ -17,8 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -58,7 +56,7 @@ func restrictNodeUsage(node *NodeUsage, deviceType string, allowedUUIDs []string
 		if deviceList == nil || deviceList.Device == nil {
 			continue
 		}
-		if strings.Contains(strings.ToLower(deviceList.Device.Type), strings.ToLower(deviceType)) {
+		if deviceTypeMatches(deviceList.Device.Type, deviceType) {
 			if _, ok := allowed[deviceList.Device.ID]; !ok {
 				continue
 			}

--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -182,9 +182,11 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 			return s.numaRefitFailureEvent(pod, "allowed device %s is in MIG mode; the NUMA refit does not support MIG", deviceList.Device.ID)
 		}
 	}
-	// The snapshot includes this container's own reservation; release it so
-	// capacity checks do not double count the pod against itself.
-	releaseContainerUsage(nodeUsage, current)
+	// The snapshot contains this pod's phase-collapsed reservation. Prepare
+	// each allowed candidate so adding the moved container produces the same
+	// effective usage as normal scheduling (for example max(init, app), not
+	// init+app, for a non-sidecar init container).
+	preparePhaseAwareRefitUsage(nodeUsage, pod, pi.Devices, allocated, req.DeviceType, req.ContainerIndex, current[0], allowed, pi.InitContainerResourceReleased)
 
 	weights, err := util.GetDeviceScoringWeightsByPod(pod)
 	if err != nil {
@@ -261,10 +263,7 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 		// init-container usage has been released, collapsing again would
 		// re-inflate the reservation back to the init peak, the same hazard
 		// PodManager.AddPod guards against on a re-add.
-		effective := device.CollapseInitContainerUsage(pod, rawDevices)
-		if pi.InitContainerResourceReleased {
-			effective = device.SteadyStateDeviceUsage(pod, rawDevices)
-		}
+		effective := effectivePodDeviceUsage(pod, rawDevices, pi.InitContainerResourceReleased)
 		if _, ok := s.podManager.ReplacePodDevices(key, effective); ok {
 			s.quotaManager.AddUsage(pod, effective)
 		} else {
@@ -311,17 +310,98 @@ func containerNameAt(pod *corev1.Pod, index int) (string, bool) {
 	return "", false
 }
 
-// releaseContainerUsage subtracts one container's reserved usage from the
-// node usage snapshot in place.
+// effectivePodDeviceUsage mirrors the accounting shape stored by PodManager.
+func effectivePodDeviceUsage(pod *corev1.Pod, raw device.PodDevices, initReleased bool) device.PodDevices {
+	if initReleased {
+		return device.SteadyStateDeviceUsage(pod, raw)
+	}
+	return device.CollapseInitContainerUsage(pod, raw)
+}
+
+// aggregateDeviceUsage returns one usage total per physical device.
+func aggregateDeviceUsage(single device.PodSingleDevice) map[string]device.ContainerDevice {
+	usage := make(map[string]device.ContainerDevice)
+	for _, containerDevices := range single {
+		for _, d := range containerDevices {
+			total := usage[d.UUID]
+			total.UUID = d.UUID
+			total.Type = d.Type
+			total.Usedmem += d.Usedmem
+			total.Usedcores += d.Usedcores
+			total.Slots += max(d.Slots, 1)
+			usage[d.UUID] = total
+		}
+	}
+	return usage
+}
+
+// effectiveUsageOnCandidate evaluates only one physical device. Init/app
+// collapsing is independent per UUID, so filtering the raw rows first avoids
+// copying and collapsing the pod's complete allocation for every candidate.
+func effectiveUsageOnCandidate(pod *corev1.Pod, withoutMoved device.PodSingleDevice, deviceType string, containerIndex int, moved device.ContainerDevice, candidateID string, initReleased bool) device.ContainerDevice {
+	candidateRows := make(device.PodSingleDevice, len(withoutMoved))
+	for index, containerDevices := range withoutMoved {
+		for _, d := range containerDevices {
+			if d.UUID == candidateID {
+				candidateRows[index] = append(candidateRows[index], d)
+			}
+		}
+	}
+	moved.UUID = candidateID
+	candidateRows[containerIndex] = append(candidateRows[containerIndex], moved)
+	effective := effectivePodDeviceUsage(pod, device.PodDevices{deviceType: candidateRows}, initReleased)
+	return aggregateDeviceUsage(effective[deviceType])[candidateID]
+}
+
+// preparePhaseAwareRefitUsage replaces this pod's cached contribution with a
+// candidate-specific preload. Nvidia.Fit then adds the moved container's raw
+// request, and the resulting per-device usage equals the pod's effective
+// init/app usage on that candidate. Computing the full hypothetical through
+// the shared collapse helpers also preserves native-sidecar ordering.
+func preparePhaseAwareRefitUsage(node *NodeUsage, pod *corev1.Pod, cached, raw device.PodDevices, deviceType string, containerIndex int, moved device.ContainerDevice, allowed map[string]struct{}, initReleased bool) {
+	for _, containerDevices := range cached[deviceType] {
+		releaseContainerUsage(node, containerDevices)
+	}
+
+	withoutMoved := raw.DeepCopy()
+	withoutMoved[deviceType][containerIndex] = nil
+	withoutUsage := aggregateDeviceUsage(effectivePodDeviceUsage(pod, withoutMoved, initReleased)[deviceType])
+
+	for _, deviceList := range node.Devices.DeviceLists {
+		candidate := deviceList.Device
+		preload, exists := withoutUsage[candidate.ID]
+		_, candidateAllowed := allowed[candidate.ID]
+		candidateTypeMatches := strings.Contains(strings.ToLower(candidate.Type), strings.ToLower(deviceType))
+		if candidateAllowed && candidateTypeMatches {
+			withUsage := effectiveUsageOnCandidate(pod, withoutMoved[deviceType], deviceType, containerIndex, moved, candidate.ID, initReleased)
+			preload = device.ContainerDevice{
+				UUID:      candidate.ID,
+				Type:      deviceType,
+				Usedmem:   max(withUsage.Usedmem-moved.Usedmem, 0),
+				Usedcores: max(withUsage.Usedcores-moved.Usedcores, 0),
+				Slots:     max(withUsage.Slots-1, 0),
+			}
+			exists = preload.Usedmem > 0 || preload.Usedcores > 0 || preload.Slots > 0
+		}
+		if !exists {
+			continue
+		}
+		candidate.Used += preload.Slots
+		candidate.Usedmem += preload.Usedmem
+		candidate.Usedcores += preload.Usedcores
+	}
+}
+
+// releaseContainerUsage subtracts reserved usage from the node usage snapshot
+// in place. Raw entries have Slots=0 and count as one; collapsed entries may
+// represent several concurrent containers.
 func releaseContainerUsage(node *NodeUsage, reserved device.ContainerDevices) {
 	for _, r := range reserved {
 		for _, deviceList := range node.Devices.DeviceLists {
 			if deviceList.Device.ID != r.UUID {
 				continue
 			}
-			if deviceList.Device.Used > 0 {
-				deviceList.Device.Used--
-			}
+			deviceList.Device.Used = max(deviceList.Device.Used-max(r.Slots, 1), 0)
 			deviceList.Device.Usedmem = max(deviceList.Device.Usedmem-r.Usedmem, 0)
 			deviceList.Device.Usedcores = max(deviceList.Device.Usedcores-r.Usedcores, 0)
 			break

--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -186,7 +186,7 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 	// each allowed candidate so adding the moved container produces the same
 	// effective usage as normal scheduling (for example max(init, app), not
 	// init+app, for a non-sidecar init container).
-	preparePhaseAwareRefitUsage(nodeUsage, pod, pi.Devices, allocated, req.DeviceType, req.ContainerIndex, current[0], allowed, pi.InitContainerResourceReleased)
+	preparePhaseAwareRefitUsage(nodeUsage, pod, pi.Devices, allocated, req.DeviceType, req.ContainerIndex, current[0].Usedmem, current[0].Usedcores, allowed, pi.InitContainerResourceReleased)
 
 	weights, err := util.GetDeviceScoringWeightsByPod(pod)
 	if err != nil {
@@ -338,7 +338,7 @@ func aggregateDeviceUsage(single device.PodSingleDevice) map[string]device.Conta
 // effectiveUsageOnCandidate evaluates only one physical device. Init/app
 // collapsing is independent per UUID, so filtering the raw rows first avoids
 // copying and collapsing the pod's complete allocation for every candidate.
-func effectiveUsageOnCandidate(pod *corev1.Pod, withoutMoved device.PodSingleDevice, deviceType string, containerIndex int, moved device.ContainerDevice, candidateID string, initReleased bool) device.ContainerDevice {
+func effectiveUsageOnCandidate(pod *corev1.Pod, withoutMoved device.PodSingleDevice, deviceType string, containerIndex int, movedMemory, movedCores int32, candidateID string, initReleased bool) device.ContainerDevice {
 	candidateRows := make(device.PodSingleDevice, len(withoutMoved))
 	for index, containerDevices := range withoutMoved {
 		for _, d := range containerDevices {
@@ -347,18 +347,26 @@ func effectiveUsageOnCandidate(pod *corev1.Pod, withoutMoved device.PodSingleDev
 			}
 		}
 	}
-	moved.UUID = candidateID
-	candidateRows[containerIndex] = append(candidateRows[containerIndex], moved)
+	// Annotation rows are raw container/device allocations and do not encode
+	// collapsed Slots. This row therefore represents exactly the one slot that
+	// NVIDIA Fit/AddResourceUsage will add after the preload is installed.
+	candidateRows[containerIndex] = append(candidateRows[containerIndex], device.ContainerDevice{
+		UUID:      candidateID,
+		Type:      deviceType,
+		Usedmem:   movedMemory,
+		Usedcores: movedCores,
+	})
 	effective := effectivePodDeviceUsage(pod, device.PodDevices{deviceType: candidateRows}, initReleased)
 	return aggregateDeviceUsage(effective[deviceType])[candidateID]
 }
 
 // preparePhaseAwareRefitUsage replaces this pod's cached contribution with a
-// candidate-specific preload. Nvidia.Fit then adds the moved container's raw
-// request, and the resulting per-device usage equals the pod's effective
-// init/app usage on that candidate. Computing the full hypothetical through
-// the shared collapse helpers also preserves native-sidecar ordering.
-func preparePhaseAwareRefitUsage(node *NodeUsage, pod *corev1.Pod, cached, raw device.PodDevices, deviceType string, containerIndex int, moved device.ContainerDevice, allowed map[string]struct{}, initReleased bool) {
+// candidate-specific preload. The production refit currently accepts NVIDIA
+// only; Nvidia.Fit adds one raw slot plus the requested memory and cores. The
+// resulting per-device usage equals the pod's effective init/app usage on that
+// candidate. Computing the full hypothetical through the shared collapse
+// helpers also preserves native-sidecar ordering.
+func preparePhaseAwareRefitUsage(node *NodeUsage, pod *corev1.Pod, cached, raw device.PodDevices, deviceType string, containerIndex int, movedMemory, movedCores int32, allowed map[string]struct{}, initReleased bool) {
 	for _, containerDevices := range cached[deviceType] {
 		releaseContainerUsage(node, containerDevices)
 	}
@@ -369,16 +377,18 @@ func preparePhaseAwareRefitUsage(node *NodeUsage, pod *corev1.Pod, cached, raw d
 
 	for _, deviceList := range node.Devices.DeviceLists {
 		candidate := deviceList.Device
+		if !deviceTypeMatches(candidate.Type, deviceType) {
+			continue
+		}
 		preload, exists := withoutUsage[candidate.ID]
 		_, candidateAllowed := allowed[candidate.ID]
-		candidateTypeMatches := strings.Contains(strings.ToLower(candidate.Type), strings.ToLower(deviceType))
-		if candidateAllowed && candidateTypeMatches {
-			withUsage := effectiveUsageOnCandidate(pod, withoutMoved[deviceType], deviceType, containerIndex, moved, candidate.ID, initReleased)
+		if candidateAllowed {
+			withUsage := effectiveUsageOnCandidate(pod, withoutMoved[deviceType], deviceType, containerIndex, movedMemory, movedCores, candidate.ID, initReleased)
 			preload = device.ContainerDevice{
 				UUID:      candidate.ID,
 				Type:      deviceType,
-				Usedmem:   max(withUsage.Usedmem-moved.Usedmem, 0),
-				Usedcores: max(withUsage.Usedcores-moved.Usedcores, 0),
+				Usedmem:   max(withUsage.Usedmem-movedMemory, 0),
+				Usedcores: max(withUsage.Usedcores-movedCores, 0),
 				Slots:     max(withUsage.Slots-1, 0),
 			}
 			exists = preload.Usedmem > 0 || preload.Usedcores > 0 || preload.Slots > 0

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -28,6 +28,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/enflame"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 )
 
@@ -69,8 +70,11 @@ func refitFixture(t *testing.T, gpuBDevmem int32) (*Scheduler, *corev1.Pod) {
 	return s, pod
 }
 
-func phaseAwareRefitFixture(t *testing.T, initContainers []corev1.Container, reserved device.PodSingleDevice, gpuBDevmem, externalGPUBMemory int32) (*Scheduler, *corev1.Pod) {
+func phaseAwareRefitFixture(t *testing.T, initContainers, containers []corev1.Container, reserved device.PodSingleDevice, gpuBDevmem, externalGPUBMemory int32) (*Scheduler, *corev1.Pod) {
 	t.Helper()
+	if len(containers) == 0 {
+		containers = []corev1.Container{{Name: "main"}}
+	}
 	nodes := newNodeManager()
 	nodes.addNode(refitNode, &device.NodeInfo{
 		ID: refitNode, Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: refitNode}},
@@ -90,7 +94,7 @@ func phaseAwareRefitFixture(t *testing.T, initContainers []corev1.Container, res
 		},
 		Spec: corev1.PodSpec{
 			InitContainers: initContainers,
-			Containers:     []corev1.Container{{Name: "main"}},
+			Containers:     containers,
 		},
 	}
 	raw := device.PodDevices{nvidia.NvidiaGPUDevice: reserved}
@@ -207,6 +211,7 @@ func TestRefitNumaAllocationUsesPhaseAwareCapacity(t *testing.T) {
 	tests := []struct {
 		name              string
 		initContainers    []corev1.Container
+		containers        []corev1.Container
 		reserved          device.PodSingleDevice
 		gpuBMemory        int32
 		externalGPUMemory int32
@@ -261,6 +266,22 @@ func TestRefitNumaAllocationUsesPhaseAwareCapacity(t *testing.T) {
 			wantSlots:      2,
 		},
 		{
+			name:           "sidecar and two apps preserve three concurrent slots",
+			initContainers: []corev1.Container{{Name: "sidecar", RestartPolicy: &always}},
+			containers:     []corev1.Container{{Name: "main"}, {Name: "worker"}},
+			reserved: device.PodSingleDevice{
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 5000, Usedcores: 10}},
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 10000, Usedcores: 20}},
+				{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+			},
+			gpuBMemory:     40000,
+			containerIndex: 2,
+			containerName:  "worker",
+			wantSucceeded:  true,
+			wantMemory:     35000,
+			wantSlots:      3,
+		},
+		{
 			name:           "sidecar and app remain concurrent",
 			initContainers: []corev1.Container{{Name: "sidecar", RestartPolicy: &always}},
 			reserved: device.PodSingleDevice{
@@ -274,7 +295,7 @@ func TestRefitNumaAllocationUsesPhaseAwareCapacity(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, _ := phaseAwareRefitFixture(t, test.initContainers, test.reserved, test.gpuBMemory, test.externalGPUMemory)
+			s, _ := phaseAwareRefitFixture(t, test.initContainers, test.containers, test.reserved, test.gpuBMemory, test.externalGPUMemory)
 			captured, calls := stubRefitPatch(t, nil)
 
 			request := refitTestRequestFor("GPU-b")
@@ -372,6 +393,11 @@ func TestRefitNumaAllocationValidation(t *testing.T) {
 			name:       "unknown device type",
 			mutate:     func(r *device.NumaRefitRequest) { r.DeviceType = "NoSuchVendor" },
 			wantReason: "unknown device type",
+		},
+		{
+			name:       "registered non-NVIDIA device type",
+			mutate:     func(r *device.NumaRefitRequest) { r.DeviceType = enflame.EnflameVGCUDevice },
+			wantReason: "not supported by the NUMA refit yet",
 		},
 		{
 			name:       "empty allowed set",

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -69,6 +69,45 @@ func refitFixture(t *testing.T, gpuBDevmem int32) (*Scheduler, *corev1.Pod) {
 	return s, pod
 }
 
+func phaseAwareRefitFixture(t *testing.T, initContainers []corev1.Container, reserved device.PodSingleDevice, gpuBDevmem, externalGPUBMemory int32) (*Scheduler, *corev1.Pod) {
+	t.Helper()
+	nodes := newNodeManager()
+	nodes.addNode(refitNode, &device.NodeInfo{
+		ID: refitNode, Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: refitNode}},
+		Devices: map[string][]device.DeviceInfo{nvidia.NvidiaGPUDevice: {
+			{ID: "GPU-a", Count: 10, Devmem: 40000, Devcore: 100, Numa: 1, Type: nvidia.NvidiaGPUDevice, Health: true},
+			{ID: "GPU-b", Count: 10, Devmem: gpuBDevmem, Devcore: 100, Numa: 0, Type: nvidia.NvidiaGPUDevice, Health: true},
+		}},
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: refitPodUID, Name: refitPodName, Namespace: "default",
+			Annotations: map[string]string{
+				device.InRequestDevices[nvidia.NvidiaGPUDevice]: device.EncodePodSingleDevice(reserved),
+				device.SupportDevices[nvidia.NvidiaGPUDevice]:   device.EncodePodSingleDevice(reserved),
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: initContainers,
+			Containers:     []corev1.Container{{Name: "main"}},
+		},
+	}
+	raw := device.PodDevices{nvidia.NvidiaGPUDevice: reserved}
+	pods := device.NewPodManager()
+	pods.AddPod(pod, refitNode, device.CollapseInitContainerUsage(pod, raw))
+	if externalGPUBMemory > 0 {
+		externalPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "external-pod", Name: "external-pod", Namespace: "default"}}
+		pods.AddPod(externalPod, refitNode, device.PodDevices{nvidia.NvidiaGPUDevice: {{{
+			UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: externalGPUBMemory, Usedcores: 10,
+		}}}})
+	}
+
+	s := &Scheduler{nodeManager: nodes, podManager: pods, quotaManager: device.NewQuotaManager()}
+	s.quotaManager.Quotas = map[string]*device.DeviceQuota{}
+	return s, pod
+}
+
 // stubRefitPatch replaces the annotation patch with a capture; returns the
 // captured map and a call counter.
 func stubRefitPatch(t *testing.T, fail error) (map[string]string, *int) {
@@ -161,6 +200,115 @@ func TestRefitNumaAllocationInsufficientCapacity(t *testing.T) {
 	assert.Assert(t, strings.Contains(response.FailureReason, "no allowed device fits"), "reason: %s", response.FailureReason)
 	assert.Equal(t, *calls, 0)
 	assert.Equal(t, trackedUUID(t, s), "GPU-a")
+}
+
+func TestRefitNumaAllocationUsesPhaseAwareCapacity(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	tests := []struct {
+		name              string
+		initContainers    []corev1.Container
+		reserved          device.PodSingleDevice
+		gpuBMemory        int32
+		externalGPUMemory int32
+		containerIndex    int
+		containerName     string
+		wantSucceeded     bool
+		wantMemory        int32
+		wantSlots         int32
+	}{
+		{
+			name:           "regular init and app use the phase peak",
+			initContainers: []corev1.Container{{Name: "init"}},
+			reserved: device.PodSingleDevice{
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+				{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+			},
+			gpuBMemory:     40000,
+			containerIndex: 1,
+			containerName:  "main",
+			wantSucceeded:  true,
+			wantMemory:     30000,
+			wantSlots:      1,
+		},
+		{
+			name:           "other pod usage is not released",
+			initContainers: []corev1.Container{{Name: "init"}},
+			reserved: device.PodSingleDevice{
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+				{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+			},
+			gpuBMemory:        40000,
+			externalGPUMemory: 15000,
+			containerIndex:    1,
+			containerName:     "main",
+		},
+		{
+			name: "sidecar starting after a larger init does not inflate the peak",
+			initContainers: []corev1.Container{
+				{Name: "prepare"},
+				{Name: "sidecar", RestartPolicy: &always},
+			},
+			reserved: device.PodSingleDevice{
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+				{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 10000, Usedcores: 10}},
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+			},
+			gpuBMemory:     30000,
+			containerIndex: 1,
+			containerName:  "sidecar",
+			wantSucceeded:  true,
+			wantMemory:     30000,
+			wantSlots:      2,
+		},
+		{
+			name:           "sidecar and app remain concurrent",
+			initContainers: []corev1.Container{{Name: "sidecar", RestartPolicy: &always}},
+			reserved: device.PodSingleDevice{
+				{{UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 30000, Usedcores: 60}},
+				{{UUID: "GPU-b", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30}},
+			},
+			gpuBMemory:    40000,
+			containerName: "sidecar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, _ := phaseAwareRefitFixture(t, test.initContainers, test.reserved, test.gpuBMemory, test.externalGPUMemory)
+			captured, calls := stubRefitPatch(t, nil)
+
+			request := refitTestRequestFor("GPU-b")
+			request.ContainerIndex = test.containerIndex
+			request.ContainerName = test.containerName
+			response := s.RefitNumaAllocation(request)
+
+			assert.Equal(t, response.Succeeded, test.wantSucceeded, "reason: %s", response.FailureReason)
+			if !test.wantSucceeded {
+				assert.Equal(t, *calls, 0)
+				assert.Assert(t, strings.Contains(response.FailureReason, "CardInsufficientMemory"), "reason: %s", response.FailureReason)
+				return
+			}
+
+			assert.Equal(t, *calls, 1)
+			allocated, err := device.DecodePodDevices(device.SupportDevices, captured)
+			assert.NilError(t, err)
+			assert.Equal(t, allocated[nvidia.NvidiaGPUDevice][test.containerIndex][0].UUID, "GPU-b")
+
+			pi, ok := s.podManager.GetPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: refitPodUID}})
+			assert.Equal(t, ok, true)
+			var usedMemory, usedSlots int32
+			for _, containerDevices := range pi.Devices[nvidia.NvidiaGPUDevice] {
+				for _, d := range containerDevices {
+					if d.UUID == "GPU-b" {
+						usedMemory += d.Usedmem
+						usedSlots += max(d.Slots, 1)
+					}
+				}
+			}
+			assert.Equal(t, usedMemory, test.wantMemory)
+			assert.Equal(t, usedSlots, test.wantSlots)
+		})
+	}
 }
 
 func TestRefitNumaAllocationUnmatchedAllowedSet(t *testing.T) {

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -40,11 +40,16 @@ func viewStatus(usage NodeUsage) {
 	}
 }
 
+// deviceTypeMatches preserves HAMi's case-insensitive substring matching for
+// mapping a registered request type to the corresponding node devices.
+func deviceTypeMatches(availableType, requestedType string) bool {
+	return strings.Contains(strings.ToLower(availableType), strings.ToLower(requestedType))
+}
+
 func getNodeResources(list NodeUsage, t string) []*device.DeviceUsage {
 	l := []*device.DeviceUsage{}
-	targetType := strings.ToLower(t)
 	for _, val := range list.Devices.DeviceLists {
-		if strings.Contains(strings.ToLower(val.Device.Type), targetType) {
+		if deviceTypeMatches(val.Device.Type, t) {
 			l = append(l, val.Device)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

NUMA refit previously treated a pod's regular init-container memory and application-container memory as concurrent usage. This could reject a valid placement with `CardInsufficientMemory`.

This PR uses HAMi's existing init-container accounting rules while checking allowed NUMA devices. Regular init and application usage now use their phase peak, while sidecars and application containers remain concurrent.

~~~text
GPU-b capacity: 40 GB

Regular init: 30 GB ─┐
                     ├── max(30, 20) = 30 GB ──> placement fits
Application:  20 GB ─┘

Sidecar:      30 GB ─┐
                     ├── 30 + 20 = 50 GB ──> placement rejected
Application:  20 GB ─┘
~~~

The candidate calculation reuses `CollapseInitContainerUsage` and `SteadyStateDeviceUsage`. It preserves the accounting of other pods and updates the cached reservation after a successful refit.

**Which issue(s) this PR fixes**:

Fixes #2856

**Special notes for your reviewer**:

Regression tests cover:

- A 30-GB regular init allocation and 20-GB application allocation fitting on a 40-GB GPU.
- Usage belonging to another pod remaining accounted.
- A sidecar starting after a larger regular init container.
- Sidecar and application memory remaining concurrent.
- Successful annotation and cached-accounting updates.

Only the NUMA-refit implementation and its focused scheduler tests are changed.

AI assistance disclosure:

I used OpenAI Codex to review the implementation and for this PR description.

**Does this PR introduce a user-facing change?**:

~~~release-note
NUMA refit now uses phase-aware init and application container accounting, preventing valid placements from being rejected by double-counted GPU memory.
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NUMA-aware resource recalculation as workloads transition from initialization to steady state.
  - Refined device capacity calculations for init containers, sidecars, reserved devices, and concurrent resource usage.
  - Corrected resource release tracking to restore the appropriate allocated capacity.
  - Device type matching is now more precise, and unsupported registered device types are rejected clearly.

- **Tests**
  - Added coverage for phase-aware NUMA allocation, concurrent sidecars, multiple application containers, and unsupported device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->