### PR TITLE
sync InitDefaultDevices with the chart device config

### DIFF
--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -295,8 +295,13 @@ func InitDevices() {
 	}
 }
 
-func InitDefaultDevices() {
-	configMapdata := `
+// defaultDeviceConfig mirrors the device configuration the Helm chart renders
+// in charts/hami/templates/scheduler/device-configmap.yaml when no
+// device-config.content override is supplied, with the chart's default values
+// substituted. InitDefaultDevices parses it, so tests exercise the same device
+// topology a default install produces rather than a smaller hand-written one.
+// TestDefaultDeviceConfigCoversChartVendors guards the two against drifting apart.
+const defaultDeviceConfig = `
 nvidia:
   resourceCountName: "nvidia.com/gpu"
   resourceMemoryName: "nvidia.com/gpumem"
@@ -307,6 +312,34 @@ nvidia:
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
+  preConfiguredDeviceMemory: 0
+  memoryFactor: 1
+  deviceSplitCount: 10
+  deviceMemoryScaling: 1
+  deviceCoreScaling: 1
+  enableNumaTopology: false
+  gpuCorePolicy: default
+  libCudaLogLevel: 1
+  runtimeClassName: ""
+  migProfileAllowlist:
+  - models: [ "A30" ]
+    profiles: [ "1g.6gb", "2g.12gb", "4g.24gb" ]
+  - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB"]
+    profiles: [ "1g.5gb", "2g.10gb", "3g.20gb", "7g.40gb" ]
+  - models: [ "A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"]
+    profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "7g.79gb" ]
+  - models: [ "H100-PCIE-80GB", "H100-SXM5-80GB"]
+    profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "7g.80gb" ]
+  - models: [ "H100-PCIE-94GB", "H100-SXM5-94GB"]
+    profiles: [ "1g.12gb", "2g.24gb", "3g.47gb", "7g.94gb" ]
+  - models: [ "H20", "H100 on GH200"]
+    profiles: [ "1g.12gb", "2g.24gb", "3g.48gb", "7g.96gb" ]
+  - models: [ "H200 NVL", "H200-SXM5"]
+    profiles: [ "1g.18gb", "2g.35gb", "3g.71gb", "7g.141gb" ]
+  - models: [ "B200" ]
+    profiles: [ "1g.23gb", "2g.45gb", "3g.90gb", "7g.180gb" ]
+  - models: [ "RTX PRO 6000 Blackwell Server Edition" ]
+    profiles: [ "1g.24gb", "2g.48gb", "4g.96gb" ]
 cambricon:
   resourceCountName: "cambricon.com/vmlu"
   resourceMemoryName: "cambricon.com/mlu.smlu.vmemory"
@@ -315,8 +348,18 @@ hygon:
   resourceCountName: "hygon.com/dcunum"
   resourceMemoryName: "hygon.com/dcumem"
   resourceCoreName: "hygon.com/dcucores"
+  memoryFactor: 1
 metax:
   resourceCountName: "metax-tech.com/gpu"
+  resourceVCountName: "metax-tech.com/sgpu"
+  resourceVMemoryName: "metax-tech.com/vmemory"
+  resourceVCoreName: "metax-tech.com/vcore"
+  sgpuTopologyAware: false
+enflame:
+  resourceNameGCU: "enflame.com/gcu"
+  resourceNameDRSGCU: "enflame.com/drs-gcu"
+  resourceNameGCUMemory: "enflame.com/gcu-memory"
+  resourceNameGCUCore: "enflame.com/gcu-core"
 mthreads:
   resourceCountName: "mthreads.com/vgpu"
   resourceMemoryName: "mthreads.com/sgpu-memory"
@@ -351,6 +394,12 @@ awsneuron:
   resourceCoreName: "aws.amazon.com/neuroncore"
 amd:
   resourceCountName: "amd.com/gpu"
+  resourceCoreName: "amd.com/gpucores"
+  resourceMemoryName: "amd.com/gpumem"
+vastai:
+  resourceCountName: "vastaitech.com/va"
+biren:
+  resourceCountName: "birentech.com/gpu"
 vnpus:
   hamiVnpuCore: false
   configs:
@@ -358,9 +407,13 @@ vnpus:
     commonWord: "Ascend910A"
     resourceName: "huawei.com/Ascend910A"
     resourceMemoryName: "huawei.com/Ascend910A-memory"
+    resourceCoreName: "huawei.com/Ascend910A-core"
     memoryAllocatable: 32768
     memoryCapacity: 32768
+    memoryFactor: 1
     aiCore: 30
+    runtimeClassName: ""
+    overwriteEnv: false
     templates:
       - name: "vir02"
         memory: 2184
@@ -378,10 +431,14 @@ vnpus:
     commonWord: Ascend910B2
     resourceName: huawei.com/Ascend910B2
     resourceMemoryName: huawei.com/Ascend910B2-memory
+    resourceCoreName: huawei.com/Ascend910B2-core
     memoryAllocatable: 65536
     memoryCapacity: 65536
+    memoryFactor: 1
     aiCore: 24
     aiCPU: 6
+    runtimeClassName: ""
+    overwriteEnv: false
     templates:
       - name: vir03_1c_8g
         memory: 8192
@@ -399,10 +456,14 @@ vnpus:
     commonWord: "Ascend910B3"
     resourceName: "huawei.com/Ascend910B3"
     resourceMemoryName: "huawei.com/Ascend910B3-memory"
+    resourceCoreName: "huawei.com/Ascend910B3-core"
     memoryAllocatable: 65536
     memoryCapacity: 65536
+    memoryFactor: 1
     aiCore: 20
     aiCPU: 7
+    runtimeClassName: ""
+    overwriteEnv: false
     templates:
       - name: "vir05_1c_16g"
         memory: 16384
@@ -412,14 +473,39 @@ vnpus:
         memory: 32768
         aiCore: 10
         aiCPU: 3
+  - chipName: 910B4-1
+    commonWord: Ascend910B4-1
+    resourceName: huawei.com/Ascend910B4-1
+    resourceMemoryName: huawei.com/Ascend910B4-1-memory
+    resourceCoreName: huawei.com/Ascend910B4-1-core
+    memoryAllocatable: 65536
+    memoryCapacity: 65536
+    memoryFactor: 1
+    aiCore: 20
+    aiCPU: 7
+    runtimeClassName: ""
+    overwriteEnv: false
+    templates:
+      - name: vir05_1c_16g
+        memory: 16384
+        aiCore: 5
+        aiCPU: 1
+      - name: vir10_3c_32g
+        memory: 32768
+        aiCore: 10
+        aiCPU: 3
   - chipName: 910B4
     commonWord: Ascend910B4
     resourceName: huawei.com/Ascend910B4
     resourceMemoryName: huawei.com/Ascend910B4-memory
+    resourceCoreName: huawei.com/Ascend910B4-core
     memoryAllocatable: 32768
     memoryCapacity: 32768
+    memoryFactor: 1
     aiCore: 20
     aiCPU: 7
+    runtimeClassName: ""
+    overwriteEnv: false
     templates:
       - name: vir05_1c_8g
         memory: 8192
@@ -433,10 +519,14 @@ vnpus:
     commonWord: "Ascend310P"
     resourceName: "huawei.com/Ascend310P"
     resourceMemoryName: "huawei.com/Ascend310P-memory"
+    resourceCoreName: "huawei.com/Ascend310P-core"
     memoryAllocatable: 21527
     memoryCapacity: 24576
+    memoryFactor: 1
     aiCore: 8
     aiCPU: 7
+    runtimeClassName: ""
+    overwriteEnv: false
     templates:
       - name: "vir01"
         memory: 3072
@@ -449,10 +539,32 @@ vnpus:
       - name: "vir04"
         memory: 12288
         aiCore: 4
-        aiCPU: 4`
+        aiCPU: 4
+  - chipName: Ascend910
+    commonWord: Ascend910C
+    resourceName: huawei.com/Ascend910C
+    resourceMemoryName: huawei.com/Ascend910C-memory
+    resourceCoreName: huawei.com/Ascend910C-core
+    memoryAllocatable: 65536
+    memoryCapacity: 65536
+    aiCore: 20
+    aiCPU: 7
+    runtimeClassName: ""
+    overwriteEnv: false
+    superPod: true
+    templates:
+      - name: vir05_1c_16g
+        memory: 16384
+        aiCore: 5
+        aiCPU: 1
+      - name: vir10_3c_32g
+        memory: 32768
+        aiCore: 10
+        aiCPU: 3`
 
+func InitDefaultDevices() {
 	var yamlData Config
-	err := yaml.Unmarshal([]byte(configMapdata), &yamlData)
+	err := yaml.Unmarshal([]byte(defaultDeviceConfig), &yamlData)
 	if err != nil {
 		klog.Fatalf("Failed to unmarshal default config: %v", err)
 		return

--- a/pkg/scheduler/config/device_config_drift_test.go
+++ b/pkg/scheduler/config/device_config_drift_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -26,122 +27,145 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// chartDeviceConfigPath is the chart template whose fallback branch renders the
-// device config a default `helm install` ships.
-const chartDeviceConfigPath = "../../../charts/hami/templates/scheduler/device-configmap.yaml"
+const (
+	// chartDeviceConfigPath is the chart template whose fallback branch renders
+	// the device config a default `helm install` ships.
+	chartDeviceConfigPath = "../../../charts/hami/templates/scheduler/device-configmap.yaml"
+	// chartValuesPath supplies the values substituted into that fallback branch.
+	chartValuesPath = "../../../charts/hami/values.yaml"
+	// chartFallbackIndent is the indentation the fallback branch carries because
+	// it is nested under the ConfigMap's data key. It is stripped to recover the
+	// device config as the scheduler receives it.
+	chartFallbackIndent = "    "
+)
 
-// chartVendorKey matches a top-level vendor section of the rendered device
-// config. Sections sit at exactly four spaces of indentation inside the
-// template's data block; their nested fields and list items are indented
-// further or start with "-", so neither is picked up.
-var chartVendorKey = regexp.MustCompile(`^ {4}([A-Za-z][A-Za-z0-9]*):`)
+var (
+	// chartFallbackStart and chartFallbackEnd delimit the `{{- else }}` branch,
+	// the one used when a chart user supplies no device-config.content override.
+	chartFallbackStart = "{{- else }}"
+	chartFallbackEnd   = "{{ end }}"
 
-// chartFallbackVendors returns the vendor sections of the chart's built-in
-// device config, that is the `{{- else }}` branch used when a chart user
-// supplies no device-config.content override.
-func chartFallbackVendors(t *testing.T) []string {
+	// chartValueRef matches the only template construct the fallback branch
+	// uses: a .Values lookup with an optional `| default <literal>` fallback.
+	// The branch has no conditionals or loops, which is what makes rendering it
+	// here a substitution rather than a reimplementation of Helm.
+	chartValueRef = regexp.MustCompile(`\{\{\s*\.Values\.([A-Za-z0-9_.]+)\s*(?:\|\s*default\s+(\S+?)\s*)?\}\}`)
+)
+
+// chartValues loads the chart's default values, the ones a user gets when they
+// override nothing.
+func chartValues(t *testing.T) map[any]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(chartValuesPath)
+	assert.NilError(t, err, "read chart values")
+
+	values := map[any]any{}
+	assert.NilError(t, yaml.Unmarshal(raw, &values), "unmarshal chart values")
+	return values
+}
+
+// lookupChartValue resolves a dotted .Values path against the chart's values.
+func lookupChartValue(values map[any]any, path string) (any, bool) {
+	var current any = values
+	for segment := range strings.SplitSeq(path, ".") {
+		node, ok := current.(map[any]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = node[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// renderChartFallback returns the device config the chart produces by default:
+// the `{{- else }}` branch with its .Values references substituted and its
+// ConfigMap indentation removed.
+func renderChartFallback(t *testing.T) string {
 	t.Helper()
 
 	raw, err := os.ReadFile(chartDeviceConfigPath)
 	assert.NilError(t, err, "read chart device config template")
+	values := chartValues(t)
 
-	var vendors []string
+	var rendered []string
 	inFallback := false
 	for line := range strings.SplitSeq(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
-		switch {
-		case trimmed == "{{- else }}":
-			inFallback = true
+		if !inFallback {
+			inFallback = trimmed == chartFallbackStart
 			continue
-		case inFallback && trimmed == "{{ end }}":
+		}
+		if trimmed == chartFallbackEnd {
 			inFallback = false
 			continue
 		}
-		if !inFallback || strings.HasPrefix(trimmed, "{{") {
-			continue
-		}
-		if m := chartVendorKey.FindStringSubmatch(line); m != nil {
-			vendors = append(vendors, m[1])
-		}
+
+		var missing []string
+		line = chartValueRef.ReplaceAllStringFunc(line, func(ref string) string {
+			groups := chartValueRef.FindStringSubmatch(ref)
+			path, fallback := groups[1], groups[2]
+			value, ok := lookupChartValue(values, path)
+			if !ok {
+				if fallback == "" {
+					missing = append(missing, path)
+					return ref
+				}
+				return strings.Trim(fallback, `"`)
+			}
+			return fmt.Sprintf("%v", value)
+		})
+		assert.Assert(t, len(missing) == 0, "chart references .Values.%s, which %s does not define", strings.Join(missing, ", .Values."), chartValuesPath)
+
+		rendered = append(rendered, strings.TrimPrefix(line, chartFallbackIndent))
 	}
 
-	assert.Assert(t, len(vendors) > 0, "found no vendor sections in %s; the template layout changed and this guard needs updating", chartDeviceConfigPath)
-	return vendors
+	out := strings.Join(rendered, "\n")
+	assert.Assert(t, strings.Contains(out, "nvidia:"), "found no device config in %s; the template layout changed and this guard needs updating", chartDeviceConfigPath)
+	return out
+}
+
+// vendorSections returns the top-level vendor keys of a device config document.
+func vendorSections(t *testing.T, document string) []string {
+	t.Helper()
+
+	parsed := yaml.MapSlice{}
+	assert.NilError(t, yaml.Unmarshal([]byte(document), &parsed), "unmarshal device config")
+
+	sections := make([]string, 0, len(parsed))
+	for _, item := range parsed {
+		sections = append(sections, fmt.Sprintf("%v", item.Key))
+	}
+	return sections
 }
 
 // TestDefaultDeviceConfigCoversChartVendors fails when a vendor is added to the
-// chart's default device config but not to defaultDeviceConfig. The two are
-// maintained by hand, so without this guard the fixture silently stops
-// representing what a default install runs.
+// chart's default device config but not to defaultDeviceConfig. It duplicates
+// part of TestDefaultDeviceConfigMatchesChart deliberately: a whole missing
+// vendor is the most likely drift, and naming it beats reading a struct diff.
 func TestDefaultDeviceConfigCoversChartVendors(t *testing.T) {
 	fixture := map[string]any{}
 	assert.NilError(t, yaml.Unmarshal([]byte(defaultDeviceConfig), &fixture), "unmarshal defaultDeviceConfig")
 
-	for _, vendor := range chartFallbackVendors(t) {
+	for _, vendor := range vendorSections(t, renderChartFallback(t)) {
 		_, ok := fixture[vendor]
 		assert.Assert(t, ok, "vendor %q is configured in %s but missing from defaultDeviceConfig; add it so tests exercise the shipped default", vendor, chartDeviceConfigPath)
 	}
 }
 
-// TestDefaultDeviceConfigMatchesChartDefaults pins the values that a bare
-// resource-count-only fixture used to omit. Each one gates behaviour that no
-// test could otherwise reach: an unset resource name matches no container spec,
-// and SuperPod gates 910C module pair allocation.
-func TestDefaultDeviceConfigMatchesChartDefaults(t *testing.T) {
-	var cfg Config
-	assert.NilError(t, yaml.Unmarshal([]byte(defaultDeviceConfig), &cfg), "unmarshal defaultDeviceConfig")
+// TestDefaultDeviceConfigMatchesChart renders the chart's default device config
+// and requires defaultDeviceConfig to parse into exactly the same Config. It
+// compares against the chart itself rather than against literals copied out of
+// it, so a changed field value cannot pass while the fixture has drifted.
+func TestDefaultDeviceConfigMatchesChart(t *testing.T) {
+	var fromChart Config
+	assert.NilError(t, yaml.Unmarshal([]byte(renderChartFallback(t)), &fromChart), "unmarshal rendered chart device config")
 
-	t.Run("backends missing from the fixture are configured", func(t *testing.T) {
-		assert.Equal(t, cfg.EnflameConfig.ResourceNameGCU, "enflame.com/gcu")
-		assert.Equal(t, cfg.EnflameConfig.ResourceNameDRSGCU, "enflame.com/drs-gcu")
-		assert.Equal(t, cfg.EnflameConfig.ResourceNameMemory, "enflame.com/gcu-memory")
-		assert.Equal(t, cfg.EnflameConfig.ResourceNameCore, "enflame.com/gcu-core")
-		assert.Equal(t, cfg.VastaiConfig.ResourceCountName, "vastaitech.com/va")
-		assert.Equal(t, cfg.BirenConfig.ResourceCountName, "birentech.com/gpu")
-	})
+	var fromFixture Config
+	assert.NilError(t, yaml.Unmarshal([]byte(defaultDeviceConfig), &fromFixture), "unmarshal defaultDeviceConfig")
 
-	t.Run("vgpu and memory/core resource names are set", func(t *testing.T) {
-		assert.Equal(t, cfg.MetaxConfig.ResourceVCountName, "metax-tech.com/sgpu")
-		assert.Equal(t, cfg.MetaxConfig.ResourceVMemoryName, "metax-tech.com/vmemory")
-		assert.Equal(t, cfg.MetaxConfig.ResourceVCoreName, "metax-tech.com/vcore")
-		assert.Equal(t, cfg.AMDGPUConfig.ResourceMemoryName, "amd.com/gpumem")
-		assert.Equal(t, cfg.AMDGPUConfig.ResourceCoreName, "amd.com/gpucores")
-		assert.Equal(t, cfg.HygonConfig.MemoryFactor, int32(1))
-	})
-
-	t.Run("nvidia mig profile allowlist is populated", func(t *testing.T) {
-		assert.Assert(t, len(cfg.NvidiaConfig.MigProfileAllowlist) > 0,
-			"migProfileAllowlist is empty, so no MIG allowlist path is reachable from this fixture")
-	})
-
-	t.Run("ascend chips carry core resource and scaling fields", func(t *testing.T) {
-		assert.Assert(t, len(cfg.VNPUs.Configs) > 0, "no Ascend chips configured")
-		for _, chip := range cfg.VNPUs.Configs {
-			assert.Assert(t, chip.ResourceCoreName != "", "chip %q has no resourceCoreName", chip.CommonWord)
-			// 910C is the one chart chip that carries no memoryFactor.
-			if chip.CommonWord != "Ascend910C" {
-				assert.Equal(t, chip.MemoryFactor, int32(1), "chip %q memoryFactor", chip.CommonWord)
-			}
-		}
-	})
-
-	t.Run("ascend chips present in the chart are present here", func(t *testing.T) {
-		byCommonWord := map[string]int{}
-		for i, chip := range cfg.VNPUs.Configs {
-			byCommonWord[chip.CommonWord] = i
-		}
-		for _, commonWord := range []string{
-			"Ascend910A", "Ascend910B2", "Ascend910B3",
-			"Ascend910B4-1", "Ascend910B4", "Ascend310P", "Ascend910C",
-		} {
-			_, ok := byCommonWord[commonWord]
-			assert.Assert(t, ok, "chip %q is in the chart default but missing here", commonWord)
-		}
-
-		c910 := cfg.VNPUs.Configs[byCommonWord["Ascend910C"]]
-		assert.Equal(t, c910.ChipName, "Ascend910")
-		// SuperPod gates 910C module pair allocation in the ascend backend; with
-		// it unset that branch is unreachable from the default fixture.
-		assert.Assert(t, c910.SuperPod, "Ascend910C must set superPod")
-	})
+	assert.DeepEqual(t, fromChart, fromFixture)
 }

--- a/pkg/scheduler/config/device_config_drift_test.go
+++ b/pkg/scheduler/config/device_config_drift_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+	"gotest.tools/v3/assert"
+)
+
+// chartDeviceConfigPath is the chart template whose fallback branch renders the
+// device config a default `helm install` ships.
+const chartDeviceConfigPath = "../../../charts/hami/templates/scheduler/device-configmap.yaml"
+
+// chartVendorKey matches a top-level vendor section of the rendered device
+// config. Sections sit at exactly four spaces of indentation inside the
+// template's data block; their nested fields and list items are indented
+// further or start with "-", so neither is picked up.
+var chartVendorKey = regexp.MustCompile(`^ {4}([A-Za-z][A-Za-z0-9]*):`)
+
+// chartFallbackVendors returns the vendor sections of the chart's built-in
+// device config, that is the `{{- else }}` branch used when a chart user
+// supplies no device-config.content override.
+func chartFallbackVendors(t *testing.T) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(chartDeviceConfigPath)
+	assert.NilError(t, err, "read chart device config template")
+
+	var vendors []string
+	inFallback := false
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "{{- else }}":
+			inFallback = true
+			continue
+		case inFallback && trimmed == "{{ end }}":
+			inFallback = false
+			continue
+		}
+		if !inFallback || strings.HasPrefix(trimmed, "{{") {
+			continue
+		}
+		if m := chartVendorKey.FindStringSubmatch(line); m != nil {
+			vendors = append(vendors, m[1])
+		}
+	}
+
+	assert.Assert(t, len(vendors) > 0, "found no vendor sections in %s; the template layout changed and this guard needs updating", chartDeviceConfigPath)
+	return vendors
+}
+
+// TestDefaultDeviceConfigCoversChartVendors fails when a vendor is added to the
+// chart's default device config but not to defaultDeviceConfig. The two are
+// maintained by hand, so without this guard the fixture silently stops
+// representing what a default install runs.
+func TestDefaultDeviceConfigCoversChartVendors(t *testing.T) {
+	fixture := map[string]any{}
+	assert.NilError(t, yaml.Unmarshal([]byte(defaultDeviceConfig), &fixture), "unmarshal defaultDeviceConfig")
+
+	for _, vendor := range chartFallbackVendors(t) {
+		_, ok := fixture[vendor]
+		assert.Assert(t, ok, "vendor %q is configured in %s but missing from defaultDeviceConfig; add it so tests exercise the shipped default", vendor, chartDeviceConfigPath)
+	}
+}
+
+// TestDefaultDeviceConfigMatchesChartDefaults pins the values that a bare
+// resource-count-only fixture used to omit. Each one gates behaviour that no
+// test could otherwise reach: an unset resource name matches no container spec,
+// and SuperPod gates 910C module pair allocation.
+func TestDefaultDeviceConfigMatchesChartDefaults(t *testing.T) {
+	var cfg Config
+	assert.NilError(t, yaml.Unmarshal([]byte(defaultDeviceConfig), &cfg), "unmarshal defaultDeviceConfig")
+
+	t.Run("backends missing from the fixture are configured", func(t *testing.T) {
+		assert.Equal(t, cfg.EnflameConfig.ResourceNameGCU, "enflame.com/gcu")
+		assert.Equal(t, cfg.EnflameConfig.ResourceNameDRSGCU, "enflame.com/drs-gcu")
+		assert.Equal(t, cfg.EnflameConfig.ResourceNameMemory, "enflame.com/gcu-memory")
+		assert.Equal(t, cfg.EnflameConfig.ResourceNameCore, "enflame.com/gcu-core")
+		assert.Equal(t, cfg.VastaiConfig.ResourceCountName, "vastaitech.com/va")
+		assert.Equal(t, cfg.BirenConfig.ResourceCountName, "birentech.com/gpu")
+	})
+
+	t.Run("vgpu and memory/core resource names are set", func(t *testing.T) {
+		assert.Equal(t, cfg.MetaxConfig.ResourceVCountName, "metax-tech.com/sgpu")
+		assert.Equal(t, cfg.MetaxConfig.ResourceVMemoryName, "metax-tech.com/vmemory")
+		assert.Equal(t, cfg.MetaxConfig.ResourceVCoreName, "metax-tech.com/vcore")
+		assert.Equal(t, cfg.AMDGPUConfig.ResourceMemoryName, "amd.com/gpumem")
+		assert.Equal(t, cfg.AMDGPUConfig.ResourceCoreName, "amd.com/gpucores")
+		assert.Equal(t, cfg.HygonConfig.MemoryFactor, int32(1))
+	})
+
+	t.Run("nvidia mig profile allowlist is populated", func(t *testing.T) {
+		assert.Assert(t, len(cfg.NvidiaConfig.MigProfileAllowlist) > 0,
+			"migProfileAllowlist is empty, so no MIG allowlist path is reachable from this fixture")
+	})
+
+	t.Run("ascend chips carry core resource and scaling fields", func(t *testing.T) {
+		assert.Assert(t, len(cfg.VNPUs.Configs) > 0, "no Ascend chips configured")
+		for _, chip := range cfg.VNPUs.Configs {
+			assert.Assert(t, chip.ResourceCoreName != "", "chip %q has no resourceCoreName", chip.CommonWord)
+			// 910C is the one chart chip that carries no memoryFactor.
+			if chip.CommonWord != "Ascend910C" {
+				assert.Equal(t, chip.MemoryFactor, int32(1), "chip %q memoryFactor", chip.CommonWord)
+			}
+		}
+	})
+
+	t.Run("ascend chips present in the chart are present here", func(t *testing.T) {
+		byCommonWord := map[string]int{}
+		for i, chip := range cfg.VNPUs.Configs {
+			byCommonWord[chip.CommonWord] = i
+		}
+		for _, commonWord := range []string{
+			"Ascend910A", "Ascend910B2", "Ascend910B3",
+			"Ascend910B4-1", "Ascend910B4", "Ascend310P", "Ascend910C",
+		} {
+			_, ok := byCommonWord[commonWord]
+			assert.Assert(t, ok, "chip %q is in the chart default but missing here", commonWord)
+		}
+
+		c910 := cfg.VNPUs.Configs[byCommonWord["Ascend910C"]]
+		assert.Equal(t, c910.ChipName, "Ascend910")
+		// SuperPod gates 910C module pair allocation in the ascend backend; with
+		// it unset that branch is unreachable from the default fixture.
+		assert.Assert(t, c910.SuperPod, "Ascend910C must set superPod")
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Sync `InitDefaultDevices()` in `pkg/scheduler/config/config.go` with the default device configuration in the Helm chart.

The two configurations had drifted apart. The test fixture was missing several vendor sections, Ascend chips, and device-specific fields such as `superPod`, MIG profiles, and resource names.

This meant the `config` and `nodes` tests were using a device configuration that did not match what a default Helm installation provides.

This PR:

* Updates `InitDefaultDevices()` to match the chart's default configuration.
* Adds the missing vendors, chips, and device fields.
* Adds a test guard to detect missing vendor sections if the chart and fixture drift again.

**Which issue(s) this PR fixes**:

Fixes #2928


**AI assistance disclosure:**
This change was developed with AI assistance. I reviewed the changes, verified the diff, and ran the required checks locally.

**Hardware validation:**
Not applicable. `InitDefaultDevices()` is only used by unit tests and has no production caller. This PR does not change device allocation or isolation logic.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
**AI assistance disclosure:**

I used an AI assistant to verify the implementation and check that the test cases pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded default accelerator support across Nvidia, Metax, Enflame, Hygon, AMD, Vastai, Biren, and Ascend hardware.
  * Added tuning options, resource mappings, memory settings, runtime configuration, and MIG profile support.
  * Added Ascend 910B4-1 and 910C configurations, including SuperPod support.
  * Improved Ascend 310P3 virtual device configuration.

* **Tests**
  * Added checks to keep default device settings aligned with chart configurations and supported hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->