### PR TITLE
fix(scheduler): bind cache readiness to leadership terms

### DIFF
--- a/pkg/scheduler/routes/numa_refit_route_test.go
+++ b/pkg/scheduler/routes/numa_refit_route_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package routes
 
 import (
-	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
@@ -65,13 +64,10 @@ func TestNumaRefitRoute_CacheNotSynced(t *testing.T) {
 		t.Fatalf("failed to marshal request: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately so WaitForCacheSync fails fast instead of polling forever
-
-	req := httptest.NewRequest("POST", "/refit", strings.NewReader(string(body))).WithContext(ctx)
+	req := httptest.NewRequest("POST", "/refit", strings.NewReader(string(body)))
 	w := httptest.NewRecorder()
 
-	handler := NumaRefit(&scheduler.Scheduler{}) // zero value: synced defaults to false
+	handler := NumaRefit(newTestScheduler(t, false))
 	handler(w, req, nil)
 
 	if w.Code != 200 {
@@ -81,7 +77,30 @@ func TestNumaRefitRoute_CacheNotSynced(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
-	if response.Succeeded || !strings.Contains(response.FailureReason, "context cancelled") {
+	if response.Succeeded || !strings.Contains(response.FailureReason, "scheduler cache is not synced") {
 		t.Errorf("expected cache-not-synced failure, got %+v", response)
+	}
+}
+
+func TestNumaRefitRoute_NotLeaderFailsFast(t *testing.T) {
+	body, err := json.Marshal(device.NumaRefitRequest{PodUID: "uid"})
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/refit", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	handler := NumaRefit(newTestScheduler(t, true))
+	handler(w, req, nil)
+
+	if w.Code != 200 {
+		t.Fatalf("expected HTTP 200 with in-band error, got %d", w.Code)
+	}
+	var response device.NumaRefitResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if response.Succeeded || !strings.Contains(response.FailureReason, "scheduler is not leader") {
+		t.Errorf("expected not-leader failure, got %+v", response)
 	}
 }

--- a/pkg/scheduler/routes/route.go
+++ b/pkg/scheduler/routes/route.go
@@ -76,22 +76,17 @@ func PredicateRoute(s *scheduler.Scheduler) httprouter.Handle {
 			extenderFilterResult = &extenderv1.ExtenderFilterResult{
 				Error: err.Error(),
 			}
+		} else if err := s.CheckSchedulingAdmission(); err != nil {
+			klog.ErrorS(err, "Cannot proceed with filtering")
+			extenderFilterResult = &extenderv1.ExtenderFilterResult{
+				Error: err.Error(),
+			}
 		} else {
-			synced := s.WaitForCacheSync(r.Context())
-			if !synced {
-				// Poll may return false when context is cancelled
-				err := fmt.Errorf("context cancelled")
-				klog.ErrorS(err, "Cache not synced, cannot proceed with filtering")
+			extenderFilterResult, err = s.Filter(extenderArgs)
+			if err != nil {
+				klog.ErrorS(err, "Filter error for pod", "pod", extenderArgs.Pod.Name)
 				extenderFilterResult = &extenderv1.ExtenderFilterResult{
 					Error: err.Error(),
-				}
-			} else {
-				extenderFilterResult, err = s.Filter(extenderArgs)
-				if err != nil {
-					klog.ErrorS(err, "Filter error for pod", "pod", extenderArgs.Pod.Name)
-					extenderFilterResult = &extenderv1.ExtenderFilterResult{
-						Error: err.Error(),
-					}
 				}
 			}
 		}
@@ -126,6 +121,11 @@ func Bind(s *scheduler.Scheduler) httprouter.Handle {
 
 		if err := json.NewDecoder(body).Decode(&extenderBindingArgs); err != nil {
 			klog.ErrorS(err, "Failed to decode extender binding arguments")
+			extenderBindingResult = &extenderv1.ExtenderBindingResult{
+				Error: err.Error(),
+			}
+		} else if err := s.CheckSchedulingAdmission(); err != nil {
+			klog.ErrorS(err, "Cannot proceed with binding")
 			extenderBindingResult = &extenderv1.ExtenderBindingResult{
 				Error: err.Error(),
 			}
@@ -203,10 +203,8 @@ func NumaRefit(s *scheduler.Scheduler) httprouter.Handle {
 		if err := json.NewDecoder(body).Decode(&request); err != nil {
 			klog.ErrorS(err, "Failed to decode NUMA refit request")
 			response = device.NumaRefitResponse{FailureReason: err.Error()}
-		} else if !s.WaitForCacheSync(r.Context()) {
-			// Poll may return false when context is cancelled
-			err := fmt.Errorf("context cancelled")
-			klog.ErrorS(err, "Cache not synced, cannot refit")
+		} else if err := s.CheckSchedulingAdmission(); err != nil {
+			klog.ErrorS(err, "Cannot proceed with NUMA refit")
 			response = device.NumaRefitResponse{FailureReason: err.Error()}
 		} else {
 			response = s.RefitNumaAllocation(request)

--- a/pkg/scheduler/routes/route_test.go
+++ b/pkg/scheduler/routes/route_test.go
@@ -18,7 +18,6 @@ package routes
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -34,6 +33,16 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler"
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 )
+
+func newTestScheduler(t *testing.T, leaderElect bool) *scheduler.Scheduler {
+	t.Helper()
+	previous := config.LeaderElect
+	config.LeaderElect = leaderElect
+	s := scheduler.NewScheduler()
+	config.LeaderElect = previous
+	t.Cleanup(s.Stop)
+	return s
+}
 
 func TestMaxRequestSize(t *testing.T) {
 	hugePayload := strings.Repeat(" ", maxRequestSize+100)
@@ -254,13 +263,10 @@ func TestPredicateRoute_CacheNotSynced(t *testing.T) {
 		t.Fatalf("failed to marshal args: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately so WaitForCacheSync fails fast instead of polling forever
-
-	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body)).WithContext(ctx)
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
-	s := &scheduler.Scheduler{} // zero value: synced defaults to false
+	s := newTestScheduler(t, false)
 	handler := PredicateRoute(s)
 	handler(w, req, nil)
 
@@ -272,8 +278,32 @@ func TestPredicateRoute_CacheNotSynced(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
-	if !strings.Contains(result.Error, "context cancelled") {
-		t.Errorf("expected 'context cancelled' error, got %q", result.Error)
+	if !strings.Contains(result.Error, "scheduler cache is not synced") {
+		t.Errorf("expected cache-not-synced error, got %q", result.Error)
+	}
+}
+
+func TestPredicateRoute_NotLeaderFailsFast(t *testing.T) {
+	args := extenderv1.ExtenderArgs{Pod: &corev1.Pod{}}
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/predicate", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler := PredicateRoute(newTestScheduler(t, true))
+	handler(w, req, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200 with in-band error, got %d", w.Code)
+	}
+	var result extenderv1.ExtenderFilterResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if !strings.Contains(result.Error, "scheduler is not leader") {
+		t.Errorf("expected not-leader error, got %q", result.Error)
 	}
 }
 
@@ -295,6 +325,46 @@ func TestBind_DecodeError(t *testing.T) {
 	}
 	if result.Error == "" {
 		t.Error("expected a decode error to be reported in the bind result")
+	}
+}
+
+func TestBindRouteRejectsUnavailableScheduler(t *testing.T) {
+	body, err := json.Marshal(extenderv1.ExtenderBindingArgs{
+		PodName:      "pod",
+		PodNamespace: "default",
+		Node:         "node",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		leaderElect bool
+		wantError   string
+	}{
+		{name: "not leader", leaderElect: true, wantError: "scheduler is not leader"},
+		{name: "cache not synced", leaderElect: false, wantError: "scheduler cache is not synced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/bind", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			handler := Bind(newTestScheduler(t, tt.leaderElect))
+			handler(w, req, nil)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected HTTP 200 with in-band error, got %d", w.Code)
+			}
+			var result extenderv1.ExtenderBindingResult
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+			if !strings.Contains(result.Error, tt.wantError) {
+				t.Errorf("expected %q, got %q", tt.wantError, result.Error)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -61,7 +61,7 @@ type Scheduler struct {
 	*nodeManager
 	podManager    *device.PodManager
 	quotaManager  *device.QuotaManager
-	leaderManager leaderelection.LeaderManager
+	leaderManager leaderelection.TermAwareLeaderManager
 
 	stopCh       chan struct{}
 	nodeNotify   chan struct{}
@@ -77,8 +77,9 @@ type Scheduler struct {
 	eventRecorder  record.EventRecorder
 	started        uint32 // 0 = false, 1 = true
 
-	lock   sync.RWMutex
-	synced atomic.Bool
+	lock          sync.RWMutex
+	syncStateLock sync.Mutex
+	syncedTerm    atomic.Uint64
 
 	// allocLock serializes reservation mutations between Filter and the
 	// NUMA refit (RefitNumaAllocation). kube-scheduler already serializes
@@ -103,20 +104,32 @@ func NewScheduler() *Scheduler {
 	s.leaderManager = leaderelection.NewDummyLeaderManager(true)
 	if config.LeaderElect {
 		callbacks := leaderelection.LeaderCallbacks{
-			OnStartedLeading: func() {
-				select {
-				case s.leaderNotify <- struct{}{}:
-				default:
-				}
-			},
-			OnStoppedLeading: func() {
-				s.synced.Store(false)
-			},
+			OnStartedLeading: s.onStartedLeading,
+			OnStoppedLeading: s.onStoppedLeading,
 		}
 		s.leaderManager = leaderelection.NewLeaderManager(config.HostName, config.LeaderElectResourceNamespace, config.LeaderElectResourceName, callbacks)
 	}
 	klog.V(2).InfoS("Scheduler initialized successfully")
 	return s
+}
+
+func (s *Scheduler) onStartedLeading() {
+	s.syncStateLock.Lock()
+	s.syncedTerm.Store(0)
+	s.syncStateLock.Unlock()
+
+	select {
+	case s.leaderNotify <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Scheduler) onStoppedLeading() {
+	// Serialize only with register's final live-leader check and publication.
+	// Lease callbacks must not wait for the full cache refresh.
+	s.syncStateLock.Lock()
+	defer s.syncStateLock.Unlock()
+	s.syncedTerm.Store(0)
 }
 
 func (s *Scheduler) GetQuotaManager() *device.QuotaManager {
@@ -129,6 +142,33 @@ func (s *Scheduler) GetPodManager() *device.PodManager {
 
 func (s *Scheduler) GetLeaderManager() leaderelection.LeaderManager {
 	return s.leaderManager
+}
+
+func (s *Scheduler) currentLeadershipState() leaderelection.LeadershipState {
+	if s.leaderManager == nil {
+		return leaderelection.LeadershipState{}
+	}
+	return s.leaderManager.CurrentState()
+}
+
+// CheckSchedulingAdmission atomically checks that the current leadership term
+// has completed a cache sync. It does not fence operations already in flight.
+func (s *Scheduler) CheckSchedulingAdmission() error {
+	s.syncStateLock.Lock()
+	defer s.syncStateLock.Unlock()
+
+	state := s.currentLeadershipState()
+	if !state.IsLeader {
+		return fmt.Errorf("scheduler is not leader")
+	}
+	if state.Term == 0 || s.syncedTerm.Load() != state.Term {
+		return fmt.Errorf("scheduler cache is not synced")
+	}
+	return nil
+}
+
+func (s *Scheduler) IsReadyToSchedule() bool {
+	return s.CheckSchedulingAdmission() == nil
 }
 
 func (s *Scheduler) doNodeNotify() {
@@ -457,15 +497,14 @@ func (s *Scheduler) RegisterFromNodeAnnotations() {
 }
 
 func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[string]bool) {
-	// Lock here to avoid setting s.synced to false, when we lost leadership, while doing register.
-	// 1. lost leadership before register: synced will set to false in callbacks, and register will be skipped because IsLeader() returns false
-	// 2. lost leadership during or after register: synced will set to true after finishing register, and callback will set it to false again after lock is acquired by callback
+	// Keep overview updates consistent with metrics reads and node cleanup.
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	// Only do registration when we are leader.
-	isLeader := s.leaderManager.IsLeader()
-	if isLeader {
+	// Capture the term for readiness publication. Reconciliation already in
+	// flight is not transactionally fenced by this check.
+	registerState := s.currentLeadershipState()
+	if registerState.IsLeader && registerState.Term != 0 {
 		s.updateSchedulerLabel()
 	} else {
 		klog.V(5).InfoS("Scheduler is not leader yet, skipping ...")
@@ -567,8 +606,17 @@ func (s *Scheduler) register(labelSelector labels.Selector, printedLog map[strin
 	}
 	s.overviewstatus = *overallnodeMap
 
-	// Set synced to true only after getNodeUsage() succeeds
-	s.synced.Store(true)
+	// Keep the final live-leader check and readiness publication atomic with
+	// leadership-loss invalidation without blocking callbacks on the refresh.
+	s.syncStateLock.Lock()
+	currentState := s.currentLeadershipState()
+	if !currentState.IsLeader || currentState.Term != registerState.Term {
+		s.syncStateLock.Unlock()
+		klog.V(4).InfoS("Discarding cache sync because the leadership term changed", "registerTerm", registerState.Term, "currentTerm", currentState.Term)
+		return
+	}
+	s.syncedTerm.Store(registerState.Term)
+	s.syncStateLock.Unlock()
 }
 
 func (s *Scheduler) updateSchedulerLabel() {
@@ -628,17 +676,17 @@ func (s *Scheduler) updateSchedulerLabel() {
 	}
 }
 
-// IsSynced returns true when the scheduler's internal node/device cache has
-// completed at least one successful sync cycle and is ready to serve requests.
-// It uses atomic lock-free reads and is safe to call from Prometheus Collect callbacks
-// without contending on the scheduler's write lock during cache refreshes.
+// IsSynced returns true when the current leadership term has completed a cache
+// sync and is ready to admit scheduling requests.
 func (s *Scheduler) IsSynced() bool {
-	return s.synced.Load()
+	return s.IsReadyToSchedule()
 }
 
+// WaitForCacheSync waits until this instance is both the active leader and
+// cache-synced, or until the context is cancelled.
 func (s *Scheduler) WaitForCacheSync(ctx context.Context) bool {
 	err := wait.PollUntilContextCancel(ctx, syncedPollPeriod, true, func(context.Context) (done bool, err error) {
-		return s.synced.Load(), nil
+		return s.IsReadyToSchedule(), nil
 	})
 	if err != nil {
 		klog.ErrorS(err, "failed to poll until context cancel")

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +51,7 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
 	"github.com/Project-HAMi/HAMi/pkg/util"
 	"github.com/Project-HAMi/HAMi/pkg/util/client"
+	"github.com/Project-HAMi/HAMi/pkg/util/leaderelection"
 	nodelockutil "github.com/Project-HAMi/HAMi/pkg/util/nodelock"
 )
 
@@ -1384,6 +1386,180 @@ func (m *registerMockDevice) AddResourceUsage(_ *corev1.Pod, _ *device.DeviceUsa
 }
 func (m *registerMockDevice) Fit(_ []*device.DeviceUsage, _ device.ContainerDeviceRequest, _ *corev1.Pod, _ *device.NodeInfo, _ *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	return false, nil, ""
+}
+
+type mutableLeaderManager struct {
+	leader atomic.Bool
+	term   atomic.Uint64
+	cache.ResourceEventHandlerFuncs
+}
+
+func (m *mutableLeaderManager) IsLeader() bool {
+	return m.leader.Load()
+}
+
+func (m *mutableLeaderManager) CurrentState() leaderelection.LeadershipState {
+	return leaderelection.LeadershipState{IsLeader: m.leader.Load(), Term: m.term.Load()}
+}
+
+func TestRegisterLeadershipLossCannotRestoreSynced(t *testing.T) {
+	const testTimeout = 5 * time.Second
+
+	oldDevicesMap := device.DevicesMap
+	t.Cleanup(func() { device.DevicesMap = oldDevicesMap })
+
+	registerEntered := make(chan struct{})
+	releaseRegister := make(chan struct{})
+	registerDone := make(chan struct{})
+	registerLaunched := false
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseRegister) })
+		if registerLaunched {
+			select {
+			case <-registerDone:
+			case <-time.After(testTimeout):
+				t.Error("register goroutine did not stop during cleanup")
+			}
+		}
+	})
+
+	nodeDevices := []*device.DeviceInfo{{
+		ID:           "mock-device-0",
+		Count:        1,
+		Devmem:       1024,
+		Devcore:      100,
+		Health:       true,
+		DeviceVendor: "mock-vendor",
+	}}
+	mockDev := &registerMockDevice{
+		health:     true,
+		needUpdate: true,
+		getNodeDevicesFunc: func(_ corev1.Node) ([]*device.DeviceInfo, error) {
+			close(registerEntered)
+			<-releaseRegister
+			return nodeDevices, nil
+		},
+	}
+	device.DevicesMap = map[string]device.Devices{"mock-vendor": mockDev}
+
+	s := NewScheduler()
+	t.Cleanup(func() { close(s.stopCh) })
+	t.Setenv("POD_NAMESPACE", "default")
+	t.Setenv("POD_NAME", "scheduler-a")
+	stoppedCallbackEntered := make(chan struct{})
+
+	manager := leaderelection.NewLeaderManager(
+		"scheduler-a",
+		"default",
+		"hami-scheduler",
+		leaderelection.LeaderCallbacks{
+			OnStartedLeading: s.onStartedLeading,
+			OnStoppedLeading: func() {
+				close(stoppedCallbackEntered)
+				s.onStoppedLeading()
+			},
+		},
+	)
+	s.leaderManager = manager
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), time.Hour)
+	require.NoError(t, informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(node))
+	s.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+	s.podLister = informerFactory.Core().V1().Pods().Lister()
+
+	duration := int32(30)
+	oldHolder := "scheduler-a_lease-id"
+	oldLease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: "hami-scheduler", Namespace: "default"},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       &oldHolder,
+			LeaseDurationSeconds: &duration,
+		},
+	}
+	manager.OnAdd(oldLease, true)
+	initialState := manager.CurrentState()
+	require.True(t, initialState.IsLeader)
+	require.NotZero(t, initialState.Term)
+	s.syncedTerm.Store(initialState.Term)
+	require.True(t, s.IsSynced())
+	require.True(t, s.IsReadyToSchedule())
+
+	registerLaunched = true
+	go func() {
+		defer close(registerDone)
+		s.register(labels.Everything(), map[string]bool{})
+	}()
+
+	select {
+	case <-registerEntered:
+	case <-time.After(testTimeout):
+		t.Fatal("register did not reach the blocking device discovery")
+	}
+
+	newHolder := "scheduler-b_lease-id"
+	newLease := oldLease.DeepCopy()
+	newLease.Spec.HolderIdentity = &newHolder
+	leaderUpdateDone := make(chan struct{})
+	go func() {
+		defer close(leaderUpdateDone)
+		manager.OnUpdate(oldLease, newLease)
+	}()
+
+	require.Eventually(t, func() bool { return !manager.CurrentState().IsLeader }, testTimeout, 10*time.Millisecond)
+	select {
+	case <-stoppedCallbackEntered:
+	case <-time.After(testTimeout):
+		t.Fatal("leadership callback did not start")
+	}
+	select {
+	case <-leaderUpdateDone:
+	case <-time.After(testTimeout):
+		t.Fatal("leadership callback was blocked by the in-progress refresh")
+	}
+	require.False(t, s.IsSynced(), "leadership loss must invalidate readiness immediately")
+	require.False(t, s.IsReadyToSchedule())
+
+	reacquiredHolder := "scheduler-a_reacquired-lease-id"
+	reacquiredLease := newLease.DeepCopy()
+	reacquiredLease.Spec.HolderIdentity = &reacquiredHolder
+	manager.OnUpdate(newLease, reacquiredLease)
+	reacquiredState := manager.CurrentState()
+	require.True(t, reacquiredState.IsLeader)
+	require.Greater(t, reacquiredState.Term, initialState.Term)
+	require.False(t, s.IsReadyToSchedule(), "a new leadership term must require a fresh cache sync")
+
+	releaseOnce.Do(func() { close(releaseRegister) })
+	select {
+	case <-registerDone:
+	case <-time.After(testTimeout):
+		t.Fatal("register did not finish")
+	}
+
+	require.False(t, s.IsSynced(), "the old-term refresh must not restore readiness after A-B-A")
+	require.False(t, s.IsReadyToSchedule())
+
+	mockDev.getNodeDevicesFunc = func(_ corev1.Node) ([]*device.DeviceInfo, error) {
+		return nodeDevices, nil
+	}
+	s.register(labels.Everything(), map[string]bool{})
+	require.True(t, s.IsReadyToSchedule(), "the new term must become ready after its own refresh")
+	require.Equal(t, reacquiredState.Term, s.syncedTerm.Load())
+
+	// Lease validity can expire without an update callback. The final live
+	// leadership check must still prevent register from publishing synced=true.
+	expiringManager := &mutableLeaderManager{}
+	expiringManager.leader.Store(true)
+	expiringManager.term.Store(reacquiredState.Term + 1)
+	s.leaderManager = expiringManager
+	s.syncedTerm.Store(0)
+	mockDev.getNodeDevicesFunc = func(_ corev1.Node) ([]*device.DeviceInfo, error) {
+		expiringManager.leader.Store(false)
+		return nodeDevices, nil
+	}
+	s.register(labels.Everything(), map[string]bool{})
+	require.False(t, s.IsSynced(), "an expired lease must not publish a completed cache sync")
 }
 
 func TestRegisterSkipsCleanupForUntrackedVendor(t *testing.T) {
@@ -3477,10 +3653,29 @@ func Test_lockAllDevices_Transactional(t *testing.T) {
 }
 
 func TestSchedulerIsSynced(t *testing.T) {
-	s := &Scheduler{}
+	s := NewScheduler()
+	t.Cleanup(s.Stop)
 	assert.Equal(t, false, s.IsSynced())
 
-	s.synced.Store(true)
+	s.syncedTerm.Store(s.currentLeadershipState().Term)
 
 	assert.Equal(t, true, s.IsSynced())
+}
+
+func TestSchedulerIsReadyToSchedule(t *testing.T) {
+	s := NewScheduler()
+	t.Cleanup(func() { close(s.stopCh) })
+	s.syncedTerm.Store(s.currentLeadershipState().Term)
+	require.True(t, s.IsReadyToSchedule())
+
+	newTerm := &mutableLeaderManager{}
+	newTerm.leader.Store(true)
+	newTerm.term.Store(2)
+	s.leaderManager = newTerm
+	require.False(t, s.IsSynced(), "an older term's cache sync is not current readiness")
+	require.ErrorContains(t, s.CheckSchedulingAdmission(), "scheduler cache is not synced")
+
+	s.leaderManager = leaderelection.NewDummyLeaderManager(false)
+	require.False(t, s.IsSynced())
+	require.ErrorContains(t, s.CheckSchedulingAdmission(), "scheduler is not leader")
 }

--- a/pkg/util/leaderelection/leaderelection.go
+++ b/pkg/util/leaderelection/leaderelection.go
@@ -22,14 +22,27 @@ import (
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/tools/cache"
 )
 
 type LeaderCallbacks struct {
-	// OnStartedLeading is called when starts leading
+	// Callbacks run after CurrentState has published the new state. A direct
+	// term-to-term transition calls OnStoppedLeading before OnStartedLeading;
+	// both callbacks observe the new term.
+	// OnStartedLeading is called when starts leading.
 	OnStartedLeading func()
-	// OnStoppedLeading is called when stops leading
+	// OnStoppedLeading is called when stops leading.
 	OnStoppedLeading func()
+}
+
+// LeadershipState is a point-in-time view of local leadership. Term is an
+// opaque, process-local generation that starts at one and advances whenever
+// this instance enters a new observed leadership term. A former leader keeps
+// its last term while IsLeader is false; zero means no term has been observed.
+type LeadershipState struct {
+	IsLeader bool
+	Term     uint64
 }
 
 type LeaderManager interface {
@@ -38,16 +51,24 @@ type LeaderManager interface {
 	cache.ResourceEventHandler
 }
 
-var _ LeaderManager = &leaderManager{}
+type TermAwareLeaderManager interface {
+	LeaderManager
+	CurrentState() LeadershipState
+}
+
+var _ TermAwareLeaderManager = &leaderManager{}
 
 type leaderManager struct {
 	hostname          string
 	resourceName      string
 	resourceNamespace string
 
-	leaseLock     sync.RWMutex
-	observedLease *coordinationv1.Lease
-	observedTime  time.Time
+	leaseLock       sync.RWMutex
+	observedLease   *coordinationv1.Lease
+	observedTime    time.Time
+	term            uint64
+	now             func() time.Time
+	notifiedLeading bool
 
 	callbacks LeaderCallbacks
 
@@ -60,6 +81,7 @@ func NewLeaderManager(hostname, namespace, name string, callbacks LeaderCallback
 		resourceName:      name,
 		resourceNamespace: namespace,
 		callbacks:         callbacks,
+		now:               time.Now,
 	}
 
 	m.FilteringResourceEventHandler = cache.FilteringResourceEventHandler{
@@ -94,13 +116,53 @@ func objectToLease(obj any) *coordinationv1.Lease {
 	return nil
 }
 
-func (m *leaderManager) setObservedRecord(lease *coordinationv1.Lease) {
+func (m *leaderManager) setObservedRecordAt(lease *coordinationv1.Lease, observedAt time.Time) {
 	m.observedLease = lease
 
 	if lease == nil {
 		m.observedTime = time.Time{}
 	} else {
-		m.observedTime = time.Now()
+		m.observedTime = observedAt
+	}
+}
+
+func (m *leaderManager) setObservedRecord(lease *coordinationv1.Lease) {
+	m.setObservedRecordAt(lease, m.now())
+}
+
+func (m *leaderManager) observe(lease *coordinationv1.Lease, forceRefresh bool) {
+	now := m.now()
+	m.leaseLock.Lock()
+	previousState := m.currentStateLocked(now)
+	previousHolder := holderIdentity(m.observedLease)
+	if lease == nil {
+		m.setObservedRecordAt(nil, now)
+	} else if forceRefresh || m.observedLease == nil || !apiequality.Semantic.DeepEqual(m.observedLease.Spec, lease.Spec) {
+		m.setObservedRecordAt(lease, now)
+	} else {
+		// Informer resync and metadata-only updates must not extend the lease.
+		m.observedLease = lease
+	}
+	currentState := m.currentStateLocked(now)
+	currentHolder := holderIdentity(lease)
+
+	// kube-scheduler includes a UUID in HolderIdentity. A changed full
+	// identity for the same hostname is therefore a new leadership term.
+	holderChanged := previousState.IsLeader && currentState.IsLeader && previousHolder != currentHolder
+	termChanged := currentState.IsLeader && (!previousState.IsLeader || holderChanged)
+	if termChanged {
+		m.term++
+	}
+	stoppedLeading := m.notifiedLeading && (!currentState.IsLeader || termChanged)
+	startedLeading := currentState.IsLeader && (!m.notifiedLeading || termChanged)
+	m.notifiedLeading = currentState.IsLeader
+	m.leaseLock.Unlock()
+
+	if stoppedLeading && m.callbacks.OnStoppedLeading != nil {
+		m.callbacks.OnStoppedLeading()
+	}
+	if startedLeading && m.callbacks.OnStartedLeading != nil {
+		m.callbacks.OnStartedLeading()
 	}
 }
 
@@ -110,63 +172,44 @@ func (m *leaderManager) onAdd(obj any) {
 	if !ok {
 		return
 	}
-
-	m.leaseLock.Lock()
-	m.setObservedRecord(lease)
-	var callback func()
-	if m.isHolderOf(lease) {
-		callback = m.callbacks.OnStartedLeading
-	}
-	m.leaseLock.Unlock()
-
-	if callback != nil {
-		callback()
-	}
+	m.observe(lease, true)
 }
 
-// onUpdate notifies when we have been elected as leader.
+// onUpdate notifies when leadership changes or an expired lease becomes valid
+// again. oldObj is validated because informer update handlers must receive two
+// Lease objects, but the manager's locked observed state is authoritative.
 func (m *leaderManager) onUpdate(oldObj, newObj any) {
+	if _, ok := oldObj.(*coordinationv1.Lease); !ok {
+		return
+	}
 	newLease, ok := newObj.(*coordinationv1.Lease)
 	if !ok {
 		return
 	}
-	oldLease, ok := oldObj.(*coordinationv1.Lease)
-	if !ok {
-		return
-	}
-
-	m.leaseLock.Lock()
-	m.setObservedRecord(newLease)
-	var callback func()
-	if !m.isHolderOf(oldLease) && m.isHolderOf(newLease) {
-		callback = m.callbacks.OnStartedLeading
-	} else if m.isHolderOf(oldLease) && !m.isHolderOf(newLease) {
-		callback = m.callbacks.OnStoppedLeading
-	}
-	m.leaseLock.Unlock()
-
-	if callback != nil {
-		callback()
-	}
+	m.observe(newLease, false)
 }
 
 func (m *leaderManager) onDelete(obj any) {
-	m.leaseLock.Lock()
-	m.setObservedRecord(nil)
-	callback := m.callbacks.OnStoppedLeading
-	m.leaseLock.Unlock()
-
-	if callback != nil {
-		callback()
+	if objectToLease(obj) == nil {
+		return
 	}
+	m.observe(nil, true)
 }
 
 func (m *leaderManager) isHolderOf(lease *coordinationv1.Lease) bool {
-	// kube-scheduler lease id take format of `hostname + "_" + string(uuid.NewUUID())`
+	// Only kube-scheduler's `hostname + "_" + UUID` identity format is
+	// supported; requiring the separator avoids hostname-prefix collisions.
 	if lease == nil || lease.Spec.HolderIdentity == nil {
 		return false
 	}
-	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname)
+	return strings.HasPrefix(*lease.Spec.HolderIdentity, m.hostname+"_")
+}
+
+func holderIdentity(lease *coordinationv1.Lease) string {
+	if lease == nil || lease.Spec.HolderIdentity == nil {
+		return ""
+	}
+	return *lease.Spec.HolderIdentity
 }
 
 func (m *leaderManager) isLeaseValid(now time.Time) bool {
@@ -176,15 +219,21 @@ func (m *leaderManager) isLeaseValid(now time.Time) bool {
 	return m.observedTime.Add(time.Second * time.Duration(*m.observedLease.Spec.LeaseDurationSeconds)).After(now)
 }
 
-func (m *leaderManager) IsLeader() bool {
+func (m *leaderManager) currentStateLocked(now time.Time) LeadershipState {
+	return LeadershipState{
+		IsLeader: m.isHolderOf(m.observedLease) && m.isLeaseValid(now),
+		Term:     m.term,
+	}
+}
+
+func (m *leaderManager) CurrentState() LeadershipState {
 	m.leaseLock.RLock()
 	defer m.leaseLock.RUnlock()
+	return m.currentStateLocked(m.now())
+}
 
-	if m.observedLease == nil {
-		return false
-	}
-
-	return m.isHolderOf(m.observedLease) && m.isLeaseValid(time.Now())
+func (m *leaderManager) IsLeader() bool {
+	return m.CurrentState().IsLeader
 }
 
 type dummyLeaderManager struct {
@@ -192,7 +241,7 @@ type dummyLeaderManager struct {
 	cache.ResourceEventHandlerFuncs
 }
 
-var _ LeaderManager = &dummyLeaderManager{}
+var _ TermAwareLeaderManager = &dummyLeaderManager{}
 
 // NewDummyLeaderManager creates a dummy leader manager which will not change its elected state during its lifetime.
 // It will always return the elected state passed in the constructor when calling IsLeader() and you will never get notified by it's channel.
@@ -206,4 +255,11 @@ func NewDummyLeaderManager(elected bool) *dummyLeaderManager {
 
 func (d *dummyLeaderManager) IsLeader() bool {
 	return d.elected
+}
+
+func (d *dummyLeaderManager) CurrentState() LeadershipState {
+	if !d.elected {
+		return LeadershipState{}
+	}
+	return LeadershipState{IsLeader: true, Term: 1}
 }

--- a/pkg/util/leaderelection/leaderelection_test.go
+++ b/pkg/util/leaderelection/leaderelection_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package leaderelection
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -130,6 +131,127 @@ func acquireLeaseWithNewHost(lease *coordinationv1.Lease, hostname string) *coor
 	new := lease.DeepCopy()
 	new.Spec.HolderIdentity = &holderIdentity
 	return new
+}
+
+func TestLeadershipTermTransitions(t *testing.T) {
+	baseTime := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name          string
+		advance       time.Duration
+		newHolder     bool
+		noRenewal     bool
+		wantLeader    bool
+		wantNewTerm   bool
+		wantStarted   int
+		wantStopped   int
+		wantCallbacks string
+	}{
+		{
+			name:          "ordinary renewal keeps term",
+			advance:       time.Second,
+			wantLeader:    true,
+			wantStarted:   1,
+			wantCallbacks: "start",
+		},
+		{
+			name:          "same holder after expiry starts new term",
+			advance:       16 * time.Second,
+			wantLeader:    true,
+			wantNewTerm:   true,
+			wantStarted:   2,
+			wantStopped:   1,
+			wantCallbacks: "start,stop,start",
+		},
+		{
+			name:          "resync update does not revive expired lease",
+			advance:       16 * time.Second,
+			noRenewal:     true,
+			wantStarted:   1,
+			wantStopped:   1,
+			wantCallbacks: "start,stop",
+		},
+		{
+			name:          "new identity on same host starts new term",
+			advance:       time.Second,
+			newHolder:     true,
+			wantLeader:    true,
+			wantNewTerm:   true,
+			wantStarted:   2,
+			wantStopped:   1,
+			wantCallbacks: "start,stop,start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := baseTime
+			started := 0
+			stopped := 0
+			var callbacks []string
+			m := NewLeaderManager("dev", "kube-system", "hami-scheduler", LeaderCallbacks{
+				OnStartedLeading: func() {
+					started++
+					callbacks = append(callbacks, "start")
+				},
+				OnStoppedLeading: func() {
+					stopped++
+					callbacks = append(callbacks, "stop")
+				},
+			})
+			m.now = func() time.Time { return now }
+
+			lease := generateLease("dev", "kube-system", "hami-scheduler")
+			m.OnAdd(lease, true)
+			initialState := m.CurrentState()
+			if !initialState.IsLeader || initialState.Term == 0 {
+				t.Fatalf("expected initial leadership term, got %+v", initialState)
+			}
+
+			now = now.Add(tt.advance)
+			if tt.advance > 15*time.Second && m.IsLeader() {
+				t.Fatal("expected the observed lease to expire")
+			}
+
+			renewed := renewLeaseAtNow(lease)
+			if tt.noRenewal {
+				renewed = lease.DeepCopy()
+				renewed.ResourceVersion = "resync"
+			} else if tt.newHolder {
+				renewed = acquireLeaseWithNewHost(lease, "dev")
+			}
+			m.OnUpdate(lease, renewed)
+			currentState := m.CurrentState()
+			if currentState.IsLeader != tt.wantLeader {
+				t.Fatalf("leadership mismatch: got %+v, want leader=%t", currentState, tt.wantLeader)
+			}
+			if tt.wantNewTerm != (currentState.Term > initialState.Term) {
+				t.Fatalf("term transition mismatch: initial=%d current=%d", initialState.Term, currentState.Term)
+			}
+			if started != tt.wantStarted || stopped != tt.wantStopped {
+				t.Fatalf("callbacks mismatch: started=%d stopped=%d", started, stopped)
+			}
+			if got := strings.Join(callbacks, ","); got != tt.wantCallbacks {
+				t.Fatalf("callback order mismatch: got %q, want %q", got, tt.wantCallbacks)
+			}
+		})
+	}
+}
+
+func TestHolderIdentityRequiresHostnameSeparator(t *testing.T) {
+	m := NewLeaderManager("dev", "kube-system", "hami-scheduler", LeaderCallbacks{})
+	valid := "dev_uuid"
+	prefixCollision := "dev2_uuid"
+	plainHostname := "dev"
+
+	if !m.isHolderOf(&coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: &valid}}) {
+		t.Fatal("expected canonical kube-scheduler holder identity to match")
+	}
+	if m.isHolderOf(&coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: &prefixCollision}}) {
+		t.Fatal("hostname prefix collision must not match")
+	}
+	if m.isHolderOf(&coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: &plainHostname}}) {
+		t.Fatal("plain holder identity without kube-scheduler separator must not match")
+	}
 }
 
 var _ = ginkgo.Describe("LeaderManager", func() {
@@ -488,5 +610,8 @@ var _ = ginkgo.Describe("DummyLeaderManager", func() {
 
 	ginkgo.It("should always be leader but not notified", func() {
 		assertElectedWithoutNotifying(lm, leaderNotify)
+		termAware, ok := lm.(TermAwareLeaderManager)
+		g.Expect(ok).Should(g.BeTrue())
+		g.Expect(termAware.CurrentState()).Should(g.Equal(LeadershipState{IsLeader: true, Term: 1}))
 	})
 })


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

Fixes a leadership-term race where scheduler cache readiness can be published by a stale `register()` operation after a leadership transition.

In an HA deployment, a registration started during leadership term A may finish after an A -> B -> A transition. Since the scheduler only checks the current leader status, the old registration can incorrectly set `synced=true` for the new leadership term.

This PR binds cache readiness to an observed, process-local leadership term.

Fixes #2911

## Changes

- Add a term-aware leadership state to the leader election package.
- Advance the leadership term when leadership is acquired, the holder identity changes, or an expired Lease is renewed, including same-holder renewal.
- Prevent informer resync and metadata-only Lease updates from extending Lease validity.
- Ensure stop/start callbacks are paired and ordered across term transitions.
- Replace the scheduler-wide synced boolean with a term-bound synced state.
- Prevent an old `register()` operation from publishing readiness for a newer leadership term.
- Keep leadership callbacks independent from the long-running registration lock.
- Reject new `/filter`, `/bind`, and `/refit` requests until the current leadership term has completed cache synchronization.
- Preserve the existing `LeaderManager` interface and add `TermAwareLeaderManager` for term-aware consumers.
- Add regression tests for A -> B -> A, same-holder Lease expiry and renewal, informer resync, callback ordering, and hostname-prefix collisions.

## Scope

This PR guarantees that cache readiness and new-request admission belong to the current observed leadership term.

This PR does not provide distributed fencing for requests that were already admitted. It also does not transactionally roll back external side effects already performed by `register()`, such as Kubernetes label updates, device cleanup, or local cache mutations.

Those behaviors require a separate design involving request cancellation, ownership tokens, resource-version preconditions, or node-lock fencing.

## Testing

- `go test ./pkg/scheduler/... ./pkg/util/leaderelection ./cmd/scheduler -count=1`
- `go test -short -race ./pkg/scheduler/... ./pkg/util/leaderelection ./cmd/scheduler -count=1`
- `go vet ./pkg/scheduler/... ./pkg/util/leaderelection ./cmd/scheduler/...`
- Leadership term tests passed with `-race -count=50`.
- Scheduler leadership tests passed with `-race -count=30`.
- `gofmt` and `git diff --check` passed.

The full repository test run still has two unrelated host-environment failures in NVIDIA hostpid/MIG tests.

## Related issues and PRs

- #1954: hami-scheduler multi-copy deployment problem
- #1957: fix_leaderNotify Block
- #1553: Implementing leader-follower high availability using leader-election
- #2758: Add Prometheus metrics for scheduler leader and cache sync state

This PR is related to #1954 and extends the existing #1957 fix. It addresses a separate remaining race involving stale cache registration results being reused across leadership terms.

## AI assistance disclosure

AI assistance was used for repository research and regression test authoring. The implementation and final changes were reviewed and validated with unit tests, race detection, and static analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduling requests now fail fast when the scheduler is not the active leader.
  * Scheduling is blocked until the scheduler cache is synchronized for the current leadership term.
  * Leadership changes and lease transitions no longer incorrectly restore scheduling readiness.
  * Improved leader identity validation and handling of leadership renewals and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->