### PR TITLE
pkg/device: use sentinel for decoded ContainerDevice.Idx

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -207,7 +207,12 @@ type ResourceNames struct {
 }
 
 type ContainerDevice struct {
-	// TODO current Idx cannot use, because EncodeContainerDevices method not encode this filed.
+	// Idx is the device's index at scheduling time. It is NOT part of the pod
+	// annotation wire format written by EncodeContainerDevices, so it does not
+	// survive a decode: DecodeContainerDevices always sets it to
+	// UnsetContainerDeviceIdx. Only read Idx on a ContainerDevice you built or
+	// received directly from scheduling (e.g. in PatchAnnotations/ScoreNode);
+	// never on one obtained via DecodeContainerDevices/DecodePodDevices.
 	Idx       int
 	UUID      string
 	Type      string
@@ -241,6 +246,13 @@ const (
 
 	// OnePodMultiContainerSplitSymbol this is when one pod having multi container and more than one container use device, use ; symbol to join device info.
 	OnePodMultiContainerSplitSymbol = ";"
+
+	// UnsetContainerDeviceIdx is the Idx value DecodeContainerDevices assigns to
+	// every decoded ContainerDevice, since Idx is not part of the wire format.
+	// It is deliberately an invalid device index (real indices are >= 0) rather
+	// than 0, so code that mistakenly reads Idx off a decoded ContainerDevice
+	// fails obviously instead of silently behaving as if device 0 was meant.
+	UnsetContainerDeviceIdx = -1
 )
 
 var (
@@ -532,6 +544,10 @@ func DecodeContainerDevices(str string) (ContainerDevices, error) {
 			return nil, fmt.Errorf("core field must not be negative: %d", devcores)
 		}
 		tmpdev := ContainerDevice{
+			// Idx is not part of the wire format (see the ContainerDevice.Idx
+			// doc comment): use the sentinel rather than the zero value, which
+			// would be indistinguishable from a real device index 0.
+			Idx:       UnsetContainerDeviceIdx,
 			UUID:      tmpstr[0],
 			Type:      tmpstr[1],
 			Usedmem:   int32(devmem),

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -46,6 +46,23 @@ func TestEmptyContainerDevicesCoding(t *testing.T) {
 	assert.DeepEqual(t, cd1, cd2)
 }
 
+// TestDecodeContainerDevices_IdxNotPreservedAcrossRoundTrip locks in that Idx
+// does not survive EncodeContainerDevices/DecodeContainerDevices: it always
+// comes back as UnsetContainerDeviceIdx, even when the original device had a
+// real, nonzero Idx. This guards against code coming to rely on Idx being
+// meaningful after a decode (see the ContainerDevice.Idx doc comment).
+func TestDecodeContainerDevices_IdxNotPreservedAcrossRoundTrip(t *testing.T) {
+	original := ContainerDevices{
+		{Idx: 3, UUID: "GPU-1", Type: "NVIDIA", Usedmem: 1000, Usedcores: 10},
+	}
+	encoded := EncodeContainerDevices(original)
+	decoded, err := DecodeContainerDevices(encoded)
+	assert.NilError(t, err)
+	assert.Equal(t, len(decoded), 1)
+	assert.Equal(t, decoded[0].Idx, UnsetContainerDeviceIdx,
+		"decoded Idx must be the sentinel, not the original device's real index (%d) or the zero value", original[0].Idx)
+}
+
 func TestDecodeContainerDevices(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -70,6 +87,7 @@ func TestDecodeContainerDevices(t *testing.T) {
 			input: "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76,NVIDIA,500,3:",
 			want: ContainerDevices{
 				{
+					Idx:       UnsetContainerDeviceIdx,
 					UUID:      "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76",
 					Type:      "NVIDIA",
 					Usedmem:   500,
@@ -83,6 +101,7 @@ func TestDecodeContainerDevices(t *testing.T) {
 			input: "GPU-zero,NVIDIA,0,0:",
 			want: ContainerDevices{
 				{
+					Idx:       UnsetContainerDeviceIdx,
 					UUID:      "GPU-zero",
 					Type:      "NVIDIA",
 					Usedmem:   0,
@@ -96,12 +115,14 @@ func TestDecodeContainerDevices(t *testing.T) {
 			input: "GPU-1,NVIDIA,1000,10:GPU-2,Cambricon,2000,20:",
 			want: ContainerDevices{
 				{
+					Idx:       UnsetContainerDeviceIdx,
 					UUID:      "GPU-1",
 					Type:      "NVIDIA",
 					Usedmem:   1000,
 					Usedcores: 10,
 				},
 				{
+					Idx:       UnsetContainerDeviceIdx,
 					UUID:      "GPU-2",
 					Type:      "Cambricon",
 					Usedmem:   2000,
@@ -115,6 +136,7 @@ func TestDecodeContainerDevices(t *testing.T) {
 			input: "GPU-1,NVIDIA,1000,10,extra1,extra2:",
 			want: ContainerDevices{
 				{
+					Idx:       UnsetContainerDeviceIdx,
 					UUID:      "GPU-1",
 					Type:      "NVIDIA",
 					Usedmem:   1000,
@@ -348,7 +370,7 @@ func TestPodDevicesCoding(t *testing.T) {
 			want: PodDevices{
 				"NVIDIA": PodSingleDevice{
 					ContainerDevices{
-						ContainerDevice{0, "UUID1", "Type1", 1000, 30, 0, nil},
+						ContainerDevice{UnsetContainerDeviceIdx, "UUID1", "Type1", 1000, 30, 0, nil},
 					},
 					ContainerDevices{},
 				},
@@ -370,10 +392,10 @@ func TestPodDevicesCoding(t *testing.T) {
 			want: PodDevices{
 				"NVIDIA": PodSingleDevice{
 					ContainerDevices{
-						ContainerDevice{0, "UUID1", "Type1", 1000, 30, 0, nil},
+						ContainerDevice{UnsetContainerDeviceIdx, "UUID1", "Type1", 1000, 30, 0, nil},
 					},
 					ContainerDevices{
-						ContainerDevice{0, "UUID1", "Type1", 1000, 30, 0, nil},
+						ContainerDevice{UnsetContainerDeviceIdx, "UUID1", "Type1", 1000, 30, 0, nil},
 					},
 					ContainerDevices{},
 				},
@@ -393,8 +415,8 @@ func TestPodDevicesCoding(t *testing.T) {
 			want: PodDevices{
 				"NVIDIA": PodSingleDevice{
 					ContainerDevices{
-						ContainerDevice{0, "UUID1", "Type1", 1000, 30, 0, nil},
-						ContainerDevice{0, "UUID2", "Type1", 1000, 30, 0, nil},
+						ContainerDevice{UnsetContainerDeviceIdx, "UUID1", "Type1", 1000, 30, 0, nil},
+						ContainerDevice{UnsetContainerDeviceIdx, "UUID2", "Type1", 1000, 30, 0, nil},
 					},
 					ContainerDevices{},
 				},
@@ -453,6 +475,7 @@ func Test_DecodePodDevices(t *testing.T) {
 				"NVIDIA": {
 					{
 						{
+							Idx:       UnsetContainerDeviceIdx,
 							UUID:      "GPU-8dcd427f-483b-b48f-d7e5-75fb19a52b76",
 							Type:      "NVIDIA",
 							Usedmem:   500,
@@ -461,6 +484,7 @@ func Test_DecodePodDevices(t *testing.T) {
 					},
 					{
 						{
+							Idx:       UnsetContainerDeviceIdx,
 							UUID:      "GPU-ebe7c3f7-303d-558d-435e-99a160631fe4",
 							Type:      "NVIDIA",
 							Usedmem:   500,

--- a/pkg/device/numa_refit_test.go
+++ b/pkg/device/numa_refit_test.go
@@ -74,7 +74,12 @@ func TestNumaRefitResponseCarriesEncodedContainerDevices(t *testing.T) {
 
 	roundTripped, err := DecodeContainerDevices(decoded.ContainerDevices)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, roundTripped, devices)
+	// Idx is not part of the wire format, so it comes back as the sentinel
+	// UnsetContainerDeviceIdx rather than whatever devices set it to (here, 0).
+	want := ContainerDevices{
+		{Idx: UnsetContainerDeviceIdx, UUID: "GPU-aaaa", Type: "NVIDIA", Usedmem: 20000, Usedcores: 30},
+	}
+	assert.DeepEqual(t, roundTripped, want)
 }
 
 func TestNumaRefitResponseFailureOmitsDevices(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ContainerDevice.Idx` is not part of the pod-annotation wire format   (`EncodeContainerDevices `/`DecodeContainerDevices`),  so a value set before encoding does not survive a decode — the decoded value always comes back as the zero value, which is indistinguishable from a real device index 0. This PR documents that behavior on the field and introduces an explicit sentinel, `UnsetContainerDeviceIdx = -1`, which `DecodeContainerDevices` now sets instead of leaving `Idx` at its implicit zero value. This makes the gap visible at the type level instead of silently produced 0s, without changing the wire format itself.

Updated the existing test assertions in `pkg/device/devices_test.go` and `pkg/device/numa_refit_test.go` that build `ContainerDevices` via decode to expect the sentinel.

**Which issue(s) this PR fixes**:

Fixes #2875

**Special notes for your reviewer**:

This is intentionally scoped as a doc/guard-only fix — no change to the annotation wire format or to how devices are actually allocated. Any code that reads `.Idx` off a *decoded* `ContainerDevice` and previously treated 0 as "valid" should now check for `UnsetContainerDeviceIdx` instead.

This PR was drafted with AI (Claude) assistance; I reviewed the diff and understand the change before opening this PR.

**Does this PR introduce a user-facing change?**:

No. Internal field semantics only — no change to allocation behavior or the annotation wire format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that decoded container device indexes are not preserved through serialization.
  * Decoded devices now use an explicit unset index value instead of defaulting to device 0.
  * Added a public sentinel constant for identifying unset indexes.

* **Tests**
  * Added coverage confirming index values are reset after encoding and decoding.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->