### PR TITLE
fix(monitor): report metrics server listen failures

### DIFF
--- a/cmd/vGPUmonitor/main.go
+++ b/cmd/vGPUmonitor/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -45,6 +46,9 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "vGPUmonitor",
 		Short: "Hami vgpu vGPUmonitor",
+		// start() now returns runtime failures, which are not usage errors;
+		// without this cobra would print the whole flag help on every one.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flag.PrintPFlags(cmd.Flags())
 			return start()
@@ -120,23 +124,35 @@ func start() error {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 
+	// A signal is a normal shutdown, an error is not: return it so main exits
+	// non-zero and the container reports the failure instead of Completed.
+	var runErr error
 	select {
 	case sig := <-signalCh:
 		klog.Infof("Received signal: %s", sig)
-		cancel()
 	case err := <-errCh:
 		klog.Errorf("Received error: %v", err)
-		cancel()
+		runErr = err
 	}
+	cancel()
 
 	// Wait for all goroutines to complete
 	wg.Wait()
 	close(errCh)
-	return nil
+	return runErr
 }
 
 func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) error {
 	klog.V(4).Info("Initializing metrics for vGPUmonitor")
+
+	// Bind before anything else. ListenAndServe fails almost exclusively on the
+	// initial bind, and that is a startup misconfiguration that never heals, so
+	// take it before the collectors are wired up and report it to the caller.
+	listener, err := net.Listen("tcp", metricsBindAddress)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", metricsBindAddress, err)
+	}
+
 	reg := prometheus.NewRegistry()
 	//reg := prometheus.NewPedanticRegistry()
 
@@ -154,15 +170,22 @@ func initMetrics(ctx context.Context, containerLister *nvidia.ContainerLister) e
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 	server := &http.Server{Addr: metricsBindAddress, Handler: mux, ReadHeaderTimeout: 15 * time.Second, ReadTimeout: 60 * time.Second}
 
-	// Starting the HTTP server in a goroutine
+	// Starting the HTTP server in a goroutine. Serving can still stop on its own
+	// later, on a fatal accept error, and the vGPUmonitor container carries no
+	// probe that would notice, so surface that too instead of only logging it.
+	serveErr := make(chan error, 1)
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			klog.Errorf("Failed to serve metrics: %v", err)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
 		}
 	}()
 
 	// Graceful shutdown on context cancellation
-	<-ctx.Done()
+	select {
+	case err := <-serveErr:
+		return fmt.Errorf("metrics server on %s stopped: %w", metricsBindAddress, err)
+	case <-ctx.Done():
+	}
 	klog.V(4).Info("Shutting down metrics server")
 	if err := server.Shutdown(context.Background()); err != nil {
 		return err

--- a/cmd/vGPUmonitor/main_test.go
+++ b/cmd/vGPUmonitor/main_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+// initMetrics must fail when it cannot bind, rather than leaving the process
+// running with nothing to scrape. It binds before touching the container
+// lister, so a nil lister never gets dereferenced on this path.
+func TestInitMetricsReturnsErrorWhenBindFails(t *testing.T) {
+	taken, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy a port for the test: %v", err)
+	}
+	defer taken.Close()
+
+	original := metricsBindAddress
+	metricsBindAddress = taken.Addr().String()
+	defer func() { metricsBindAddress = original }()
+
+	if err := initMetrics(context.Background(), nil); err == nil {
+		t.Fatalf("expected an error when %s is already in use", metricsBindAddress)
+	}
+}


### PR DESCRIPTION
A failed metrics bind was only logged, so `initMetrics` kept blocking on the context and the container stayed up with nothing to scrape and no probe to catch it. This binds before wiring up the collectors so the failure is caught at startup, and lets `start()` return the error so the process exits non-zero instead of Completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The monitoring process now exits with an error when startup or runtime failures occur.
  * Metrics service startup failures, including unavailable network ports, are now detected and reported instead of being silently logged.
  * Metrics shutdown is handled more gracefully when the application is canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Does this PR introduce a user-facing change?**:

```release-note
vGPUmonitor now exits with an error when the metrics server cannot bind, instead of staying up with no metrics endpoint.
```
