### PR TITLE
fix(chart): keep workload labels on scraped HAMi metrics

### DIFF
--- a/charts/hami/templates/device-plugin/servicemonitor.yaml
+++ b/charts/hami/templates/device-plugin/servicemonitor.yaml
@@ -19,4 +19,5 @@ spec:
   endpoints:
   - port: monitorport
     path: "/metrics"
+    honorLabels: true
 {{- end }}

--- a/charts/hami/templates/scheduler/servicemonitor.yaml
+++ b/charts/hami/templates/scheduler/servicemonitor.yaml
@@ -19,4 +19,5 @@ spec:
   endpoints:
   - port: monitor
     path: "/metrics"
+    honorLabels: true
 {{- end }}


### PR DESCRIPTION
Nine vGPUmonitor metrics and two scheduler metrics carry `namespace`, `pod` and `container` labels naming the GPU workload, but the Prometheus Operator sets those same three names as target labels for every ServiceMonitor endpoint and both endpoints left `honorLabels` unset, so Prometheus overwrites them with the scrape target and moves the workload values to `exported_namespace`, `exported_pod` and `exported_container`. Every series then reports the vgpu-monitor pod rather than the workload, and the dashboard `namespace` variable only ever offers the namespace HAMi itself runs in, so set `honorLabels` on both endpoints.

Does this PR introduce a user-facing change? The device plugin and scheduler ServiceMonitors now set honorLabels, so the namespace, pod and container labels on HAMi metrics keep identifying the GPU workload instead of being replaced by the scrape target. A Prometheus resource with overrideHonorLabels enabled still forces them back.