### PR TITLE
fix(scheduler): keep multi-slot device usage across annotation round trip

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -543,17 +543,14 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 			Usedmem:   int32(devmem),
 			Usedcores: int32(devcores),
 		}
-		// The 5th field is optional and only written for multi-slot entries,
-		// so annotations produced by older versions stay readable.
+		// The 5th field is optional. An unusable value is ignored rather than
+		// rejected: dropping the whole annotation undercounts far more than one slot.
 		if len(tmpstr) >= 5 {
-			devslots, err := strconv.ParseInt(tmpstr[4], 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid slots field: %w", err)
+			if devslots, err := strconv.ParseInt(tmpstr[4], 10, 32); err == nil && devslots >= 0 {
+				tmpdev.Slots = int32(devslots)
+			} else {
+				klog.V(5).Infof("ignoring unusable slots field %q in segment %q", tmpstr[4], val)
 			}
-			if devslots < 0 {
-				return nil, fmt.Errorf("slots field must not be negative: %d", devslots)
-			}
-			tmpdev.Slots = int32(devslots)
 		}
 		contdev = append(contdev, tmpdev)
 	}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -451,6 +451,12 @@ func UnMarshalNodeDevices(str string) ([]*DeviceInfo, error) {
 func EncodeContainerDevices(cd ContainerDevices) string {
 	var builder strings.Builder
 	for _, val := range cd {
+		// Slots is appended as an optional 5th field only when it exceeds 1, so
+		// single-slot allocations keep the historical 4-field encoding.
+		if val.Slots > 1 {
+			fmt.Fprintf(&builder, "%s,%s,%d,%d,%d%s", val.UUID, val.Type, val.Usedmem, val.Usedcores, val.Slots, OneContainerMultiDeviceSplitSymbol)
+			continue
+		}
 		fmt.Fprintf(&builder, "%s,%s,%d,%d%s", val.UUID, val.Type, val.Usedmem, val.Usedcores, OneContainerMultiDeviceSplitSymbol)
 	}
 	tmp := builder.String()
@@ -536,6 +542,18 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 			Type:      tmpstr[1],
 			Usedmem:   int32(devmem),
 			Usedcores: int32(devcores),
+		}
+		// The 5th field is optional and only written for multi-slot entries,
+		// so annotations produced by older versions stay readable.
+		if len(tmpstr) >= 5 {
+			devslots, err := strconv.ParseInt(tmpstr[4], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid slots field: %w", err)
+			}
+			if devslots < 0 {
+				return nil, fmt.Errorf("slots field must not be negative: %d", devslots)
+			}
+			tmpdev.Slots = int32(devslots)
 		}
 		contdev = append(contdev, tmpdev)
 	}

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1305,6 +1305,7 @@ func TestGetDevicesUUIDList(t *testing.T) {
 		})
 	}
 }
+
 // TestEncodeDecodeContainerDevicesSlots covers the optional slots field: it is
 // only written when it exceeds 1, so single-slot entries keep the 4-field form.
 func TestEncodeDecodeContainerDevicesSlots(t *testing.T) {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -139,16 +139,29 @@ func TestDecodeContainerDevices(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "invalid non-numeric slots",
+			name:        "invalid non-numeric slots is ignored",
 			input:       "GPU-1,NVIDIA,1000,10,invalid:",
-			want:        nil,
-			expectError: true,
+			want:        ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10}},
+			expectError: false,
 		},
 		{
-			name:        "negative slots value",
+			name:        "negative slots value is ignored",
 			input:       "GPU-1,NVIDIA,1000,10,-1:",
-			want:        nil,
-			expectError: true,
+			want:        ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10}},
+			expectError: false,
+		},
+		{
+			name:  "existing valid fields preserved with extra optional fields",
+			input: "GPU-1,NVIDIA,1000,10,extra1,extra2:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-1",
+					Type:      "NVIDIA",
+					Usedmem:   1000,
+					Usedcores: 10,
+				},
+			},
+			expectError: false,
 		},
 		{
 			name:        "malformed segment without comma",

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -111,17 +111,44 @@ func TestDecodeContainerDevices(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:  "existing valid fields preserved with extra optional fields",
-			input: "GPU-1,NVIDIA,1000,10,extra1,extra2:",
+			name:  "optional slots field is decoded",
+			input: "GPU-1,NVIDIA,1000,10,3:",
 			want: ContainerDevices{
 				{
 					UUID:      "GPU-1",
 					Type:      "NVIDIA",
 					Usedmem:   1000,
 					Usedcores: 10,
+					Slots:     3,
 				},
 			},
 			expectError: false,
+		},
+		{
+			name:  "fields after slots are ignored",
+			input: "GPU-1,NVIDIA,1000,10,3,extra:",
+			want: ContainerDevices{
+				{
+					UUID:      "GPU-1",
+					Type:      "NVIDIA",
+					Usedmem:   1000,
+					Usedcores: 10,
+					Slots:     3,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid non-numeric slots",
+			input:       "GPU-1,NVIDIA,1000,10,invalid:",
+			want:        nil,
+			expectError: true,
+		},
+		{
+			name:        "negative slots value",
+			input:       "GPU-1,NVIDIA,1000,10,-1:",
+			want:        nil,
+			expectError: true,
 		},
 		{
 			name:        "malformed segment without comma",
@@ -1278,6 +1305,58 @@ func TestGetDevicesUUIDList(t *testing.T) {
 		})
 	}
 }
+// TestEncodeDecodeContainerDevicesSlots covers the optional slots field: it is
+// only written when it exceeds 1, so single-slot entries keep the 4-field form.
+func TestEncodeDecodeContainerDevicesSlots(t *testing.T) {
+	tests := []struct {
+		name        string
+		cd          ContainerDevices
+		wantEncoded string
+		wantDecoded ContainerDevices
+	}{
+		{
+			name:        "multi slot entry encodes the slots field",
+			cd:          ContainerDevices{{UUID: "GPU-1", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3}},
+			wantEncoded: "GPU-1,Enflame,20480,50,3:",
+			wantDecoded: ContainerDevices{{UUID: "GPU-1", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3}},
+		},
+		{
+			name:        "single slot entry keeps the legacy four fields",
+			cd:          ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10, Slots: 1}},
+			wantEncoded: "GPU-1,NVIDIA,1000,10:",
+			wantDecoded: ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10}},
+		},
+		{
+			name:        "unset slots keeps the legacy four fields",
+			cd:          ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10}},
+			wantEncoded: "GPU-1,NVIDIA,1000,10:",
+			wantDecoded: ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10}},
+		},
+		{
+			name: "mixed entries in one container",
+			cd: ContainerDevices{
+				{UUID: "GPU-1", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3},
+				{UUID: "GPU-2", Type: "Enflame", Usedmem: 6144, Usedcores: 17},
+			},
+			wantEncoded: "GPU-1,Enflame,20480,50,3:GPU-2,Enflame,6144,17:",
+			wantDecoded: ContainerDevices{
+				{UUID: "GPU-1", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3},
+				{UUID: "GPU-2", Type: "Enflame", Usedmem: 6144, Usedcores: 17},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := EncodeContainerDevices(tt.cd)
+			assert.Equal(t, encoded, tt.wantEncoded)
+			decoded, err := DecodeContainerDevices(encoded)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tt.wantDecoded, decoded)
+		})
+	}
+}
+
 func TestEncodeContainerDeviceType(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1964,15 +2043,19 @@ func FuzzDecodeContainerDevices(f *testing.F) {
 }
 
 func FuzzEncodeDecodeContainerDevices(f *testing.F) {
-	f.Add("GPU-uuid", "NVIDIA", int32(1024), int32(10))
-	f.Add("GPU-uuid2", "Cambricon", int32(0), int32(0))
-	f.Add("GPU-boundary", "NVIDIA", int32(2147483647), int32(2147483647))
-	f.Fuzz(func(t *testing.T, uuid, deviceType string, usedmem, usedcores int32) {
+	f.Add("GPU-uuid", "NVIDIA", int32(1024), int32(10), int32(0))
+	f.Add("GPU-uuid2", "Cambricon", int32(0), int32(0), int32(1))
+	f.Add("GPU-boundary", "NVIDIA", int32(2147483647), int32(2147483647), int32(2147483647))
+	f.Fuzz(func(t *testing.T, uuid, deviceType string, usedmem, usedcores, slots int32) {
 		if strings.ContainsAny(uuid, ",:;") || strings.ContainsAny(deviceType, ",:;") {
 			t.Skip()
 		}
-		if uuid == "" || deviceType == "" || usedmem < 0 || usedcores < 0 {
+		if uuid == "" || deviceType == "" || usedmem < 0 || usedcores < 0 || slots < 0 {
 			t.Skip()
+		}
+		// Slots below 2 is not encoded, so it always decodes back as unset.
+		if slots < 2 {
+			slots = 0
 		}
 
 		want := ContainerDevices{{
@@ -1980,6 +2063,7 @@ func FuzzEncodeDecodeContainerDevices(f *testing.F) {
 			Type:      deviceType,
 			Usedmem:   usedmem,
 			Usedcores: usedcores,
+			Slots:     slots,
 		}}
 		encoded := EncodeContainerDevices(want)
 		got, err := DecodeContainerDevices(encoded)

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -454,6 +454,9 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 				Type:      k.Type,
 				Usedmem:   profileMemoryMiB,
 				Usedcores: profileCorePercent,
+				// A DRS profile consumes profile.Size slices; recording it here keeps
+				// the count across the annotation round trip that drops CustomInfo.
+				Slots: int32(profile.Size),
 				CustomInfo: map[string]any{
 					"profileName": profile.Name,
 					"profileID":   profile.ID,

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -429,16 +429,16 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			continue
 		}
 
-		if isMutex && dev.Used > 0 {
-			reason[common.ExclusiveDeviceAllocateConflict]++
-			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
-			continue
-		}
 		// The whole profile has to fit: a 3 slice profile needs 3 free slices,
 		// not just one.
 		if dev.Count-dev.Used < profileSlices {
 			reason[common.CardTimeSlicingExhausted]++
 			klog.V(5).InfoS(common.CardTimeSlicingExhausted, "pod", klog.KObj(pod), "device", dev.ID, "count", dev.Count, "used", dev.Used, "request slices", profileSlices)
+			continue
+		}
+		if isMutex && dev.Used > 0 {
+			reason[common.ExclusiveDeviceAllocateConflict]++
+			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue
 		}
 		if dev.Totalmem-dev.Usedmem < profileMemoryMiB {

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -255,10 +255,7 @@ func (dev *EnflameDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[stri
 				continue
 			}
 			chosen := ctrDevices[0]
-			slice := clampToInt32(readCustomInfoInt(chosen.CustomInfo, "drsSlice"))
-			if slice <= 0 {
-				slice = 1
-			}
+			slice := sliceCount(&chosen)
 			ctrName := containerNameByIndex(pod, ctridx)
 			profileName := readCustomInfoString(chosen.CustomInfo, "profileName")
 			profileID := readCustomInfoString(chosen.CustomInfo, "profileID")
@@ -368,12 +365,24 @@ func (dev *EnflameDevices) ScoreNode(node *corev1.Node, podDevices device.PodSin
 	return 0
 }
 
-func (dev *EnflameDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
-	slice := clampToInt32(readCustomInfoInt(ctr.CustomInfo, "drsSlice"))
-	if slice <= 0 {
-		slice = 1
+// sliceCount returns the DRS slices an entry occupies. Slots is authoritative;
+// CustomInfo is the fallback for entries built before Fit recorded Slots.
+func sliceCount(ctr *device.ContainerDevice) int32 {
+	if ctr == nil {
+		return 1
 	}
-	n.Used = clampToInt32(int(n.Used) + int(slice))
+	slice := ctr.Slots
+	if slice <= 0 {
+		slice = clampToInt32(readCustomInfoInt(ctr.CustomInfo, "drsSlice"))
+	}
+	if slice <= 0 {
+		return 1
+	}
+	return slice
+}
+
+func (dev *EnflameDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
+	n.Used = clampToInt32(int(n.Used) + int(sliceCount(ctr)))
 	n.Usedcores += ctr.Usedcores
 	n.Usedmem += ctr.Usedmem
 	return nil

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -405,6 +405,10 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	}
 	profileMemoryMiB := int32(profile.MemoryGB * 1024)
 	profileCorePercent := int32(profile.CorePercent)
+	// profile.Size is already range checked above, so this is the single
+	// bounded conversion reused by the slice guard and the allocation.
+	profileSlices := int32(profile.Size)
+
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
@@ -425,14 +429,16 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 			continue
 		}
 
-		if dev.Count <= dev.Used {
-			reason[common.CardTimeSlicingExhausted]++
-			klog.V(5).InfoS(common.CardTimeSlicingExhausted, "pod", klog.KObj(pod), "device", dev.ID, "count", dev.Count, "used", dev.Used)
-			continue
-		}
 		if isMutex && dev.Used > 0 {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
+			continue
+		}
+		// The whole profile has to fit: a 3 slice profile needs 3 free slices,
+		// not just one.
+		if dev.Count-dev.Used < profileSlices {
+			reason[common.CardTimeSlicingExhausted]++
+			klog.V(5).InfoS(common.CardTimeSlicingExhausted, "pod", klog.KObj(pod), "device", dev.ID, "count", dev.Count, "used", dev.Used, "request slices", profileSlices)
 			continue
 		}
 		if dev.Totalmem-dev.Usedmem < profileMemoryMiB {
@@ -456,7 +462,7 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 				Usedcores: profileCorePercent,
 				// A DRS profile consumes profile.Size slices; recording it here keeps
 				// the count across the annotation round trip that drops CustomInfo.
-				Slots: int32(profile.Size),
+				Slots: profileSlices,
 				CustomInfo: map[string]any{
 					"profileName": profile.Name,
 					"profileID":   profile.ID,

--- a/pkg/device/enflame/device_test.go
+++ b/pkg/device/enflame/device_test.go
@@ -285,9 +285,11 @@ func TestFit_MutexRejectsUsedDevice(t *testing.T) {
 	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
 	devices := []*device.DeviceUsage{
 		{
-			ID:       "node-a-enflame-drs-0",
+			ID: "node-a-enflame-drs-0",
+			// 5 of 6 slices free, so the 3-slice profile clears the slice guard
+			// and the mutex check is the binding constraint.
 			Index:    0,
-			Count:    2,
+			Count:    6,
 			Used:     1,
 			Totalmem: 40960,
 			Type:     EnflameVGCUDevice,

--- a/pkg/device/enflame/drs_reconstruction_test.go
+++ b/pkg/device/enflame/drs_reconstruction_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package enflame
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -24,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
 )
 
 // drsCard returns a DRS card with 6 slices and a 3-profile menu. Totalmem and
@@ -79,6 +81,31 @@ func TestDRSSlice_SlotCountSurvivesReconstruction(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(decoded), 1)
 	assert.Equal(t, max(decoded[0].Slots, 1), liveCard.Used)
+}
+
+// TestDRSSlice_PartialCapacityRejectsFullProfile checks that a profile only
+// fits when every slice it needs is free, not just one.
+func TestDRSSlice_PartialCapacityRejectsFullProfile(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	enf := &EnflameDevices{}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	// Totalcore 0 skips the core guard, so slices are the binding constraint.
+	card := drsCard(400000, 0)
+	card.Used = 4
+
+	// 2 of 6 slices are free, so the 3 slice "3g.20gb" profile must not fit.
+	threeSlices := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 3}
+	fit, _, reason := enf.Fit([]*device.DeviceUsage{card}, threeSlices, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, false)
+	assert.Assert(t, strings.Contains(reason, common.CardTimeSlicingExhausted))
+
+	// The 1 slice "1g.6gb" profile still fits in the remaining capacity.
+	oneSlice := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 1}
+	fit, result, reason := enf.Fit([]*device.DeviceUsage{card}, oneSlice, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, reason, "")
+	assert.Equal(t, result[EnflameVGCUDevice][0].Slots, int32(1))
 }
 
 // TestDRSSlice_ReconstructionRejectsSliceOversubscription checks that a card

--- a/pkg/device/enflame/drs_reconstruction_test.go
+++ b/pkg/device/enflame/drs_reconstruction_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package enflame
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -106,6 +107,41 @@ func TestDRSSlice_PartialCapacityRejectsFullProfile(t *testing.T) {
 	assert.Equal(t, fit, true)
 	assert.Equal(t, reason, "")
 	assert.Equal(t, result[EnflameVGCUDevice][0].Slots, int32(1))
+}
+
+// TestDRSSlice_SliceCountPrefersSlots checks that Slots is authoritative and
+// that CustomInfo only fills in for entries built before Fit recorded Slots.
+func TestDRSSlice_SliceCountPrefersSlots(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	enf := &EnflameDevices{}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	tests := []struct {
+		name string
+		ctr  device.ContainerDevice
+		want int32
+	}{
+		{"slots wins over a stale CustomInfo", device.ContainerDevice{Slots: 3, CustomInfo: map[string]any{"drsSlice": 1}}, 3},
+		{"custominfo fills in when slots is unset", device.ContainerDevice{CustomInfo: map[string]any{"drsSlice": 3}}, 3},
+		{"neither set counts as one slice", device.ContainerDevice{}, 1},
+		{"annotation round trip keeps the count", device.ContainerDevice{Slots: 3}, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, sliceCount(&tt.ctr), tt.want)
+
+			// AddResourceUsage and PatchAnnotations must agree on the same entry.
+			card := drsCard(400000, 0)
+			assert.NilError(t, enf.AddResourceUsage(pod, card, &tt.ctr))
+			assert.Equal(t, card.Used, tt.want)
+
+			annos := map[string]string{}
+			enf.PatchAnnotations(pod, &annos, device.PodDevices{
+				EnflameVGCUDevice: {device.ContainerDevices{tt.ctr}},
+			})
+			assert.Equal(t, annos[PodRequestGCUSize], strconv.FormatInt(int64(tt.want), 10))
+		})
+	}
 }
 
 // TestDRSSlice_ReconstructionRejectsSliceOversubscription checks that a card

--- a/pkg/device/enflame/drs_reconstruction_test.go
+++ b/pkg/device/enflame/drs_reconstruction_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enflame
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+// drsCard returns a DRS card with 6 slices and a 3-profile menu. Totalmem and
+// Totalcore are parameterised so callers pick which constraint is binding.
+func drsCard(totalmem, totalcore int32) *device.DeviceUsage {
+	return &device.DeviceUsage{
+		ID:        "GPU-enflame-drs-0",
+		Index:     0,
+		Count:     6,
+		Used:      0,
+		Totalmem:  totalmem,
+		Totalcore: totalcore,
+		Type:      EnflameVGCUDevice,
+		Health:    true,
+		CustomInfo: map[string]any{
+			"minor": "0",
+			"index": "0",
+			"profiles": map[string]string{
+				"1g.6gb":  "0",
+				"3g.20gb": "1",
+				"6g.40gb": "2",
+			},
+		},
+	}
+}
+
+// TestDRSSlice_SlotCountSurvivesReconstruction checks that the slice count a
+// live allocation consumes is recovered from the pod annotation.
+func TestDRSSlice_SlotCountSurvivesReconstruction(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	enf := &EnflameDevices{}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	// Memreq 3 selects the 3-slice "3g.20gb" profile.
+	req := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 3}
+
+	fit, result, reason := enf.Fit([]*device.DeviceUsage{drsCard(40960, 100)}, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fit, true)
+	assert.Equal(t, reason, "")
+	ctrDevs := result[EnflameVGCUDevice]
+	assert.Equal(t, len(ctrDevs), 1)
+	assert.Equal(t, ctrDevs[0].Slots, int32(3))
+
+	// Live path: AddResourceUsage consumes profile.Size slices.
+	liveCard := drsCard(40960, 100)
+	assert.NilError(t, enf.AddResourceUsage(pod, liveCard, &ctrDevs[0]))
+	assert.Equal(t, liveCard.Used, int32(3))
+
+	// Reconstruction path: persist to the annotation and read it back the way
+	// getNodesUsage does.
+	encoded := device.EncodeContainerDevices(ctrDevs)
+	decoded, err := device.DecodeContainerDevices(encoded)
+	assert.NilError(t, err)
+	assert.Equal(t, len(decoded), 1)
+	assert.Equal(t, max(decoded[0].Slots, 1), liveCard.Used)
+}
+
+// TestDRSSlice_ReconstructionRejectsSliceOversubscription checks that a card
+// already full on slices still rejects a new instance after a restart.
+func TestDRSSlice_ReconstructionRejectsSliceOversubscription(t *testing.T) {
+	InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+	enf := &EnflameDevices{}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+	req := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 3}
+
+	// Totalcore 0 skips the core guard, so slices are the binding constraint.
+	liveCard := drsCard(400000, 0)
+	var persisted device.ContainerDevices
+	for range 2 {
+		fit, result, _ := enf.Fit([]*device.DeviceUsage{liveCard}, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+		assert.Equal(t, fit, true)
+		ctr := result[EnflameVGCUDevice][0]
+		assert.NilError(t, enf.AddResourceUsage(pod, liveCard, &ctr))
+		persisted = append(persisted, ctr)
+	}
+	assert.Equal(t, liveCard.Used, int32(6))
+
+	fitFull, _, _ := enf.Fit([]*device.DeviceUsage{liveCard}, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fitFull, false)
+
+	// Restart: rebuild Used from the persisted annotations.
+	rebuilt := drsCard(400000, 0)
+	for _, ctr := range persisted {
+		encoded := device.EncodeContainerDevices(device.ContainerDevices{ctr})
+		decoded, err := device.DecodeContainerDevices(encoded)
+		assert.NilError(t, err)
+		rebuilt.Used += max(decoded[0].Slots, 1)
+		rebuilt.Usedmem += decoded[0].Usedmem
+		rebuilt.Usedcores += decoded[0].Usedcores
+	}
+	assert.Equal(t, rebuilt.Used, liveCard.Used)
+
+	fitAfterRestart, _, _ := enf.Fit([]*device.DeviceUsage{rebuilt}, req, pod, &device.NodeInfo{}, &device.PodDevices{})
+	assert.Equal(t, fitAfterRestart, false)
+}

--- a/pkg/device/initContainer.go
+++ b/pkg/device/initContainer.go
@@ -30,6 +30,12 @@ type usage struct {
 	slots int32
 }
 
+// slotsOf returns the concurrent-task count an entry occupies on its device.
+// Raw allocations leave Slots unset, which means a single slot.
+func slotsOf(dev ContainerDevice) int32 {
+	return max(dev.Slots, 1)
+}
+
 func isSidecarAt(pod *corev1.Pod, cidx int) bool {
 	if cidx < 0 || cidx >= len(pod.Spec.InitContainers) {
 		return false
@@ -71,7 +77,7 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 					// joins the set of running containers.
 					s.sc.mem += dev.Usedmem
 					s.sc.cores += dev.Usedcores
-					s.sc.slots++
+					s.sc.slots += slotsOf(dev)
 					s.peak.mem = max(s.peak.mem, s.sc.mem)
 					s.peak.cores = max(s.peak.cores, s.sc.cores)
 					s.peak.slots = max(s.peak.slots, s.sc.slots)
@@ -81,14 +87,14 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 					s := get(dev.UUID)
 					s.peak.mem = max(s.peak.mem, s.sc.mem+dev.Usedmem)
 					s.peak.cores = max(s.peak.cores, s.sc.cores+dev.Usedcores)
-					s.peak.slots = max(s.peak.slots, s.sc.slots+1)
+					s.peak.slots = max(s.peak.slots, s.sc.slots+slotsOf(dev))
 				}
 			default:
 				for _, dev := range ctrDevs {
 					s := get(dev.UUID)
 					s.app.mem += dev.Usedmem
 					s.app.cores += dev.Usedcores
-					s.app.slots++
+					s.app.slots += slotsOf(dev)
 				}
 			}
 		}
@@ -130,7 +136,7 @@ func SteadyStateDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 				s := sums[dev.UUID]
 				s.mem += dev.Usedmem
 				s.cores += dev.Usedcores
-				s.slots++ // each concurrent app container occurrence is one slot
+				s.slots += slotsOf(dev)
 				sums[dev.UUID] = s
 			}
 		}

--- a/pkg/device/initContainer_test.go
+++ b/pkg/device/initContainer_test.go
@@ -247,6 +247,20 @@ func TestCollapseInitContainerUsage_MultiAppSameGPUSlots(t *testing.T) {
 	assert.Equal(t, result["NVIDIA"][0][0].Slots, int32(3))
 }
 
+// A multi-slot allocation such as an Enflame DRS profile already carries its own
+// slot count, so two app containers holding three slices each collapse to six.
+func TestCollapseInitContainerUsage_MultiSlotAppContainers(t *testing.T) {
+	pod := makePod("test", 0, 2)
+	raw := PodDevices{
+		"Enflame": PodSingleDevice{
+			{ContainerDevice{UUID: "gcu0", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3}},
+			{ContainerDevice{UUID: "gcu0", Type: "Enflame", Usedmem: 20480, Usedcores: 50, Slots: 3}},
+		},
+	}
+	result := CollapseInitContainerUsage(pod, raw)
+	assert.Equal(t, result["Enflame"][0][0].Slots, int32(6))
+}
+
 func TestSteadyStateDeviceUsage_NilInput(t *testing.T) {
 	result := SteadyStateDeviceUsage(nil, nil)
 	assert.Assert(t, result == nil)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ContainerDevice.Slots` is the number of concurrent tasks a collapsed entry occupies on a device, but `EncodeContainerDevices` never wrote it. The pod annotation lost the value, `DecodeContainerDevices` always returned `Slots == 0`, and `getNodesUsage` clamps that to 1 when it rebuilds the node cache. Any allocation worth more than one slot was undercounted after a scheduler restart.

Enflame DRS is the concrete case. `Fit()` picks a profile of `profile.Size` slices and `AddResourceUsage` charges that many live, so a card with 6 slices filled by two 3 slice profiles reported `Used 6` while running and `Used 2` after the cache rebuild. The slice guard `dev.Count <= dev.Used` then admitted DRS instances the card had no slices left for.

Changes:

- Encode `Slots` as an optional 5th field, written only when it exceeds 1, and decode it back when present with validation for negative and non numeric values.
- Set `Slots` from `profile.Size` in the Enflame DRS `Fit()` path, since `CustomInfo["drsSlice"]` does not survive the annotation.
- Sum the recorded slot count in `CollapseInitContainerUsage` and `SteadyStateDeviceUsage` instead of counting one per container occurrence.

**Which issue(s) this PR fixes**:
Fixes #2876

**Special notes for your reviewer**:

The annotation change is compatible in both directions. Single slot allocations keep the historical 4 field encoding byte for byte, and the decoder's pre existing guard is `len(fields) < 4`, so an older parser reads a 5 field entry without error and a new parser reads old annotations unchanged.

New unit tests: `pkg/device/enflame/drs_reconstruction_test.go` asserts that the slice count survives the round trip and that a rebuilt card still rejects slice oversubscription; `pkg/device/devices_test.go` covers the optional field, invalid and negative values, and extends the encode/decode fuzz target with a slots argument; `pkg/device/initContainer_test.go` covers collapsing two multi slot app containers.

`go vet` and `go test -short -count=1` pass for `pkg/device/...` except `pkg/device/nvidia`, and `pkg/scheduler/...` could not be built on my machine because go-nvml requires cgo and my local toolchain cannot build 64 bit cgo objects. Those packages are untouched by this PR, so I am relying on CI for `make verify` and the full `make test`.

This PR was prepared with AI assistance.

**Does this PR introduce a user-facing change?**:

The device allocation annotation gains an optional 5th field carrying the slot count for multi slot allocations. It is only written when the count exceeds 1, so existing annotations are unchanged and both old and new parsers read either form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-slot device allocations are preserved when assignments are encoded and restored.
  - Device usage accounting reflects each allocation’s declared slot count.
  - Enflame DRS slice usage and allocation state are accurately reconstructed after restarts.

- **Bug Fixes**
  - Prevented oversubscription during multi-slot allocations.
  - Maintained compatibility with existing annotations without slot information.
  - Invalid or negative slot values are safely ignored during restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->