### PR TITLE
fix(metrics): drop the constant container index label

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -331,29 +331,35 @@ func (cc ClusterManagerCollector) collectQuotaMetrics(ch chan<- prometheus.Metri
 // pods. AMD core allocations are normalized to a percentage via
 // normalizeAMDCoreMetrics (issue #2518); legacy metrics keep raw values.
 func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.Metric, nu *map[string]*schedulerpkg.NodeUsage, legacy bool) {
+	// PodManager only ever stores the pod's collapsed device usage, a single
+	// entry per device type, so there is no per-container breakdown to label
+	// with. See device.CollapseInitContainerUsage and SteadyStateDeviceUsage.
 	ctrvGPUdeviceAllocatedMemoryDesc := prometheus.NewDesc(
 		"hami_vgpu_memory_allocated_bytes",
-		"vGPU memory allocated from a container",
-		[]string{"namespace", "node", "pod", "container_index", "device_uuid"}, nil,
+		"vGPU memory allocated from a pod",
+		[]string{"namespace", "node", "pod", "device_uuid"}, nil,
 	)
 	ctrvGPUdeviceAllocatedCoreDesc := prometheus.NewDesc(
 		"hami_vgpu_core_allocated_ratio",
-		"vGPU core allocated from a container",
-		[]string{"namespace", "node", "pod", "container_index", "device_uuid"}, nil,
+		"vGPU core allocated from a pod",
+		[]string{"namespace", "node", "pod", "device_uuid"}, nil,
 	)
 	var (
 		legacyAllocatedMemory *prometheus.Desc
 		legacyAllocatedCore   *prometheus.Desc
 	)
 	if legacy {
+		// Legacy metrics exist to keep pre-existing dashboards working, so
+		// containeridx stays even though it is always "0". Only the new
+		// hami_vgpu_* pair drops it.
 		legacyAllocatedMemory = prometheus.NewDesc(
 			"vGPUMemoryAllocated",
-			"vGPU memory allocated from a container",
+			"vGPU memory allocated from a pod",
 			[]string{"podnamespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
 		)
 		legacyAllocatedCore = prometheus.NewDesc(
 			"vGPUCoreAllocated",
-			"vGPU core allocated from a container",
+			"vGPU core allocated from a pod",
 			[]string{"podnamespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
 		)
 	}
@@ -386,7 +392,7 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 						"found", found,
 						"nodeID", val.NodeID,
 					)
-					containerLabels := []string{val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID}
+					containerLabels := []string{val.Namespace, val.NodeID, val.Name, ctrdevval.UUID}
 					usedMemBytes := mibToBytes(ctrdevval.Usedmem)
 					if err := sendMetric(ch, ctrvGPUdeviceAllocatedMemoryDesc, prometheus.GaugeValue, usedMemBytes, containerLabels...); err != nil {
 						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedMemoryDesc metric: %v", err)
@@ -396,8 +402,9 @@ func (cc ClusterManagerCollector) collectContainerMetrics(ch chan<- prometheus.M
 						klog.V(4).Infof("Failed to send ctrvGPUdeviceAllocatedCoreDesc metric: %v", err)
 					}
 					if legacy {
-						sendLegacyMetric(ch, legacyAllocatedMemory, prometheus.GaugeValue, usedMemBytes, containerLabels...)
-						sendLegacyMetric(ch, legacyAllocatedCore, prometheus.GaugeValue, float64(ctrdevval.Usedcores), containerLabels...)
+						legacyLabels := []string{val.Namespace, val.NodeID, val.Name, fmt.Sprint(ctridx), ctrdevval.UUID}
+						sendLegacyMetric(ch, legacyAllocatedMemory, prometheus.GaugeValue, usedMemBytes, legacyLabels...)
+						sendLegacyMetric(ch, legacyAllocatedCore, prometheus.GaugeValue, float64(ctrdevval.Usedcores), legacyLabels...)
 					}
 				}
 			}

--- a/cmd/scheduler/metrics_test.go
+++ b/cmd/scheduler/metrics_test.go
@@ -279,9 +279,9 @@ func TestAMDCoreAllocatedRatioNormalization(t *testing.T) {
 # HELP hami_gpu_core_allocated_ratio Device core allocated for a certain GPU
 # TYPE hami_gpu_core_allocated_ratio gauge
 hami_gpu_core_allocated_ratio{device_index="0",device_type="AMDGPU",device_uuid="AMD-1",node="node-1"} 50
-# HELP hami_vgpu_core_allocated_ratio vGPU core allocated from a container
+# HELP hami_vgpu_core_allocated_ratio vGPU core allocated from a pod
 # TYPE hami_vgpu_core_allocated_ratio gauge
-hami_vgpu_core_allocated_ratio{container_index="0",device_uuid="AMD-1",namespace="default",node="node-1",pod="amd-pod"} 50
+hami_vgpu_core_allocated_ratio{device_uuid="AMD-1",namespace="default",node="node-1",pod="amd-pod"} 50
 `
 	if err := promtestutil.CollectAndCompare(
 		newCollector,
@@ -302,7 +302,7 @@ hami_vgpu_core_allocated_ratio{container_index="0",device_uuid="AMD-1",namespace
 		},
 	}
 	legacyWant := `
-# HELP vGPUCoreAllocated vGPU core allocated from a container
+# HELP vGPUCoreAllocated vGPU core allocated from a pod
 # TYPE vGPUCoreAllocated gauge
 vGPUCoreAllocated{containeridx="0",deviceuuid="AMD-1",nodename="node-1",podname="amd-pod",podnamespace="default"} 32
 `

--- a/skill/hami-vgpu-metrics-summary/SKILL.md
+++ b/skill/hami-vgpu-metrics-summary/SKILL.md
@@ -151,7 +151,7 @@ These are the primary metrics if `--legacy-metrics=false`:
 - `hami_node_gpu_overview`
 - `hami_node_gpu_mig_instance_info`
 
-**Pod/container-level allocation**
+**Pod-level allocation**
 - `hami_vgpu_core_allocated_ratio`
 - `hami_vgpu_memory_allocated_bytes`
 
@@ -182,7 +182,7 @@ If the scheduler is started with `--legacy-metrics=true`, the same allocation st
 - `nodeGPUOverview`
 - `nodeGPUMigInstance`
 
-**Pod/container-level allocation**
+**Pod-level allocation**
 - `vGPUCoreAllocated`
 - `vGPUMemoryAllocated`
 
@@ -416,7 +416,6 @@ Use:
 Join records by:
 - `podnamespace`
 - `podname`
-- `containeridx`
 - `deviceuuid`
 - `nodename`
 
@@ -596,7 +595,7 @@ For every pod identified in Step 7 that has a GPU allocation, exec into the pod 
 
 #### A. Identify the correct container
 
-Each pod may have multiple containers. The GPU-using container is usually identified by `containeridx` from `vGPUCoreAllocated` / `vGPUMemoryAllocated`. Prefer to exec into the container at `containeridx`. If the index is not directly mappable to a container name, use the first non-sidecar container, or try each container.
+Each pod may have multiple containers. `vGPUCoreAllocated` / `vGPUMemoryAllocated` are reported per pod and device, so `containeridx` is always `0` and cannot point at one container. Use the first non-sidecar container, or try each container.
 
 **List containers for a pod:**
 ```bash
@@ -766,8 +765,8 @@ If the user asks in English, answer in English.
 | `hami_node_gpu_memory_allocated_ratio` / `nodeGPUMemoryPercentage` | Memory allocation ratio on the GPU | device |
 | `hami_node_gpu_overview` / `nodeGPUOverview` | Combined single-device overview | device |
 | `hami_node_gpu_mig_instance_info` / `nodeGPUMigInstance` | MIG/MPS sharing-mode instance information | device |
-| `hami_vgpu_core_allocated_ratio` / `vGPUCoreAllocated` | GPU core share allocated to a container | pod/container |
-| `hami_vgpu_memory_allocated_bytes` / `vGPUMemoryAllocated` | GPU memory allocated to a container | pod/container |
+| `hami_vgpu_core_allocated_ratio` / `vGPUCoreAllocated` | GPU core share allocated to a pod on one device | pod/device |
+| `hami_vgpu_memory_allocated_bytes` / `vGPUMemoryAllocated` | GPU memory allocated to a pod on one device | pod/device |
 | `hami_resource_quota_used` / `QuotaUsed` | Namespace-level quota usage | namespace |
 | `hami_resource_quota_limit` | Namespace-level quota limit | namespace |
 | `hami_host_gpu_memory_used_bytes` / `HostGPUMemoryUsage` | Runtime physical GPU memory used from vGPU monitor | runtime/device |


### PR DESCRIPTION
`PodManager` only stores each pod's collapsed device usage, one entry per device type, so `container_index` and `containeridx` were always 0 and two containers sharing a GPU landed in a single series that looked per container. This drops the label from the four vGPU allocation metrics and corrects the skill doc that told operators to pick a container by it.

