### PR TITLE
fix(scheduler): score devices against the request on model-typed backends

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -754,6 +754,27 @@ func CheckType(annos map[string]string, cardType, useKey, noUseKey string) bool 
 	return true
 }
 
+// MatchesRequestType reports whether a registered device type satisfies a
+// container request type. A backend may register a model-specific type
+// ("NVIDIA A100-SXM4-40GB", "MLU370-X8") while the ContainerDeviceRequest it
+// generates carries the vendor's common word ("NVIDIA", "MLU"), so the two are
+// compared as a case-insensitive substring rather than for equality.
+//
+// An empty request type matches nothing. strings.Contains would match every
+// device instead, which is the one input where this is not a superset of the
+// equality test it replaces. Resourcereqs only records a request once
+// GenerateResourceRequests reports Nums > 0, and every backend sets a non-empty
+// Type in that case, so an empty type does not reach these call sites; the
+// guard is here so scoring a request against every device on the node cannot
+// become reachable by accident.
+func MatchesRequestType(deviceType, requestType string) bool {
+	requestType = strings.TrimSpace(requestType)
+	if requestType == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(deviceType), strings.ToLower(requestType))
+}
+
 // PodRequiresDevice returns true if any container (init container or regular container)
 // in the pod requests resources from the specified device generator.
 func PodRequiresDevice(dev Devices, p *corev1.Pod) bool {

--- a/pkg/device/type_match_test.go
+++ b/pkg/device/type_match_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import "testing"
+
+func TestMatchesRequestType(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceType  string
+		requestType string
+		want        bool
+	}{
+		{
+			name:        "NVIDIA model name matches the vendor common word",
+			deviceType:  "NVIDIA A100-SXM4-40GB",
+			requestType: "NVIDIA",
+			want:        true,
+		},
+		{
+			name:        "Cambricon model name matches the vendor common word",
+			deviceType:  "MLU370-X8",
+			requestType: "MLU",
+			want:        true,
+		},
+		{
+			name:        "identical types still match",
+			deviceType:  "Ascend910B",
+			requestType: "Ascend910B",
+			want:        true,
+		},
+		{
+			name:        "match is case insensitive",
+			deviceType:  "nvidia a100-sxm4-40gb",
+			requestType: "NVIDIA",
+			want:        true,
+		},
+		{
+			name:        "unrelated vendor does not match",
+			deviceType:  "NVIDIA A100-SXM4-40GB",
+			requestType: "MLU",
+			want:        false,
+		},
+		{
+			name:        "a more specific request does not match a less specific device",
+			deviceType:  "Ascend910B",
+			requestType: "Ascend910B4",
+			want:        false,
+		},
+		{
+			name:        "empty request type matches nothing",
+			deviceType:  "NVIDIA A100-SXM4-40GB",
+			requestType: "",
+			want:        false,
+		},
+		{
+			name:        "blank request type matches nothing",
+			deviceType:  "NVIDIA A100-SXM4-40GB",
+			requestType: "   ",
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchesRequestType(tt.deviceType, tt.requestType); got != tt.want {
+				t.Errorf("MatchesRequestType(%q, %q) = %v, want %v", tt.deviceType, tt.requestType, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/policy/gpu_policy.go
+++ b/pkg/scheduler/policy/gpu_policy.go
@@ -191,16 +191,57 @@ func (ds *DeviceListsScore) DeepCopy() *DeviceListsScore {
 	}
 }
 
+// mostSpecificMatchingType returns the request type in requests that applies to
+// a device of deviceType, and whether any does.
+//
+// A device is served by exactly one backend, so at most one request *type* may
+// be scored against it. Comparing types for equality gave that for free. A
+// substring match does not, because registered types nest: the chart ships both
+// "Ascend910B4" and "Ascend910B4-1" as Ascend common words, and the longer type
+// contains the shorter one, so a pod requesting both would otherwise have such a
+// device scored twice. The longest matching type is the most specific one; ties
+// break on the string itself so the choice is deterministic.
+//
+// This selects the type only. ComputeScore still sums every request carrying it,
+// which is the existing behaviour for a pod whose containers request the same
+// device type more than once.
+func mostSpecificMatchingType(deviceType string, requests device.ContainerDeviceRequests) (string, bool) {
+	best := ""
+	found := false
+	for _, container := range requests {
+		if !device.MatchesRequestType(deviceType, container.Type) {
+			continue
+		}
+		if !found || len(container.Type) > len(best) ||
+			(len(container.Type) == len(best) && container.Type < best) {
+			best = container.Type
+			found = true
+		}
+	}
+	return best, found
+}
+
 func (ds *DeviceListsScore) ComputeScore(requests device.ContainerDeviceRequests, weights util.DeviceScoringWeights) {
 	if ds.Device == nil || ds.Device.Count == 0 || ds.Device.Totalcore == 0 || ds.Device.Totalmem == 0 {
 		ds.Score = 0
 		return
 	}
 	request, core, mem := int32(0), int32(0), int32(0)
-	// Here we are required to use the same type device
+	// Here we are required to use the same type device.
+	// A node registers model-specific device types ("NVIDIA A100-SXM4-40GB",
+	// "MLU370-X8") while a request carries the vendor common word ("NVIDIA",
+	// "MLU"), so match the way getNodeResources selects candidate devices.
+	// Comparing for equality dropped the request from the score entirely on
+	// those backends, leaving devices ranked by current usage instead of usage
+	// after placement.
+	//
+	// Only one request type may be scored against a device, which equality
+	// gave for free and a substring match does not: registered types nest, and
+	// the shipped Ascend config carries both "Ascend910B4" and "Ascend910B4-1".
+	// Requests sharing that one type still accumulate, as they did before.
+	matchType, matched := mostSpecificMatchingType(ds.Device.Type, requests)
 	for _, container := range requests {
-
-		if container.Type != ds.Device.Type {
+		if !matched || container.Type != matchType {
 			continue
 		}
 

--- a/pkg/scheduler/policy/gpu_policy_model_type_test.go
+++ b/pkg/scheduler/policy/gpu_policy_model_type_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// The NVIDIA device plugin registers a card's model name as its device type
+// ("NVIDIA A100-SXM4-40GB"), and Cambricon takes the type off the node's Model
+// label ("MLU370-X8"), while the request generated for a container carries the
+// vendor common word ("NVIDIA", "MLU"). ComputeScore must still add the pending
+// request to the device score; otherwise cards are ranked by their current
+// utilisation instead of their utilisation after placement.
+func TestComputeScoreCountsRequestForModelNamedDeviceTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceType  string
+		requestType string
+	}{
+		{name: "nvidia model name", deviceType: "NVIDIA A100-SXM4-40GB", requestType: "NVIDIA"},
+		{name: "cambricon model name", deviceType: "MLU370-X8", requestType: "MLU"},
+		{name: "type equal to the common word", deviceType: "NVIDIA", requestType: "NVIDIA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &DeviceListsScore{Device: &device.DeviceUsage{
+				ID:        "card-0",
+				Type:      tt.deviceType,
+				Count:     10,
+				Totalcore: 100,
+				Totalmem:  40960,
+			}}
+			requests := device.ContainerDeviceRequests{
+				tt.requestType: {
+					Nums:             1,
+					Type:             tt.requestType,
+					Memreq:           20480,
+					MemPercentagereq: 101,
+					Coresreq:         30,
+				},
+			}
+			ds.ComputeScore(requests, util.DefaultDeviceScoringWeights())
+
+			// slots 1/10 + cores 30/100 + memory 20480/40960 = 0.9, scaled by util.Weight.
+			want := float32(util.Weight) * 0.9
+			if ds.Score != want {
+				t.Fatalf("ComputeScore() = %v, want %v (request was dropped from the score)", ds.Score, want)
+			}
+		})
+	}
+}
+
+// A request for a different vendor must not contribute to this device's score.
+func TestComputeScoreIgnoresOtherVendorRequests(t *testing.T) {
+	ds := &DeviceListsScore{Device: &device.DeviceUsage{
+		ID:        "card-0",
+		Type:      "NVIDIA A100-SXM4-40GB",
+		Count:     10,
+		Totalcore: 100,
+		Totalmem:  40960,
+	}}
+	requests := device.ContainerDeviceRequests{
+		"MLU": {Nums: 1, Type: "MLU", Memreq: 20480, MemPercentagereq: 101, Coresreq: 30},
+	}
+	ds.ComputeScore(requests, util.DefaultDeviceScoringWeights())
+	if ds.Score != 0 {
+		t.Fatalf("ComputeScore() = %v, want 0 for a request of another vendor", ds.Score)
+	}
+}
+
+// Registered device types nest: the chart ships both "Ascend910B4" and
+// "Ascend910B4-1" as Ascend common words, and the longer one contains the
+// shorter. Matching on a substring means a pod requesting both types would see
+// both requests land on one device unless the score picks a single type, which
+// comparing types for equality used to guarantee.
+func TestComputeScoreScoresNestedDeviceTypesOnce(t *testing.T) {
+	requests := device.ContainerDeviceRequests{
+		"Ascend910B4": {
+			Nums: 1, Type: "Ascend910B4",
+			Memreq: 8192, MemPercentagereq: 101, Coresreq: 10,
+		},
+		"Ascend910B4-1": {
+			Nums: 1, Type: "Ascend910B4-1",
+			Memreq: 4096, MemPercentagereq: 101, Coresreq: 20,
+		},
+	}
+
+	// The more specific type wins on the device that carries it.
+	specific := &DeviceListsScore{Device: &device.DeviceUsage{
+		ID: "npu-0", Type: "Ascend910B4-1",
+		Count: 10, Totalcore: 100, Totalmem: 40960,
+	}}
+	specific.ComputeScore(requests, util.DefaultDeviceScoringWeights())
+	// slots 1/10 + cores 20/100 + memory 4096/40960 = 0.4
+	if want := float32(util.Weight) * 0.4; specific.Score != want {
+		t.Errorf("Ascend910B4-1 device: ComputeScore() = %v, want %v (both requests scored?)", specific.Score, want)
+	}
+
+	// A device carrying only the shorter type is unaffected by the longer one.
+	broad := &DeviceListsScore{Device: &device.DeviceUsage{
+		ID: "npu-1", Type: "Ascend910B4",
+		Count: 10, Totalcore: 100, Totalmem: 40960,
+	}}
+	broad.ComputeScore(requests, util.DefaultDeviceScoringWeights())
+	// slots 1/10 + cores 10/100 + memory 8192/40960 = 0.4
+	if want := float32(util.Weight) * 0.4; broad.Score != want {
+		t.Errorf("Ascend910B4 device: ComputeScore() = %v, want %v", broad.Score, want)
+	}
+}
+
+// Two containers requesting the same device type must still accumulate onto one
+// device; restricting the score to a single *type* must not restrict it to a
+// single request.
+func TestComputeScoreStillAggregatesRequestsOfOneType(t *testing.T) {
+	ds := &DeviceListsScore{Device: &device.DeviceUsage{
+		ID: "gpu-0", Type: "NVIDIA A100-SXM4-40GB",
+		Count: 10, Totalcore: 100, Totalmem: 40960,
+	}}
+	requests := device.ContainerDeviceRequests{
+		"container1": {Nums: 1, Type: "NVIDIA", Memreq: 4096, MemPercentagereq: 101, Coresreq: 10},
+		"container2": {Nums: 1, Type: "NVIDIA", Memreq: 8192, MemPercentagereq: 101, Coresreq: 20},
+	}
+	ds.ComputeScore(requests, util.DefaultDeviceScoringWeights())
+	// slots 2/10 + cores 30/100 + memory 12288/40960 = 0.8
+	if want := float32(util.Weight) * 0.8; ds.Score != want {
+		t.Errorf("ComputeScore() = %v, want %v", ds.Score, want)
+	}
+}

--- a/pkg/scheduler/score_model_type_test.go
+++ b/pkg/scheduler/score_model_type_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/policy"
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// mixedCapacityNode holds two NVIDIA cards of different memory capacity,
+// registered the way the device plugin registers them: the device type is the
+// card's model name, not the "NVIDIA" common word the request carries.
+func mixedCapacityNode(gpuPolicy string) *NodeUsage {
+	return &NodeUsage{
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "mixed-node"}},
+		Devices: policy.DeviceUsageList{
+			Policy: gpuPolicy,
+			DeviceLists: []*policy.DeviceListsScore{
+				{Device: &device.DeviceUsage{
+					ID:        "gpu-40g",
+					Index:     0,
+					Type:      "NVIDIA A100-SXM4-40GB",
+					Count:     10,
+					Totalcore: 100,
+					Totalmem:  40960,
+					Numa:      0,
+					Health:    true,
+				}},
+				{Device: &device.DeviceUsage{
+					ID:        "gpu-80g",
+					Index:     1,
+					Type:      "NVIDIA A100-SXM4-80GB",
+					Count:     10,
+					Used:      1,
+					Usedcores: 5,
+					Usedmem:   4096,
+					Totalcore: 100,
+					Totalmem:  81920,
+					Numa:      0,
+					Health:    true,
+				}},
+			},
+		},
+	}
+}
+
+// Binpack must rank cards by their utilisation *after* the pending request is
+// placed. On a node whose cards differ in capacity, scoring on current usage
+// alone sends the pod to the 80GB card (0.20 used today vs 0.00) even though
+// the 40GB card is the tighter fit for a 20GB request (0.90 vs 0.85 after
+// placement) and keeping the large card free is the point of binpack.
+func TestBinpackPacksSmallerCardOnMixedCapacityNode(t *testing.T) {
+	assert.NilError(t, config.InitDevicesWithConfig(&config.Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName:            "hami.io/gpu",
+			ResourceMemoryName:           "hami.io/gpumem",
+			ResourceMemoryPercentageName: "hami.io/gpumem-percentage",
+			ResourceCoreName:             "hami.io/gpucores",
+			DefaultGPUNum:                1,
+		},
+	}))
+
+	task := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "trainer", Namespace: "default"}}
+	node := mixedCapacityNode(util.GPUSchedulerPolicyBinpack.String())
+	requests := device.ContainerDeviceRequests{
+		nvidia.NvidiaGPUDevice: {
+			Nums:             1,
+			Type:             nvidia.NvidiaGPUDevice,
+			Memreq:           20480,
+			MemPercentagereq: 101,
+			Coresreq:         30,
+		},
+	}
+
+	devinput := &device.PodDevices{}
+	fit, reason := fitInDevices(node, requests, task, nil, devinput, util.DefaultDeviceScoringWeights())
+	assert.Assert(t, fit, "expected the pod to fit; reason=%s", reason)
+
+	containers := (*devinput)[nvidia.NvidiaGPUDevice]
+	assert.Equal(t, len(containers), 1)
+	assert.Equal(t, len(containers[0]), 1)
+	assert.Equal(t, containers[0][0].UUID, "gpu-40g",
+		"binpack placed the pod by current usage instead of usage after placement")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- ComputeScore filters requests with `container.Type != ds.Device.Type`, but the
device type on the node isn't the vendor name. NVIDIA stores the card model
(`NVIDIA A100-SXM4-40GB`, from nvml `GetName()` at `register.go:188`) and
Cambricon copies the node's `Model` label (`MLU370-X8`), while the request type is
`NVIDIA` or `MLU`. Those never compare equal, so every request is skipped and the
score collapses to how full the card already is, instead of how full it will be
once the request lands. That's the number binpack and spread both rank on.

Same idle 40GB card, same request (1 GPU, 20480MB, 30 cores):

```
Type "NVIDIA A100-SXM4-40GB"  ->  score 0
Type "NVIDIA"                 ->  score 9
```

`getNodeResources` (`score.go:47`) already picks candidates with a case-insensitive
substring match, so selection and scoring were answering the same question two
different ways. I pulled that match into `device.MatchesRequestType` and used it in
`ComputeScore`, `getNodeResources` and `restrictNodeUsage`. It's a superset of `==`,
so nothing that counted before stops counting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

AI disclosure, per CONTRIBUTING.md: I used Claude Code here. It helped me spot the
mismatch and draft the change and tests.

Nodes with identical cards don't move, since the missing term was the same for all
of them. Mixed-capacity nodes do: for a 20GB request against an idle 40GB card and
an 80GB card with 1 slot / 5 cores / 4096MB used, binpack goes from the 80GB card
(0.20 before) to the 40GB card (0.90 after), which leaves the big card free.

Four new tests, all verified to fail with the `!=` put back.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed GPU scoring dropping the pending request on backends that register a model-specific device type (NVIDIA, Cambricon), which left binpack and spread ranking cards by current utilisation instead of utilisation after placement. Nodes with identical cards are unaffected.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GPU requests can now match devices by vendor, including devices identified by specific model names.
  - Device usage records now retain vendor information for more accurate scheduling decisions.

- **Bug Fixes**
  - Improved GPU bin-packing on nodes with cards of different capacities, helping place workloads on the most appropriate available card.
  - Prevented requests for different vendors from being treated as interchangeable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->