### PR TITLE
feat(dashboard): compare allocated and host GPU memory

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -47,8 +47,8 @@ specific Prometheus UID — Grafana asks which data source to bind on import.
 
 - **Cluster overview** — physical GPU count, total and allocated GPU memory,
   cluster memory-allocated %, and shared-container count.
-- **Physical GPUs (host)** — per-device memory used and utilization, as measured by
-  the vGPU monitor.
+- **Physical GPUs (host)** — per-device memory used, utilization, and
+  scheduler-allocated memory compared with host-used memory.
 - **Scheduler / allocation** — allocated vs limit GPU memory, per-node memory and
   core allocation ratios, and per-device shared count.
 - **vGPU / container workloads** — per-container vGPU memory used vs limit,

--- a/dashboards/dashboard_test.go
+++ b/dashboards/dashboard_test.go
@@ -119,7 +119,7 @@ func TestPhysicalGPUAllocatedVsHostUsedPanelComparesDeviceMemory(t *testing.T) {
 	if got.Targets[0].Expr != `hami_gpu_memory_allocated_bytes{node=~"$node"}` {
 		t.Errorf("allocated expr = %q", got.Targets[0].Expr)
 	}
-	if got.Targets[1].Expr != `hami_host_gpu_memory_used_bytes and on (device_uuid) hami_gpu_memory_limit_bytes{node=~"$node"}` {
+	if got.Targets[1].Expr != `hami_host_gpu_memory_used_bytes{node=~"$node"}` {
 		t.Errorf("host used expr = %q", got.Targets[1].Expr)
 	}
 }

--- a/dashboards/dashboard_test.go
+++ b/dashboards/dashboard_test.go
@@ -86,3 +86,40 @@ func TestNodeGPUMemoryAllocatedRatioPanelUsesFractionScale(t *testing.T) {
 		}
 	}
 }
+
+func TestPhysicalGPUAllocatedVsHostUsedPanelComparesDeviceMemory(t *testing.T) {
+	data, err := os.ReadFile("hami-vgpu-dashboard.json")
+	if err != nil {
+		t.Fatalf("read dashboard: %v", err)
+	}
+
+	var d dashboard
+	if err := json.Unmarshal(data, &d); err != nil {
+		t.Fatalf("parse dashboard: %v", err)
+	}
+
+	const title = "GPU memory: allocated vs host used"
+	var got *panel
+	for i := range d.Panels {
+		if d.Panels[i].Title == title {
+			got = &d.Panels[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("panel %q not found", title)
+	}
+
+	if got.FieldConfig.Defaults.Unit != "bytes" {
+		t.Errorf("unit = %q, want bytes", got.FieldConfig.Defaults.Unit)
+	}
+	if len(got.Targets) != 2 {
+		t.Fatalf("panel %q target count = %d, want 2", title, len(got.Targets))
+	}
+	if got.Targets[0].Expr != `hami_gpu_memory_allocated_bytes{node=~"$node"}` {
+		t.Errorf("allocated expr = %q", got.Targets[0].Expr)
+	}
+	if got.Targets[1].Expr != `hami_host_gpu_memory_used_bytes and on (device_uuid) hami_gpu_memory_limit_bytes{node=~"$node"}` {
+		t.Errorf("host used expr = %q", got.Targets[1].Expr)
+	}
+}

--- a/dashboards/hami-vgpu-dashboard.json
+++ b/dashboards/hami-vgpu-dashboard.json
@@ -378,7 +378,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "hami_host_gpu_memory_used_bytes and on (device_uuid) hami_gpu_memory_limit_bytes{node=~\"$node\"}",
+          "expr": "hami_host_gpu_memory_used_bytes{node=~\"$node\"}",
           "legendFormat": "host used {{node}} idx{{device_index}} ({{device_uuid}})",
           "refId": "B"
         }

--- a/dashboards/hami-vgpu-dashboard.json
+++ b/dashboards/hami-vgpu-dashboard.json
@@ -328,8 +328,67 @@
       "type": "timeseries"
     },
     {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Scheduler-allocated GPU memory and physical host memory used, grouped by physical GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "/host used/" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } },
+              { "id": "custom.fillOpacity", "value": 0 }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "hami_gpu_memory_allocated_bytes{node=~\"$node\"}",
+          "legendFormat": "allocated {{node}} idx{{device_index}} ({{device_uuid}})",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "hami_host_gpu_memory_used_bytes and on (device_uuid) hami_gpu_memory_limit_bytes{node=~\"$node\"}",
+          "legendFormat": "host used {{node}} idx{{device_index}} ({{device_uuid}})",
+          "refId": "B"
+        }
+      ],
+      "title": "GPU memory: allocated vs host used",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
       "id": 102,
       "panels": [],
       "title": "Scheduler / allocation",
@@ -369,7 +428,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
       "id": 20,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -431,7 +490,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
       "id": 21,
       "options": {
         "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -477,7 +536,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
       "id": 22,
       "options": {
         "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -521,7 +580,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
       "id": 23,
       "options": {
         "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -541,7 +600,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
       "id": 103,
       "panels": [],
       "title": "vGPU / container workloads",
@@ -581,7 +640,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
       "id": 30,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -634,7 +693,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
       "id": 31,
       "options": {
         "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -689,7 +748,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
       "id": 32,
       "options": {
         "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
@@ -728,7 +787,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
       "id": 33,
       "options": {
         "cellHeight": "sm",


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

This adds one Grafana panel under `Physical GPUs (host)` to show two memory views for each physical GPU:

- memory allocated by HAMi scheduler: `hami_gpu_memory_allocated_bytes`
- memory currently used on the host GPU: `hami_host_gpu_memory_used_bytes`

This makes it easier to compare scheduler allocation with actual host-side GPU memory usage without changing any metric behavior.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

This only updates the dashboard JSON, dashboard README, and dashboard test. It does not change scheduling, device allocation, or runtime behavior.

AI assistance disclosure: I used ChatGPT/Codex to inspect the existing dashboard structure and help prepare this small dashboard change. I reviewed the diff and ran the validation locally.

**Does this PR introduce a user-facing change?**:

Yes. Release note: Add a Grafana dashboard panel comparing scheduler-allocated GPU memory with host GPU memory used per physical GPU.

**Validation**:

- `go test ./dashboards`
- `jq empty dashboards/hami-vgpu-dashboard.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-width dashboard panel comparing scheduler-allocated GPU memory with physical host usage per GPU.
  * Displayed memory values in bytes for clearer capacity comparisons.
  * Updated the dashboard description to reflect the new memory comparison.

* **Tests**
  * Added coverage validating the panel’s queries, unit, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->