### PR TITLE
fix(hack): write the coverage mode line and data to the same file

### DIFF
--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -47,6 +47,10 @@ cov_file="./_output/coverage/coverage_pkg.txt"
 go test $(go list ./pkg/... ./cmd/...) -short --race -count=1 -covermode=atomic -coverprofile=${cov_file}
 cat $cov_file | grep -v mode: | grep -v pkg/version | grep -v fake | grep -v main.go >>${mergeF}
 #merge them
-echo "mode: atomic" >coverage.out
-cat ${mergeF} >>./_output/coverage/coverage.out
-go tool cover -func=coverage.out
+# The mode line and the profile data have to land in the same file: go tool
+# cover rejects a profile whose first line is not the mode, and the truncating
+# redirect keeps repeated local runs from appending a second copy of the data.
+outF="./_output/coverage/coverage.out"
+echo "mode: atomic" >${outF}
+cat ${mergeF} >>${outF}
+go tool cover -func=${outF}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the coverage output in `hack/unit-test.sh`.

The script was writing the coverage header and data to different files. Because of this:

* `make test` reported **0% coverage**.
* The coverage file uploaded to Codecov was invalid because it had no `mode:` header.
* Running `make test` multiple times appended duplicate coverage data.

This PR writes the header and data to the same file and truncates the file before writing.

**Which issue(s) this PR fixes**:

Fixes #2933

**AI assistance disclosure:**
I used an AI assistant to verify the implementation and test cases. I reviewed the changes and validation results.

**Hardware validation:**
Not applicable. This change only affects test/coverage tooling and does not change production or device code.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
**AI assistance disclosure:**

I used an AI assistant to verify the implementation and test cases. I reviewed the changes and validation results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coverage report generation so merged results are written to the expected output location.
  * Prevented duplicate coverage mode lines when running coverage aggregation repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->