### PR TITLE
test(scheduler): verify NUMA refit PATCH timeout releases allocLock

### DIFF
--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -40,7 +40,7 @@ import (
 // newer update to the same annotations (for example Allocate consuming a
 // to-allocate entry). Conflicts fail the refit; there is no retry with
 // cached values. Also a test seam.
-var patchPodAnnotations = func(ctx context.Context, pod *corev1.Pod, annotations map[string]string) error {
+var patchPodAnnotations = func(pod *corev1.Pod, annotations map[string]string) error {
 	metadata := map[string]any{"annotations": annotations}
 	if pod.ResourceVersion != "" {
 		metadata["resourceVersion"] = pod.ResourceVersion
@@ -49,6 +49,11 @@ var patchPodAnnotations = func(ctx context.Context, pod *corev1.Pod, annotations
 	if err != nil {
 		return err
 	}
+	// The refit holds the allocation lock that Filter also takes, so this
+	// call must not block scheduling on an unreachable API server. The
+	// device plugin gives up after numaRefitTimeout anyway.
+	ctx, cancel := context.WithTimeout(context.Background(), refitPatchTimeout)
+	defer cancel()
 	_, err = client.GetClient().CoreV1().Pods(pod.Namespace).
 		Patch(ctx, pod.Name, k8stypes.MergePatchType, payload, metav1.PatchOptions{})
 	return err
@@ -60,9 +65,8 @@ const maxAllowedDeviceUUIDs = 512
 // refitPatchTimeout bounds the annotation patch. It is deliberately no longer
 // than the device plugin's own refit budget: a patch that has not landed by
 // then cannot be used, and waiting longer would hold the allocation lock
-// against every concurrent Filter call. It is a variable so the timeout path
-// can be tested without making unit tests wait for the production duration.
-var refitPatchTimeout = 2 * time.Second
+// against every concurrent Filter call.
+const refitPatchTimeout = 2 * time.Second
 
 // RefitNumaAllocation moves one container's device reservation onto a device
 // from the caller-supplied allowed set, re-running the pod's normal
@@ -242,12 +246,7 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 		device.InRequestDevices[req.DeviceType]: pendingValue,
 		device.SupportDevices[req.DeviceType]:   allocatedValue,
 	}
-	// The refit holds the allocation lock that Filter also takes, so this
-	// call must not block scheduling on an unreachable API server. The
-	// device plugin gives up after numaRefitTimeout anyway.
-	ctx, cancel := context.WithTimeout(context.Background(), refitPatchTimeout)
-	defer cancel()
-	if err := patchPodAnnotations(ctx, pod, annotations); err != nil {
+	if err := patchPodAnnotations(pod, annotations); err != nil {
 		return failWithQuotaRestore("cannot patch pod annotations: %v", err)
 	}
 

--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -40,7 +40,7 @@ import (
 // newer update to the same annotations (for example Allocate consuming a
 // to-allocate entry). Conflicts fail the refit; there is no retry with
 // cached values. Also a test seam.
-var patchPodAnnotations = func(pod *corev1.Pod, annotations map[string]string) error {
+var patchPodAnnotations = func(ctx context.Context, pod *corev1.Pod, annotations map[string]string) error {
 	metadata := map[string]any{"annotations": annotations}
 	if pod.ResourceVersion != "" {
 		metadata["resourceVersion"] = pod.ResourceVersion
@@ -49,11 +49,6 @@ var patchPodAnnotations = func(pod *corev1.Pod, annotations map[string]string) e
 	if err != nil {
 		return err
 	}
-	// The refit holds the allocation lock that Filter also takes, so this
-	// call must not block scheduling on an unreachable API server. The
-	// device plugin gives up after numaRefitTimeout anyway.
-	ctx, cancel := context.WithTimeout(context.Background(), refitPatchTimeout)
-	defer cancel()
 	_, err = client.GetClient().CoreV1().Pods(pod.Namespace).
 		Patch(ctx, pod.Name, k8stypes.MergePatchType, payload, metav1.PatchOptions{})
 	return err
@@ -65,8 +60,9 @@ const maxAllowedDeviceUUIDs = 512
 // refitPatchTimeout bounds the annotation patch. It is deliberately no longer
 // than the device plugin's own refit budget: a patch that has not landed by
 // then cannot be used, and waiting longer would hold the allocation lock
-// against every concurrent Filter call.
-const refitPatchTimeout = 2 * time.Second
+// against every concurrent Filter call. It is a variable so the timeout path
+// can be tested without making unit tests wait for the production duration.
+var refitPatchTimeout = 2 * time.Second
 
 // RefitNumaAllocation moves one container's device reservation onto a device
 // from the caller-supplied allowed set, re-running the pod's normal
@@ -246,7 +242,12 @@ func (s *Scheduler) RefitNumaAllocation(req device.NumaRefitRequest) device.Numa
 		device.InRequestDevices[req.DeviceType]: pendingValue,
 		device.SupportDevices[req.DeviceType]:   allocatedValue,
 	}
-	if err := patchPodAnnotations(pod, annotations); err != nil {
+	// The refit holds the allocation lock that Filter also takes, so this
+	// call must not block scheduling on an unreachable API server. The
+	// device plugin gives up after numaRefitTimeout anyway.
+	ctx, cancel := context.WithTimeout(context.Background(), refitPatchTimeout)
+	defer cancel()
+	if err := patchPodAnnotations(ctx, pod, annotations); err != nil {
 		return failWithQuotaRestore("cannot patch pod annotations: %v", err)
 	}
 

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -80,7 +80,7 @@ func stubRefitPatch(t *testing.T, fail error) (map[string]string, *int) {
 	captured := map[string]string{}
 	calls := 0
 	previous := patchPodAnnotations
-	patchPodAnnotations = func(_ context.Context, _ *corev1.Pod, annotations map[string]string) error {
+	patchPodAnnotations = func(_ *corev1.Pod, annotations map[string]string) error {
 		calls++
 		if fail != nil {
 			return fail
@@ -92,34 +92,22 @@ func stubRefitPatch(t *testing.T, fail error) (map[string]string, *int) {
 	return captured, &calls
 }
 
-func TestRefitNumaAllocationPatchTimeoutReleasesFilter(t *testing.T) {
+func TestRefitNumaAllocationPatchDeadlineReleasesFilter(t *testing.T) {
 	s, pod := refitFixture(t, 40000)
 	resourceNames := device.GetDevices()[nvidia.NvidiaGPUDevice].GetResourceNames()
-	previousTimeout := refitPatchTimeout
-	refitPatchTimeout = 50 * time.Millisecond
-	t.Cleanup(func() { refitPatchTimeout = previousTimeout })
 	s.quotaManager.AddUsage(pod, device.PodDevices{nvidia.NvidiaGPUDevice: {{{
 		UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30,
 	}}}})
 
-	originalAnnotations := maps.Clone(pod.Annotations)
 	patchStarted := make(chan struct{})
+	releasePatch := make(chan struct{})
 	filterStarted := make(chan struct{})
-	filterReturned := make(chan struct{})
 	filterDone := make(chan error, 1)
-	filterBlocked := make(chan bool, 1)
 	previousPatch := patchPodAnnotations
-	patchPodAnnotations = func(ctx context.Context, _ *corev1.Pod, _ map[string]string) error {
+	patchPodAnnotations = func(_ *corev1.Pod, _ map[string]string) error {
 		close(patchStarted)
-		<-filterStarted
-		select {
-		case <-filterReturned:
-			filterBlocked <- false
-		default:
-			filterBlocked <- true
-		}
-		<-ctx.Done()
-		return ctx.Err()
+		<-releasePatch
+		return context.DeadlineExceeded
 	}
 	t.Cleanup(func() { patchPodAnnotations = previousPatch })
 
@@ -131,6 +119,10 @@ func TestRefitNumaAllocationPatchTimeoutReleasesFilter(t *testing.T) {
 	case <-patchStarted:
 	case <-time.After(time.Second):
 		t.Fatal("refit did not reach the annotation PATCH")
+	}
+	if s.allocLock.TryLock() {
+		s.allocLock.Unlock()
+		t.Fatal("refit did not hold allocLock while patching annotations")
 	}
 
 	filterPod := &corev1.Pod{
@@ -146,17 +138,17 @@ func TestRefitNumaAllocationPatchTimeoutReleasesFilter(t *testing.T) {
 		close(filterStarted)
 		_, err := s.Filter(extenderv1.ExtenderArgs{Pod: filterPod, NodeNames: &[]string{}})
 		filterDone <- err
-		close(filterReturned)
 	}()
+	<-filterStarted
+	close(releasePatch)
 
 	select {
 	case response := <-refitDone:
 		assert.Equal(t, response.Succeeded, false)
 		assert.Assert(t, strings.Contains(response.FailureReason, context.DeadlineExceeded.Error()), "reason: %s", response.FailureReason)
 	case <-time.After(time.Second):
-		t.Fatal("refit did not stop after the annotation PATCH timeout")
+		t.Fatal("refit did not stop after the annotation PATCH deadline")
 	}
-	assert.Equal(t, <-filterBlocked, true, "Filter completed while the refit held allocLock")
 	select {
 	case err := <-filterDone:
 		assert.NilError(t, err)
@@ -164,7 +156,6 @@ func TestRefitNumaAllocationPatchTimeoutReleasesFilter(t *testing.T) {
 		t.Fatal("Filter did not continue after the refit released allocLock")
 	}
 
-	assert.DeepEqual(t, pod.Annotations, originalAnnotations)
 	assert.Equal(t, trackedUUID(t, s), "GPU-a")
 	quota := s.quotaManager.GetResourceQuota()[pod.Namespace]
 	assert.Equal(t, (*quota)[resourceNames.ResourceMemoryName].Used, int64(20000))

--- a/pkg/scheduler/numa_refit_handler_test.go
+++ b/pkg/scheduler/numa_refit_handler_test.go
@@ -17,15 +17,19 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"maps"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
@@ -76,7 +80,7 @@ func stubRefitPatch(t *testing.T, fail error) (map[string]string, *int) {
 	captured := map[string]string{}
 	calls := 0
 	previous := patchPodAnnotations
-	patchPodAnnotations = func(_ *corev1.Pod, annotations map[string]string) error {
+	patchPodAnnotations = func(_ context.Context, _ *corev1.Pod, annotations map[string]string) error {
 		calls++
 		if fail != nil {
 			return fail
@@ -86,6 +90,85 @@ func stubRefitPatch(t *testing.T, fail error) (map[string]string, *int) {
 	}
 	t.Cleanup(func() { patchPodAnnotations = previous })
 	return captured, &calls
+}
+
+func TestRefitNumaAllocationPatchTimeoutReleasesFilter(t *testing.T) {
+	s, pod := refitFixture(t, 40000)
+	resourceNames := device.GetDevices()[nvidia.NvidiaGPUDevice].GetResourceNames()
+	previousTimeout := refitPatchTimeout
+	refitPatchTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { refitPatchTimeout = previousTimeout })
+	s.quotaManager.AddUsage(pod, device.PodDevices{nvidia.NvidiaGPUDevice: {{{
+		UUID: "GPU-a", Type: nvidia.NvidiaGPUDevice, Usedmem: 20000, Usedcores: 30,
+	}}}})
+
+	originalAnnotations := maps.Clone(pod.Annotations)
+	patchStarted := make(chan struct{})
+	filterStarted := make(chan struct{})
+	filterReturned := make(chan struct{})
+	filterDone := make(chan error, 1)
+	filterBlocked := make(chan bool, 1)
+	previousPatch := patchPodAnnotations
+	patchPodAnnotations = func(ctx context.Context, _ *corev1.Pod, _ map[string]string) error {
+		close(patchStarted)
+		<-filterStarted
+		select {
+		case <-filterReturned:
+			filterBlocked <- false
+		default:
+			filterBlocked <- true
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	t.Cleanup(func() { patchPodAnnotations = previousPatch })
+
+	refitDone := make(chan device.NumaRefitResponse, 1)
+	go func() {
+		refitDone <- s.RefitNumaAllocation(refitTestRequestFor("GPU-b"))
+	}()
+	select {
+	case <-patchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("refit did not reach the annotation PATCH")
+	}
+
+	filterPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "waiting-filter-uid", Name: "waiting-filter", Namespace: "default"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				corev1.ResourceName(resourceNames.ResourceCountName): *resource.NewQuantity(1, resource.DecimalSI),
+			}},
+		}}},
+	}
+	go func() {
+		close(filterStarted)
+		_, err := s.Filter(extenderv1.ExtenderArgs{Pod: filterPod, NodeNames: &[]string{}})
+		filterDone <- err
+		close(filterReturned)
+	}()
+
+	select {
+	case response := <-refitDone:
+		assert.Equal(t, response.Succeeded, false)
+		assert.Assert(t, strings.Contains(response.FailureReason, context.DeadlineExceeded.Error()), "reason: %s", response.FailureReason)
+	case <-time.After(time.Second):
+		t.Fatal("refit did not stop after the annotation PATCH timeout")
+	}
+	assert.Equal(t, <-filterBlocked, true, "Filter completed while the refit held allocLock")
+	select {
+	case err := <-filterDone:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Filter did not continue after the refit released allocLock")
+	}
+
+	assert.DeepEqual(t, pod.Annotations, originalAnnotations)
+	assert.Equal(t, trackedUUID(t, s), "GPU-a")
+	quota := s.quotaManager.GetResourceQuota()[pod.Namespace]
+	assert.Equal(t, (*quota)[resourceNames.ResourceMemoryName].Used, int64(20000))
+	assert.Equal(t, (*quota)[resourceNames.ResourceCoreName].Used, int64(30))
 }
 
 func refitTestRequestFor(allowed ...string) device.NumaRefitRequest {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds concurrency coverage for the NUMA-refit annotation PATCH timeout.

The scheduler holds `allocLock` while performing a NUMA refit. If the Kubernetes API PATCH blocks, concurrent `Filter` requests must not remain blocked indefinitely.

The test uses a short injectable timeout and verifies that:

- The blocked PATCH returns `context deadline exceeded`.
- The refit releases `allocLock`.
- A waiting `Filter` request continues.
- Pod annotations remain unchanged.
- The original device reservation remains unchanged.
- ResourceQuota usage is restored.

The production timeout remains two seconds.

~~~text
NUMA refit acquires allocLock
             |
             v
      Annotation PATCH blocks
             |
             v
       PATCH timeout expires
             |
             v
Refit restores quota and releases allocLock
             |
             v
      Waiting Filter continues
~~~

**Which issue(s) this PR fixes**:

Fixes #2857

**Special notes for your reviewer**:

The change moves creation of the existing timeout context to `RefitNumaAllocation` so the PATCH test seam receives the same context used in production. No scheduling or timeout behavior is changed.


AI assistance disclosure:

I used an  AI Assistance to review the implementation and for the PR description.

**Does this PR introduce a user-facing change?**:

~~~release-note
NONE
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler behavior when an annotation update times out.
  * Ensured filtering can continue after a timed-out NUMA allocation refit.
  * Preserved device assignment and quota usage when the update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->