### PR TITLE
fix(device-plugin): propagate IMEX channels into the NVIDIA plugin

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -177,8 +177,6 @@ func getPluginSocketPath(resource spec.ResourceName) string {
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
 func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.DeviceConfig, resourceManager rm.ResourceManager, sConfig *config.Config, mode string) (Interface, error) {
-	_, name := resourceManager.Resource().Split()
-
 	deviceListStrategies, _ := spec.NewDeviceListStrategies(*nvconfig.Flags.Plugin.DeviceListStrategy)
 
 	klog.Infoln("reading config=", nvconfig, "resourceName", nvconfig.ResourceName, "configfile=", *ConfigFile, "sconfig=", sConfig)
@@ -197,6 +195,24 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 			return nil, fmt.Errorf("init MIG instance manager: %w", err)
 		}
 	}
+	return o.newNvidiaDevicePlugin(ctx, nvconfig, resourceManager, deviceListStrategies, sConfig.NvidiaConfig, mode, migMgr), nil
+}
+
+// newNvidiaDevicePlugin assembles an NvidiaDevicePlugin from the options and the
+// values devicePluginForResource resolves at startup. Keeping the assembly in its
+// own method lets the wiring from options into the plugin (for example the IMEX
+// channels) be unit tested without initializing devices, MIG, or NVML.
+func (o *options) newNvidiaDevicePlugin(
+	ctx context.Context,
+	nvconfig *nvidia.DeviceConfig,
+	resourceManager rm.ResourceManager,
+	deviceListStrategies spec.DeviceListStrategies,
+	schedulerConfig nvidia.NvidiaConfig,
+	mode string,
+	migMgr *MigInstanceManager,
+) *NvidiaDevicePlugin {
+	_, name := resourceManager.Resource().Split()
+
 	return &NvidiaDevicePlugin{
 		ctx:                        ctx,
 		rm:                         resourceManager,
@@ -211,9 +227,10 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 		socket:                     kubeletdevicepluginv1beta1.DevicePluginPath + "nvidia-" + name + ".sock",
 		cdiHandler:                 o.cdiHandler,
 		cdiAnnotationPrefix:        *o.config.Flags.Plugin.CDIAnnotationPrefix,
-		schedulerConfig:            sConfig.NvidiaConfig,
+		schedulerConfig:            schedulerConfig,
 		operatingMode:              mode,
 		migMgr:                     migMgr,
+		imexChannels:               o.imexChannels,
 		deviceCache:                "",
 
 		// These will be reinitialized every
@@ -221,7 +238,7 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 		server: nil,
 		health: nil,
 		stop:   nil,
-	}, nil
+	}
 }
 
 func (plugin *NvidiaDevicePlugin) initialize() {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -195,7 +195,7 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 			return nil, fmt.Errorf("init MIG instance manager: %w", err)
 		}
 	}
-	return o.newNvidiaDevicePlugin(ctx, nvconfig, resourceManager, deviceListStrategies, sConfig.NvidiaConfig, mode, migMgr), nil
+	return o.newNvidiaDevicePlugin(ctx, resourceManager, deviceListStrategies, sConfig.NvidiaConfig, mode, migMgr), nil
 }
 
 // newNvidiaDevicePlugin assembles an NvidiaDevicePlugin from the options and the
@@ -204,19 +204,16 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 // channels) be unit tested without initializing devices, MIG, or NVML.
 func (o *options) newNvidiaDevicePlugin(
 	ctx context.Context,
-	nvconfig *nvidia.DeviceConfig,
 	resourceManager rm.ResourceManager,
 	deviceListStrategies spec.DeviceListStrategies,
 	schedulerConfig nvidia.NvidiaConfig,
 	mode string,
 	migMgr *MigInstanceManager,
 ) *NvidiaDevicePlugin {
-	_, name := resourceManager.Resource().Split()
-
 	return &NvidiaDevicePlugin{
 		ctx:                        ctx,
 		rm:                         resourceManager,
-		config:                     nvconfig,
+		config:                     o.config,
 		deviceListEnvvar:           "NVIDIA_VISIBLE_DEVICES",
 		deviceListStrategies:       deviceListStrategies,
 		applyMutex:                 sync.Mutex{},
@@ -224,7 +221,7 @@ func (o *options) newNvidiaDevicePlugin(
 		ackDisableHealthChecks:     nil,
 		disableWatchAndRegister:    nil,
 		ackDisableWatchAndRegister: nil,
-		socket:                     kubeletdevicepluginv1beta1.DevicePluginPath + "nvidia-" + name + ".sock",
+		socket:                     getPluginSocketPath(resourceManager.Resource()),
 		cdiHandler:                 o.cdiHandler,
 		cdiAnnotationPrefix:        *o.config.Flags.Plugin.CDIAnnotationPrefix,
 		schedulerConfig:            schedulerConfig,

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -237,7 +237,6 @@ func TestNewNvidiaDevicePluginPropagatesImexChannels(t *testing.T) {
 
 	plugin := o.newNvidiaDevicePlugin(
 		context.Background(),
-		o.config,
 		resourceManager,
 		deviceListStrategies,
 		nvidia.NvidiaConfig{},
@@ -247,6 +246,25 @@ func TestNewNvidiaDevicePluginPropagatesImexChannels(t *testing.T) {
 
 	require.Equal(t, channels, plugin.imexChannels,
 		"newNvidiaDevicePlugin must copy imexChannels from options into the plugin")
+}
+
+// TestUpdateResponseForImexChannelsEnvVarExposesChannels covers the container-facing
+// half of the IMEX wiring: once the channels are on the plugin, the allocate response
+// must expose them to the container through the IMEX channel env var. With
+// TestNewNvidiaDevicePluginPropagatesImexChannels (options into the plugin) this pins
+// the full path the #2892 regression broke.
+func TestUpdateResponseForImexChannelsEnvVarExposesChannels(t *testing.T) {
+	plugin := NvidiaDevicePlugin{
+		imexChannels: imex.Channels{{ID: "0"}, {ID: "3"}},
+	}
+
+	response := kubeletdevicepluginv1beta1.ContainerAllocateResponse{
+		Envs: map[string]string{},
+	}
+	plugin.updateResponseForImexChannelsEnvVar(&response)
+
+	require.Equal(t, "0,3", response.Envs[v1.ImexChannelEnvVar],
+		"updateResponseForImexChannelsEnvVar must expose the plugin's IMEX channels to the container")
 }
 
 func TestSelectPreferredDeviceIDsFromAnnotatedDevices(t *testing.T) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -207,6 +207,48 @@ func TestCDIAllocateResponse(t *testing.T) {
 	}
 }
 
+// TestNewNvidiaDevicePluginPropagatesImexChannels guards the wiring from options
+// into the plugin: WithImexChannels stores the channels on options, and the
+// plugin the constructor builds must carry them, otherwise updateResponseForCDI,
+// updateResponseForImexChannelsEnvVar, updateResponseForDeviceMounts, and
+// apiDeviceSpecs all see an empty list and IMEX channels are never exposed to the
+// container.
+func TestNewNvidiaDevicePluginPropagatesImexChannels(t *testing.T) {
+	channels := imex.Channels{{ID: "0"}, {ID: "1"}}
+	o := &options{
+		imexChannels: channels,
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							CDIAnnotationPrefix: ptr("cdi.k8s.io/"),
+						},
+					},
+				},
+			},
+		},
+	}
+	resourceManager := &rm.ResourceManagerMock{
+		ResourceFunc: func() v1.ResourceName { return "nvidia.com/gpu" },
+	}
+	deviceListStrategies, err := v1.NewDeviceListStrategies([]string{"envvar"})
+	require.NoError(t, err)
+
+	plugin := o.newNvidiaDevicePlugin(
+		context.Background(),
+		o.config,
+		resourceManager,
+		deviceListStrategies,
+		nvidia.NvidiaConfig{},
+		"hami-core",
+		nil,
+	)
+
+	require.Equal(t, channels, plugin.imexChannels,
+		"newNvidiaDevicePlugin must copy imexChannels from options into the plugin")
+}
+
 func TestSelectPreferredDeviceIDsFromAnnotatedDevices(t *testing.T) {
 	plugin := &NvidiaDevicePlugin{}
 	// Use real NVIDIA GPU UUID format: GPU-xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The NVIDIA device plugin discovers IMEX channels at startup and passes them into the plugin options via `plugin.WithImexChannels(...)`. `WithImexChannels` stores the channels on the `options` struct, but `devicePluginForResource` assembled the `NvidiaDevicePlugin` struct literal without copying `o.imexChannels` into the plugin's `imexChannels` field, so the field was always nil.

As a result the four allocation-time methods that range over `plugin.imexChannels` (`updateResponseForCDI`, `updateResponseForImexChannelsEnvVar`, `updateResponseForDeviceMounts`, and `apiDeviceSpecs`) silently produced nothing. On systems where IMEX channels are discovered (for example GB200 / NVL72), containers were created without the IMEX channel device nodes, mounts, and environment variable. The defect was easy to miss because the CDI handler receives its own separate copy of the channels on the same call site.

This PR:
- Adds the missing `imexChannels: o.imexChannels` field so discovered channels reach the four methods above.
- Extracts the struct assembly into a small `newNvidiaDevicePlugin` method so the wiring from options into the plugin can be unit tested without initializing devices, MIG, or NVML (the untestable constructor is why the omission went unnoticed).
- Adds `TestNewNvidiaDevicePluginPropagatesImexChannels`, which fails on the current code and passes with the fix.

There is no behavior change other than the IMEX field; the extracted method is a straight move of the existing struct assembly.

**Which issue(s) this PR fixes**:
Fixes #2891

**Special notes for your reviewer**:

Verified locally on Linux (LF, matching CI): `gofmt -l` clean, `go vet`, `make lint`, `make verify`, and `make test` (full `./pkg/... ./cmd/...` with `-race -short`) all pass. As a sensitivity check, removing only the new `imexChannels: o.imexChannels` line makes the new test fail, confirming it guards the exact bug.

AI assistance: this change was prepared with the help of an AI coding assistant, and all code and tests were reviewed and verified by me.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the NVIDIA device plugin dropping discovered IMEX channels, which left the IMEX device nodes, mounts, and environment variable out of allocated containers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NVIDIA device allocations now expose configured IMEX channel identifiers through the allocation response environment.

* **Refactor**
  * Streamlined NVIDIA device plugin initialization while preserving existing behavior.
  * Improved propagation of configured IMEX channels to the initialized plugin.

* **Tests**
  * Added coverage verifying that multiple IMEX channel settings are retained and returned correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->