### PR TITLE
feat(ascend): honor deviceCoreScaling in hami-core Fit budget

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -239,6 +239,8 @@ This document provides detailed descriptions of all configurable values paramete
 | `devices.ascend.extraArgs` | Extra arguments | `[]` |
 | `devices.ascend.nodeSelector` | Node selector | `{"ascend": "on"}` |
 | `devices.ascend.tolerations` | Tolerations | `[]` |
+| `devices.ascend.hamiVnpuCore` | Enable hami-vnpu-core soft-partitioning on all nodes | `false` |
+| `devices.ascend.deviceCoreScaling` | hami-core compute oversell ratio; Fit budget is `100 * deviceCoreScaling` | `1` |
 | `devices.ascend.customresources` | Custom resources | `["huawei.com/Ascend910A", "huawei.com/Ascend910A-memory", ...]` |
 
 ### Iluvatar

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -113,6 +113,7 @@ data:
       resourceCountName: {{ .Values.birenResourceName }}
     vnpus:
       hamiVnpuCore: {{ .Values.devices.ascend.hamiVnpuCore | default false }}
+      deviceCoreScaling: {{ .Values.devices.ascend.deviceCoreScaling | default 1 }}
       configs:
       - chipName: 910A
         commonWord: Ascend910A

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -530,6 +530,7 @@ devices:
     tolerations: []
     runtimeClassName: ""  # Name of the runtime class to set the Pod .spec.runtimeClassName utilizing Ascend NPU
     hamiVnpuCore: false  # When true, all nodes will enable soft-partitioning based on hami-vnpu-core (node-level annotation takes higher priority)
+    deviceCoreScaling: 1  # hami-core Fit budget = 100 * deviceCoreScaling (1.5 → 150, 2.0 → 200)
     customresources:
       - huawei.com/Ascend910A
       - huawei.com/Ascend910A-memory

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -116,10 +116,14 @@ func InitDevices(vnpus VNPUs) []*Devices {
 
 func (npu *Devices) hamiCoreBudget() int32 {
 	scale := npu.coreScaling
-	if scale <= 0 {
+	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
 		scale = 1
 	}
-	return int32(math.Round(100 * scale))
+	budget := math.Round(100 * scale)
+	if budget < 1 || budget > float64(math.MaxInt32) {
+		return 100
+	}
+	return int32(budget)
 }
 
 func ParseConfig(fs *flag.FlagSet) {
@@ -546,10 +550,17 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", effectiveTotalCore, "device used core", dev.Usedcores, "request cores", k.Coresreq)
 			continue
 		}
-		// Coresreq=100 indicates it want this card exclusively
+		// Coresreq=100 indicates it want this card exclusively.
 		if k.Coresreq == 100 && dev.Used > 0 {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
+			continue
+		}
+		// A single occupant that already reserved 100% owns the card exclusively,
+		// even when deviceCoreScaling raises the Fit budget above 100.
+		if dev.Used == 1 && dev.Usedcores == 100 {
+			reason[common.ExclusiveDeviceAllocateConflict]++
+			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used, "usedcores", dev.Usedcores)
 			continue
 		}
 		// You can't allocate core=0 job to an already full GPU

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -55,6 +55,7 @@ type Devices struct {
 	noUseUUIDAnno    string
 	handshakeAnno    string
 	hamiVnpuCore     bool
+	coreScaling      float64
 }
 
 type RuntimeInfo struct {
@@ -83,6 +84,10 @@ func InitDevices(vnpus VNPUs) []*Devices {
 	if !enableAscend {
 		return devs
 	}
+	coreScaling := vnpus.DeviceCoreScaling
+	if coreScaling <= 0 {
+		coreScaling = 1
+	}
 	for _, vnpu := range vnpus.Configs {
 		commonWord := vnpu.CommonWord
 		dev := &Devices{
@@ -92,6 +97,7 @@ func InitDevices(vnpus VNPUs) []*Devices {
 			noUseUUIDAnno:    fmt.Sprintf("hami.io/no-use-%s-uuid", commonWord),
 			handshakeAnno:    fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
 			hamiVnpuCore:     vnpus.HamiVnpuCore,
+			coreScaling:      coreScaling,
 		}
 		sort.Slice(dev.config.Templates, func(i, j int) bool {
 			return dev.config.Templates[i].Memory < dev.config.Templates[j].Memory
@@ -103,9 +109,17 @@ func InitDevices(vnpus VNPUs) []*Devices {
 			util.HandshakeAnnos[commonWord] = dev.handshakeAnno
 		}
 		devs = append(devs, dev)
-		klog.Infof("load ascend vnpu config %s: %v", commonWord, dev.config)
+		klog.Infof("load ascend vnpu config %s coreScaling=%.2f: %v", commonWord, coreScaling, dev.config)
 	}
 	return devs
+}
+
+func (npu *Devices) hamiCoreBudget() int32 {
+	scale := npu.coreScaling
+	if scale <= 0 {
+		scale = 1
+	}
+	return int32(math.Round(100 * scale))
 }
 
 func ParseConfig(fs *flag.FlagSet) {
@@ -521,10 +535,10 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)
 			continue
 		}
-		// Set dev.Totalcore to 100 if vnpuMode is hami-core
+		// hami-core uses a 100-point percentage scale, optionally oversold by coreScaling.
 		effectiveTotalCore := dev.Totalcore
 		if isHAMiCore {
-			effectiveTotalCore = 100
+			effectiveTotalCore = npu.hamiCoreBudget()
 		}
 
 		if effectiveTotalCore-dev.Usedcores < k.Coresreq {
@@ -533,7 +547,7 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			continue
 		}
 		// Coresreq=100 indicates it want this card exclusively
-		if effectiveTotalCore == 100 && k.Coresreq == 100 && dev.Used > 0 {
+		if k.Coresreq == 100 && dev.Used > 0 {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2970,4 +2970,25 @@ func TestDevices_Fit_HamiCoreOversell(t *testing.T) {
 			t.Fatalf("unexpected result %#v", result)
 		}
 	})
+	t.Run("R=1.5 exclusive 100 then 50 rejected", func(t *testing.T) {
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, DeviceCoreScaling: 1.5, Configs: cfg})[0]
+		exclusive := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Type: "Ascend910B3",
+			Used: 1, Count: 4,
+			Usedmem: 1024, Totalmem: 65536,
+			Usedcores: 100, Totalcore: 20,
+			Health: true,
+		}}
+		share := device.ContainerDeviceRequest{
+			Nums: 1, Type: "Ascend910B3",
+			Memreq: 1024, MemPercentagereq: 0, Coresreq: 50,
+		}
+		fit, _, reason := dev.Fit(exclusive, share, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected exclusive occupant to block 50, got fit reason=%s", reason)
+		}
+		if reason != "1/1 ExclusiveDeviceAllocateConflict" {
+			t.Fatalf("expected ExclusiveDeviceAllocateConflict, got %s", reason)
+		}
+	})
 }

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2918,3 +2918,56 @@ func TestFit_CoresValidation(t *testing.T) {
 		assert.Equal(t, reason, "core limit out of range")
 	})
 }
+
+func TestDevices_Fit_HamiCoreOversell(t *testing.T) {
+	enableAscend = true
+	cfg := []VNPUConfig{{
+		CommonWord:         "Ascend910B3",
+		ChipName:           "910B3",
+		ResourceName:       "huawei.com/Ascend910B3",
+		ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+		MemoryAllocatable:  65536,
+		Templates:          []Template{{Name: "vir05", Memory: 16384}},
+	}}
+	card := []*device.DeviceUsage{{
+		ID: "dev-0", Index: 0, Type: "Ascend910B3",
+		Used: 3, Count: 4,
+		Usedmem: 3072, Totalmem: 65536,
+		Usedcores: 90, Totalcore: 20,
+		Health: true,
+	}}
+	req := device.ContainerDeviceRequest{
+		Nums: 1, Type: "Ascend910B3",
+		Memreq: 1024, MemPercentagereq: 0, Coresreq: 20,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		VNPUModeAnnotation: VNPUModeHamiCore,
+	}}}
+	nodeInfo := &device.NodeInfo{
+		ID: "node1",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			VNPUNodeSelectorAnnotation: "true",
+		}}},
+	}
+
+	t.Run("R=1 3x30+20 rejected", func(t *testing.T) {
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, DeviceCoreScaling: 1, Configs: cfg})[0]
+		fit, _, reason := dev.Fit(card, req, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected reject at 110>100, got fit reason=%s", reason)
+		}
+		if reason != "1/1 CardInsufficientCore" {
+			t.Fatalf("expected CardInsufficientCore, got %s", reason)
+		}
+	})
+	t.Run("R=1.5 3x30+20 admitted", func(t *testing.T) {
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, DeviceCoreScaling: 1.5, Configs: cfg})[0]
+		fit, result, reason := dev.Fit(card, req, pod, nodeInfo, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected admit at 110<=150, got reason=%s", reason)
+		}
+		if len(result["Ascend910B3"]) != 1 || result["Ascend910B3"][0].UUID != "dev-0" {
+			t.Fatalf("unexpected result %#v", result)
+		}
+	})
+}

--- a/pkg/device/ascend/vnpu.go
+++ b/pkg/device/ascend/vnpu.go
@@ -43,6 +43,10 @@ type VNPUConfig struct {
 // VNPUs holds the global Ascend VNPU configuration, including a flag to enable
 // hami-vnpu-core soft-partitioning for all nodes and the per-chip config list.
 type VNPUs struct {
-	HamiVnpuCore bool         `yaml:"hamiVnpuCore"`
-	Configs      []VNPUConfig `yaml:"configs"`
+	HamiVnpuCore bool `yaml:"hamiVnpuCore"`
+	// DeviceCoreScaling is the hami-core compute oversell ratio.
+	// Fit uses effectiveTotalCore = 100 * DeviceCoreScaling (default 1 → 100).
+	// 1.5 → 150; 2.0 → 200. Zero or negative is treated as 1.
+	DeviceCoreScaling float64      `yaml:"deviceCoreScaling"`
+	Configs           []VNPUConfig `yaml:"configs"`
 }

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -353,6 +353,7 @@ amd:
   resourceCountName: "amd.com/gpu"
 vnpus:
   hamiVnpuCore: false
+  deviceCoreScaling: 1
   configs:
   - chipName: "910A"
     commonWord: "Ascend910A"


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What this PR does / why we need it**:

Ascend hami-core Fit currently hardcodes `effectiveTotalCore = 100`, so compute cannot be oversold. NVIDIA already supports `deviceCoreScaling`. This adds the same knob for Ascend hami-core:

- `effectiveTotalCore = round(100 * deviceCoreScaling)` (default `1`, existing clusters unchanged)
- `Coresreq == 100` remains exclusive even when the budget is oversold

Helm value: `devices.ascend.deviceCoreScaling` (default `1`), rendered into the scheduler device ConfigMap as `vnpus.deviceCoreScaling`.

**Which issue(s) this PR fixes**:
Fixes #2884

**Special notes for your reviewer**:

Unit test `TestDevices_Fit_HamiCoreOversell`: R=1 rejects 90+20; R=1.5 admits.

Hardware validation (scheduler extender Fit path):
- Device: 8 × Ascend 910B3
- Driver / npu-smi: 25.5.0
- `deviceCoreScaling=1.5` (budget 150)
- Workload: 3 pods with `-core: "30"` plus 1 pod with `-core: "20"` pinned to the same UUID
- Result: all four scheduled on that card (110 ≤ 150). With the default budget of 100 the fourth pod is rejected (`CardInsufficientCore`).

**Does this PR introduce a user-facing change?**:

Yes. New optional Helm value `devices.ascend.deviceCoreScaling` (default `1`). No behavior change unless the value is set above 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Ascend device-core scaling for Huawei VNPU workloads.
  * Added Helm chart values and documentation for configuring the scaling factor.

* **Bug Fixes**
  * Improved handling of invalid scaling values and budget limits.
  * Preserved exclusive device allocation when scaled capacity exceeds physical limits.

* **Tests**
  * Added coverage for oversubscription, scaled allocation, and exclusive-device behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->