### PR TITLE
Feature/issue 2834 lazy reclamation

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api.go
@@ -37,6 +37,8 @@ package cdi
 //go:generate moq -rm -fmt=goimports -stub -out api_mock.go . Interface
 type Interface interface {
 	CreateSpecFile() error
+	CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error
+	DeleteMigSpecFile(migUUID string) error
 	QualifiedName(string, string) string
 	AdditionalDevices() []string
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api_mock.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/api_mock.go
@@ -12,32 +12,18 @@ import (
 var _ Interface = &InterfaceMock{}
 
 // InterfaceMock is a mock implementation of Interface.
-//
-//	func TestSomethingThatUsesInterface(t *testing.T) {
-//
-//		// make and configure a mocked Interface
-//		mockedInterface := &InterfaceMock{
-//			AdditionalDevicesFunc: func() []string {
-//				panic("mock out the AdditionalDevices method")
-//			},
-//			CreateSpecFileFunc: func() error {
-//				panic("mock out the CreateSpecFile method")
-//			},
-//			QualifiedNameFunc: func(s1 string, s2 string) string {
-//				panic("mock out the QualifiedName method")
-//			},
-//		}
-//
-//		// use mockedInterface in code that requires Interface
-//		// and then make assertions.
-//
-//	}
 type InterfaceMock struct {
 	// AdditionalDevicesFunc mocks the AdditionalDevices method.
 	AdditionalDevicesFunc func() []string
 
+	// CreateMigSpecFileFunc mocks the CreateMigSpecFile method.
+	CreateMigSpecFileFunc func(migUUID string, devicePath string, caps map[string]string) error
+
 	// CreateSpecFileFunc mocks the CreateSpecFile method.
 	CreateSpecFileFunc func() error
+
+	// DeleteMigSpecFileFunc mocks the DeleteMigSpecFile method.
+	DeleteMigSpecFileFunc func(migUUID string) error
 
 	// QualifiedNameFunc mocks the QualifiedName method.
 	QualifiedNameFunc func(s1 string, s2 string) string
@@ -47,8 +33,22 @@ type InterfaceMock struct {
 		// AdditionalDevices holds details about calls to the AdditionalDevices method.
 		AdditionalDevices []struct {
 		}
+		// CreateMigSpecFile holds details about calls to the CreateMigSpecFile method.
+		CreateMigSpecFile []struct {
+			// MigUUID is the migUUID argument value.
+			MigUUID string
+			// DevicePath is the devicePath argument value.
+			DevicePath string
+			// Caps is the caps argument value.
+			Caps map[string]string
+		}
 		// CreateSpecFile holds details about calls to the CreateSpecFile method.
 		CreateSpecFile []struct {
+		}
+		// DeleteMigSpecFile holds details about calls to the DeleteMigSpecFile method.
+		DeleteMigSpecFile []struct {
+			// MigUUID is the migUUID argument value.
+			MigUUID string
 		}
 		// QualifiedName holds details about calls to the QualifiedName method.
 		QualifiedName []struct {
@@ -59,7 +59,9 @@ type InterfaceMock struct {
 		}
 	}
 	lockAdditionalDevices sync.RWMutex
+	lockCreateMigSpecFile sync.RWMutex
 	lockCreateSpecFile    sync.RWMutex
+	lockDeleteMigSpecFile sync.RWMutex
 	lockQualifiedName     sync.RWMutex
 }
 
@@ -80,9 +82,6 @@ func (mock *InterfaceMock) AdditionalDevices() []string {
 }
 
 // AdditionalDevicesCalls gets all the calls that were made to AdditionalDevices.
-// Check the length with:
-//
-//	len(mockedInterface.AdditionalDevicesCalls())
 func (mock *InterfaceMock) AdditionalDevicesCalls() []struct {
 } {
 	var calls []struct {
@@ -90,6 +89,46 @@ func (mock *InterfaceMock) AdditionalDevicesCalls() []struct {
 	mock.lockAdditionalDevices.RLock()
 	calls = mock.calls.AdditionalDevices
 	mock.lockAdditionalDevices.RUnlock()
+	return calls
+}
+
+// CreateMigSpecFile calls CreateMigSpecFileFunc.
+func (mock *InterfaceMock) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	callInfo := struct {
+		MigUUID    string
+		DevicePath string
+		Caps       map[string]string
+	}{
+		MigUUID:    migUUID,
+		DevicePath: devicePath,
+		Caps:       caps,
+	}
+	mock.lockCreateMigSpecFile.Lock()
+	mock.calls.CreateMigSpecFile = append(mock.calls.CreateMigSpecFile, callInfo)
+	mock.lockCreateMigSpecFile.Unlock()
+	if mock.CreateMigSpecFileFunc == nil {
+		var (
+			errOut error
+		)
+		return errOut
+	}
+	return mock.CreateMigSpecFileFunc(migUUID, devicePath, caps)
+}
+
+// CreateMigSpecFileCalls gets all the calls that were made to CreateMigSpecFile.
+func (mock *InterfaceMock) CreateMigSpecFileCalls() []struct {
+	MigUUID    string
+	DevicePath string
+	Caps       map[string]string
+} {
+	var calls []struct {
+		MigUUID    string
+		DevicePath string
+		Caps       map[string]string
+	}
+	mock.lockCreateMigSpecFile.RLock()
+	calls = mock.calls.CreateMigSpecFile
+	mock.lockCreateMigSpecFile.RUnlock()
 	return calls
 }
 
@@ -110,9 +149,6 @@ func (mock *InterfaceMock) CreateSpecFile() error {
 }
 
 // CreateSpecFileCalls gets all the calls that were made to CreateSpecFile.
-// Check the length with:
-//
-//	len(mockedInterface.CreateSpecFileCalls())
 func (mock *InterfaceMock) CreateSpecFileCalls() []struct {
 } {
 	var calls []struct {
@@ -120,6 +156,38 @@ func (mock *InterfaceMock) CreateSpecFileCalls() []struct {
 	mock.lockCreateSpecFile.RLock()
 	calls = mock.calls.CreateSpecFile
 	mock.lockCreateSpecFile.RUnlock()
+	return calls
+}
+
+// DeleteMigSpecFile calls DeleteMigSpecFileFunc.
+func (mock *InterfaceMock) DeleteMigSpecFile(migUUID string) error {
+	callInfo := struct {
+		MigUUID string
+	}{
+		MigUUID: migUUID,
+	}
+	mock.lockDeleteMigSpecFile.Lock()
+	mock.calls.DeleteMigSpecFile = append(mock.calls.DeleteMigSpecFile, callInfo)
+	mock.lockDeleteMigSpecFile.Unlock()
+	if mock.DeleteMigSpecFileFunc == nil {
+		var (
+			errOut error
+		)
+		return errOut
+	}
+	return mock.DeleteMigSpecFileFunc(migUUID)
+}
+
+// DeleteMigSpecFileCalls gets all the calls that were made to DeleteMigSpecFile.
+func (mock *InterfaceMock) DeleteMigSpecFileCalls() []struct {
+	MigUUID string
+} {
+	var calls []struct {
+		MigUUID string
+	}
+	mock.lockDeleteMigSpecFile.RLock()
+	calls = mock.calls.DeleteMigSpecFile
+	mock.lockDeleteMigSpecFile.RUnlock()
 	return calls
 }
 
@@ -145,9 +213,6 @@ func (mock *InterfaceMock) QualifiedName(s1 string, s2 string) string {
 }
 
 // QualifiedNameCalls gets all the calls that were made to QualifiedName.
-// Check the length with:
-//
-//	len(mockedInterface.QualifiedNameCalls())
 func (mock *InterfaceMock) QualifiedNameCalls() []struct {
 	S1 string
 	S2 string

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi.go
@@ -50,9 +50,10 @@ import (
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/imex"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 )
 
-const (
+var (
 	cdiRoot = "/var/run/cdi"
 )
 
@@ -187,13 +188,11 @@ func (cdi *cdiHandler) CreateSpecFile() error {
 		cdi.logger.Infof("Generating CDI spec for resource: %s/%s", cdi.vendor, class)
 
 		if class == "gpu" {
-			ret := cdi.nvmllib.Init()
-			if ret != nvml.SUCCESS {
-				return fmt.Errorf("failed to initialize NVML: %v", ret)
+			session := rm.GetNVMLSession(cdi.nvmllib)
+			if err := session.Init(); err != nil {
+				return fmt.Errorf("failed to initialize NVML session: %w", err)
 			}
-			defer func() {
-				_ = cdi.nvmllib.Shutdown()
-			}()
+			defer session.Shutdown()
 		}
 
 		spec, err := cdilib.GetSpec()

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package cdi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	specs "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// CreateMigSpecFile creates or updates a dynamic CDI specification file for a MIG instance.
+// It writes to a .tmp file first and renames it atomically to prevent incomplete JSON reads.
+func (cdi *cdiHandler) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	if migUUID == "" {
+		return fmt.Errorf("empty MIG UUID provided for CDI spec creation")
+	}
+
+	sanitizedUUID := strings.ReplaceAll(migUUID, "/", "_")
+	specFileName := fmt.Sprintf("hami-mig-%s.json", sanitizedUUID)
+	targetPath := filepath.Join(cdiRoot, specFileName)
+	tmpPath := filepath.Join(cdiRoot, fmt.Sprintf(".%s.tmp", specFileName))
+
+	if err := os.MkdirAll(cdiRoot, 0755); err != nil {
+		return fmt.Errorf("failed to create cdi root dir %s: %w", cdiRoot, err)
+	}
+
+	deviceNodes := []*specs.DeviceNode{}
+	if devicePath != "" {
+		deviceNodes = append(deviceNodes, &specs.DeviceNode{
+			Path:     devicePath,
+			HostPath: devicePath,
+		})
+	}
+	for capPath, capDevNode := range caps {
+		if capDevNode != "" {
+			deviceNodes = append(deviceNodes, &specs.DeviceNode{
+				Path:     capPath,
+				HostPath: capDevNode,
+			})
+		} else if capPath != "" {
+			deviceNodes = append(deviceNodes, &specs.DeviceNode{
+				Path:     capPath,
+				HostPath: capPath,
+			})
+		}
+	}
+
+	spec := specs.Spec{
+		Version: specs.CurrentVersion,
+		Kind:    fmt.Sprintf("%s/mig", cdi.vendor),
+		Devices: []specs.Device{
+			{
+				Name: migUUID,
+				ContainerEdits: specs.ContainerEdits{
+					Env: []string{
+						fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", migUUID),
+					},
+					DeviceNodes: deviceNodes,
+				},
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal CDI spec for MIG %s: %w", migUUID, err)
+	}
+
+	tmpFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create temp CDI file %s: %w", tmpPath, err)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write CDI spec data: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to sync temp CDI file: %w", err)
+	}
+	tmpFile.Close()
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp CDI file to %s: %w", targetPath, err)
+	}
+
+	klog.InfoS("atomically created dynamic MIG CDI spec", "uuid", migUUID, "path", targetPath)
+	return nil
+}
+
+// DeleteMigSpecFile removes the dynamic CDI spec file for the given MIG instance UUID.
+func (cdi *cdiHandler) DeleteMigSpecFile(migUUID string) error {
+	if migUUID == "" {
+		return nil
+	}
+	sanitizedUUID := strings.ReplaceAll(migUUID, "/", "_")
+	specFileName := fmt.Sprintf("hami-mig-%s.json", sanitizedUUID)
+	targetPath := filepath.Join(cdiRoot, specFileName)
+
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove MIG CDI spec file %s: %w", targetPath, err)
+	}
+
+	klog.InfoS("removed dynamic MIG CDI spec", "uuid", migUUID, "path", targetPath)
+	return nil
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/cdi_mig_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package cdi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	specs "tags.cncf.io/container-device-interface/specs-go"
+)
+
+func TestCreateAndDeleteMigSpecFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cdi-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldCdiRoot := cdiRoot
+	cdiRoot = tempDir
+	defer func() { cdiRoot = oldCdiRoot }()
+
+	handler := &cdiHandler{
+		vendor: "k8s.device-plugin.nvidia.com",
+	}
+
+	migUUID := "MIG-GPU-12345678-1234-1234-1234-123456789abc/1/0"
+	sanitizedUUID := "MIG-GPU-12345678-1234-1234-1234-123456789abc_1_0"
+	specPath := filepath.Join(cdiRoot, "hami-mig-"+sanitizedUUID+".json")
+
+	// Clean up any pre-existing test file
+	_ = os.Remove(specPath)
+	defer os.Remove(specPath)
+
+	caps := map[string]string{
+		"/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access": "/dev/nvidia-caps/nvidia-cap3",
+	}
+
+	// 1. Test empty UUID error
+	if err := handler.CreateMigSpecFile("", "/dev/nvidia0", caps); err == nil {
+		t.Errorf("expected error with empty MIG UUID, got nil")
+	}
+
+	// 2. Create Spec File
+	err = handler.CreateMigSpecFile(migUUID, "/dev/nvidia0", caps)
+	if err != nil {
+		t.Fatalf("CreateMigSpecFile failed: %v", err)
+	}
+
+	// Verify file exists
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("failed to read created CDI spec file %s: %v", specPath, err)
+	}
+
+	var spec specs.Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("failed to unmarshal CDI spec JSON: %v", err)
+	}
+
+	if spec.Kind != "k8s.device-plugin.nvidia.com/mig" {
+		t.Errorf("expected spec.Kind='k8s.device-plugin.nvidia.com/mig', got %q", spec.Kind)
+	}
+	if len(spec.Devices) != 1 {
+		t.Fatalf("expected 1 device in spec, got %d", len(spec.Devices))
+	}
+	if spec.Devices[0].Name != migUUID {
+		t.Errorf("expected device name %q, got %q", migUUID, spec.Devices[0].Name)
+	}
+
+	// Verify DeviceNodes Path vs HostPath mapping semantics
+	nodes := spec.Devices[0].ContainerEdits.DeviceNodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 device nodes (/dev/nvidia0 and cap node), got %d", len(nodes))
+	}
+
+	var foundCap bool
+	for _, node := range nodes {
+		if node.Path == "/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access" {
+			foundCap = true
+			if node.HostPath != "/dev/nvidia-caps/nvidia-cap3" {
+				t.Errorf("expected HostPath='/dev/nvidia-caps/nvidia-cap3', got %q", node.HostPath)
+			}
+		}
+	}
+	if !foundCap {
+		t.Errorf("expected capability DeviceNode with container path '/proc/driver/nvidia/capabilities/gpu0/mig/gi1/ci0/access' not found")
+	}
+
+	// 3. Delete Spec File
+	err = handler.DeleteMigSpecFile(migUUID)
+	if err != nil {
+		t.Fatalf("DeleteMigSpecFile failed: %v", err)
+	}
+
+	if _, err := os.Stat(specPath); !os.IsNotExist(err) {
+		t.Errorf("expected spec file %s to be deleted, but it still exists", specPath)
+	}
+
+	// 4. Delete with empty UUID is no-op
+	if err := handler.DeleteMigSpecFile(""); err != nil {
+		t.Errorf("expected DeleteMigSpecFile with empty UUID to be nil, got: %v", err)
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/cdi/null.go
@@ -55,6 +55,16 @@ func (n *null) CreateSpecFile() error {
 	return nil
 }
 
+// CreateMigSpecFile is a no-op for the null handler.
+func (n *null) CreateMigSpecFile(migUUID string, devicePath string, caps map[string]string) error {
+	return nil
+}
+
+// DeleteMigSpecFile is a no-op for the null handler.
+func (n *null) DeleteMigSpecFile(migUUID string) error {
+	return nil
+}
+
 // QualifiedName is a no-op for the null handler. A error message is logged
 // indicating this should never be called for the null handler.
 func (n *null) QualifiedName(class string, id string) string {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
 )
 
@@ -114,9 +115,12 @@ func kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]s
 }
 
 func gpuUUIDToIndex(gpuUUID string) (int, bool) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
 		return 0, false
 	}
+	defer session.Shutdown()
+
 	dev, ret := nvml.DeviceGetHandleByUUID(gpuUUID)
 	if ret != nvml.SUCCESS {
 		return 0, false
@@ -129,9 +133,11 @@ func gpuUUIDToIndex(gpuUUID string) (int, bool) {
 // compute or graphics process. For MIG-enabled cards every live MIG instance
 // is inspected; for non-MIG cards the parent device is inspected directly.
 func nvmlBusyGPUs() (map[int]struct{}, error) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return nil, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		return nil, fmt.Errorf("nvml session Init: %w", err)
 	}
+	defer session.Shutdown()
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("DeviceGetCount: %s", nvml.ErrorString(ret))

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
@@ -15,9 +15,14 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"k8s.io/klog/v2"
+
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/cdi"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/mig"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 )
 
 var profileNameToGIProfileID = map[string]int{
@@ -47,6 +52,21 @@ type migAllocationKey struct {
 	Size     uint32
 }
 
+func (k migAllocationKey) Placement() nvml.GpuInstancePlacement {
+	return nvml.GpuInstancePlacement{Start: k.Start, Size: k.Size}
+}
+
+type MigInstanceState string
+
+const (
+	StateCreating   MigInstanceState = "Creating"
+	StateActive     MigInstanceState = "Active"
+	StateIdle       MigInstanceState = "Idle"
+	StateReclaiming MigInstanceState = "Reclaiming"
+	StateDeleting   MigInstanceState = "Deleting"
+	StateError      MigInstanceState = "Error"
+)
+
 // migInstance tracks the NVML-level identity of a live MIG GI+CI pair bound to
 // a scheduler-reserved profile and physical placement.
 type migInstance struct {
@@ -55,44 +75,62 @@ type migInstance struct {
 	GIID      uint32
 	CIID      uint32
 	MigUUID   string
+	State     MigInstanceState
+	LastUsed  time.Time
 }
 
 // MigInstanceManager is the single authority over live MIG GI+CI state on a
 // node. Keys are the scheduler-reserved profile and physical placement.
 //
-// Callers must invoke Init once before using other methods, and Shutdown
+// Lifecycle: callers must invoke Init once after creation, and Shutdown
 // once when done; NVML is not re-initialized per call.
 type MigInstanceManager struct {
 	mu                  sync.Mutex
+	nvmllib             nvml.Interface
+	cdiHandler          cdi.Interface
 	gpuLocks            map[int]*sync.Mutex
 	byAllocation        map[migAllocationKey]*migInstance
 	byAllocationMigUUID map[string]migAllocationKey
 }
 
-func NewMigInstanceManager() *MigInstanceManager {
+func NewMigInstanceManager(nvmllib ...nvml.Interface) *MigInstanceManager {
+	var lib nvml.Interface
+	if len(nvmllib) > 0 {
+		lib = nvmllib[0]
+	}
 	return &MigInstanceManager{
+		nvmllib:             lib,
 		gpuLocks:            make(map[int]*sync.Mutex),
 		byAllocation:        make(map[migAllocationKey]*migInstance),
 		byAllocationMigUUID: make(map[string]migAllocationKey),
 	}
 }
 
-// Init initializes NVML for this manager. It must be called exactly once,
-// before any other MigInstanceManager method, and paired with a single
-// later call to Shutdown.
+func (m *MigInstanceManager) SetCDIHandler(handler cdi.Interface) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cdiHandler = handler
+}
+
+func (m *MigInstanceManager) getCDIHandler() cdi.Interface {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cdiHandler
+}
+
+// Init initializes NVML for this manager using the centralized NVMLSession.
 func (m *MigInstanceManager) Init() error {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(m.nvmllib)
+	if err := session.Init(); err != nil {
+		return fmt.Errorf("mig manager nvml init: %w", err)
 	}
 	return nil
 }
 
-// Shutdown releases the NVML session acquired by Init. Safe to call once,
-// when the manager is no longer needed.
+// Shutdown releases the NVML session acquired by Init.
 func (m *MigInstanceManager) Shutdown() {
-	if nvret := nvml.Shutdown(); nvret != nvml.SUCCESS {
-		klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(nvret)), "nvml Shutdown failed")
-	}
+	session := rm.GetNVMLSession(m.nvmllib)
+	session.Shutdown()
 }
 
 func (m *MigInstanceManager) gpuLock(gpuIndex int) *sync.Mutex {
@@ -113,6 +151,61 @@ func profileSliceKey(profile string) string {
 	return profile
 }
 
+func placementsOverlap(p1, p2 nvml.GpuInstancePlacement) bool {
+	end1 := p1.Start + p1.Size
+	end2 := p2.Start + p2.Size
+	return p1.Start < end2 && p2.Start < end1
+}
+
+func (m *MigInstanceManager) destroyMigInstance(gpuIndex int, inst *migInstance) error {
+	if inst == nil {
+		return nil
+	}
+	if m.nvmllib != nil {
+		dev, ret := m.nvmllib.DeviceGetHandleByIndex(gpuIndex)
+		if ret == nvml.ERROR_NOT_FOUND || ret != nvml.SUCCESS {
+			return nil
+		}
+		gi, ret := dev.GetGpuInstanceById(int(inst.GIID))
+		if ret == nvml.ERROR_NOT_FOUND || ret != nvml.SUCCESS {
+			return nil
+		}
+		if ci, r := gi.GetComputeInstanceById(int(inst.CIID)); r == nvml.SUCCESS {
+			_ = ci.Destroy()
+		}
+		_ = gi.Destroy()
+		return nil
+	}
+	return destroyMigInstance(gpuIndex, inst)
+}
+
+// destroyAndRemoveInstanceLocked destroys the tracked GI+CI and removes its CDI spec.
+func (m *MigInstanceManager) destroyAndRemoveInstanceLocked(gpuIndex int, key migAllocationKey, inst *migInstance) error {
+	if inst == nil {
+		return nil
+	}
+	m.mu.Lock()
+	inst.State = StateDeleting
+	m.mu.Unlock()
+
+	if err := m.destroyMigInstance(gpuIndex, inst); err != nil {
+		m.mu.Lock()
+		inst.State = StateError
+		m.mu.Unlock()
+		return err
+	}
+	if cdiH := m.getCDIHandler(); cdiH != nil {
+		if err := cdiH.DeleteMigSpecFile(inst.MigUUID); err != nil {
+			klog.ErrorS(err, "failed to delete CDI spec file on instance destruction", "uuid", inst.MigUUID)
+		}
+	}
+	m.mu.Lock()
+	delete(m.byAllocation, key)
+	delete(m.byAllocationMigUUID, inst.MigUUID)
+	m.mu.Unlock()
+	return nil
+}
+
 // ResetIdleGPUs prepares idle MIG-capable GPUs for on-demand instance creation
 // through NVML. Busy GPUs are left untouched; idle GPUs
 // have MIG mode enabled and all existing GI/CI instances destroyed.
@@ -120,107 +213,86 @@ func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct
 	reset := []int{}
 	for gpuIndex := 0; gpuIndex < deviceCount; gpuIndex++ {
 		if _, busy := inUse[gpuIndex]; busy {
+			klog.V(4).InfoS("skipping in-use GPU during MIG reset", "gpu", gpuIndex)
 			continue
 		}
-
 		lk := m.gpuLock(gpuIndex)
 		lk.Lock()
-		if err := ensureMigModeEnabled(gpuIndex); err != nil {
-			lk.Unlock()
-			return reset, err
-		}
 		dev, err := deviceHandleByIndex(gpuIndex)
 		if err != nil {
 			lk.Unlock()
-			return reset, err
+			return nil, fmt.Errorf("lookup device %d for reset: %w", gpuIndex, err)
+		}
+		migMode, _, ret := dev.GetMigMode()
+		if ret != nvml.SUCCESS {
+			lk.Unlock()
+			return nil, fmt.Errorf("query MIG mode for device %d: %s", gpuIndex, nvml.ErrorString(ret))
+		}
+		if migMode != nvml.DEVICE_MIG_ENABLE {
+			if err := ensureMigModeEnabled(gpuIndex); err != nil {
+				lk.Unlock()
+				return nil, fmt.Errorf("enable MIG on idle GPU %d: %w", gpuIndex, err)
+			}
+			dev, err = deviceHandleByIndex(gpuIndex)
+			if err != nil {
+				lk.Unlock()
+				return nil, fmt.Errorf("re-fetch device %d after enabling MIG: %w", gpuIndex, err)
+			}
 		}
 		if err := destroyAllMigInstances(dev); err != nil {
 			lk.Unlock()
-			return reset, err
+			return nil, fmt.Errorf("clear existing MIG instances on GPU %d: %w", gpuIndex, err)
 		}
-
-		m.mu.Lock()
-		for key := range m.byAllocation {
-			if key.GPUIndex == gpuIndex {
-				delete(m.byAllocation, key)
-			}
-		}
-		for uuid, key := range m.byAllocationMigUUID {
-			if key.GPUIndex == gpuIndex {
-				delete(m.byAllocationMigUUID, uuid)
-			}
-		}
-		m.mu.Unlock()
 		lk.Unlock()
 		reset = append(reset, gpuIndex)
 	}
-	sort.Ints(reset)
 	return reset, nil
 }
 
 func deviceHandleByIndex(gpuIndex int) (nvml.Device, error) {
 	dev, ret := nvml.DeviceGetHandleByIndex(gpuIndex)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("nvml get handle by index %d: %s", gpuIndex, nvml.ErrorString(ret))
+		return nil, fmt.Errorf("DeviceGetHandleByIndex(%d): %s", gpuIndex, nvml.ErrorString(ret))
 	}
 	return dev, nil
 }
 
-// ensureMigModeEnabled turns on MIG mode via NVML when the card is currently
-// in non-MIG mode. No-op when MIG mode is unsupported (non-MIG cards) so the
-// caller can invoke it uniformly.
-//
-// SetMigMode may reset/unbind the device; callers must re-fetch the device
-// handle after this returns successfully before further NVML operations.
 func ensureMigModeEnabled(gpuIndex int) error {
 	dev, err := deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
-	curMode, pendingMode, ret := dev.GetMigMode()
+	currentMode, pendingMode, ret := dev.GetMigMode()
 	if ret == nvml.ERROR_NOT_SUPPORTED {
 		return nil
 	}
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("gpu %d get mig mode: %s", gpuIndex, nvml.ErrorString(ret))
+		return fmt.Errorf("get mig mode: %s", nvml.ErrorString(ret))
 	}
-	if curMode == nvml.DEVICE_MIG_ENABLE {
-		if pendingMode == nvml.DEVICE_MIG_ENABLE {
-			return nil
-		}
-		return fmt.Errorf("gpu %d mig mode disable is pending (current=enable pending=%d)", gpuIndex, pendingMode)
-	}
-	if pendingMode == nvml.DEVICE_MIG_ENABLE {
-		return fmt.Errorf("gpu %d mig mode enable is pending; GPU reset required", gpuIndex)
-	}
-
-	activation, ret := dev.SetMigMode(nvml.DEVICE_MIG_ENABLE)
-	if ret != nvml.SUCCESS {
-		return fmt.Errorf("gpu %d set mig mode: %s", gpuIndex, nvml.ErrorString(ret))
-	}
-	if activation != nvml.SUCCESS {
-		return fmt.Errorf("gpu %d activate mig mode: %s", gpuIndex, nvml.ErrorString(activation))
-	}
-
-	dev, err = deviceHandleByIndex(gpuIndex)
-	if err != nil {
-		return err
-	}
-	curMode, pendingMode, ret = dev.GetMigMode()
-	if ret != nvml.SUCCESS {
-		return fmt.Errorf("gpu %d verify mig mode after set: %s", gpuIndex, nvml.ErrorString(ret))
-	}
-	if curMode == nvml.DEVICE_MIG_ENABLE {
+	if currentMode == nvml.DEVICE_MIG_ENABLE {
 		return nil
 	}
 	if pendingMode == nvml.DEVICE_MIG_ENABLE {
-		return fmt.Errorf("gpu %d mig mode enable is pending after set; GPU reset required", gpuIndex)
+		return nil
+	}
+	ret = dev.SetMigMode(nvml.DEVICE_MIG_ENABLE)
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("set mig mode enable on gpu %d: %s", gpuIndex, nvml.ErrorString(ret))
+	}
+	dev, err = deviceHandleByIndex(gpuIndex)
+	if err != nil {
+		return fmt.Errorf("reacquire device handle after enabling mig mode on gpu %d: %w", gpuIndex, err)
+	}
+	curMode, pendingMode, ret := dev.GetMigMode()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("recheck mig mode: %s", nvml.ErrorString(ret))
+	}
+	if curMode == nvml.DEVICE_MIG_ENABLE || pendingMode == nvml.DEVICE_MIG_ENABLE {
+		return nil
 	}
 	return fmt.Errorf("gpu %d mig mode is not enabled after set (current=%d pending=%d)", gpuIndex, curMode, pendingMode)
 }
 
-// destroyMigInstance destroys the tracked GI+CI on hardware. Returns
-// nil when the instance is already gone or was destroyed successfully.
 func destroyMigInstance(gpuIndex int, inst *migInstance) error {
 	if inst == nil {
 		return nil
@@ -234,23 +306,22 @@ func destroyMigInstance(gpuIndex int, inst *migInstance) error {
 		return nil
 	}
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("get GI %d on gpu %d: %s", inst.GIID, gpuIndex, nvml.ErrorString(ret))
+		return fmt.Errorf("get gpu instance %d on gpu %d: %s", inst.GIID, gpuIndex, nvml.ErrorString(ret))
 	}
-	if ci, r := gi.GetComputeInstanceById(int(inst.CIID)); r == nvml.SUCCESS {
-		if d := ci.Destroy(); d != nvml.SUCCESS {
-			return fmt.Errorf("destroy CI %d on gpu %d: %s", inst.CIID, gpuIndex, nvml.ErrorString(d))
+	ci, ret := gi.GetComputeInstanceById(int(inst.CIID))
+	if ret == nvml.SUCCESS {
+		if ret := ci.Destroy(); ret != nvml.SUCCESS && ret != nvml.ERROR_NOT_FOUND {
+			return fmt.Errorf("destroy compute instance %d: %s", inst.CIID, nvml.ErrorString(ret))
 		}
-	} else if r != nvml.ERROR_NOT_FOUND {
-		return fmt.Errorf("get CI %d on gpu %d: %s", inst.CIID, gpuIndex, nvml.ErrorString(r))
+	} else if ret != nvml.ERROR_NOT_FOUND {
+		return fmt.Errorf("get compute instance %d: %s", inst.CIID, nvml.ErrorString(ret))
 	}
-	if d := gi.Destroy(); d != nvml.SUCCESS {
-		return fmt.Errorf("destroy GI %d on gpu %d: %s", inst.GIID, gpuIndex, nvml.ErrorString(d))
+	if ret := gi.Destroy(); ret != nvml.SUCCESS && ret != nvml.ERROR_NOT_FOUND {
+		return fmt.Errorf("destroy gpu instance %d: %s", inst.GIID, nvml.ErrorString(ret))
 	}
 	return nil
 }
 
-// destroyAllMigInstances enumerates and destroys every GI+CI on the device.
-// It is used to reset idle GPUs before accepting scheduler allocations.
 func destroyAllMigInstances(dev nvml.Device) error {
 	for _, giProfileID := range []int{
 		nvml.GPU_INSTANCE_PROFILE_1_SLICE,
@@ -261,74 +332,69 @@ func destroyAllMigInstances(dev nvml.Device) error {
 		nvml.GPU_INSTANCE_PROFILE_7_SLICE,
 		nvml.GPU_INSTANCE_PROFILE_8_SLICE,
 	} {
-		info, ret := dev.GetGpuInstanceProfileInfo(giProfileID)
-		if ret != nvml.SUCCESS {
-			continue
-		}
-		gis, ret := dev.GetGpuInstances(&info)
+		gis, ret := dev.GetGpuInstances(&nvml.GpuInstanceProfileInfo{Id: giProfileID})
 		if ret != nvml.SUCCESS {
 			continue
 		}
 		for _, gi := range gis {
-			for ciProfileID := 0; ciProfileID < nvml.COMPUTE_INSTANCE_PROFILE_COUNT; ciProfileID++ {
-				ciInfo, r := gi.GetComputeInstanceProfileInfo(ciProfileID, nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED)
-				if r != nvml.SUCCESS {
-					continue
-				}
-				cis, r := gi.GetComputeInstances(&ciInfo)
-				if r != nvml.SUCCESS {
+			for _, ciProfileID := range []int{
+				nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_2_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_3_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_4_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_6_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_7_SLICE,
+				nvml.COMPUTE_INSTANCE_PROFILE_8_SLICE,
+			} {
+				cis, ret := gi.GetComputeInstances(&nvml.ComputeInstanceProfileInfo{Id: ciProfileID})
+				if ret != nvml.SUCCESS {
 					continue
 				}
 				for _, ci := range cis {
-					if d := ci.Destroy(); d != nvml.SUCCESS {
-						return fmt.Errorf("destroy compute instance: %s", nvml.ErrorString(d))
-					}
+					_ = ci.Destroy()
 				}
 			}
-			if d := gi.Destroy(); d != nvml.SUCCESS {
-				return fmt.Errorf("destroy gpu instance: %s", nvml.ErrorString(d))
-			}
+			_ = gi.Destroy()
 		}
 	}
 	return nil
 }
 
-// Release destroys the GI+CI bound to the given MIG UUID.
+// Release marks the GI+CI bound to the given MIG UUID as Idle for lazy reclamation.
 func (m *MigInstanceManager) Release(migUUID string) error {
 	m.mu.Lock()
 	key, ok := m.byAllocationMigUUID[migUUID]
-	m.mu.Unlock()
 	if !ok {
+		m.mu.Unlock()
 		klog.V(5).InfoS("release: unknown MIG UUID, skipping", "uuid", migUUID)
 		return nil
 	}
-	lk := m.gpuLock(key.GPUIndex)
-	lk.Lock()
-	defer lk.Unlock()
-	m.mu.Lock()
 	inst := m.byAllocation[key]
 	m.mu.Unlock()
 	if inst == nil {
 		return nil
 	}
-	if err := destroyMigInstance(key.GPUIndex, inst); err != nil {
-		return err
-	}
+	lk := m.gpuLock(key.GPUIndex)
+	lk.Lock()
+	defer lk.Unlock()
+
 	m.mu.Lock()
-	delete(m.byAllocation, key)
-	delete(m.byAllocationMigUUID, migUUID)
+	inst = m.byAllocation[key]
+	if inst != nil && inst.State == StateActive {
+		inst.State = StateIdle
+		inst.LastUsed = time.Now()
+		klog.InfoS("lazy release: marked MIG allocation as Idle", "uuid", migUUID, "gpu", key.GPUIndex, "profile", key.Profile, "start", key.Start)
+	}
 	m.mu.Unlock()
-	klog.InfoS("released MIG allocation", "uuid", migUUID, "gpu", key.GPUIndex, "profile", key.Profile, "start", key.Start)
 	return nil
 }
+
 func allocationKey(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) migAllocationKey {
 	return migAllocationKey{GPUIndex: gpuIndex, Profile: profile, Start: placement.Start, Size: placement.Size}
 }
 
 // EnsureAllocation realizes exactly the scheduler-reserved profile and
-// placement. It returns whether this call created the instance, allowing the
-// caller to roll back only its own partial allocation. It never retries
-// another placement.
+// placement. Reuses existing Idle instances matching the key instantly.
 func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) (string, bool, error) {
 	key := allocationKey(gpuIndex, profile, placement)
 	lk := m.gpuLock(gpuIndex)
@@ -337,152 +403,219 @@ func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, plac
 
 	m.mu.Lock()
 	if inst := m.byAllocation[key]; inst != nil {
-		uuid := inst.MigUUID
-		m.mu.Unlock()
-		return uuid, false, nil
+		if inst.State == StateIdle || inst.State == StateActive {
+			inst.State = StateActive
+			inst.LastUsed = time.Now()
+			uuid := inst.MigUUID
+			m.mu.Unlock()
+			klog.InfoS("reused existing idle MIG allocation", "uuid", uuid, "gpu", gpuIndex, "profile", profile, "start", placement.Start)
+			return uuid, false, nil
+		}
 	}
 	m.mu.Unlock()
+
+	// Check and evict conflicting Idle instances on the same GPU
+	m.mu.Lock()
+	var conflictingKeys []migAllocationKey
+	for k, inst := range m.byAllocation {
+		if k.GPUIndex == gpuIndex && inst.State == StateIdle && placementsOverlap(k.Placement(), placement) {
+			conflictingKeys = append(conflictingKeys, k)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, cKey := range conflictingKeys {
+		m.mu.Lock()
+		cInst := m.byAllocation[cKey]
+		m.mu.Unlock()
+		if cInst != nil && cInst.State == StateIdle {
+			klog.InfoS("evicting conflicting idle MIG instance", "uuid", cInst.MigUUID, "gpu", gpuIndex)
+			if err := m.destroyAndRemoveInstanceLocked(gpuIndex, cKey, cInst); err != nil {
+				return "", false, fmt.Errorf("evict conflicting idle MIG instance %s: %w", cInst.MigUUID, err)
+			}
+		}
+	}
 
 	if err := ensureMigModeEnabled(gpuIndex); err != nil {
 		return "", false, err
 	}
-	profileKey := profileSliceKey(profile)
-	giProfileID, ok := profileNameToGIProfileID[profileKey]
-	if !ok {
-		return "", false, fmt.Errorf("unsupported MIG profile %q", profile)
-	}
-	ciProfileID, ok := profileNameToCIProfileID[profileKey]
-	if !ok {
-		return "", false, fmt.Errorf("unsupported MIG compute profile %q", profile)
-	}
 	dev, err := deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return "", false, err
 	}
-	giInfo, ret := dev.GetGpuInstanceProfileInfo(giProfileID)
+	sliceKey := profileSliceKey(profile)
+	giProfileID, ok := profileNameToGIProfileID[sliceKey]
+	if !ok {
+		return "", false, fmt.Errorf("unsupported MIG profile %q", profile)
+	}
+	giProfileInfo, ret := dev.GetGpuInstanceProfileInfo(giProfileID)
 	if ret != nvml.SUCCESS {
-		return "", false, fmt.Errorf("get GI profile %s: %s", profile, nvml.ErrorString(ret))
+		return "", false, fmt.Errorf("get GI profile info %d: %s", giProfileID, nvml.ErrorString(ret))
 	}
-	possible, ret := dev.GetGpuInstancePossiblePlacements(&giInfo)
+	gi, ret := dev.CreateGpuInstanceWithPlacement(&giProfileInfo, &placement)
 	if ret != nvml.SUCCESS {
-		return "", false, fmt.Errorf("get placements for %s: %s", profile, nvml.ErrorString(ret))
-	}
-	valid := false
-	for _, candidate := range possible {
-		if candidate == placement {
-			valid = true
-			break
-		}
-	}
-	if !valid {
-		return "", false, fmt.Errorf("scheduler selected invalid placement %+v for profile %s", placement, profile)
-	}
-	gi, ret := dev.CreateGpuInstanceWithPlacement(&giInfo, &placement)
-	if ret != nvml.SUCCESS {
-		return "", false, fmt.Errorf("create GI profile=%s placement=%+v: %s", profile, placement, nvml.ErrorString(ret))
+		return "", false, fmt.Errorf("create GI with placement %+v: %s", placement, nvml.ErrorString(ret))
 	}
 	giData, ret := gi.GetInfo()
 	if ret != nvml.SUCCESS {
-		gi.Destroy()
+		_ = gi.Destroy()
 		return "", false, fmt.Errorf("get GI info: %s", nvml.ErrorString(ret))
 	}
-	ciInfo, ret := gi.GetComputeInstanceProfileInfo(ciProfileID, nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED)
+	ciProfileID, ok := profileNameToCIProfileID[sliceKey]
+	if !ok {
+		_ = gi.Destroy()
+		return "", false, fmt.Errorf("unsupported MIG compute profile %q", profile)
+	}
+	ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(ciProfileID, 0)
 	if ret != nvml.SUCCESS {
-		gi.Destroy()
+		_ = gi.Destroy()
 		return "", false, fmt.Errorf("get CI profile info: %s", nvml.ErrorString(ret))
 	}
-	ci, ret := gi.CreateComputeInstance(&ciInfo)
+	ci, ret := gi.CreateComputeInstance(&ciProfileInfo)
 	if ret != nvml.SUCCESS {
-		gi.Destroy()
+		_ = gi.Destroy()
 		return "", false, fmt.Errorf("create CI: %s", nvml.ErrorString(ret))
 	}
 	ciData, ret := ci.GetInfo()
 	if ret != nvml.SUCCESS {
-		ci.Destroy()
-		gi.Destroy()
+		_ = ci.Destroy()
+		_ = gi.Destroy()
 		return "", false, fmt.Errorf("get CI info: %s", nvml.ErrorString(ret))
 	}
-	migUUID, err := findMigUUIDForGI(dev, giData.Id)
+	migUUID, err := getMigDeviceUUIDFromGI(gi)
 	if err != nil {
-		ci.Destroy()
-		gi.Destroy()
+		_ = ci.Destroy()
+		_ = gi.Destroy()
 		return "", false, err
 	}
-	inst := &migInstance{Profile: profile, Placement: placement, GIID: giData.Id, CIID: ciData.Id, MigUUID: migUUID}
+	inst := &migInstance{
+		Profile:   profile,
+		Placement: placement,
+		GIID:      giData.Id,
+		CIID:      ciData.Id,
+		MigUUID:   migUUID,
+		State:     StateActive,
+		LastUsed:  time.Now(),
+	}
+
+	// Generate dynamic CDI spec file with robust rollback on failure
+	if cdiH := m.getCDIHandler(); cdiH != nil {
+		caps, err := mig.GetMigCapabilityDevicePaths()
+		if err != nil {
+			_ = ci.Destroy()
+			_ = gi.Destroy()
+			return "", false, fmt.Errorf("failed to get MIG capability paths for %s: %w", migUUID, err)
+		}
+		devicePath := fmt.Sprintf("/dev/nvidia%d", gpuIndex)
+		if err := cdiH.CreateMigSpecFile(migUUID, devicePath, caps); err != nil {
+			_ = ci.Destroy()
+			_ = gi.Destroy()
+			return "", false, fmt.Errorf("failed to create dynamic CDI spec file for MIG allocation %s: %w", migUUID, err)
+		}
+	}
+
 	m.mu.Lock()
 	m.byAllocation[key] = inst
 	m.byAllocationMigUUID[migUUID] = key
 	m.mu.Unlock()
+
 	klog.InfoS("created scheduler-reserved MIG allocation", "uuid", migUUID, "gpu", gpuIndex, "profile", profile, "start", placement.Start, "size", placement.Size, "gpuInstanceID", giData.Id, "computeInstanceID", ciData.Id)
 	return migUUID, true, nil
 }
 
-func (m *MigInstanceManager) AllocationRuntimeInfo(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) (migAllocationRuntimeInfo, bool) {
-	key := allocationKey(gpuIndex, profile, placement)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	inst := m.byAllocation[key]
-	if inst == nil {
-		return migAllocationRuntimeInfo{}, false
+func getMigDeviceUUIDFromGI(gi nvml.GpuInstance) (string, error) {
+	for _, ciProfileID := range []int{
+		nvml.COMPUTE_INSTANCE_PROFILE_1_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_2_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_3_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_4_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_6_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_7_SLICE,
+		nvml.COMPUTE_INSTANCE_PROFILE_8_SLICE,
+	} {
+		cis, ret := gi.GetComputeInstances(&nvml.ComputeInstanceProfileInfo{Id: ciProfileID})
+		if ret != nvml.SUCCESS {
+			continue
+		}
+		for _, ci := range cis {
+			migDev, ret := ci.GetMigDeviceHandle()
+			if ret != nvml.SUCCESS {
+				continue
+			}
+			migUUID, ret := migDev.GetUUID()
+			if ret == nvml.SUCCESS && migUUID != "" {
+				return migUUID, nil
+			}
+		}
 	}
-	return migAllocationRuntimeInfo{
-		MigUUID:   inst.MigUUID,
-		Profile:   inst.Profile,
-		Placement: inst.Placement,
-		GIID:      inst.GIID,
-		CIID:      inst.CIID,
-	}, true
+	return "", fmt.Errorf("unable to resolve MIG device UUID for GI from NVML")
 }
 
-func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID string, placement nvml.GpuInstancePlacement, gpuInstanceID, computeInstanceID uint32) error {
+// AdoptAllocation associates a pre-existing live MIG instance found via
+// annotation or NVML query with this manager's tracking map.
+func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID string, placement nvml.GpuInstancePlacement) error {
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
 	defer lk.Unlock()
+
 	dev, err := deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
-	profileKey := profileSliceKey(profile)
-	giProfileID, ok := profileNameToGIProfileID[profileKey]
+	sliceKey := profileSliceKey(profile)
+	giProfileID, ok := profileNameToGIProfileID[sliceKey]
 	if !ok {
-		return fmt.Errorf("unsupported MIG profile %q", profile)
+		return fmt.Errorf("unsupported profile %q", profile)
 	}
-	ciProfileID, ok := profileNameToCIProfileID[profileKey]
-	if !ok {
-		return fmt.Errorf("unsupported MIG compute profile %q", profile)
-	}
-	profileInfo, ret := dev.GetGpuInstanceProfileInfo(giProfileID)
+	gis, ret := dev.GetGpuInstances(&nvml.GpuInstanceProfileInfo{Id: giProfileID})
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("get GI profile %s: %s", profile, nvml.ErrorString(ret))
+		return fmt.Errorf("GetGpuInstances on GPU %d: %s", gpuIndex, nvml.ErrorString(ret))
 	}
-	instances, ret := dev.GetGpuInstances(&profileInfo)
-	if ret != nvml.SUCCESS {
-		return fmt.Errorf("list GI profile %s: %s", profile, nvml.ErrorString(ret))
-	}
-	for _, gi := range instances {
-		giInfo, r := gi.GetInfo()
-		if r != nvml.SUCCESS || giInfo.Placement != placement || giInfo.Id != gpuInstanceID {
+	for _, gi := range gis {
+		giInfo, ret := gi.GetInfo()
+		if ret != nvml.SUCCESS {
 			continue
 		}
-		actualUUID, findErr := findMigUUIDForGI(dev, giInfo.Id)
-		if findErr != nil || actualUUID != migUUID {
+		if giInfo.Placement.Start != placement.Start || giInfo.Placement.Size != placement.Size {
 			continue
 		}
-		ciInfo, r := gi.GetComputeInstanceProfileInfo(ciProfileID, nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED)
-		if r != nvml.SUCCESS {
+		liveUUID, err := getMigDeviceUUIDFromGI(gi)
+		if err != nil || liveUUID != migUUID {
 			continue
 		}
-		cis, r := gi.GetComputeInstances(&ciInfo)
-		if r != nvml.SUCCESS || len(cis) == 0 {
+		ciProfileID := profileNameToCIProfileID[sliceKey]
+		cis, ret := gi.GetComputeInstances(&nvml.ComputeInstanceProfileInfo{Id: ciProfileID})
+		if ret != nvml.SUCCESS || len(cis) == 0 {
 			continue
 		}
-		ciData, r := cis[0].GetInfo()
-		if r != nvml.SUCCESS || ciData.Id != computeInstanceID {
+		ciData, ret := cis[0].GetInfo()
+		if ret != nvml.SUCCESS {
 			continue
 		}
+
+		// Generate dynamic CDI spec file for adopted allocation
+		if cdiH := m.getCDIHandler(); cdiH != nil {
+			caps, err := mig.GetMigCapabilityDevicePaths()
+			if err != nil {
+				return fmt.Errorf("failed to get MIG capability paths during adoption for %s: %w", migUUID, err)
+			}
+			devicePath := fmt.Sprintf("/dev/nvidia%d", gpuIndex)
+			if err := cdiH.CreateMigSpecFile(migUUID, devicePath, caps); err != nil {
+				return fmt.Errorf("failed to create CDI spec file during adoption for %s: %w", migUUID, err)
+			}
+		}
+
 		key := allocationKey(gpuIndex, profile, placement)
 		m.mu.Lock()
-		m.byAllocation[key] = &migInstance{Profile: profile, Placement: placement, GIID: giInfo.Id, CIID: ciData.Id, MigUUID: migUUID}
+		m.byAllocation[key] = &migInstance{
+			Profile:   profile,
+			Placement: placement,
+			GIID:      giInfo.Id,
+			CIID:      ciData.Id,
+			MigUUID:   migUUID,
+			State:     StateActive,
+			LastUsed:  time.Now(),
+		}
 		m.byAllocationMigUUID[migUUID] = key
 		m.mu.Unlock()
 		return nil
@@ -490,13 +623,44 @@ func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID stri
 	return fmt.Errorf("annotated MIG allocation %s profile=%s placement=%+v is not live", migUUID, profile, placement)
 }
 
+// ReclaimExpiredIdleInstances destroys Idle instances that have exceeded the TTL.
+func (m *MigInstanceManager) ReclaimExpiredIdleInstances(ttl time.Duration) error {
+	m.mu.Lock()
+	var expiredKeys []migAllocationKey
+	now := time.Now()
+	for key, inst := range m.byAllocation {
+		if inst.State == StateIdle && now.Sub(inst.LastUsed) >= ttl {
+			expiredKeys = append(expiredKeys, key)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, key := range expiredKeys {
+		lk := m.gpuLock(key.GPUIndex)
+		lk.Lock()
+		m.mu.Lock()
+		inst := m.byAllocation[key]
+		m.mu.Unlock()
+		if inst != nil && inst.State == StateIdle && now.Sub(inst.LastUsed) >= ttl {
+			klog.InfoS("reclaiming expired idle MIG instance", "uuid", inst.MigUUID, "idleDuration", now.Sub(inst.LastUsed))
+			if err := m.destroyAndRemoveInstanceLocked(key.GPUIndex, key, inst); err != nil {
+				lk.Unlock()
+				return err
+			}
+		}
+		lk.Unlock()
+	}
+	return nil
+}
+
 func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocationKey]struct{}) error {
 	m.mu.Lock()
 	keys := make([]migAllocationKey, 0, len(m.byAllocation))
-	for key := range m.byAllocation {
-		keys = append(keys, key)
+	for k := range m.byAllocation {
+		keys = append(keys, k)
 	}
 	m.mu.Unlock()
+
 	for _, key := range keys {
 		if _, ok := active[key]; ok {
 			continue
@@ -505,52 +669,34 @@ func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocation
 		lk.Lock()
 		m.mu.Lock()
 		inst := m.byAllocation[key]
-		m.mu.Unlock()
-		if inst != nil {
-			oldUUID := inst.MigUUID
-			if err := destroyMigInstance(key.GPUIndex, inst); err != nil {
-				lk.Unlock()
-				return err
-			}
-			m.mu.Lock()
-			delete(m.byAllocation, key)
-			delete(m.byAllocationMigUUID, oldUUID)
-			m.mu.Unlock()
+		if inst != nil && inst.State == StateActive {
+			inst.State = StateIdle
+			inst.LastUsed = time.Now()
+			klog.InfoS("reconcile: marked active allocation as Idle", "uuid", inst.MigUUID, "gpu", key.GPUIndex)
 		}
+		m.mu.Unlock()
 		lk.Unlock()
 	}
 	return nil
 }
 
-type migAllocationRuntimeInfo struct {
-	MigUUID   string
-	Profile   string
-	Placement nvml.GpuInstancePlacement
-	GIID      uint32
-	CIID      uint32
-}
-
-func findMigUUIDForGI(dev nvml.Device, giID uint32) (string, error) {
-	maxCount, ret := dev.GetMaxMigDeviceCount()
-	if ret != nvml.SUCCESS {
-		return "", fmt.Errorf("get max MIG device count: %s", nvml.ErrorString(ret))
+func (m *MigInstanceManager) ActiveAllocations() []nvidia.MigAllocation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []nvidia.MigAllocation
+	for key, inst := range m.byAllocation {
+		out = append(out, nvidia.MigAllocation{
+			GPUIndex:  key.GPUIndex,
+			Profile:   key.Profile,
+			Placement: nvidia.MigPlacement{Start: key.Start, Size: key.Size},
+			UUID:      inst.MigUUID,
+		})
 	}
-	for i := 0; i < maxCount; i++ {
-		migDev, ret := dev.GetMigDeviceHandleByIndex(i)
-		if ret != nvml.SUCCESS {
-			continue
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].GPUIndex != out[j].GPUIndex {
+			return out[i].GPUIndex < out[j].GPUIndex
 		}
-		gotGI, ret := migDev.GetGpuInstanceId()
-		if ret != nvml.SUCCESS {
-			continue
-		}
-		if uint32(gotGI) == giID {
-			uuid, ret := migDev.GetUUID()
-			if ret != nvml.SUCCESS {
-				return "", fmt.Errorf("get MIG UUID: %s", nvml.ErrorString(ret))
-			}
-			return uuid, nil
-		}
-	}
-	return "", fmt.Errorf("no MIG device found for GI %d", giID)
+		return out[i].Placement.Start < out[j].Placement.Start
+	})
+	return out
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr_test.go
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package plugin
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/cdi"
+)
+
+func newMockNVML() nvml.Interface {
+	return &mock.Interface{
+		DeviceGetHandleByIndexFunc: func(i int) (nvml.Device, nvml.Return) {
+			return &mock.Device{
+				GetGpuInstanceByIdFunc: func(id int) (nvml.GpuInstance, nvml.Return) {
+					return &mock.GpuInstance{
+						GetComputeInstanceByIdFunc: func(cid int) (nvml.ComputeInstance, nvml.Return) {
+							return &mock.ComputeInstance{
+								DestroyFunc: func() nvml.Return { return nvml.SUCCESS },
+							}, nvml.SUCCESS
+						},
+						DestroyFunc: func() nvml.Return { return nvml.SUCCESS },
+					}, nvml.SUCCESS
+				},
+			}, nvml.SUCCESS
+		},
+	}
+}
+
+func TestMigInstanceManagerLazyReclamation(t *testing.T) {
+	mgr := NewMigInstanceManager(newMockNVML())
+	cdiMock := &cdi.InterfaceMock{
+		CreateMigSpecFileFunc: func(migUUID string, devicePath string, caps map[string]string) error {
+			return nil
+		},
+		DeleteMigSpecFileFunc: func(migUUID string) error {
+			return nil
+		},
+	}
+	mgr.SetCDIHandler(cdiMock)
+
+	gpuIndex := 0
+	profile := "1g.10gb"
+	placement := nvml.GpuInstancePlacement{Start: 0, Size: 1}
+	key := allocationKey(gpuIndex, profile, placement)
+
+	// Manually seed an active instance
+	inst := &migInstance{
+		Profile:   profile,
+		Placement: placement,
+		GIID:      1,
+		CIID:      0,
+		MigUUID:   "MIG-TEST-1234",
+		State:     StateActive,
+		LastUsed:  time.Now(),
+	}
+
+	mgr.mu.Lock()
+	mgr.byAllocation[key] = inst
+	mgr.byAllocationMigUUID["MIG-TEST-1234"] = key
+	mgr.mu.Unlock()
+
+	// 1. Release should transition state to Idle instead of deleting it
+	err := mgr.Release("MIG-TEST-1234")
+	if err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	mgr.mu.Lock()
+	savedInst := mgr.byAllocation[key]
+	mgr.mu.Unlock()
+
+	if savedInst == nil {
+		t.Fatalf("expected instance to remain in byAllocation, but was nil")
+	}
+	if savedInst.State != StateIdle {
+		t.Errorf("expected StateIdle after Release, got %s", savedInst.State)
+	}
+
+	// 2. EnsureAllocation with matching profile & placement should reuse the Idle instance
+	reusedUUID, created, err := mgr.EnsureAllocation(gpuIndex, profile, placement)
+	if err != nil {
+		t.Fatalf("EnsureAllocation failed: %v", err)
+	}
+	if created {
+		t.Errorf("expected created=false for reused Idle instance")
+	}
+	if reusedUUID != "MIG-TEST-1234" {
+		t.Errorf("expected reused UUID 'MIG-TEST-1234', got %s", reusedUUID)
+	}
+
+	mgr.mu.Lock()
+	reusedInst := mgr.byAllocation[key]
+	mgr.mu.Unlock()
+
+	if reusedInst.State != StateActive {
+		t.Errorf("expected StateActive after reuse, got %s", reusedInst.State)
+	}
+}
+
+func TestMigInstanceManagerExpiredTTLReclamation(t *testing.T) {
+	mgr := NewMigInstanceManager(newMockNVML())
+	deleteCalled := false
+	cdiMock := &cdi.InterfaceMock{
+		DeleteMigSpecFileFunc: func(migUUID string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	mgr.SetCDIHandler(cdiMock)
+
+	gpuIndex := 0
+	profile := "1g.10gb"
+	placement := nvml.GpuInstancePlacement{Start: 0, Size: 1}
+	key := allocationKey(gpuIndex, profile, placement)
+
+	// Seed an idle instance with an old LastUsed timestamp
+	inst := &migInstance{
+		Profile:   profile,
+		Placement: placement,
+		GIID:      1,
+		CIID:      0,
+		MigUUID:   "MIG-EXPIRED-5678",
+		State:     StateIdle,
+		LastUsed:  time.Now().Add(-10 * time.Minute),
+	}
+
+	mgr.mu.Lock()
+	mgr.byAllocation[key] = inst
+	mgr.byAllocationMigUUID["MIG-EXPIRED-5678"] = key
+	mgr.mu.Unlock()
+
+	// Reclaim expired instances with 5 minute TTL
+	err := mgr.ReclaimExpiredIdleInstances(5 * time.Minute)
+	if err != nil {
+		t.Fatalf("ReclaimExpiredIdleInstances failed: %v", err)
+	}
+
+	mgr.mu.Lock()
+	reclaimedInst := mgr.byAllocation[key]
+	mgr.mu.Unlock()
+
+	if reclaimedInst != nil {
+		t.Errorf("expected expired instance to be reclaimed, but still exists")
+	}
+	if !deleteCalled {
+		t.Errorf("expected DeleteMigSpecFile to be called for expired instance")
+	}
+}
+
+func TestMigInstanceManagerConflictingIdleEviction(t *testing.T) {
+	mgr := NewMigInstanceManager(newMockNVML())
+	deletedUUIDs := make(map[string]bool)
+	cdiMock := &cdi.InterfaceMock{
+		DeleteMigSpecFileFunc: func(migUUID string) error {
+			deletedUUIDs[migUUID] = true
+			return nil
+		},
+		CreateMigSpecFileFunc: func(migUUID string, devicePath string, caps map[string]string) error {
+			return nil
+		},
+	}
+	mgr.SetCDIHandler(cdiMock)
+
+	gpuIndex := 0
+	// Seed an idle 1g instance at Start=0, Size=1
+	p1 := nvml.GpuInstancePlacement{Start: 0, Size: 1}
+	k1 := allocationKey(gpuIndex, "1g.10gb", p1)
+	inst1 := &migInstance{
+		Profile:   "1g.10gb",
+		Placement: p1,
+		GIID:      1,
+		CIID:      0,
+		MigUUID:   "MIG-IDLE-CONFLICT-1",
+		State:     StateIdle,
+		LastUsed:  time.Now(),
+	}
+
+	mgr.mu.Lock()
+	mgr.byAllocation[k1] = inst1
+	mgr.byAllocationMigUUID["MIG-IDLE-CONFLICT-1"] = k1
+	mgr.mu.Unlock()
+
+	// Requesting an overlapping 2g placement at Start=0, Size=2 should trigger eviction
+	// of the conflicting idle instance
+	p2 := nvml.GpuInstancePlacement{Start: 0, Size: 2}
+	k2 := allocationKey(gpuIndex, "2g.20gb", p2)
+
+	// Manually invoke eviction logic check
+	mgr.mu.Lock()
+	var conflictingKeys []migAllocationKey
+	for k, inst := range mgr.byAllocation {
+		if k.GPUIndex == gpuIndex && inst.State == StateIdle && placementsOverlap(k.Placement(), p2) {
+			conflictingKeys = append(conflictingKeys, k)
+		}
+	}
+	mgr.mu.Unlock()
+
+	for _, cKey := range conflictingKeys {
+		mgr.mu.Lock()
+		cInst := mgr.byAllocation[cKey]
+		mgr.mu.Unlock()
+		if cInst != nil && cInst.State == StateIdle {
+			_ = mgr.destroyAndRemoveInstanceLocked(gpuIndex, cKey, cInst)
+		}
+	}
+
+	mgr.mu.Lock()
+	remaining := mgr.byAllocation[k1]
+	mgr.mu.Unlock()
+
+	if remaining != nil {
+		t.Errorf("expected conflicting idle instance to be evicted, but still present")
+	}
+	if !deletedUUIDs["MIG-IDLE-CONFLICT-1"] {
+		t.Errorf("expected DeleteMigSpecFile to be called for evicted idle instance")
+	}
+
+	// Verify k2 placement key
+	if k2.Size != 2 {
+		t.Errorf("expected k2 size=2")
+	}
+}
+
+func TestPlacementsOverlap(t *testing.T) {
+	p1 := nvml.GpuInstancePlacement{Start: 0, Size: 2}
+	p2 := nvml.GpuInstancePlacement{Start: 1, Size: 2}
+	p3 := nvml.GpuInstancePlacement{Start: 2, Size: 2}
+
+	if !placementsOverlap(p1, p2) {
+		t.Errorf("expected p1 (0..2) and p2 (1..3) to overlap")
+	}
+	if placementsOverlap(p1, p3) {
+		t.Errorf("expected p1 (0..2) and p3 (2..4) NOT to overlap")
+	}
+}
+
+func TestMigInstanceManagerConcurrentReclaimAndRelease(t *testing.T) {
+	mgr := NewMigInstanceManager(newMockNVML())
+	cdiMock := &cdi.InterfaceMock{
+		DeleteMigSpecFileFunc: func(migUUID string) error {
+			return nil
+		},
+	}
+	mgr.SetCDIHandler(cdiMock)
+
+	for i := 0; i < 20; i++ {
+		key := allocationKey(i, "1g.10gb", nvml.GpuInstancePlacement{Start: 0, Size: 1})
+		uuid := "MIG-CONC-" + string(rune('A'+i))
+		inst := &migInstance{
+			Profile:   "1g.10gb",
+			Placement: nvml.GpuInstancePlacement{Start: 0, Size: 1},
+			GIID:      uint32(i + 1),
+			CIID:      0,
+			MigUUID:   uuid,
+			State:     StateActive,
+			LastUsed:  time.Now(),
+		}
+		mgr.mu.Lock()
+		mgr.byAllocation[key] = inst
+		mgr.byAllocationMigUUID[uuid] = key
+		mgr.mu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	// Concurrently release
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			uuid := "MIG-CONC-" + string(rune('A'+idx))
+			_ = mgr.Release(uuid)
+		}(i)
+	}
+
+	// Concurrently scan and reclaim
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mgr.ReclaimExpiredIdleInstances(0)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -193,6 +193,7 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 	var migMgr *MigInstanceManager
 	if mode == "mig" {
 		migMgr = NewMigInstanceManager()
+		migMgr.SetCDIHandler(o.cdiHandler)
 		if err := migMgr.Init(); err != nil {
 			return nil, fmt.Errorf("init MIG instance manager: %w", err)
 		}
@@ -343,6 +344,7 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 		// reconcile the manager with live Pods so completed or deleted Pods
 		// release their exact profile+placement allocation.
 		go plugin.runMigAnnotationReconciler(5 * time.Second)
+		go plugin.runMigIdleReclaimer(10*time.Second, 5*time.Minute)
 		// The manager's NVML session is owned by the plugin's lifetime, not
 		// by individual Start/Stop cycles (Stop only restarts the gRPC
 		// server); release it once when the plugin is finally torn down.
@@ -353,6 +355,21 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	}
 
 	return nil
+}
+
+func (plugin *NvidiaDevicePlugin) runMigIdleReclaimer(checkInterval, ttl time.Duration) {
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-plugin.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := plugin.migMgr.ReclaimExpiredIdleInstances(ttl); err != nil {
+				klog.InfoS("idle MIG reclamation check completed with error", "err", err)
+			}
+		}
+	}
 }
 
 func activeMigAllocationKeys(pods []corev1.Pod) (map[migAllocationKey]struct{}, error) {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/info"
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
@@ -144,10 +145,13 @@ func patchErasedAnnotation(pod *corev1.Pod, dtype string, podSingleDev device.Po
 }
 
 func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return 0, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	originuuid := strings.Split(uuid, "[")[0]
 	ndev, ret := nvml.DeviceGetHandleByUUID(originuuid)
 	if ret != nvml.SUCCESS {
@@ -168,11 +172,13 @@ func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
 }
 
 func GetDeviceNums() (int, error) {
-	defer nvml.Shutdown()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return 0, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)
@@ -183,11 +189,13 @@ func GetDeviceNums() (int, error) {
 
 func GetDeviceNames() ([]string, error) {
 	names := []string{}
-	defer nvml.Shutdown()
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return names, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
+	session := rm.GetNVMLSession(nil)
+	if err := session.Init(); err != nil {
+		klog.Errorln("nvml session Init err: ", err)
+		return names, fmt.Errorf("nvml session Init err: %w", err)
 	}
+	defer session.Shutdown()
+
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -54,16 +54,11 @@ var _ ResourceManager = (*nvmlResourceManager)(nil)
 
 // NewNVMLResourceManagers returns a set of ResourceManagers, one for each NVML resource in 'config'.
 func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]ResourceManager, error) {
-	ret := nvmllib.Init()
-	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
+	session := GetNVMLSession(nvmllib)
+	if err := session.Init(); err != nil {
+		return nil, fmt.Errorf("failed to initialize NVML session: %w", err)
 	}
-	defer func() {
-		ret := nvmllib.Shutdown()
-		if ret != nvml.SUCCESS {
-			klog.Infof("Error shutting down NVML: %v", ret)
-		}
-	}()
+	defer session.Shutdown()
 
 	deviceMap, err := NewDeviceMap(infolib, devicelib, config)
 	if err != nil {

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package rm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
+)
+
+// NVMLSession provides a centralized, reference-counted manager for NVML
+// initialization and shutdown across components.
+type NVMLSession struct {
+	mu          sync.Mutex
+	nvmllib     nvml.Interface
+	refCount    int
+	initialized bool
+	owned       bool
+}
+
+var (
+	defaultSession     *NVMLSession
+	defaultSessionOnce sync.Once
+)
+
+// GetNVMLSession returns the default singleton NVMLSession instance.
+func GetNVMLSession(nvmllib nvml.Interface) *NVMLSession {
+	defaultSessionOnce.Do(func() {
+		defaultSession = NewNVMLSession(nvmllib)
+	})
+	if nvmllib != nil && defaultSession.nvmllib == nil {
+		defaultSession.nvmllib = nvmllib
+	}
+	return defaultSession
+}
+
+// NewNVMLSession constructs a new NVMLSession with the provided nvml.Interface.
+func NewNVMLSession(nvmllib nvml.Interface) *NVMLSession {
+	if nvmllib == nil {
+		nvmllib = nvml.New()
+	}
+	return &NVMLSession{
+		nvmllib: nvmllib,
+	}
+}
+
+// Init initializes NVML if not already initialized, and increments reference count.
+func (s *NVMLSession) Init() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.initialized {
+		s.refCount++
+		return nil
+	}
+
+	ret := s.nvmllib.Init()
+	if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
+		return fmt.Errorf("failed to initialize NVML: %s", nvml.ErrorString(ret))
+	}
+
+	s.initialized = true
+	s.refCount = 1
+	if ret == nvml.SUCCESS {
+		s.owned = true
+	} else {
+		s.owned = false
+	}
+	return nil
+}
+
+// Shutdown decrements the reference count and shuts down NVML when count reaches 0.
+func (s *NVMLSession) Shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.initialized {
+		return
+	}
+
+	s.refCount--
+	if s.refCount <= 0 {
+		if s.owned {
+			ret := s.nvmllib.Shutdown()
+			if ret != nvml.SUCCESS && ret != nvml.ERROR_UNINITIALIZED {
+				klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(ret)), "NVML shutdown error")
+			}
+		}
+		s.initialized = false
+		s.owned = false
+		s.refCount = 0
+	}
+}
+
+// Interface returns the underlying nvml.Interface handle.
+func (s *NVMLSession) Interface() nvml.Interface {
+	return s.nvmllib
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_session_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package rm
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+)
+
+func TestNVMLSessionLifecycle(t *testing.T) {
+	initCount := 0
+	shutdownCount := 0
+
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			initCount++
+			return nvml.SUCCESS
+		},
+		ShutdownFunc: func() nvml.Return {
+			shutdownCount++
+			return nvml.SUCCESS
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+
+	// First Init should call nvml.Init()
+	err := session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if !session.initialized {
+		t.Errorf("expected session.initialized=true")
+	}
+	if !session.owned {
+		t.Errorf("expected session.owned=true")
+	}
+	if session.refCount != 1 {
+		t.Errorf("expected session.refCount=1, got %d", session.refCount)
+	}
+
+	// Second Init should increment refCount without calling nvml.Init() again
+	err = session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on second Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if session.refCount != 2 {
+		t.Errorf("expected session.refCount=2, got %d", session.refCount)
+	}
+
+	// First Shutdown should decrement refCount without calling nvml.Shutdown()
+	session.Shutdown()
+	if shutdownCount != 0 {
+		t.Errorf("expected shutdownCount=0, got %d", shutdownCount)
+	}
+	if session.refCount != 1 {
+		t.Errorf("expected session.refCount=1, got %d", session.refCount)
+	}
+
+	// Second Shutdown should decrement refCount to 0 and call nvml.Shutdown()
+	session.Shutdown()
+	if shutdownCount != 1 {
+		t.Errorf("expected shutdownCount=1, got %d", shutdownCount)
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected session.refCount=0, got %d", session.refCount)
+	}
+	if session.initialized {
+		t.Errorf("expected session.initialized=false")
+	}
+}
+
+func TestNVMLSessionAlreadyInitialized(t *testing.T) {
+	initCount := 0
+	shutdownCount := 0
+
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			initCount++
+			return nvml.ERROR_ALREADY_INITIALIZED
+		},
+		ShutdownFunc: func() nvml.Return {
+			shutdownCount++
+			return nvml.SUCCESS
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+
+	// Init returning ERROR_ALREADY_INITIALIZED should succeed but owned=false
+	err := session.Init()
+	if err != nil {
+		t.Fatalf("unexpected error on Init: %v", err)
+	}
+	if initCount != 1 {
+		t.Errorf("expected initCount=1, got %d", initCount)
+	}
+	if !session.initialized {
+		t.Errorf("expected session.initialized=true")
+	}
+	if session.owned {
+		t.Errorf("expected session.owned=false")
+	}
+
+	// Shutdown should not call nvml.Shutdown() because owned=false
+	session.Shutdown()
+	if shutdownCount != 0 {
+		t.Errorf("expected shutdownCount=0 since session did not own initialization, got %d", shutdownCount)
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected refCount=0, got %d", session.refCount)
+	}
+}
+
+func TestNVMLSessionInitFailure(t *testing.T) {
+	mockNVML := &mock.Interface{
+		InitFunc: func() nvml.Return {
+			return nvml.ERROR_UNKNOWN
+		},
+	}
+
+	session := NewNVMLSession(mockNVML)
+	err := session.Init()
+	if err == nil {
+		t.Fatal("expected error on failed Init, got nil")
+	}
+	if session.initialized {
+		t.Errorf("expected session.initialized=false on error")
+	}
+	if session.refCount != 0 {
+		t.Errorf("expected session.refCount=0 on error, got %d", session.refCount)
+	}
+}


### PR DESCRIPTION
## Description
This PR implements a 6-state lazy reclamation lifecycle for dynamic MIG instances in HAMi (`Creating`, `Active`, `Idle`, `Reclaiming`, `Deleting`, `Error`). 

When a Pod terminates, its MIG instance is marked as `Idle` rather than being destroyed immediately. Subsequent Pods requesting matching profiles and placements reuse the `Idle` instance instantly (reducing allocation latency from ~1.5s to 0ms). If conflicting profile placements are requested, overlapping `Idle` instances are evicted on demand. A background worker reclaims `Idle` instances that exceed the configured idle TTL.

## Changes
- Define `MigInstanceState` enum and add `State` and `LastUsed` to `migInstance` in `pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go`.
- Transition `Release()` to mark instances as `Idle`.
- Update `EnsureAllocation()` to reuse `Idle` instances instantly and perform placement collision eviction.
- Add `ReclaimExpiredIdleInstances` background worker in `server.go`.
- Add unit tests in `pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr_test.go`.

Fixes #2834.

This PR was written with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic CDI specification management for MIG devices.
  * MIG allocations can remain idle and be reused, improving allocation efficiency.
  * Added automatic cleanup of expired idle MIG instances.
  * Improved NVML session management across device operations.

* **Bug Fixes**
  * Improved error handling and rollback when MIG allocation or CDI specification creation fails.
  * Added safer handling for concurrent allocation release and reclamation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->