### PR TITLE
fixing the reject unknown fields in device-config.yml

### DIFF
--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -489,7 +489,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	var yamlData Config
-	if err := yaml.Unmarshal(data, &yamlData); err != nil {
+	if err := yaml.UnmarshalStrict(data, &yamlData); err != nil {
 		return nil, err
 	}
 	klog.Info("Successfully read and parsed config file")

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -227,6 +229,57 @@ func Test_LoadConfig(t *testing.T) {
 	assert.DeepEqual(t, configData.VNPUs, expectedVNPUs)
 	expectedIluvatars := createIluvatarConfigs()
 	assert.DeepEqual(t, configData.IluvatarConfig, expectedIluvatars)
+}
+
+func TestLoadConfigRejectsInvalidFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name:   "valid configuration",
+			config: "nvidia:\n  resourceCountName: nvidia.com/gpu\n",
+		},
+		{
+			name:    "unknown top-level field",
+			config:  "unknown: true\n",
+			wantErr: "field unknown not found",
+		},
+		{
+			name: "unknown nested field",
+			config: "nvidia:\n" +
+				"  resourceCountNmae: nvidia.com/gpu\n",
+			wantErr: "field resourceCountNmae not found",
+		},
+		{
+			name: "duplicate field",
+			config: "nvidia:\n" +
+				"  resourceCountName: nvidia.com/gpu\n" +
+				"  resourceCountName: nvidia.com/gpu2\n",
+			wantErr: "resourceCountName already set",
+		},
+		{
+			name: "invalid value type",
+			config: "nvidia:\n" +
+				"  defaultGPUNum: not-a-number\n",
+			wantErr: "cannot unmarshal",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "device-config.yaml")
+			assert.NilError(t, os.WriteFile(path, []byte(test.config), 0o600))
+
+			_, err := LoadConfig(path)
+			if test.wantErr == "" {
+				assert.NilError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, test.wantErr)
+		})
+	}
 }
 
 func createNvidiaConfig() nvidia.NvidiaConfig {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR makes device configuration parsing strict.

Previously, an unknown or misspelled field in `device-config.yaml` could be ignored silently. The scheduler could then start with unintended default values.

This change uses strict YAML decoding so invalid configuration fails early with a clear error.

**What is included**:

- Reject unknown top-level configuration fields.
- Reject unknown nested device fields.
- Reject duplicate YAML fields.
- Reject invalid YAML value types.
- Add regression tests for valid and invalid device configurations.

**Which issue(s) this PR fixes**:

Fixes #2940

**Special notes for your reviewer**:

Valid existing device configurations keep their current behavior.

Configurations with invalid or previously ignored fields will now fail during scheduler startup instead of silently using defaults.

**Does this PR introduce a user-facing change?**:

Yes. Invalid `device-config.yaml` files now fail early with a clear validation error.

**AI assistance disclosure**:

I am using an AI assistance(Codex)  for drafting the PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now reports errors for unknown, duplicate, or incorrectly typed YAML fields instead of silently accepting invalid settings.
  * Valid configurations continue to load successfully.
  * Configuration validation now provides more reliable feedback when YAML contains unsupported fields, repeated entries, or values with invalid types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->