### PR TITLE
fix(ascend): guard against empty ResourceMemoryName injection in admission

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -179,9 +179,9 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 			return true, errors.New("vNPU not supported for multiple devices")
 		}
 	}
-	// Requests may be nil when the pod declares only limits; writing to a
-	// nil map panics.
 	if dev.config.ResourceMemoryName != "" {
+		// Requests may be nil when the pod declares only limits; writing to a
+		// nil map panics.
 		if ctr.Resources.Requests == nil {
 			ctr.Resources.Requests = corev1.ResourceList{}
 		}

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -181,11 +181,13 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 	// Requests may be nil when the pod declares only limits; writing to a
 	// nil map panics.
-	if ctr.Resources.Requests == nil {
-		ctr.Resources.Requests = corev1.ResourceList{}
+	if dev.config.ResourceMemoryName != "" {
+		if ctr.Resources.Requests == nil {
+			ctr.Resources.Requests = corev1.ResourceList{}
+		}
+		ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
+		ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 	}
-	ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
-	ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
 
 	// Set runtime class name if it is not set by user and the runtime class name is configured
 	if p.Spec.RuntimeClassName == nil && dev.config.RuntimeClassName != "" {

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -794,8 +794,8 @@ func Test_MutateAdmission_EmptyResourceMemoryName(t *testing.T) {
 			CommonWord:         "Ascend910A",
 			ResourceName:       "huawei.com/Ascend910A",
 			ResourceMemoryName: "",
-			MemoryCapacity:     32768,
-			MemoryAllocatable:  32768,
+			MemoryCapacity:     0,
+			MemoryAllocatable:  0,
 		},
 	}
 	ctr := corev1.Container{

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -787,6 +787,40 @@ func Test_MutateAdmission_NilRequests(t *testing.T) {
 	}
 }
 
+func Test_MutateAdmission_EmptyResourceMemoryName(t *testing.T) {
+	dev := Devices{
+		config: VNPUConfig{
+			ChipName:           "Ascend910A",
+			CommonWord:         "Ascend910A",
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "",
+			MemoryCapacity:     32768,
+			MemoryAllocatable:  32768,
+		},
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"huawei.com/Ascend910A": resource.MustParse("1"),
+			},
+		},
+	}
+	pod := corev1.Pod{}
+	result, err := dev.MutateAdmission(&ctr, &pod)
+	if err != nil {
+		t.Fatalf("MutateAdmission returned unexpected error: %v", err)
+	}
+	if !result {
+		t.Fatalf("MutateAdmission expected true, got false")
+	}
+	if _, ok := ctr.Resources.Limits[corev1.ResourceName("")]; ok {
+		t.Fatalf("MutateAdmission should not inject empty resource name into Limits")
+	}
+	if _, ok := ctr.Resources.Requests[corev1.ResourceName("")]; ok {
+		t.Fatalf("MutateAdmission should not inject empty resource name into Requests")
+	}
+}
+
 func Test_MutateAdmission910C(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `pkg/device/ascend/device.go`, `MutateAdmission` unconditionally writes to container `Limits` and `Requests` with `corev1.ResourceName(dev.config.ResourceMemoryName)`:

```go
// Before:
if ctr.Resources.Requests == nil {
    ctr.Resources.Requests = corev1.ResourceList{}
}
ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
```

When an Ascend configuration does not specify a `ResourceMemoryName` (e.g. count-only NPU devices where memory slicing is not configured), `corev1.ResourceName(dev.config.ResourceMemoryName)` evaluates to an empty string `""`. This causes the webhook to inject an invalid resource key (`limits[""] = 0` and `requests[""] = 0`), which fails Kubernetes API server validation.

This PR fixes it by wrapping the memory limit/request injection with a non-empty check:

```go
// After:
if dev.config.ResourceMemoryName != "" {
    if ctr.Resources.Requests == nil {
        ctr.Resources.Requests = corev1.ResourceList{}
    }
    ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
    ctr.Resources.Requests[corev1.ResourceName(dev.config.ResourceMemoryName)] = resource.MustParse(fmt.Sprint(trimMem))
}
```

And adds unit test `Test_MutateAdmission_EmptyResourceMemoryName` in `pkg/device/ascend/device_test.go`.

**Which issue(s) this PR fixes**:

Fixes #2888 

**Special notes for your reviewer**:

- Authored and verified manually with AI pair-programming assistance (Antigravity).
- Tests are pure Go unit tests and do not require physical GPU hardware.
- Verified locally via `go test -v ./pkg/device/ascend/...`.

**Does this PR introduce a user-facing change?**:

NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming admission processing succeeds when no memory resource name is configured.
  - Verified that empty-named memory limits and requests are not added to containers.
  - Improved regression protection for admission behavior under an empty memory resource configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->