### PR TITLE
 honor hami.io/device-cordon in all backends

### DIFF
--- a/pkg/device/amd/device.go
+++ b/pkg/device/amd/device.go
@@ -276,12 +276,18 @@ func (amddevice *AMDDevices) Fit(devices []*device.DeviceUsage, request device.C
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeinfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		klog.V(3).InfoS("Type check", "device", dev.Type, "req", k.Type, "dev=", dev)

--- a/pkg/device/amd/device_cordon_test.go
+++ b/pkg/device/amd/device_cordon_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amd
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitAMDGPUDevice(AMDConfig{ResourceCountName: "amd.com/gpu"})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 1000, Totalcore: 100, Type: AMDDevice, Health: true, CustomInfo: map[string]any{}},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 1000, Totalcore: 100, Type: AMDDevice, Health: true, CustomInfo: map[string]any{}},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 500, Coresreq: 50, Type: AMDDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[AMDDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 500
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[AMDDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[AMDDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -477,6 +477,7 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 	// same gate MutateAdmission uses. Split mode carves vNPUs out of single
 	// devices and must not be forced onto whole physical cards.
 	pair910C := k.Type == Ascend910CType && originReq > 1 && npu.config.SuperPod
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
@@ -484,6 +485,11 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, numa := npu.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/ascend/device_cordon_test.go
+++ b/pkg/device/ascend/device_cordon_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ascend
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	const commonWord = "Ascend910B2"
+	dev := &Devices{config: VNPUConfig{CommonWord: commonWord}}
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: commonWord, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: commonWord, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: commonWord}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[commonWord][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[commonWord][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[commonWord][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/awsneuron/device.go
+++ b/pkg/device/awsneuron/device.go
@@ -389,7 +389,11 @@ func addCoreUsage(prev map[string]any, require int) map[string]any {
 	}
 	return res
 }
-func continuousDeviceAvailable(devices []*device.DeviceUsage, start int, count int) []int {
+
+// continuousDeviceAvailable reports the indices of a run of `count` allocatable
+// devices starting at `start`. A cordoned device is treated as unavailable, so
+// a run is only reported when it steps over none of them.
+func continuousDeviceAvailable(devices []*device.DeviceUsage, start int, count int, cordoned map[string]struct{}) []int {
 	if len(devices) < start+count {
 		return []int{}
 	}
@@ -399,13 +403,16 @@ func continuousDeviceAvailable(devices []*device.DeviceUsage, start int, count i
 		if devices[iterator].Used > 0 || !devices[iterator].Health {
 			return []int{}
 		}
+		if _, isCordoned := cordoned[devices[iterator].ID]; isCordoned {
+			return []int{}
+		}
 		res = append(res, iterator)
 		iterator++
 	}
 	return res
 }
 
-func graphSelect(devices []*device.DeviceUsage, count int) []int {
+func graphSelect(devices []*device.DeviceUsage, count int, cordoned map[string]struct{}) []int {
 	if len(devices) == 0 || devices[0].CustomInfo == nil || devices[0].CustomInfo[AWSNodeType] == nil {
 		return []int{}
 	}
@@ -417,7 +424,7 @@ func graphSelect(devices []*device.DeviceUsage, count int) []int {
 		//Deal with ring
 		start := 0
 		for start < len(devices) {
-			res := continuousDeviceAvailable(devices, start, count)
+			res := continuousDeviceAvailable(devices, start, count, cordoned)
 			if len(res) > 0 {
 				return res
 			}
@@ -430,7 +437,7 @@ func graphSelect(devices []*device.DeviceUsage, count int) []int {
 		{
 			start := 0
 			for start < len(devices) {
-				res := continuousDeviceAvailable(devices, start, count)
+				res := continuousDeviceAvailable(devices, start, count, cordoned)
 				if len(res) > 0 {
 					return res
 				}
@@ -449,11 +456,25 @@ func (neuron *AWSNeuronDevices) Fit(devices []*device.DeviceUsage, request devic
 	tmpDevs := make(map[string]device.ContainerDevices)
 	reason := make(map[string]int)
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeinfo)
 	if k.Nums > 1 {
-		alloc := graphSelect(devices, int(request.Nums))
+		// graphSelect reads topology from slice positions, so cordoned devices are
+		// rejected inside its availability check rather than filtered out here.
+		alloc := graphSelect(devices, int(request.Nums), cordoned)
 		if len(alloc) == 0 {
-			reason[common.NumaNotFit]++
-			klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
+			cordonedCount := 0
+			for _, dev := range devices {
+				if _, isCordoned := cordoned[dev.ID]; isCordoned {
+					cordonedCount++
+					klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
+				}
+			}
+			if cordonedCount > 0 {
+				reason[common.CardCordoned] += cordonedCount
+			} else {
+				reason[common.NumaNotFit]++
+				klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
+			}
 			return false, tmpDevs, common.GenReason(reason, len(devices))
 		}
 		for _, dev := range alloc {
@@ -484,6 +505,11 @@ func (neuron *AWSNeuronDevices) Fit(devices []*device.DeviceUsage, request devic
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		klog.V(3).InfoS("Type check", "device", dev.Type, "req", k.Type, "dev=", dev)

--- a/pkg/device/awsneuron/device_cordon_test.go
+++ b/pkg/device/awsneuron/device_cordon_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsneuron
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func cordonNode(uuids string) *device.NodeInfo {
+	return &device.NodeInfo{Node: &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+	}}
+}
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitAWSNeuronDevice(AWSNeuronConfig{
+		ResourceCountName: "aws.amazon.com/neuron",
+		ResourceCoreName:  "aws.amazon.com/neuroncore",
+	})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			makeAWSDeviceUsage("dev-0", 0, 0, 2, 3, 0, "trn", true),
+			makeAWSDeviceUsage("dev-1", 1, 0, 12, 3, 0, "trn", true),
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Coresreq: 2, Type: AWSNeuronDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, cordonNode("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[AWSNeuronDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, cordonNode("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      cordonNode(""),
+			"annotation whitespace": cordonNode("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[AWSNeuronDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}
+
+// newRingDevices builds the 16-device ring graphSelect walks by slice position.
+// Only the first device carries the node type, matching how the node reports it.
+func newRingDevices() []*device.DeviceUsage {
+	devices := make([]*device.DeviceUsage, 16)
+	for i := range devices {
+		du := &device.DeviceUsage{
+			ID:     fmt.Sprintf("dev-%d", i),
+			Index:  uint(i),
+			Type:   AWSNeuronDevice,
+			Health: true,
+		}
+		if i == 0 {
+			du.CustomInfo = map[string]any{AWSNodeType: "inf2"}
+		}
+		devices[i] = du
+	}
+	return devices
+}
+
+func TestFit_DeviceCordonMultiCardTopology(t *testing.T) {
+	dev := InitAWSNeuronDevice(AWSNeuronConfig{
+		ResourceCountName: "aws.amazon.com/neuron",
+		ResourceCoreName:  "aws.amazon.com/neuroncore",
+	})
+	request := device.ContainerDeviceRequest{Nums: 4, Type: AWSNeuronDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("a run stepping over a cordoned device is rejected, the next run wins", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newRingDevices(), request, pod, cordonNode("dev-0"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit on a run clear of the cordoned device, got reason: %s", reason)
+		}
+		allocated := result[AWSNeuronDevice]
+		if len(allocated) != 4 {
+			t.Fatalf("expected 4 allocated devices, got %d", len(allocated))
+		}
+		// The contiguous run must start after the cordoned device, keeping the
+		// ring positions intact rather than compacting the slice.
+		for i, d := range allocated {
+			if want := fmt.Sprintf("dev-%d", i+1); d.UUID != want {
+				t.Errorf("expected %s at position %d, got %s", want, i, d.UUID)
+			}
+			if d.UUID == "dev-0" {
+				t.Errorf("cordoned dev-0 must not be allocated")
+			}
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned rather than NumaNotFit", func(t *testing.T) {
+		all := make([]string, 16)
+		for i := range all {
+			all[i] = fmt.Sprintf("dev-%d", i)
+		}
+		fit, _, reason := dev.Fit(newRingDevices(), request, pod, cordonNode(strings.Join(all, ",")), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "16/16 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("nothing cordoned still reports NumaNotFit when no run exists", func(t *testing.T) {
+		devices := newRingDevices()
+		// Break every possible run of 4 without cordoning anything.
+		for i := 3; i < len(devices); i += 4 {
+			devices[i].Used = 1
+		}
+		fit, _, reason := dev.Fit(devices, request, pod, &device.NodeInfo{}, &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, no contiguous run of 4 is available")
+		}
+		if want := "1/16 " + common.NumaNotFit; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+}

--- a/pkg/device/awsneuron/device_test.go
+++ b/pkg/device/awsneuron/device_test.go
@@ -867,7 +867,7 @@ func Test_graphSelect(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result1 := graphSelect(test.args.d, test.args.c)
+			result1 := graphSelect(test.args.d, test.args.c, nil)
 			assert.DeepEqual(t, result1, test.want1)
 		})
 	}

--- a/pkg/device/biren/device.go
+++ b/pkg/device/biren/device.go
@@ -185,11 +185,17 @@ func (br *BirenDevices) Fit(devices []*device.DeviceUsage, request device.Contai
 	tmpDevs := make(map[string]device.ContainerDevices)
 	reason := make(map[string]int)
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, dev := range slices.Backward(devices) {
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, _ := br.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/biren/device_cordon_test.go
+++ b/pkg/device/biren/device_cordon_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package biren
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitBirenDevice(BirenConfig{ResourceCountName: "birentech.com/gpu"})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 1, Type: BirenDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 1, Type: BirenDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: BirenDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[BirenDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[BirenDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[BirenDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/cambricon/device.go
+++ b/pkg/device/cambricon/device.go
@@ -400,12 +400,18 @@ func (cam *CambriconDevices) Fit(devices []*device.DeviceUsage, request device.C
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, numa := cam.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/cambricon/device_cordon_test.go
+++ b/pkg/device/cambricon/device_cordon_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cambricon
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitMLUDevice(CambriconConfig{
+		ResourceCountName:  "cambricon.com/mlu",
+		ResourceMemoryName: "cambricon.com/mlu.smlu.vmemory",
+		ResourceCoreName:   "cambricon.com/mlu.smlu.vcore",
+	})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: CambriconMLUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: CambriconMLUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: CambriconMLUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[CambriconMLUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[CambriconMLUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[CambriconMLUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -707,6 +707,34 @@ func Resourcereqs(pod *corev1.Pod) (counts PodDeviceRequests) {
 	return counts
 }
 
+// DeviceCordonAnnotation is a node annotation holding a comma-separated list of
+// device UUIDs to exclude from new allocations, without affecting pods already
+// running on those devices. It's a live, per-device equivalent of `kubectl
+// cordon`; unlike a device-plugin register filter it takes effect immediately
+// and needs no device-plugin restart.
+const DeviceCordonAnnotation = "hami.io/device-cordon"
+
+// CordonedDevices parses the DeviceCordonAnnotation off the node into a UUID
+// lookup set. Missing node, missing annotation, or an empty value all mean
+// "nothing cordoned". Malformed entries (stray whitespace/commas) are
+// tolerated by trimming and skipping empties, same as CheckUUID's parsing.
+func CordonedDevices(nodeInfo *NodeInfo) map[string]struct{} {
+	cordoned := make(map[string]struct{})
+	if nodeInfo == nil || nodeInfo.Node == nil {
+		return cordoned
+	}
+	raw, ok := nodeInfo.Node.Annotations[DeviceCordonAnnotation]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return cordoned
+	}
+	for uuid := range strings.SplitSeq(raw, ",") {
+		if uuid = strings.TrimSpace(uuid); uuid != "" {
+			cordoned[uuid] = struct{}{}
+		}
+	}
+	return cordoned
+}
+
 func CheckUUID(annos map[string]string, id, useKey, noUseKey, deviceType string) bool {
 	match := func(list string) bool {
 		return slices.ContainsFunc(strings.Split(list, ","), func(u string) bool {

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1714,6 +1714,64 @@ func TestCheckUUID(t *testing.T) {
 	}
 }
 
+func TestCordonedDevices(t *testing.T) {
+	nodeWithAnnos := func(annos map[string]string) *NodeInfo {
+		return &NodeInfo{Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: annos}}}
+	}
+	tests := []struct {
+		name     string
+		nodeInfo *NodeInfo
+		want     []string
+	}{
+		{
+			name:     "nil NodeInfo means nothing cordoned",
+			nodeInfo: nil,
+			want:     nil,
+		},
+		{
+			name:     "nil Node means nothing cordoned",
+			nodeInfo: &NodeInfo{},
+			want:     nil,
+		},
+		{
+			name:     "annotation absent means nothing cordoned",
+			nodeInfo: nodeWithAnnos(map[string]string{}),
+			want:     nil,
+		},
+		{
+			name:     "empty annotation means nothing cordoned",
+			nodeInfo: nodeWithAnnos(map[string]string{DeviceCordonAnnotation: ""}),
+			want:     nil,
+		},
+		{
+			name:     "whitespace-only annotation means nothing cordoned",
+			nodeInfo: nodeWithAnnos(map[string]string{DeviceCordonAnnotation: "   "}),
+			want:     nil,
+		},
+		{
+			name:     "single uuid",
+			nodeInfo: nodeWithAnnos(map[string]string{DeviceCordonAnnotation: "dev-0"}),
+			want:     []string{"dev-0"},
+		},
+		{
+			name:     "several uuids with stray whitespace and empty entries",
+			nodeInfo: nodeWithAnnos(map[string]string{DeviceCordonAnnotation: " dev-0 ,, dev-1,"}),
+			want:     []string{"dev-0", "dev-1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := CordonedDevices(test.nodeInfo)
+			assert.Equal(t, len(test.want), len(got))
+			for _, uuid := range test.want {
+				_, ok := got[uuid]
+				assert.Equal(t, true, ok)
+			}
+		})
+	}
+}
+
 func TestCheckType(t *testing.T) {
 	useKey := "example.com/use-gputype"
 	noUseKey := "example.com/nouse-gputype"

--- a/pkg/device/enflame/device.go
+++ b/pkg/device/enflame/device.go
@@ -409,12 +409,18 @@ func (enf *EnflameDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	}
 	profileMemoryMiB := int32(profile.MemoryGB * 1024)
 	profileCorePercent := int32(profile.CorePercent)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, _ := enf.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/enflame/device_cordon_test.go
+++ b/pkg/device/enflame/device_cordon_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enflame
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func cordonNode(uuids string) *device.NodeInfo {
+	return &device.NodeInfo{Node: &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+	}}
+}
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitEnflameDevice(EnflameConfig{ResourceNameDRSGCU: "enflame.com/drs-gcu"})
+
+	newDevices := func() []*device.DeviceUsage {
+		profiles := map[string]string{"1g.6gb": "0", "3g.20gb": "1", "6g.40gb": "2"}
+		return []*device.DeviceUsage{
+			{
+				ID: "drs-0", Index: 0, Count: 6, Totalmem: 40960, Type: EnflameVGCUDevice, Health: true,
+				CustomInfo: map[string]any{"minor": "0", "index": "0", "profiles": profiles},
+			},
+			{
+				ID: "drs-1", Index: 1, Count: 6, Totalmem: 40960, Type: EnflameVGCUDevice, Health: true,
+				CustomInfo: map[string]any{"minor": "1", "index": "1", "profiles": profiles},
+			},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: EnflameVGCUDevice, Memreq: 3}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, cordonNode("drs-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[EnflameVGCUDevice][0].UUID; got != "drs-0" {
+			t.Errorf("expected drs-0 (drs-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, cordonNode("drs-0,drs-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      cordonNode(""),
+			"annotation whitespace": cordonNode("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[EnflameVGCUDevice][0].UUID; got != "drs-1" {
+				t.Errorf("%s: expected drs-1, got %s", name, got)
+			}
+		}
+	})
+}
+
+func TestGCUFit_DeviceCordon(t *testing.T) {
+	dev := InitGCUDevice(EnflameConfig{ResourceNameGCU: "enflame.com/gcu"})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 1, Totalmem: 100, Totalcore: 100, Type: EnflameGCUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 1, Totalmem: 100, Totalcore: 100, Type: EnflameGCUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 100, MemPercentagereq: 100, Coresreq: 100, Type: EnflameGCUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, cordonNode("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[EnflameGCUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, cordonNode("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      cordonNode(""),
+			"annotation whitespace": cordonNode("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[EnflameGCUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/enflame/gcu.go
+++ b/pkg/device/enflame/gcu.go
@@ -147,12 +147,18 @@ func (gcuDev *GCUDevices) Fit(devices []*device.DeviceUsage, request device.Cont
 	klog.InfoS("Allocating device for container request", "pod", klog.KObj(pod), "card request", k)
 	tmpDevs := make(map[string]device.ContainerDevices)
 	reason := make(map[string]int)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		if !gcuDev.checkType(k) {

--- a/pkg/device/hygon/device.go
+++ b/pkg/device/hygon/device.go
@@ -258,12 +258,18 @@ func (dcu *DCUDevices) Fit(devices []*device.DeviceUsage, request device.Contain
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, numa := dcu.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/hygon/device_cordon_test.go
+++ b/pkg/device/hygon/device_cordon_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hygon
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitDCUDevice(HygonConfig{
+		ResourceCountName:  "hygon.com/dcunum",
+		ResourceMemoryName: "hygon.com/dcumem",
+		ResourceCoreName:   "hygon.com/dcucores",
+	})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: HygonDCUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: HygonDCUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: HygonDCUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[HygonDCUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[HygonDCUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[HygonDCUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/iluvatar/device.go
+++ b/pkg/device/iluvatar/device.go
@@ -269,12 +269,18 @@ func (ilu *IluvatarDevices) Fit(devices []*device.DeviceUsage, request device.Co
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, numa := ilu.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/iluvatar/device_cordon_test.go
+++ b/pkg/device/iluvatar/device_cordon_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iluvatar
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	const chip = "MR-V100"
+	dev := IluvatarDevices{
+		config: IluvatarConfig{
+			CommonWord:         chip,
+			ChipName:           chip,
+			ResourceCountName:  "iluvatar.ai/MR-V100-vgpu",
+			ResourceMemoryName: "iluvatar.ai/MR-V100.vMem",
+			ResourceCoreName:   "iluvatar.ai/MR-V100.vCore",
+		},
+	}
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: chip, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: chip, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: chip}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[chip][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[chip][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[chip][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/kunlun/device.go
+++ b/pkg/device/kunlun/device.go
@@ -190,10 +190,17 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 	reason := make(map[string]int)
 
 	// graghSelect decides topology from the position of a device in the slice,
-	// so the uuid constraint has to be applied through fitFn rather than by
-	// filtering the slice first.
+	// so the uuid and cordon constraints have to be applied through fitFn rather
+	// than by filtering the slice first.
+	cordoned := device.CordonedDevices(nodeInfo)
+	cordonedHits := make(map[string]bool)
 	uuidMismatches := make(map[string]bool)
 	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
+		if _, isCordoned := cordoned[d.ID]; isCordoned {
+			cordonedHits[d.ID] = true
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", d.ID)
+			return false
+		}
 		if !device.CheckUUID(pod.GetAnnotations(), d.ID, UseUUIDAnno, NoUseUUIDAnno, kl.CommonWord()) ||
 			!device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, kl.CommonWord()) {
 			uuidMismatches[d.ID] = true
@@ -205,10 +212,13 @@ func (kl *KunlunDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 
 	alloc := graghSelect(devices, request, fitFn)
 	if len(alloc) == 0 {
+		if cordonedCount := len(cordonedHits); cordonedCount > 0 {
+			reason[common.CardCordoned] += cordonedCount
+		}
 		uuidMismatch := len(uuidMismatches)
 		if uuidMismatch > 0 {
 			reason[common.CardUUIDMismatch] += uuidMismatch
-		} else {
+		} else if len(reason) == 0 {
 			reason[common.NumaNotFit]++
 			klog.V(5).InfoS(common.NumaNotFit, "pod", klog.KObj(pod), "device", devices, "request nums", request.Nums, "numa")
 		}

--- a/pkg/device/kunlun/device_cordon_test.go
+++ b/pkg/device/kunlun/device_cordon_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kunlun
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func cordonNode(uuids string) *device.NodeInfo {
+	return &device.NodeInfo{Node: &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+	}}
+}
+
+// newXPUs builds the 8-card topology graghSelect reads by slice position, so a
+// cordoned card must be rejected in place rather than filtered out of the slice.
+func newXPUs(count int32) []*device.DeviceUsage {
+	devices := make([]*device.DeviceUsage, 8)
+	for i := range devices {
+		devices[i] = &device.DeviceUsage{
+			Index:     uint(i),
+			ID:        fmt.Sprintf("xpu-%d", i),
+			Count:     count,
+			Totalmem:  KunlunMaxMemory,
+			Totalcore: 100,
+			Health:    true,
+		}
+	}
+	return devices
+}
+
+func allXPUs() string {
+	all := ""
+	for i := range 8 {
+		if i > 0 {
+			all += ","
+		}
+		all += fmt.Sprintf("xpu-%d", i)
+	}
+	return all
+}
+
+func TestKunlunDevices_Fit_DeviceCordon(t *testing.T) {
+	dev := &KunlunDevices{}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: KunlunGPUDevice}
+	pod := &corev1.Pod{}
+
+	t.Run("a cordoned card is not allocated, positions are preserved", func(t *testing.T) {
+		// Take whatever the uncordoned topology picks, then cordon exactly that
+		// card: the fit must survive and land somewhere else.
+		fit, result, reason := dev.Fit(newXPUs(1), request, pod, &device.NodeInfo{}, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit with nothing cordoned, got reason: %s", reason)
+		}
+		picked := result[KunlunGPUDevice][0].UUID
+
+		fit, result, reason = dev.Fit(newXPUs(1), request, pod, cordonNode(picked+", "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto another card, got reason: %s", reason)
+		}
+		if got := result[KunlunGPUDevice][0].UUID; got == picked {
+			t.Errorf("expected a card other than the cordoned %s, got %s", picked, got)
+		}
+	})
+
+	t.Run("all cards cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newXPUs(1), request, pod, cordonNode(allXPUs()), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all cards are cordoned")
+		}
+		if want := "8/8 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      cordonNode(""),
+			"annotation whitespace": cordonNode("   "),
+		} {
+			fit, _, reason := dev.Fit(newXPUs(1), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+		}
+	})
+}
+
+func TestKunlunVDevices_Fit_DeviceCordon(t *testing.T) {
+	dev := &KunlunVDevices{}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: XPUDevice, Memreq: KunlunMaxMemory}
+	pod := &corev1.Pod{}
+
+	t.Run("a cordoned card is not allocated, positions are preserved", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newXPUs(10), request, pod, &device.NodeInfo{}, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit with nothing cordoned, got reason: %s", reason)
+		}
+		picked := result[XPUDevice][0].UUID
+
+		fit, result, reason = dev.Fit(newXPUs(10), request, pod, cordonNode(picked+", "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto another card, got reason: %s", reason)
+		}
+		if got := result[XPUDevice][0].UUID; got == picked {
+			t.Errorf("expected a card other than the cordoned %s, got %s", picked, got)
+		}
+	})
+
+	t.Run("all cards cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newXPUs(10), request, pod, cordonNode(allXPUs()), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all cards are cordoned")
+		}
+		if want := "8/8 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("a cordoned card is not double-counted under the mutex policy", func(t *testing.T) {
+		// Every card is in use, so without the cordon each would be reported as
+		// an ExclusiveDeviceAllocateConflict. Cordoned cards must be reported
+		// only as CardCordoned.
+		devices := newXPUs(10)
+		for _, d := range devices {
+			d.Used = 1
+		}
+		mutexPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"hami.io/gpu-scheduler-policy": "mutex"},
+		}}
+		fit, _, reason := dev.Fit(devices, request, mutexPod, cordonNode(allXPUs()), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all cards are cordoned and in use")
+		}
+		if want := "8/8 " + common.CardCordoned; reason != want {
+			t.Errorf("expected only the cordon reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      cordonNode(""),
+			"annotation whitespace": cordonNode("   "),
+		} {
+			fit, _, reason := dev.Fit(newXPUs(10), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+		}
+	})
+}

--- a/pkg/device/kunlun/vdevice.go
+++ b/pkg/device/kunlun/vdevice.go
@@ -228,10 +228,17 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		}
 	}
 	// graghSelect decides topology from the position of a device in the slice,
-	// so the uuid constraint has to be applied through fitFn rather than by
-	// filtering the slice first.
+	// so the uuid and cordon constraints have to be applied through fitFn rather
+	// than by filtering the slice first.
+	cordoned := device.CordonedDevices(nodeInfo)
+	cordonedHits := make(map[string]bool)
 	uuidMismatches := make(map[string]bool)
 	fitFn := func(d *device.DeviceUsage, r device.ContainerDeviceRequest) bool {
+		if _, isCordoned := cordoned[d.ID]; isCordoned {
+			cordonedHits[d.ID] = true
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", d.ID)
+			return false
+		}
 		if !device.CheckUUID(pod.GetAnnotations(), d.ID, UseUUIDAnno, NoUseUUIDAnno, dev.CommonWord()) ||
 			!device.CheckUUID(pod.GetAnnotations(), d.ID, KunlunUseUUID, KunlunNoUseUUID, dev.CommonWord()) {
 			uuidMismatches[d.ID] = true
@@ -242,8 +249,15 @@ func (dev *KunlunVDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	}
 	alloc := graghSelect(devices, request, fitFn)
 	if len(alloc) == 0 {
+		if cordonedCount := len(cordonedHits); cordonedCount > 0 {
+			reason[common.CardCordoned] += cordonedCount
+		}
 		if isMutex {
 			for _, dev := range devices {
+				// A cordoned device is already reported as such; don't count it twice.
+				if _, isCordoned := cordoned[dev.ID]; isCordoned {
+					continue
+				}
 				if dev.Used > 0 && FitVXPU(dev, request) {
 					reason[common.ExclusiveDeviceAllocateConflict]++
 					klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "used", dev.Used)

--- a/pkg/device/metax/device.go
+++ b/pkg/device/metax/device.go
@@ -226,12 +226,18 @@ func (mat *MetaxDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, numa := mat.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/metax/device_cordon_test.go
+++ b/pkg/device/metax/device_cordon_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metax
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func nodeWithCordon(uuids string) *device.NodeInfo {
+	return &device.NodeInfo{Node: &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+	}}
+}
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitMetaxDevice(MetaxConfig{ResourceCountName: "metax-tech.com/gpu"})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: MetaxGPUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: MetaxGPUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: MetaxGPUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[MetaxGPUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[MetaxGPUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[MetaxGPUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}
+
+func TestSDeviceFit_DeviceCordon(t *testing.T) {
+	dev := InitMetaxSDevice(MetaxConfig{
+		ResourceVCountName:  "metax-tech.com/sgpu",
+		ResourceVCoreName:   "metax-tech.com/vcore",
+		ResourceVMemoryName: "metax-tech.com/vmemory",
+	})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: MetaxSGPUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: MetaxSGPUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: MetaxSGPUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[MetaxSGPUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[MetaxSGPUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/metax/sdevice.go
+++ b/pkg/device/metax/sdevice.go
@@ -323,6 +323,7 @@ func (mats *MetaxSDevices) Fit(devices []*device.DeviceUsage, request device.Con
 	// filter device
 	reason := make(map[string]int)
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	candidateDevices := []*device.DeviceUsage{}
 	for i, v := range slices.Backward(devices) {
 		dev := v
@@ -336,6 +337,12 @@ func (mats *MetaxSDevices) Fit(devices []*device.DeviceUsage, request device.Con
 		if !dev.Health {
 			reason[CardUnhealthy]++
 			klog.V(5).InfoS(CardUnhealthy, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 

--- a/pkg/device/mthreads/device.go
+++ b/pkg/device/mthreads/device.go
@@ -301,12 +301,18 @@ func (mth *MthreadsDevices) Fit(devices []*device.DeviceUsage, request device.Co
 		return false, tmpDevs, "core limit out of range"
 	}
 	isMutex := util.PolicyContains(util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod), util.GPUSchedulerPolicyMutex)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, v := range slices.Backward(devices) {
 		dev := v
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		klog.V(3).InfoS("Type check", "device", dev.Type, "req", k.Type)

--- a/pkg/device/mthreads/device_cordon_test.go
+++ b/pkg/device/mthreads/device_cordon_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mthreads
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitMthreadsDevice(MthreadsConfig{
+		ResourceCountName:  "mthreads.com/vgpu",
+		ResourceMemoryName: "mthreads.com/sgpu-memory",
+		ResourceCoreName:   "mthreads.com/sgpu-core",
+	})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 100, Totalmem: 128, Totalcore: 100, Type: MthreadsGPUDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 100, Totalmem: 128, Totalcore: 100, Type: MthreadsGPUDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Memreq: 64, Coresreq: 50, Type: MthreadsGPUDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[MthreadsGPUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		devices[1].Usedcores = 50
+		devices[1].Usedmem = 64
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[MthreadsGPUDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[MthreadsGPUDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -51,12 +51,10 @@ const (
 	// GPUNoUseUUID annotation specifies a comma-separated list of GPU UUIDs to exclude.
 	GPUNoUseUUID = "nvidia.com/nouse-gpuuuid"
 	AllocateMode = "nvidia.com/vgpu-mode"
-	// DeviceCordonAnnotation is a node annotation holding a comma-separated list of
-	// GPU UUIDs to exclude from new allocations, without affecting pods already
-	// running on those devices. It's a live, per-GPU equivalent of `kubectl cordon`;
-	// unlike FilterDeviceToRegister, it takes effect immediately and needs no
-	// device-plugin restart.
-	DeviceCordonAnnotation = "hami.io/device-cordon"
+	// DeviceCordonAnnotation is an alias of the shared device.DeviceCordonAnnotation,
+	// which every backend honors. Kept so existing NVIDIA-scoped references keep
+	// resolving.
+	DeviceCordonAnnotation = device.DeviceCordonAnnotation
 
 	MigMode      = "mig"
 	HamiCoreMode = "hami-core"
@@ -704,27 +702,6 @@ func fitQuota(pod *corev1.Pod, tmpDevs map[string]device.ContainerDevices, alloc
 	return device.GetLocalCache().FitQuota(ns, mem, MemoryFactor, core, NvidiaGPUDevice)
 }
 
-// cordonedDevices parses the DeviceCordonAnnotation off the node into a UUID
-// lookup set. Missing node, missing annotation, or an empty value all mean
-// "nothing cordoned". Malformed entries (stray whitespace/commas) are
-// tolerated by trimming and skipping empties, same as CheckUUID's parsing.
-func cordonedDevices(nodeInfo *device.NodeInfo) map[string]struct{} {
-	cordoned := make(map[string]struct{})
-	if nodeInfo == nil || nodeInfo.Node == nil {
-		return cordoned
-	}
-	raw, ok := nodeInfo.Node.Annotations[DeviceCordonAnnotation]
-	if !ok || strings.TrimSpace(raw) == "" {
-		return cordoned
-	}
-	for uuid := range strings.SplitSeq(raw, ",") {
-		if uuid = strings.TrimSpace(uuid); uuid != "" {
-			cordoned[uuid] = struct{}{}
-		}
-	}
-	return cordoned
-}
-
 func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
@@ -736,7 +713,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 	gpuPolicy := util.GetGPUSchedulerPolicyByPod(device.GPUSchedulerPolicy, pod)
 	needTopology := util.PolicyContains(gpuPolicy, util.GPUSchedulerPolicyTopology)
 	isMutex := util.PolicyContains(gpuPolicy, util.GPUSchedulerPolicyMutex)
-	cordoned := cordonedDevices(nodeInfo)
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i := len(devices) - 1; i >= 0; i-- {
 		dev := devices[i]
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)

--- a/pkg/device/vastai/device.go
+++ b/pkg/device/vastai/device.go
@@ -238,11 +238,17 @@ func (va *VastaiDevices) Fit(devices []*device.DeviceUsage, request device.Conta
 			}
 		}
 	}
+	cordoned := device.CordonedDevices(nodeInfo)
 	for i, dev := range slices.Backward(devices) {
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
 		if !dev.Health {
 			reason[common.CardNotHealth]++
 			klog.V(5).InfoS(common.CardNotHealth, "pod", klog.KObj(pod), "device", dev.ID, "health", dev.Health)
+			continue
+		}
+		if _, isCordoned := cordoned[dev.ID]; isCordoned {
+			reason[common.CardCordoned]++
+			klog.V(5).InfoS(common.CardCordoned, "pod", klog.KObj(pod), "device", dev.ID)
 			continue
 		}
 		_, found, _ := va.checkType(pod.GetAnnotations(), *dev, k)

--- a/pkg/device/vastai/device_cordon_test.go
+++ b/pkg/device/vastai/device_cordon_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vastai
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
+)
+
+func TestFit_DeviceCordon(t *testing.T) {
+	dev := InitVastaiDevice(VastaiConfig{ResourceCountName: "vastaitech.com/va"})
+
+	newDevices := func() []*device.DeviceUsage {
+		return []*device.DeviceUsage{
+			{ID: "dev-0", Index: 0, Count: 1, Type: VastaiDevice, Health: true},
+			{ID: "dev-1", Index: 1, Count: 1, Type: VastaiDevice, Health: true},
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: VastaiDevice}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+	nodeWithCordon := func(uuids string) *device.NodeInfo {
+		return &device.NodeInfo{Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{device.DeviceCordonAnnotation: uuids}},
+		}}
+	}
+
+	t.Run("cordoned device is skipped, healthy sibling still fits", func(t *testing.T) {
+		fit, result, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-1, "), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit, got reason: %s", reason)
+		}
+		if got := result[VastaiDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0 (dev-1 is cordoned), got %s", got)
+		}
+	})
+
+	t.Run("all devices cordoned fails with CardCordoned reason", func(t *testing.T) {
+		fit, _, reason := dev.Fit(newDevices(), request, pod, nodeWithCordon("dev-0,dev-1"), &device.PodDevices{})
+		if fit {
+			t.Fatal("expected no fit, all devices are cordoned")
+		}
+		if want := "2/2 " + common.CardCordoned; reason != want {
+			t.Errorf("expected reason %q, got %q", want, reason)
+		}
+	})
+
+	t.Run("running pods on a cordoned device are unaffected", func(t *testing.T) {
+		devices := newDevices()
+		devices[1].Used = 1
+		fit, result, reason := dev.Fit(devices, request, pod, nodeWithCordon("dev-1"), &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected fit onto the non-cordoned device, got reason: %s", reason)
+		}
+		if got := result[VastaiDevice][0].UUID; got != "dev-0" {
+			t.Errorf("expected dev-0, got %s", got)
+		}
+		if devices[1].Used != 1 {
+			t.Errorf("cordon must not touch existing usage on dev-1, got Used=%d", devices[1].Used)
+		}
+	})
+
+	t.Run("no annotation or no node info means nothing cordoned", func(t *testing.T) {
+		for name, nodeInfo := range map[string]*device.NodeInfo{
+			"empty NodeInfo":        {},
+			"node without annos":    {Node: &corev1.Node{}},
+			"annotation empty":      nodeWithCordon(""),
+			"annotation whitespace": nodeWithCordon("   "),
+		} {
+			fit, result, reason := dev.Fit(newDevices(), request, pod, nodeInfo, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("%s: expected fit, got reason: %s", name, reason)
+			}
+			if got := result[VastaiDevice][0].UUID; got != "dev-1" {
+				t.Errorf("%s: expected dev-1, got %s", name, got)
+			}
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Adds `pkg/scheduler/score_bench_test.go` with benchmarks for the scheduler scoring path:

* `BenchmarkCalcScore` — benchmarks `calcScoreWithOptions` with 10, 100, and 1000 nodes.
* `BenchmarkScoreNode` — benchmarks `scoreNode` with 0, 1, and 4 non-sidecar init containers.
* Uses `b.ReportAllocs()` to track both execution time and allocations.

These benchmarks provide a baseline for the current scoring performance and will help evaluate future changes such as the bounded worker pool proposed in #2858.

This PR is test-only; no production code is changed.

**Which issue(s) does this PR fix?**

Fixes #2925

**Special notes for reviewers:**

* Benchmark fixtures are rebuilt for each iteration because scoring mutates `NodeUsage`.
* `klog` output is redirected to `io.Discard` so logging does not affect benchmark results.
* Real NVIDIA device scoring is used instead of `fitMockDevice` to benchmark the actual `Fit` path.
* A separate `newBenchmarkNodes` helper is used because the benchmarks require configurable node/GPU counts.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

**AI assistance disclosure:**

AI was used to assist with the implementation and review of the benchmark code and PR description. The final changes were reviewed and verified before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added node-level device cordoning to prevent new workloads from using selected devices while preserving running workloads.
  * Device scheduling now consistently skips cordoned devices across supported accelerator types and reports clear allocation reasons.
  * Improved device selection with UUID constraints and topology-aware handling.

* **Bug Fixes**
  * Added validation for invalid device counts, memory values, and core percentages.
  * Prevented unsupported or out-of-range requests from being silently adjusted.
  * Improved resource request handling and device allocation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->