### PR TITLE
fix(chart): target the scheduler metrics port by name

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -139,7 +139,7 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.service.httpPort` | HTTP port | `443` |
 | `scheduler.service.schedulerPort` | Scheduler NodePort | `31998` |
 | `scheduler.service.monitorPort` | Monitor port | `31993` |
-| `scheduler.service.monitorTargetPort` | Monitor target port | `9395` |
+| `scheduler.service.monitorTargetPort` | Monitor target port | `metrics` |
 
 ## Device Plugin Configuration
 

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -24,7 +24,7 @@ spec:
       protocol: TCP
     - name: monitor
       port: {{ .Values.scheduler.service.monitorPort | default 31993 }}  # Default monitoring port is 31993
-      targetPort: {{ .Values.scheduler.service.monitorTargetPort | default 9395 }}
+      targetPort: {{ .Values.scheduler.service.monitorTargetPort | default "metrics" }}
       {{- if eq (.Values.scheduler.service.type | default "NodePort") "NodePort" }}  # If type is NodePort, set nodePort
       nodePort: {{ .Values.scheduler.service.monitorPort | default 31993 }}
       {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -273,7 +273,7 @@ scheduler:
     httpPort: 443   # HTTP port
     schedulerPort: 31998  # NodePort for HTTP
     monitorPort: 31993    # Monitoring port
-    monitorTargetPort: 9395
+    monitorTargetPort: metrics  # Name of the container port, so it follows scheduler.metricsBindAddress
     httpTargetPort: 443
     labels: {}
     annotations: {}

--- a/skill/hami-vgpu-metrics-summary/SKILL.md
+++ b/skill/hami-vgpu-metrics-summary/SKILL.md
@@ -109,7 +109,7 @@ Repository-backed defaults and relationships:
 - Container metrics port name: `metrics`
 - Service port name: `monitor`
 - Default Service `monitor` port: `31993`
-- Default Service targetPort: `9395`
+- Default Service targetPort: `metrics` (the named container port, which follows `scheduler.metricsBindAddress`)
 - Metrics path: `/metrics`
 
 **F. Port-forward the scheduler Service and fetch metrics**


### PR DESCRIPTION
The scheduler monitor service hardcoded targetPort 9395 while the container port is derived from `scheduler.metricsBindAddress`, so changing only that value left the service pointing at a closed port and the ServiceMonitor target down with no error. This targets the named `metrics` port instead, so the service follows the configured bind address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the scheduler monitoring Service to target the named `metrics` port by default.
  * Monitoring traffic now follows the configured metrics endpoint rather than relying on a fixed port number.

* **Documentation**
  * Updated Helm chart values and monitoring guidance to reflect the new default monitoring target.
  * Clarified that the Service target follows the scheduler’s configured metrics bind address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Does this PR introduce a user-facing change?**:

```release-note
The scheduler monitoring Service now targets the named metrics container port, so it follows scheduler.metricsBindAddress instead of a fixed 9395. Setting scheduler.service.monitorTargetPort still overrides it.
```
