### PR TITLE
fix(nvidia): keep device registration order stable across scans

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -37,6 +37,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -206,6 +207,9 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() *[]*device.DeviceInfo {
 		res = append(res, info)
 		klog.V(3).Infof("Registered device id=%v, memory=%vMB, type=%v, numa=%v, health=%v", idx, registeredmem, Model, numa, health)
 	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Index < res[j].Index
+	})
 	return &res
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
+	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
@@ -143,6 +144,73 @@ func TestGetAPIDevicesShutsDownAfterNVMLInit(t *testing.T) {
 	devices := plugin.getAPIDevices()
 	if devices == nil || len(*devices) != 0 {
 		t.Fatalf("getAPIDevices() = %v, want non-nil empty slice", devices)
+	}
+}
+
+func TestGetAPIDevicesReturnsStableOrder(t *testing.T) {
+	originalInit := nvmlInit
+	originalShutdown := nvml.Shutdown
+	originalGetHandleByUUID := nvml.DeviceGetHandleByUUID
+	nvmlInit = func() nvml.Return { return nvml.SUCCESS }
+	nvml.Shutdown = func() nvml.Return { return nvml.SUCCESS }
+	defer func() {
+		nvmlInit = originalInit
+		nvml.Shutdown = originalShutdown
+		nvml.DeviceGetHandleByUUID = originalGetHandleByUUID
+	}()
+
+	nvmlDevices := map[string]nvml.Device{
+		"GPU-0": &nvmlmock.Device{
+			GetIndexFunc:      func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+			GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) { return nvml.Memory{Total: 8 * 1024 * 1024 * 1024}, nvml.SUCCESS },
+			GetNameFunc:       func() (string, nvml.Return) { return "A100", nvml.SUCCESS },
+			GetPciInfoFunc:    func() (nvml.PciInfo, nvml.Return) { return nvml.PciInfo{}, nvml.ERROR_NOT_SUPPORTED },
+		},
+		"GPU-1": &nvmlmock.Device{
+			GetIndexFunc:      func() (int, nvml.Return) { return 1, nvml.SUCCESS },
+			GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) { return nvml.Memory{Total: 8 * 1024 * 1024 * 1024}, nvml.SUCCESS },
+			GetNameFunc:       func() (string, nvml.Return) { return "A100", nvml.SUCCESS },
+			GetPciInfoFunc:    func() (nvml.PciInfo, nvml.Return) { return nvml.PciInfo{}, nvml.ERROR_NOT_SUPPORTED },
+		},
+	}
+	nvml.DeviceGetHandleByUUID = func(uuid string) (nvml.Device, nvml.Return) {
+		dev, ok := nvmlDevices[uuid]
+		if !ok {
+			return nil, nvml.ERROR_NOT_FOUND
+		}
+		return dev, nvml.SUCCESS
+	}
+
+	rmDevices := make(rm.Devices, len(nvmlDevices))
+	for uuid := range nvmlDevices {
+		dev := &rm.Device{}
+		dev.ID = uuid
+		dev.Health = "Healthy"
+		rmDevices[uuid] = dev
+	}
+	splitCount := uint(1)
+	memoryScaling := 1.0
+	coreScaling := 1.0
+	plugin := &NvidiaDevicePlugin{
+		rm: &rm.ResourceManagerMock{DevicesFunc: func() rm.Devices { return rmDevices }},
+		schedulerConfig: nvidia.NvidiaConfig{NodeDefaultConfig: nvidia.NodeDefaultConfig{
+			DeviceSplitCount:    &splitCount,
+			DeviceMemoryScaling: &memoryScaling,
+			DeviceCoreScaling:   &coreScaling,
+		}},
+	}
+
+	first := plugin.getAPIDevices()
+	second := plugin.getAPIDevices()
+	for i, dev := range *first {
+		if dev.Index != uint(i) {
+			t.Fatalf("getAPIDevices()[%d].Index = %d, want %d", i, dev.Index, i)
+		}
+	}
+	firstEncoded := device.MarshalNodeDevices(*first)
+	secondEncoded := device.MarshalNodeDevices(*second)
+	if firstEncoded != secondEncoded {
+		t.Fatalf("encoded device output changed across scans:\nfirst:  %s\nsecond: %s", firstEncoded, secondEncoded)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Sorts the NVIDIA devices returned by `getAPIDevices` by their stable NVML index before they are encoded for the node registration annotation. This prevents Go map iteration order from changing the annotation payload and triggering an unnecessary node patch on every scan.

Adds a mocked two-GPU regression test that calls `getAPIDevices` twice, verifies index ordering, and asserts that both encoded payloads are identical.

**Which issue(s) this PR fixes**:

Fixes #2893

**Special notes for your reviewer**:

- `go fmt` and `git diff --check` pass for the touched files.
- Linux verification passed on Ubuntu 22.04: the focused regression test ran 20 times, and the complete `nvinternal/plugin` package test suite passed ([workflow run](https://github.com/libaojiang/HAMi/actions/runs/33316986244)).
- No GPU hardware was used. NVML is mocked by the regression test, and this change does not affect device allocation or in-container isolation behavior.
- AI assistance disclosure: I used OpenAI Codex to inspect the relevant code, prepare the small implementation and regression test, and run the available checks. I reviewed the resulting diff and understand the map-ordering bug, the index sort, and the test setup.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```