### PR TITLE
feat(chart): expose node-lock-retry-timeout and extender httpTimeout

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -77,7 +77,7 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.kubeBurst` | Burst to use while talking with the kube-apiserver; empty keeps the binary default (`10`) | `""` |
 | `scheduler.kubeTimeout` | Timeout in seconds while talking with the kube-apiserver; empty keeps the binary default (`0`, no timeout) | `""` |
 | `scheduler.nodeLockRetryTimeout` | How long Bind retries LockNode when another PodGroup member holds the node lock; empty keeps the binary default (`28s`), `0` disables retry | `""` |
-| `scheduler.extenderHTTPTimeout` | `httpTimeout` given to the HAMi extender in the generated KubeSchedulerConfiguration, in seconds; keep it above `scheduler.nodeLockRetryTimeout` | `30` |
+| `scheduler.extenderHTTPTimeout` | `httpTimeout` given to the HAMi extender in the generated scheduler configuration, in seconds. Applies to both the KubeSchedulerConfiguration used on Kubernetes 1.22+ and the legacy Policy format used below it. Keep it above `scheduler.nodeLockRetryTimeout` | `30` |
 | `scheduler.forceOverwriteDefaultScheduler` | Whether to force overwrite default scheduler | `true` |
 | `scheduler.livenessProbe` | Whether to enable liveness probe | `false` |
 | `scheduler.leaderElect` | Whether to enable leader election | `true` |

--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -76,6 +76,8 @@ This document provides detailed descriptions of all configurable values paramete
 | `scheduler.kubeQPS` | QPS to use while talking with the kube-apiserver; empty keeps the binary default (`5`) | `""` |
 | `scheduler.kubeBurst` | Burst to use while talking with the kube-apiserver; empty keeps the binary default (`10`) | `""` |
 | `scheduler.kubeTimeout` | Timeout in seconds while talking with the kube-apiserver; empty keeps the binary default (`0`, no timeout) | `""` |
+| `scheduler.nodeLockRetryTimeout` | How long Bind retries LockNode when another PodGroup member holds the node lock; empty keeps the binary default (`28s`), `0` disables retry | `""` |
+| `scheduler.extenderHTTPTimeout` | `httpTimeout` given to the HAMi extender in the generated KubeSchedulerConfiguration, in seconds; keep it above `scheduler.nodeLockRetryTimeout` | `30` |
 | `scheduler.forceOverwriteDefaultScheduler` | Whether to force overwrite default scheduler | `true` |
 | `scheduler.livenessProbe` | Whether to enable liveness probe | `false` |
 | `scheduler.leaderElect` | Whether to enable leader election | `true` |

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -38,7 +38,7 @@ data:
       bindVerb: bind
       nodeCacheCapable: true
       weight: 1
-      httpTimeout: 30s
+      httpTimeout: {{ .Values.scheduler.extenderHTTPTimeout }}s
       managedResources:
       {{- include "hami-vgpu.scheduler.managedResources" . | nindent 6 }}
 {{- else }}
@@ -63,7 +63,7 @@ data:
                 "bindVerb": "bind",
                 "weight": 1,
                 "nodeCacheCapable": true,
-                "httpTimeout": 30000000000,
+                "httpTimeout": {{ mul .Values.scheduler.extenderHTTPTimeout 1000000000 }},
                 "managedResources": {{ include "hami-vgpu.scheduler.managedResources" . | fromYamlArray | toJson }},
                 "ignoreable": false
             }

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -142,6 +142,10 @@ spec:
             {{- if .Values.scheduler.kubeTimeout }}
             - --kube-timeout={{ .Values.scheduler.kubeTimeout }}
             {{- end }}
+            {{- /* Compared as a string so an explicit 0, which disables retry, is passed through rather than treated as unset. */}}
+            {{- if ne (toString .Values.scheduler.nodeLockRetryTimeout) "" }}
+            - --node-lock-retry-timeout={{ .Values.scheduler.nodeLockRetryTimeout }}
+            {{- end }}
             {{- range .Values.scheduler.extender.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -85,6 +85,13 @@ scheduler:
   kubeBurst: ""
   # kubeTimeout is in seconds; 0 means no timeout.
   kubeTimeout: ""
+  # How long Bind retries LockNode when another PodGroup member holds the node
+  # lock. Empty keeps the binary default (28s); 0 disables retry entirely.
+  nodeLockRetryTimeout: ""
+  # httpTimeout the generated KubeSchedulerConfiguration gives the HAMi extender,
+  # in seconds. Keep it above nodeLockRetryTimeout, otherwise kube-scheduler cuts
+  # the bind call off while the extender is still retrying the node lock.
+  extenderHTTPTimeout: 30
   # If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it
   forceOverwriteDefaultScheduler: true
   livenessProbe: false

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -88,9 +88,12 @@ scheduler:
   # How long Bind retries LockNode when another PodGroup member holds the node
   # lock. Empty keeps the binary default (28s); 0 disables retry entirely.
   nodeLockRetryTimeout: ""
-  # httpTimeout the generated KubeSchedulerConfiguration gives the HAMi extender,
-  # in seconds. Keep it above nodeLockRetryTimeout, otherwise kube-scheduler cuts
-  # the bind call off while the extender is still retrying the node lock.
+  # httpTimeout the generated scheduler configuration gives the HAMi extender, in
+  # seconds. It is applied to the KubeSchedulerConfiguration used on Kubernetes
+  # 1.22+ and to the legacy Policy format used below it, which is why it is
+  # expressed in seconds rather than as a duration: the two formats want
+  # different units. Keep it above nodeLockRetryTimeout, otherwise kube-scheduler
+  # cuts the bind call off while the extender is still retrying the node lock.
   extenderHTTPTimeout: 30
   # If set to false, When Pod.Spec.SchedulerName equals to the const DefaultSchedulerName in k8s.io/api/core/v1 package, webhook will not overwrite it
   forceOverwriteDefaultScheduler: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The scheduler already supports `--node-lock-retry-timeout`, but the Helm chart did not expose it. The extender `httpTimeout` was also hardcoded to `30s`.

This PR adds two Helm values:

* `scheduler.nodeLockRetryTimeout`
* `scheduler.extenderHTTPTimeout`

This allows operators to configure both timeouts and keep them aligned.

**Which issue(s) this PR fixes**:

Fixes #2943


**AI assistance disclosure:**
I used AI assistance during implementation to help with analysis, chart changes, and validation. I reviewed the changes and verified the implementation and test results.



**User-facing change:**

```release-note
Added `scheduler.nodeLockRetryTimeout` and `scheduler.extenderHTTPTimeout` Helm values to configure scheduler timeouts. Defaults are unchanged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable scheduler timeout settings for node-lock retries and extender HTTP requests.
  - Node-lock retry behavior can be customized, including disabling retries.
  - Extender HTTP timeout configuration now works consistently across supported Kubernetes versions.

- **Documentation**
  - Added Helm chart documentation covering defaults, units, behavior, and timeout relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->