### PR TITLE
fix(chart): render service labels at the right indent level

### DIFF
--- a/charts/hami/templates/device-plugin/monitorservice.yaml
+++ b/charts/hami/templates/device-plugin/monitorservice.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: hami-device-plugin
     {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- if .Values.devicePlugin.service.labels }}  # Use devicePlugin instead of scheduler
-    {{ toYaml .Values.devicePlugin.service.labels | indent 4 }}
+    {{- toYaml .Values.devicePlugin.service.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.devicePlugin.service.annotations }}  # Use devicePlugin instead of scheduler
   annotations: {{ toYaml .Values.devicePlugin.service.annotations | nindent 4 }}

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: hami-scheduler
     {{- include "hami-vgpu.labels" . | nindent 4 }}
     {{- if .Values.scheduler.service.labels }}
-    {{ toYaml .Values.scheduler.service.labels | indent 4 }}
+    {{- toYaml .Values.scheduler.service.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.scheduler.service.annotations }}
   annotations: {{ toYaml .Values.scheduler.service.annotations | nindent 4 }}


### PR DESCRIPTION
Both Service templates emitted the optional label map with four literal spaces of template indentation followed by `indent 4`, so the first rendered key landed at column 8 and setting `scheduler.service.labels` or `devicePlugin.service.labels` made `helm template` and `helm install` fail with a YAML parse error. Switch both to `nindent 4`, matching the `annotations` line directly below them in the same files.

Does this PR introduce a user-facing change?

Setting scheduler.service.labels or devicePlugin.service.labels no longer breaks chart rendering with a YAML parse error.
