### PR TITLE
fix(scheduler): preserve allocation slots for model-specific types

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -223,7 +223,23 @@ func applyPeakUsage(node *NodeUsage, appNodeCopy *NodeUsage, peakUsage map[strin
 	}
 }
 
-func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
+// fitInDevices stores allocations under the request type (for example,
+// "NVIDIA"), while nodes may register a model-specific device type. Include
+// both sets of keys so empty container slots are added to every allocation row.
+func allocationTypeKeys(resourceReqs device.PodDeviceRequests, baseTypes map[string]struct{}) map[string]struct{} {
+	allocTypes := make(map[string]struct{}, len(baseTypes))
+	for typ := range baseTypes {
+		allocTypes[typ] = struct{}{}
+	}
+	for _, ctrReqs := range resourceReqs {
+		for _, req := range ctrReqs {
+			allocTypes[req.Type] = struct{}{}
+		}
+	}
+	return allocTypes
+}
+
+func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, numInitContainers int, peakUsage map[string]peakUsageSnapshot, weights util.DeviceScoringWeights) (device.PodDevices, bool, string) {
 	initAllocs := make(device.PodDevices)
 
 	for i, req := range resourceReqs {
@@ -231,7 +247,7 @@ func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.
 			break
 		}
 		if len(req) == 0 {
-			for typ := range baseTypes {
+			for typ := range allocTypes {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
 			}
 			continue
@@ -244,7 +260,7 @@ func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.
 			return nil, false, reason
 		}
 		updatePeakUsage(peakUsage, nodeCopy)
-		for typ := range baseTypes {
+		for typ := range allocTypes {
 			if len(initAllocs[typ]) == i {
 				initAllocs[typ] = append(initAllocs[typ], device.ContainerDevices{})
 			}
@@ -253,7 +269,7 @@ func allocateInitContainers(node *NodeUsage, nodeID string, resourceReqs device.
 	return initAllocs, true, ""
 }
 
-func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, baseTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
+func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, resourceReqs device.PodDeviceRequests, task *corev1.Pod, nodeInfo *device.NodeInfo, allocTypes map[string]struct{}, numInitContainers int, nodeID string, weights util.DeviceScoringWeights) (string, bool) {
 	appIndex := 0
 	for ctrid, n := range resourceReqs {
 		if ctrid < numInitContainers {
@@ -264,7 +280,7 @@ func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, reso
 			sums += int(k.Nums)
 		}
 		if sums == 0 {
-			for typ := range baseTypes {
+			for typ := range allocTypes {
 				score.Devices[typ] = append(score.Devices[typ], device.ContainerDevices{})
 			}
 			appIndex++
@@ -275,7 +291,7 @@ func allocateAppContainers(score *policy.NodeScore, appNodeCopy *NodeUsage, reso
 			klog.V(4).InfoS(common.NodeUnfitPod, "pod", klog.KObj(task), "node", nodeID, "reason", reason)
 			return reason, false
 		}
-		for typ := range baseTypes {
+		for typ := range allocTypes {
 			if len(score.Devices[typ]) == appIndex {
 				score.Devices[typ] = append(score.Devices[typ], device.ContainerDevices{})
 			}
@@ -305,12 +321,13 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 	}
 
 	baseTypes := nodeDeviceBaseTypes(node.Devices)
+	allocTypes := allocationTypeKeys(resourceReqs, baseTypes)
 	peakUsage := snapshotPeakUsage(node.Devices)
 	numInitContainers := len(task.Spec.InitContainers)
 
 	var initAllocs device.PodDevices
 	if numInitContainers > 0 {
-		allocs, fit, reason := allocateInitContainers(node, nodeID, resourceReqs, task, nodeInfo, baseTypes, numInitContainers, peakUsage, weights)
+		allocs, fit, reason := allocateInitContainers(node, nodeID, resourceReqs, task, nodeInfo, allocTypes, numInitContainers, peakUsage, weights)
 		if !fit {
 			return nodeScoreResult{reason: reason}
 		}
@@ -327,7 +344,7 @@ func (s *Scheduler) scoreNode(nodeID string, node *NodeUsage, resourceReqs devic
 	score.ComputeDefaultScore(appNodeCopy.Devices)
 	snapshot := score.SnapshotDevice(appNodeCopy.Devices)
 
-	if reason, fit := allocateAppContainers(&score, appNodeCopy, resourceReqs, task, nodeInfo, baseTypes, numInitContainers, nodeID, weights); !fit {
+	if reason, fit := allocateAppContainers(&score, appNodeCopy, resourceReqs, task, nodeInfo, allocTypes, numInitContainers, nodeID, weights); !fit {
 		return nodeScoreResult{reason: reason}
 	}
 

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3288,6 +3288,68 @@ func Test_calcScore(t *testing.T) {
 	}
 }
 
+func TestScoreNodePreservesSlotsForModelSpecificDeviceType(t *testing.T) {
+	nodeObject := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	node := &NodeUsage{
+		Node:     nodeObject,
+		NodeInfo: &device.NodeInfo{ID: nodeObject.Name, Node: nodeObject},
+		Devices: policy.DeviceUsageList{
+			Policy: util.NodeSchedulerPolicyBinpack.String(),
+			DeviceLists: []*policy.DeviceListsScore{
+				{Device: &device.DeviceUsage{
+					ID: "uuid1", Index: 0, Type: "NVIDIA-Tesla T4", Health: true,
+					Count: 10, Totalcore: 100, Totalmem: 8000,
+				}},
+			},
+		},
+	}
+	gpuRequest := func() device.ContainerDeviceRequests {
+		return device.ContainerDeviceRequests{
+			nvidia.NvidiaGPUDevice: {
+				Nums: 1, Type: nvidia.NvidiaGPUDevice, Memreq: 1000, Coresreq: 30,
+			},
+		}
+	}
+	requests := device.PodDeviceRequests{
+		{},           // init without a GPU
+		gpuRequest(), // first app container
+		{},           // app container without a GPU
+		gpuRequest(), // third app container
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-specific-slots", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "setup"}},
+			Containers: []corev1.Container{
+				{Name: "worker-a"},
+				{Name: "helper-without-gpu"},
+				{Name: "worker-b"},
+			},
+		},
+	}
+
+	result := (&Scheduler{}).scoreNode(
+		nodeObject.Name,
+		node,
+		requests,
+		pod,
+		util.NodeSchedulerPolicyBinpack.String(),
+		util.DefaultDeviceScoringWeights(),
+	)
+
+	assert.NilError(t, result.err)
+	assert.Equal(t, result.reason, "")
+	assert.Assert(t, result.score != nil)
+	allocated := result.score.Devices[nvidia.NvidiaGPUDevice]
+	assert.DeepEqual(t, allocated, device.PodSingleDevice{
+		{},
+		{{Idx: 0, UUID: "uuid1", Type: nvidia.NvidiaGPUDevice, Usedmem: 1000, Usedcores: 30}},
+		{},
+		{{Idx: 0, UUID: "uuid1", Type: nvidia.NvidiaGPUDevice, Usedmem: 1000, Usedcores: 30}},
+	})
+	assert.Equal(t, device.EncodePodSingleDevice(allocated), ";uuid1,NVIDIA,1000,30:;;uuid1,NVIDIA,1000,30:;")
+}
+
 func Test_fitInCertainDevice(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Backports the allocation-type key union from #2723 to `release-v2.10`.

On v2.10.0, nodes can register a model-specific type such as
`NVIDIA-Tesla T4`, while NVIDIA requests and fitted allocations use the
generic `NVIDIA` key. Empty init or app container slots were padded only under
the model key, so the encoded `NVIDIA` annotation dropped those positions and
shifted device ownership between containers.

This change pads both registered and requested device-type rows. It adds one
regression test covering empty init and app slots and the final annotation wire
format. The unrelated native-sidecar changes from #2723 are intentionally not
included.

**Which issue(s) this PR fixes**:

Fixes #2899

**Special notes for your reviewer**:

Current `master` already contains the functional fix through #2723; this is the
minimal patch-release backport.

Verification:

- `go test ./pkg/scheduler -count=1`
- `go test -race ./pkg/scheduler -run '^TestScoreNodePreservesSlotsForModelSpecificDeviceType$' -count=1`

**Does this PR introduce a user-facing change?**:

```release-note
Fix allocation annotations on model-specific NVIDIA nodes so init and app container slots remain aligned.
```
