### PR TITLE
expose scheduler kube-qps, kube-burst and kube-timeout as values

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -73,6 +73,9 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy` | Node scheduler policy | `binpack` |
 | `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy` | GPU scheduler policy | `spread` |
 | `scheduler.metricsBindAddress` | Metrics bind address | `":9395"` |
+| `scheduler.kubeQPS` | QPS to use while talking with the kube-apiserver; empty keeps the binary default (`5`) | `""` |
+| `scheduler.kubeBurst` | Burst to use while talking with the kube-apiserver; empty keeps the binary default (`10`) | `""` |
+| `scheduler.kubeTimeout` | Timeout in seconds while talking with the kube-apiserver; empty keeps the binary default (`0`, no timeout) | `""` |
 | `scheduler.forceOverwriteDefaultScheduler` | Whether to force overwrite default scheduler | `true` |
 | `scheduler.livenessProbe` | Whether to enable liveness probe | `false` |
 | `scheduler.leaderElect` | Whether to enable leader election | `true` |

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -133,6 +133,15 @@ spec:
             {{- if .Values.legacyMetrics }}
             - --legacy-metrics=true
             {{- end }}
+            {{- if .Values.scheduler.kubeQPS }}
+            - --kube-qps={{ .Values.scheduler.kubeQPS }}
+            {{- end }}
+            {{- if .Values.scheduler.kubeBurst }}
+            - --kube-burst={{ .Values.scheduler.kubeBurst }}
+            {{- end }}
+            {{- if .Values.scheduler.kubeTimeout }}
+            - --kube-timeout={{ .Values.scheduler.kubeTimeout }}
+            {{- end }}
             {{- range .Values.scheduler.extender.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -77,6 +77,14 @@ scheduler:
     nodeSchedulerPolicy: binpack
     gpuSchedulerPolicy: spread
   metricsBindAddress: ":9395"
+  # Client-side rate limiting and timeout for the scheduler's connection to the kube-apiserver.
+  # Leave empty to keep the binary defaults (QPS 5, burst 10, no timeout). Raising kubeQPS and
+  # kubeBurst helps on large clusters, where node registration patches and per-pod annotation
+  # writes can be throttled by the default limits.
+  kubeQPS: ""
+  kubeBurst: ""
+  # kubeTimeout is in seconds; 0 means no timeout.
+  kubeTimeout: ""
   # If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it
   forceOverwriteDefaultScheduler: true
   livenessProbe: false


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Adds three optional Helm values for scheduler kube-apiserver client tuning:

| Value                   | Flag             | Default |
| ----------------------- | ---------------- | ------- |
| `scheduler.kubeQPS`     | `--kube-qps`     | `5`     |
| `scheduler.kubeBurst`   | `--kube-burst`   | `10`    |
| `scheduler.kubeTimeout` | `--kube-timeout` | `0`     |

These flags already exist in the scheduler binary but were not directly configurable through Helm. Previously, users had to use `scheduler.extender.extraArgs`, which can replace the default argument list and unintentionally remove flags such as `--debug` and `-v=4`.

**Changes:**

* Added the three values to `charts/hami/values.yaml`.
* Added conditional flag rendering to `charts/hami/templates/scheduler/deployment.yaml`.
* Documented the values in `charts/hami/README.md`.
* Kept `extraArgs` unchanged and rendered it last so existing overrides continue to take precedence.
* No Go code changes are required.

**Which issue(s) does this PR fix?**

Fixes #2904

**Testing:**

* Verified the default `helm template` output is unchanged.
* Verified all three flags render correctly when configured.
* Verified partial configuration works as expected.
* Verified `helm lint --with-subcharts`.
* Verified `make -C charts validate`.
* Verified `hack/verify-chart-version.sh`.
* Built the scheduler and confirmed the flag names and defaults with `--help`.
* Tested with Helm v3.14.0.
* Trivy validation was not run because it requires Docker.

**Does this PR introduce a user-facing change?**

```release-note
Added `scheduler.kubeQPS`, `scheduler.kubeBurst`, and `scheduler.kubeTimeout` Helm values to configure the scheduler's kube-apiserver client. Defaults preserve existing behavior.
```

 **AI assistance disclosure:** I used an AI assistant to verify the implementation and check whether the test cases are covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart settings to tune scheduler communication with the Kubernetes API server.
  * Configurable request rate, burst capacity, and request timeout are now available.
  * Leaving these settings empty preserves the existing defaults; timeout values use seconds, with `0` meaning no timeout.
* **Documentation**
  * Updated chart values documentation with descriptions and default behavior for the new settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->