### PR TITLE
fix(monitor): reuse the node-scoped pod informer for metrics

### DIFF
--- a/cmd/vGPUmonitor/metrics.go
+++ b/cmd/vGPUmonitor/metrics.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -591,22 +590,37 @@ func sendMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, valueType pr
 }
 
 // NewClusterManager creates a ClusterManager for the given zone, backs its pod
-// lookups with a shared informer, and registers its collector with reg through
-// a wrapping Registerer that adds the zone as a label.
+// lookups with the container lister's pod informer, and registers its collector
+// with reg through a wrapping Registerer that adds the zone as a label.
+//
+// Both collectors below narrow their pod lookups to this node, so they reuse the
+// informer ContainerLister already runs. It is scoped with a spec.nodeName field
+// selector and is waited on before use, unlike the cluster-wide unsynced informer
+// this used to start on every node in addition to that one.
+//
+// The scheduler writes the hami.io/vgpu-node label the collectors select on, and
+// the kubelet sets spec.nodeName, so between those two writes a pod carries the
+// label without matching the field selector yet. collectPodAndContainerInfo is
+// unaffected because it needs a running container anyway, while
+// collectPodAndContainerMigInfo reads annotations alone and so skips such a pod
+// for the rest of that scrape. It is picked up on the next one.
 func NewClusterManager(zone string, reg prometheus.Registerer, containerLister *nvidia.ContainerLister, legacyMetrics bool) *ClusterManager {
 	if legacyMetrics {
 		initLegacyDescriptors()
+	}
+	if containerLister == nil || containerLister.PodLister() == nil {
+		// NewContainerLister always initializes the informer, so this only
+		// happens if a caller builds a ContainerLister by hand. Fail here
+		// rather than nil panic on the first scrape.
+		klog.Error("container lister has no pod lister; not registering the vGPUmonitor collector")
+		return nil
 	}
 	c := &ClusterManager{
 		Zone:            zone,
 		containerLister: containerLister,
 		LegacyMetrics:   legacyMetrics,
+		PodLister:       containerLister.PodLister(),
 	}
-
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(containerLister.Clientset(), time.Hour*1)
-	c.PodLister = informerFactory.Core().V1().Pods().Lister()
-	stopCh := make(chan struct{})
-	informerFactory.Start(stopCh)
 
 	cc := ClusterManagerCollector{ClusterManager: c}
 	prometheus.WrapRegistererWith(prometheus.Labels{"zone": zone}, reg).MustRegister(cc)

--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -161,6 +161,13 @@ func (l *ContainerLister) Clientset() *kubernetes.Clientset {
 	return l.clientset
 }
 
+// PodLister returns the lister backed by the node-scoped pod informer that
+// initInformerWithConfig starts and waits for. Callers that only need pods
+// assigned to this node should reuse it rather than starting a second informer.
+func (l *ContainerLister) PodLister() corelisters.PodLister {
+	return l.podLister
+}
+
 // SetContainersForTest replaces the internal container map; use only in tests.
 func (l *ContainerLister) SetContainersForTest(m map[string]*ContainerUsage) {
 	l.mutex.Lock()

--- a/pkg/monitor/nvidia/cudevshr_test.go
+++ b/pkg/monitor/nvidia/cudevshr_test.go
@@ -110,6 +110,7 @@ func Test_ContainerLister_Accessors(t *testing.T) {
 	}
 	assert.Equal(t, len(l.ListContainers()), 1)
 	assert.Assert(t, l.Clientset() == nil)
+	assert.Assert(t, l.PodLister() == nil)
 
 	l.Lock()
 	l.UnLock()


### PR DESCRIPTION
`NewClusterManager` started a second pod informer with no field selector and no cache sync, so every vGPUmonitor cached all pods in the cluster and served empty container metrics until its cache filled. Both collectors already narrow to this node, so this reuses the informer `ContainerLister` runs with a `spec.nodeName` selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster monitoring by reusing available pod information, reducing redundant background processing.
  * Improved reliability and consistency when collecting container and pod metrics.
  * Added safeguards to ensure monitoring continues safely when pod information is unavailable.
  * Expanded validation for monitoring behavior in configurations without pod data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
