### PR TITLE
build(deps): bump github/codeql-action from 4.37.8 to 4.37.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily" 
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -65,4 +65,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
Make dependabot happy.

**Which issue(s) this PR fixes**:
This PR fixes the error in #2920 and #2921 which both init and analyze should be updated to same commit in one PR

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**AI Assistance Disclosure**:
The fixed code was created by myself and the changes to `.github/dependabot.yaml` was generated by Codex. I have check the doc of GitHub and I think it should fix the error in previoues PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated automated security scanning to use a newer CodeQL action version while remaining on the v4 release track.
- Improved maintenance of security-scanning updates by grouping related updates for coordinated review.
- No changes were made to the product’s user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->