### PR TITLE
docs: add quick start guide for new contributors

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -1,0 +1,117 @@
+# Quick Start Guide for New Contributors
+
+This guide will help you set up your development environment and start contributing to HAMi.
+
+## Prerequisites
+
+- **Go 1.26.5** or later (see `go.mod` for the exact version)
+- **Git**
+- **Docker** (for building images)
+- **kubectl** with access to a Kubernetes cluster
+- **Helm** (optional, for chart development)
+
+## Setting Up the Development Environment
+
+1. Fork and clone the repository:
+
+```bash
+git clone https://github.com/<your-username>/HAMi.git
+cd HAMi
+```
+
+2. Install dependencies:
+
+```bash
+make tidy
+```
+
+## Building
+
+Build all binaries (scheduler, vGPUmonitor, nvidia-device-plugin):
+
+```bash
+make build
+```
+
+Binaries are output to `bin/`.
+
+## Running Tests
+
+Run the full test suite:
+
+```bash
+make test
+```
+
+Run a specific test:
+
+```bash
+go test ./pkg/scheduler/... -run TestSpecificFunc -short --race -count=1
+```
+
+## Code Quality
+
+Run linting:
+
+```bash
+make lint
+```
+
+Run all verification checks (license headers, import aliases, linting):
+
+```bash
+make verify
+```
+
+## Project Structure
+
+- `cmd/` — Entry points for scheduler, vGPUmonitor, and device plugins
+- `pkg/device/` — Device abstraction layer with backends for NVIDIA, Cambricon, Hygon, etc.
+- `pkg/scheduler/` — Scheduler extender logic (filter, score, bind)
+- `pkg/device-plugin/` — Kubernetes device plugin internals
+- `charts/` — Helm charts
+- `test/e2e/` — End-to-end tests using Ginkgo/Gomega
+
+## Contribution Workflow
+
+1. Create a feature branch from `master`:
+
+```bash
+git checkout -b feature/your-feature master
+```
+
+2. Make your changes and ensure tests pass:
+
+```bash
+make test
+make verify
+```
+
+3. Commit with a descriptive message following [conventional commits](https://www.conventionalcommits.org/):
+
+```
+feat: add support for new device type
+
+Signed-off-by: Your Name <your@email.com>
+```
+
+4. Push and create a pull request against `master`.
+
+## Commit Convention
+
+HAMi follows conventional commits. Use prefixes like:
+
+- `feat:` for new features
+- `fix:` for bug fixes
+- `docs:` for documentation changes
+- `test:` for test additions/changes
+- `refactor:` for code refactoring
+- `chore:` for maintenance tasks
+
+Always include `Signed-off-by:` in your commits (use `git commit -s`).
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Join the community discussions
+- Check existing documentation in `docs/`


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it

Adds a quick start guide for new contributors covering:
- Prerequisites and development environment setup
- Build commands (scheduler, vGPUmonitor, nvidia)
- Running tests and code quality checks
- Project structure overview
- Contribution workflow and commit conventions

## Which issue(s) this PR fixes

Replaces #2885 (closed due to incorrect build commands and Go version)

## Does this PR introduce a user-facing change?

No

## AI Assistance Disclosure

This PR was created with AI assistance. I have reviewed and verified all content for accuracy against the actual project configuration.

## Notes

- Go version matches go.mod (1.26.5)
- Build targets verified from Makefile (scheduler, vGPUmonitor, nvidia)
- All commands tested against the actual project structure

Signed-off-by: Ankita Salaria <255383093+Ankitavasudev@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a contributor quick-start guide for the HAMi project.
  * Documented prerequisites, development setup, build and test commands, code-quality checks, project structure, contribution workflow, commit conventions, and support resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->