### PR TITLE
Feature/issue 2833 dynamic mig cdi

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api.go
@@ -37,6 +37,8 @@ package cdi
 //go:generate moq -rm -fmt=goimports -stub -out api_mock.go . Interface
 type Interface interface {
 	CreateSpecFile() error
+	CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error
+	DeleteMigSpecFile(migUUID string) error
 	QualifiedName(string, string) string
 	AdditionalDevices() []string
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api_mock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api_mock.go
@@ -12,32 +12,18 @@ import (
 var _ Interface = &InterfaceMock{}
 
 // InterfaceMock is a mock implementation of Interface.
-//
-//	func TestSomethingThatUsesInterface(t *testing.T) {
-//
-//		// make and configure a mocked Interface
-//		mockedInterface := &InterfaceMock{
-//			AdditionalDevicesFunc: func() []string {
-//				panic("mock out the AdditionalDevices method")
-//			},
-//			CreateSpecFileFunc: func() error {
-//				panic("mock out the CreateSpecFile method")
-//			},
-//			QualifiedNameFunc: func(s1 string, s2 string) string {
-//				panic("mock out the QualifiedName method")
-//			},
-//		}
-//
-//		// use mockedInterface in code that requires Interface
-//		// and then make assertions.
-//
-//	}
 type InterfaceMock struct {
 	// AdditionalDevicesFunc mocks the AdditionalDevices method.
 	AdditionalDevicesFunc func() []string
 
+	// CreateMigSpecFileFunc mocks the CreateMigSpecFile method.
+	CreateMigSpecFileFunc func(migUUID string, devicePath string, caps map[string]string) error
+
 	// CreateSpecFileFunc mocks the CreateSpecFile method.
 	CreateSpecFileFunc func() error
+
+	// DeleteMigSpecFileFunc mocks the DeleteMigSpecFile method.
+	DeleteMigSpecFileFunc func(migUUID string) error
 
 	// QualifiedNameFunc mocks the QualifiedName method.
 	QualifiedNameFunc func(s1 string, s2 string) string
@@ -47,8 +33,22 @@ type InterfaceMock struct {
 		// AdditionalDevices holds details about calls to the AdditionalDevices method.
 		AdditionalDevices []struct {
 		}
+		// CreateMigSpecFile holds details about calls to the CreateMigSpecFile method.
+		CreateMigSpecFile []struct {
+			// MigUUID is the migUUID argument value.
+			MigUUID string
+			// DevicePath is the devicePath argument value.
+			DevicePath string
+			// Caps is the caps argument value.
+			Caps map[string]string
+		}
 		// CreateSpecFile holds details about calls to the CreateSpecFile method.
 		CreateSpecFile []struct {
+		}
+		// DeleteMigSpecFile holds details about calls to the DeleteMigSpecFile method.
+		DeleteMigSpecFile []struct {
+			// MigUUID is the migUUID argument value.
+			MigUUID string
 		}
 		// QualifiedName holds details about calls to the QualifiedName method.
 		QualifiedName []struct {
@@ -59,7 +59,9 @@ type InterfaceMock struct {
 		}
 	}
 	lockAdditionalDevices sync.RWMutex
+	lockCreateMigSpecFile sync.RWMutex
 	lockCreateSpecFile    sync.RWMutex
+	lockDeleteMigSpecFile sync.RWMutex
 	lockQualifiedName     sync.RWMutex
 }
 
@@ -80,9 +82,6 @@ func (mock *InterfaceMock) AdditionalDevices() []string {
 }
 
 // AdditionalDevicesCalls gets all the calls that were made to AdditionalDevices.
-// Check the length with:
-//
-//	len(mockedInterface.AdditionalDevicesCalls())
 func (mock *InterfaceMock) AdditionalDevicesCalls() []struct {
 } {
 	var calls []struct {
@@ -90,6 +89,46 @@ func (mock *InterfaceMock) AdditionalDevicesCalls() []struct {
 	mock.lockAdditionalDevices.RLock()
 	calls = mock.calls.AdditionalDevices
 	mock.lockAdditionalDevices.RUnlock()
+	return calls
+}
+
+// CreateMigSpecFile calls CreateMigSpecFileFunc.
+func (mock *InterfaceMock) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	callInfo := struct {
+		MigUUID    string
+		DevicePath string
+		Caps       map[string]string
+	}{
+		MigUUID:    migUUID,
+		DevicePath: devicePath,
+		Caps:       caps,
+	}
+	mock.lockCreateMigSpecFile.Lock()
+	mock.calls.CreateMigSpecFile = append(mock.calls.CreateMigSpecFile, callInfo)
+	mock.lockCreateMigSpecFile.Unlock()
+	if mock.CreateMigSpecFileFunc == nil {
+		var (
+			errOut error
+		)
+		return errOut
+	}
+	return mock.CreateMigSpecFileFunc(migUUID, devicePath, caps)
+}
+
+// CreateMigSpecFileCalls gets all the calls that were made to CreateMigSpecFile.
+func (mock *InterfaceMock) CreateMigSpecFileCalls() []struct {
+	MigUUID    string
+	DevicePath string
+	Caps       map[string]string
+} {
+	var calls []struct {
+		MigUUID    string
+		DevicePath string
+		Caps       map[string]string
+	}
+	mock.lockCreateMigSpecFile.RLock()
+	calls = mock.calls.CreateMigSpecFile
+	mock.lockCreateMigSpecFile.RUnlock()
 	return calls
 }
 
@@ -110,9 +149,6 @@ func (mock *InterfaceMock) CreateSpecFile() error {
 }
 
 // CreateSpecFileCalls gets all the calls that were made to CreateSpecFile.
-// Check the length with:
-//
-//	len(mockedInterface.CreateSpecFileCalls())
 func (mock *InterfaceMock) CreateSpecFileCalls() []struct {
 } {
 	var calls []struct {
@@ -120,6 +156,38 @@ func (mock *InterfaceMock) CreateSpecFileCalls() []struct {
 	mock.lockCreateSpecFile.RLock()
 	calls = mock.calls.CreateSpecFile
 	mock.lockCreateSpecFile.RUnlock()
+	return calls
+}
+
+// DeleteMigSpecFile calls DeleteMigSpecFileFunc.
+func (mock *InterfaceMock) DeleteMigSpecFile(migUUID string) error {
+	callInfo := struct {
+		MigUUID string
+	}{
+		MigUUID: migUUID,
+	}
+	mock.lockDeleteMigSpecFile.Lock()
+	mock.calls.DeleteMigSpecFile = append(mock.calls.DeleteMigSpecFile, callInfo)
+	mock.lockDeleteMigSpecFile.Unlock()
+	if mock.DeleteMigSpecFileFunc == nil {
+		var (
+			errOut error
+		)
+		return errOut
+	}
+	return mock.DeleteMigSpecFileFunc(migUUID)
+}
+
+// DeleteMigSpecFileCalls gets all the calls that were made to DeleteMigSpecFile.
+func (mock *InterfaceMock) DeleteMigSpecFileCalls() []struct {
+	MigUUID string
+} {
+	var calls []struct {
+		MigUUID string
+	}
+	mock.lockDeleteMigSpecFile.RLock()
+	calls = mock.calls.DeleteMigSpecFile
+	mock.lockDeleteMigSpecFile.RUnlock()
 	return calls
 }
 
@@ -145,9 +213,6 @@ func (mock *InterfaceMock) QualifiedName(s1 string, s2 string) string {
 }
 
 // QualifiedNameCalls gets all the calls that were made to QualifiedName.
-// Check the length with:
-//
-//	len(mockedInterface.QualifiedNameCalls())
 func (mock *InterfaceMock) QualifiedNameCalls() []struct {
 	S1 string
 	S2 string

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi.go
@@ -50,9 +50,10 @@ import (
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/imex"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 )
 
-const (
+var (
 	cdiRoot = "/var/run/cdi"
 )
 
@@ -187,13 +188,11 @@ func (cdi *cdiHandler) CreateSpecFile() error {
 		cdi.logger.Infof("Generating CDI spec for resource: %s/%s", cdi.vendor, class)
 
 		if class == "gpu" {
-			ret := cdi.nvmllib.Init()
-			if ret != nvml.SUCCESS {
-				return fmt.Errorf("failed to initialize NVML: %v", ret)
+			session := rm.GetNVMLSession(cdi.nvmllib)
+			if err := session.Init(); err != nil {
+				return fmt.Errorf("failed to initialize NVML session: %w", err)
 			}
-			defer func() {
-				_ = cdi.nvmllib.Shutdown()
-			}()
+			defer session.Shutdown()
 		}
 
 		spec, err := cdilib.GetSpec()

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package cdi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	specs "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// CreateMigSpecFile creates or updates a dynamic CDI specification file for a MIG instance.
+// It writes to a .tmp file first and renames it atomically to prevent incomplete JSON reads.
+func (cdi *cdiHandler) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	if migUUID == "" {
+		return fmt.Errorf("empty MIG UUID provided for CDI spec creation")
+	}
+
+	sanitizedUUID := strings.ReplaceAll(migUUID, "/", "_")
+	specFileName := fmt.Sprintf("hami-mig-%s.json", sanitizedUUID)
+	targetPath := filepath.Join(cdiRoot, specFileName)
+	tmpPath := filepath.Join(cdiRoot, fmt.Sprintf(".%s.tmp", specFileName))
+
+	if err := os.MkdirAll(cdiRoot, 0755); err != nil {
+		return fmt.Errorf("failed to create cdi root dir %s: %w", cdiRoot, err)
+	}
+
+	deviceNodes := []*specs.DeviceNode{}
+	if devicePath != "" {
+		deviceNodes = append(deviceNodes, &specs.DeviceNode{
+			Path:     devicePath,
+			HostPath: devicePath,
+		})
+	}
+	for capPath, capDevNode := range caps {
+		if capDevNode != "" {
+			deviceNodes = append(deviceNodes, &specs.DeviceNode{
+				Path:     capPath,
+				HostPath: capDevNode,
+			})
+		} else if capPath != "" {
+			deviceNodes = append(deviceNodes, &specs.DeviceNode{
+				Path:     capPath,
+				HostPath: capPath,
+			})
+		}
+	}
+
+	spec := specs.Spec{
+		Version: specs.CurrentVersion,
+		Kind:    fmt.Sprintf("%s/mig", cdi.vendor),
+		Devices: []specs.Device{
+			{
+				Name: migUUID,
+				ContainerEdits: specs.ContainerEdits{
+					Env: []string{
+						fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", migUUID),
+					},
+					DeviceNodes: deviceNodes,
+				},
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal CDI spec for MIG %s: %w", migUUID, err)
+	}
+
+	tmpFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create temp CDI file %s: %w", tmpPath, err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write CDI spec data: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to sync temp CDI file: %w", err)
+	}
+	tmpFile.Close()
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp CDI file to %s: %w", targetPath, err)
+	}
+
+	klog.InfoS("atomically created dynamic MIG CDI spec", "uuid", migUUID, "path", targetPath)
+	return nil
+}
+
+// DeleteMigSpecFile removes the dynamic CDI spec file for the given MIG instance UUID.
+func (cdi *cdiHandler) DeleteMigSpecFile(migUUID string) error {
+	if migUUID == "" {
+		return nil
+	}
+	sanitizedUUID := strings.ReplaceAll(migUUID, "/", "_")
+	specFileName := fmt.Sprintf("hami-mig-%s.json", sanitizedUUID)
+	targetPath := filepath.Join(cdiRoot, specFileName)
+
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove MIG CDI spec file %s: %w", targetPath, err)
+	}
+
+	klog.InfoS("removed dynamic MIG CDI spec", "uuid", migUUID, "path", targetPath)
+	return nil
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package cdi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	specs "tags.cncf.io/container-device-interface/specs-go"
+)
+
+func TestCreateAndDeleteMigSpecFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cdi-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldCdiRoot := cdiRoot
+	cdiRoot = tempDir
+	defer func() { cdiRoot = oldCdiRoot }()
+
+	handler := &cdiHandler{
+		vendor: "k8s.device-plugin.nvidia.com",
+	}
+
+	migUUID := "MIG-GPU-12345678-1234-1234-1234-123456789abc/1/0"
+	sanitizedUUID := "MIG-GPU-12345678-1234-1234-1234-123456789abc_1_0"
+	specPath := filepath.Join(cdiRoot, "hami-mig-"+sanitizedUUID+".json")
+
+	// Clean up any pre-existing test file
+	_ = os.Remove(specPath)
+	defer os.Remove(specPath)
+
+	caps := map[string]string{
+		"/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access": "/dev/nvidia-caps/nvidia-cap3",
+	}
+
+	// 1. Test empty UUID error
+	if err := handler.CreateMigSpecFile("", "/dev/nvidia0", caps); err == nil {
+		t.Errorf("expected error with empty MIG UUID, got nil")
+	}
+
+	// 2. Create Spec File
+	err = handler.CreateMigSpecFile(migUUID, "/dev/nvidia0", caps)
+	if err != nil {
+		t.Fatalf("CreateMigSpecFile failed: %v", err)
+	}
+
+	// Verify file exists
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read created CDI spec file %s: %v", specPath, err)
+	}
+
+	var spec specs.Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("failed to unmarshal CDI spec JSON: %v", err)
+	}
+
+	if spec.Kind != "k8s.device-plugin.nvidia.com/mig" {
+		t.Errorf("expected spec.Kind='k8s.device-plugin.nvidia.com/mig', got %q", spec.Kind)
+	}
+	if len(spec.Devices) != 1 {
+		t.Fatalf("expected 1 device in spec, got %d", len(spec.Devices))
+	}
+	if spec.Devices[0].Name != migUUID {
+		t.Errorf("expected device name %q, got %q", migUUID, spec.Devices[0].Name)
+	}
+
+	// Verify DeviceNodes Path vs HostPath mapping semantics
+	nodes := spec.Devices[0].ContainerEdits.DeviceNodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 device nodes (/dev/nvidia0 and cap node), got %d", len(nodes))
+	}
+
+	var foundCap bool
+	for _, node := range nodes {
+		if node.Path == "/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access" {
+			foundCap = true
+			if node.HostPath != "/dev/nvidia-caps/nvidia-cap3" {
+				t.Errorf("expected HostPath='/dev/nvidia-caps/nvidia-cap3', got %q", node.HostPath)
+			}
+		}
+	}
+	if !foundCap {
+		t.Errorf("expected capability DeviceNode with container path '/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access' not found")
+	}
+
+	// 3. Delete Spec File
+	err = handler.DeleteMigSpecFile(migUUID)
+	if err != nil {
+		t.Fatalf("DeleteMigSpecFile failed: %v", err)
+	}
+
+	if _, err := os.Stat(specPath); !os.IsNotExist(err) {
+		t.Errorf("expected spec file %s to be deleted, but it still exists", specPath)
+	}
+
+	// 4. Delete with empty UUID is no-op
+	if err := handler.DeleteMigSpecFile(""); err != nil {
+		t.Errorf("expected DeleteMigSpecFile with empty UUID to be nil, got: %v", err)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null.go
@@ -55,6 +55,16 @@ func (n *null) CreateSpecFile() error {
 	return nil
 }
 
+// CreateMigSpecFile is a no-op for the null handler.
+func (n *null) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	return nil
+}
+
+// DeleteMigSpecFile is a no-op for the null handler.
+func (n *null) DeleteMigSpecFile(migUUID string) error {
+	return nil
+}
+
 // QualifiedName is a no-op for the null handler. A error message is logged
 // indicating this should never be called for the null handler.
 func (n *null) QualifiedName(class string, id string) string {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
 
@@ -114,9 +115,12 @@ func kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]s
 }
 
 func gpuUUIDToIndex(gpuUUID string) (int, bool) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
 		return 0, false
 	}
+	defer session.Shutdown()
+
 	dev, ret := nvml.DeviceGetHandleByUUID(gpuUUID)
 	if ret != nvml.SUCCESS {
 		return 0, false
@@ -129,9 +133,11 @@ func gpuUUIDToIndex(gpuUUID string) (int, bool) {
 // compute or graphics process. For MIG-enabled cards every live MIG instance
 // is inspected; for non-MIG cards the parent device is inspected directly.
 func nvmlBusyGPUs() (map[int]struct{}, error) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return nil, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		return nil, fmt.Errorf("nvml session Init: %w", err)
 	}
+	defer session.Shutdown()
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("DeviceGetCount: %s", nvml.ErrorString(ret))

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/info"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
@@ -144,10 +145,13 @@ func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.Po
 }
 
 func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return 0, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	originuuid := strings.Split(uuid, "[")[0]
 	ndev, ret := nvml.DeviceGetHandleByUUID(originuuid)
 	if ret != nvml.SUCCESS {
@@ -168,11 +172,13 @@ func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
 }
 
 func GetDeviceNums() (int, error) {
-	defer nvml.Shutdown()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return 0, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)
@@ -183,11 +189,13 @@ func GetDeviceNums() (int, error) {
 
 func GetDeviceNames() ([]string, error) {
 	names := []string{}
-	defer nvml.Shutdown()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return names, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return names, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -54,16 +54,11 @@ var _ ResourceManager = (*nvmlResourceManager)(nil)
 
 // NewNVMLResourceManagers returns a set of ResourceManagers, one for each NVML resource in 'config'.
 func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]ResourceManager, error) {
-	ret := nvmllib.Init()
-	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
+	session := GetNVMLSession(nvmllib)
+	if err := session.Init(); err != nil {
+		return nil, fmt.Errorf("failed to initialize NVML session: %w", err)
 	}
-	defer func() {
-		ret := nvmllib.Shutdown()
-		if ret != nvml.SUCCESS {
-			klog.Infof("Error shutting down NVML: %v", ret)
-		}
-	}()
+	defer session.Shutdown()
 
 	deviceMap, err := NewDeviceMap(infolib, devicelib, config)
 	if err != nil {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package rm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
+)
+
+// NVMLSession provides a centralized, reference-counted manager for NVML
+// initialization and shutdown across components.
+type NVMLSession struct {
+	mu          sync.Mutex
+	nvmllib     nvml.Interface
+	refCount    int
+	initialized bool
+	owned       bool
+}
+
+var (
+	defaultSession     *NVMLSession
+	defaultSessionOnce sync.Once
+)
+
+// GetNVMLSession returns the default singleton NVMLSession instance.
+func GetNVMLSession(nvmllib nvml.Interface) *NVMLSession {
+	defaultSessionOnce.Do(func() {
+		defaultSession = NewNVMLSession(nvmllib)
+	})
+	if nvmllib != nil && defaultSession.nvmllib == nil {
+		defaultSession.nvmllib = nvmllib
+	}
+	return defaultSession
+}
+
+// NewNVMLSession constructs a new NVMLSession with the provided nvml.Interface.
+func NewNVMLSession(nvmllib nvml.Interface) *NVMLSession {
+	if nvmllib == nil {
+		nvmllib = nvml.New()
+	}
+	return &NVMLSession{
+		nvmllib: nvmllib,
+	}
+}
+
+// Init initializes NVML if not already initialized, and increments reference count.
+func (s *NVMLSession) Init() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.initialized {
+		s.refCount++
+		return nil
+	}
+
+	ret := s.nvmllib.Init()
+	if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
+		return fmt.Errorf("failed to initialize NVML: %s", nvml.ErrorString(ret))
+	}
+
+	s.initialized = true
+	s.refCount = 1
+	if ret == nvml.SUCCESS {
+		s.owned = true
+	} else {
+		s.owned = false
+	}
+	return nil
+}
+
+// Shutdown decrements the reference count and shuts down NVML when count reaches 0.
+func (s *NVMLSession) Shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.initialized {
+		return
+	}
+
+	s.refCount--
+	if s.refCount <= 0 {
+		if s.owned {
+			ret := s.nvmllib.Shutdown()
+			if ret != nvml.SUCCESS && ret != nvml.ERROR_UNINITIALIZED {
+				klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(ret)), "NVML shutdown error")
+			}
+		}
+		s.initialized = false
+		s.owned = false
+		s.refCount = 0
+	}
+}
+
+// Interface returns the underlying nvml.Interface handle.
+func (s *NVMLSession) Interface() nvml.Interface {
+	return s.nvmllib
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package rm
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+)
+
+func TestNVMLSessionLifecycle(t *testing.T) {
+	initCount := 0
+	shutdownCount := 0
+
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			initCount++
+			return nvml.SUCCESS
+		},
+		ShutdownFunc: func() nvml.Return {
+			shutdownCount++
+			return nvml.SUCCESS
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+
+	// First Init should call nvml.Init()
+	err := session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if !session.initialized {
+		t.Errorf("expected session.initialized=true")
+	}
+	if !session.owned {
+		t.Errorf("expected session.owned=true")
+	}
+	if session.refCount != 1 {
+		t.Errorf("expected session.refCount=1, got %d", session.refCount)
+	}
+
+	// Second Init should increment refCount without calling nvml.Init() again
+	err = session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on second Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if session.refCount != 2 {
+		t.Errorf("expected session.refCount=2, got %d", session.refCount)
+	}
+
+	// First Shutdown should decrement refCount without calling nvml.Shutdown()
+	session.Shutdown()
+	if shutdownCount != 0 {
+		t.Errorf("expected shutdownCount=0, got %d", shutdownCount)
+	}
+	if session.refCount != 1 {
+		t.Errorf("expected session.refCount=1, got %d", session.refCount)
+	}
+
+	// Second Shutdown should decrement refCount to 0 and call nvml.Shutdown()
+	session.Shutdown()
+	if shutdownCount != 1 {
+		t.Errorf("expected shutdownCount=1, got %d", shutdownCount)
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected session.refCount=0, got %d", session.refCount)
+	}
+	if session.initialized {
+		t.Errorf("expected session.initialized=false")
+	}
+}
+
+func TestNVMLSessionAlreadyInitialized(t *testing.T) {
+	initCount := 0
+	shutdownCount := 0
+
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			initCount++
+			return nvml.ERROR_ALREADY_INITIALIZED
+		},
+		ShutdownFunc: func() nvml.Return {
+			shutdownCount++
+			return nvml.SUCCESS
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+
+	// Init returning ERROR_ALREADY_INITIALIZED should succeed but owned=false
+	err := session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if !session.initialized {
+		t.Errorf("expected session.initialized=true")
+	}
+	if session.owned {
+		t.Errorf("expected session.owned=false")
+	}
+
+	// Shutdown should not call nvml.Shutdown() because owned=false
+	session.Shutdown()
+	if shutdownCount != 0 {
+		t.Errorf("expected shutdownCount=0 since session did not own initialization, got %d", shutdownCount)
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected refCount=0, got %d", session.refCount)
+	}
+}
+
+func TestNVMLSessionInitFailure(t *testing.T) {
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			return nvml.ERROR_UNKNOWN
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+	err := session.Init()
+	if err == nil {
+		t.Fatal("expected error on failed Init, got nil")
+	}
+	if session.initialized {
+		t.Errorf("expected session.initialized=false on error")
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected session.refCount=0 on error, got %d", session.refCount)
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces dynamic Container Device Interface (CDI) specification file generation and cleanup for dynamic MIG instances. CDI specs are generated on-demand when a MIG instance is allocated and deleted when the instance is reclaimed.

To prevent container runtimes (`containerd`/`cri-o`) from reading partially written spec files, writes are performed atomically to `.tmp` files prior to `os.Rename`.

## Changes
- Extend `cdi.Interface` with `CreateMigSpecFile` and `DeleteMigSpecFile` in `pkg/device-plugin/nvidiadevice/nvinternal/cdi/api.go`.
- Implement dynamic spec builder and atomic rename handler in `pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig.go`.
- Integrate dynamic CDI spec creation in `MigInstanceManager` allocation and adoption flows.
- Add unit tests in `pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig_test.go`.

Fixes #2833.

This PR was written with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic CDI specification management for NVIDIA MIG devices, including creation and deletion of device specification files.
  * Improved NVIDIA device initialization and cleanup through coordinated NVML session handling.
  * Added safe reuse of NVML sessions across device operations.

* **Bug Fixes**
  * Improved handling of repeated NVML initialization and shutdown operations.
  * Added safer atomic creation and cleanup of MIG device specification files.

* **Tests**
  * Added coverage for MIG specification lifecycle management and NVML session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->