### PR TITLE
feat(ascend): honor plugin-advertised hami-core percentage budget

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -430,19 +430,25 @@ func (dev *Devices) GetResourceNames() device.ResourceNames {
 	}
 }
 
-// hamiCoreFitBudget is the 0-100 percentage capacity used by hami-core Fit.
-// Coresreq is a percentage, not physical AI cores. Existing plugins may still
-// register Devcore as the hardware AICore count (20/24/32). Keep today's 100-point
-// budget in that case so admission does not change.
+// hamiCorePercentBase is the fixed 0-100 percentage scale hami-core Coresreq
+// is expressed in.
+const hamiCorePercentBase = 100
+
+// hamiCoreFitBudget is the percentage capacity used by hami-core Fit.
 //
-// Coupled plugin change (https://github.com/Project-HAMi/ascend-device-plugin/pull/132)
-// advertises Devcore = round(100 * deviceCoreScaling) for hami-core, which is >= 100.
-// Honor that advertised percentage when it is larger than 100.
+// Coresreq is a percentage, not physical AI cores, so dev.Totalcore cannot be
+// used directly: a plugin that has not enabled hami-core registers Devcore as
+// the hardware AICore count (8/20/24/30). Keep the percentage base for any
+// advertised value at or below it so admission does not change.
+//
+// The coupled plugin change (Project-HAMi/ascend-device-plugin#132) advertises
+// Devcore = round(100 * deviceCoreScaling) for hami-core and never reports less
+// than the base, so any higher value is an intentional oversell budget.
 func hamiCoreFitBudget(advertisedTotalcore int32) int32 {
-	if advertisedTotalcore > 100 {
+	if advertisedTotalcore > hamiCorePercentBase {
 		return advertisedTotalcore
 	}
-	return 100
+	return hamiCorePercentBase
 }
 
 func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
@@ -545,12 +551,15 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)
 			continue
 		}
-		// hami-core Coresreq is a 0-100 percentage. Do not treat physical AICore
-		// (dev.Totalcore) as that budget. Default remains 100; honor plugin
-		// oversell only when advertised Devcore > 100.
+		// hami-core Coresreq is a percentage. Do not treat physical AICore
+		// (dev.Totalcore) as that budget; honor plugin oversell only when the
+		// advertised Devcore is above the percentage base.
 		effectiveTotalCore := dev.Totalcore
 		if isHAMiCore {
 			effectiveTotalCore = hamiCoreFitBudget(dev.Totalcore)
+			if effectiveTotalCore != dev.Totalcore {
+				klog.V(5).InfoS("hami-core budget clamped to the percentage base", "pod", klog.KObj(pod), "device", dev.ID, "advertised total core", dev.Totalcore, "budget", effectiveTotalCore)
+			}
 		}
 
 		if effectiveTotalCore-dev.Usedcores < k.Coresreq {
@@ -558,14 +567,20 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", effectiveTotalCore, "device used core", dev.Usedcores, "request cores", k.Coresreq)
 			continue
 		}
-		// Coresreq=100 stays exclusive for hami-core even when the plugin
-		// advertises a budget above 100 (deviceCoreScaling > 1).
-		if k.Coresreq == 100 && dev.Used > 0 && (isHAMiCore || effectiveTotalCore == 100) {
+		// Coresreq at the percentage base stays exclusive for hami-core even when
+		// the plugin advertises an oversold budget.
+		if k.Coresreq == hamiCorePercentBase && dev.Used > 0 && (isHAMiCore || effectiveTotalCore == hamiCorePercentBase) {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue
 		}
-		if isHAMiCore && dev.Used == 1 && dev.Usedcores >= 100 {
+		// A card held by a single full-core occupant rejects every later request.
+		// Oversell lifts the budget above that occupant's share, so neither the
+		// capacity check above nor CardComputeUnitsExhausted below still catches
+		// this. The requesting pod's own mode is irrelevant: only hami-core pods on
+		// non-hami-core nodes are filtered out, so a legacy vNPU pod still reaches
+		// an oversold card.
+		if dev.Used == 1 && dev.Usedcores >= hamiCorePercentBase {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used, "usedcores", dev.Usedcores)
 			continue

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -574,21 +574,21 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
 			continue
 		}
-		// A card held by a single full-core occupant rejects every later request.
-		// Oversell lifts the budget above that occupant's share, so neither the
-		// capacity check above nor CardComputeUnitsExhausted below still catches
-		// this. The requesting pod's own mode is irrelevant: only hami-core pods on
-		// non-hami-core nodes are filtered out, so a legacy vNPU pod still reaches
-		// an oversold card.
-		if dev.Used == 1 && dev.Usedcores >= hamiCorePercentBase {
-			reason[common.ExclusiveDeviceAllocateConflict]++
-			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used, "usedcores", dev.Usedcores)
-			continue
-		}
 		// You can't allocate core=0 job to an already full GPU
 		if effectiveTotalCore != 0 && dev.Usedcores == effectiveTotalCore && k.Coresreq == 0 {
 			reason[common.CardComputeUnitsExhausted]++
 			klog.V(5).InfoS(common.CardComputeUnitsExhausted, "pod", klog.KObj(pod), "device", dev.ID, "device index", i)
+			continue
+		}
+		// A card held by a single full-core occupant rejects every later request.
+		// Oversell lifts the budget above that occupant's share, so the check above
+		// no longer recognizes the card as full. Running after it keeps the
+		// non-oversold rejection reason as CardComputeUnitsExhausted. The requesting
+		// pod's own mode is irrelevant: only hami-core pods on non-hami-core nodes
+		// are filtered out, so a legacy vNPU pod still reaches an oversold card.
+		if dev.Used == 1 && dev.Usedcores >= hamiCorePercentBase {
+			reason[common.ExclusiveDeviceAllocateConflict]++
+			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used, "usedcores", dev.Usedcores)
 			continue
 		}
 		if k.Nums > 0 {

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -430,6 +430,21 @@ func (dev *Devices) GetResourceNames() device.ResourceNames {
 	}
 }
 
+// hamiCoreFitBudget is the 0-100 percentage capacity used by hami-core Fit.
+// Coresreq is a percentage, not physical AI cores. Existing plugins may still
+// register Devcore as the hardware AICore count (20/24/32). Keep today's 100-point
+// budget in that case so admission does not change.
+//
+// Coupled plugin change (https://github.com/Project-HAMi/ascend-device-plugin/pull/132)
+// advertises Devcore = round(100 * deviceCoreScaling) for hami-core, which is >= 100.
+// Honor that advertised percentage when it is larger than 100.
+func hamiCoreFitBudget(advertisedTotalcore int32) int32 {
+	if advertisedTotalcore > 100 {
+		return advertisedTotalcore
+	}
+	return 100
+}
+
 func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
 	k := request
 	originReq := k.Nums
@@ -530,10 +545,12 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientMemory, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total memory", dev.Totalmem, "device used memory", dev.Usedmem, "request memory", memreq)
 			continue
 		}
-		// Set dev.Totalcore to 100 if vnpuMode is hami-core
+		// hami-core Coresreq is a 0-100 percentage. Do not treat physical AICore
+		// (dev.Totalcore) as that budget. Default remains 100; honor plugin
+		// oversell only when advertised Devcore > 100.
 		effectiveTotalCore := dev.Totalcore
 		if isHAMiCore {
-			effectiveTotalCore = 100
+			effectiveTotalCore = hamiCoreFitBudget(dev.Totalcore)
 		}
 
 		if effectiveTotalCore-dev.Usedcores < k.Coresreq {
@@ -541,10 +558,16 @@ func (npu *Devices) Fit(devices []*device.DeviceUsage, request device.ContainerD
 			klog.V(5).InfoS(common.CardInsufficientCore, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "device total core", effectiveTotalCore, "device used core", dev.Usedcores, "request cores", k.Coresreq)
 			continue
 		}
-		// Coresreq=100 indicates it want this card exclusively
-		if effectiveTotalCore == 100 && k.Coresreq == 100 && dev.Used > 0 {
+		// Coresreq=100 stays exclusive for hami-core even when the plugin
+		// advertises a budget above 100 (deviceCoreScaling > 1).
+		if k.Coresreq == 100 && dev.Used > 0 && (isHAMiCore || effectiveTotalCore == 100) {
 			reason[common.ExclusiveDeviceAllocateConflict]++
 			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used)
+			continue
+		}
+		if isHAMiCore && dev.Used == 1 && dev.Usedcores >= 100 {
+			reason[common.ExclusiveDeviceAllocateConflict]++
+			klog.V(5).InfoS(common.ExclusiveDeviceAllocateConflict, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "used", dev.Used, "usedcores", dev.Usedcores)
 			continue
 		}
 		// You can't allocate core=0 job to an already full GPU

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2636,6 +2636,48 @@ func TestDevices_Fit_HamiCoreOversell(t *testing.T) {
 			t.Fatalf("unexpected result %#v", result)
 		}
 	})
+	t.Run("advertised 150 admits a second tenant below the exclusive threshold", func(t *testing.T) {
+		partial := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Type: "Ascend910B3",
+			Used: 1, Count: 8,
+			Usedmem: 8192, Totalmem: 65536,
+			Usedcores: 60, Totalcore: 150,
+			Health: true,
+		}}
+		share := device.ContainerDeviceRequest{
+			Nums: 1, Type: "Ascend910B3",
+			Memreq: 8192, MemPercentagereq: 0, Coresreq: 50,
+		}
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit(partial, share, pod, nodeInfo, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected 60+50 to fit a 150 budget, got reason=%s", reason)
+		}
+	})
+	t.Run("advertised 150 exclusive occupant rejects a legacy vnpu pod", func(t *testing.T) {
+		exclusive := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Type: "Ascend910B3",
+			Used: 1, Count: 8,
+			Usedmem: 8192, Totalmem: 65536,
+			Usedcores: 100, Totalcore: 150,
+			Health: true,
+		}}
+		// No vnpu-mode annotation: Fit only filters hami-core pods off
+		// non-hami-core nodes, so this pod still reaches the oversold card.
+		legacyPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}}
+		zeroCore := device.ContainerDeviceRequest{
+			Nums: 1, Type: "Ascend910B3",
+			Memreq: 1024, MemPercentagereq: 0, Coresreq: 0,
+		}
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit(exclusive, zeroCore, legacyPod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected exclusive occupant to reject a legacy vNPU pod, got reason=%s", reason)
+		}
+		if reason != "1/1 ExclusiveDeviceAllocateConflict" {
+			t.Fatalf("expected ExclusiveDeviceAllocateConflict, got %s", reason)
+		}
+	})
 	t.Run("advertised 150 exclusive occupant rejects later share", func(t *testing.T) {
 		exclusive := []*device.DeviceUsage{{
 			ID: "dev-0", Index: 0, Type: "Ascend910B3",

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2636,6 +2636,27 @@ func TestDevices_Fit_HamiCoreOversell(t *testing.T) {
 			t.Fatalf("unexpected result %#v", result)
 		}
 	})
+	t.Run("default budget 100 keeps CardComputeUnitsExhausted for a full card", func(t *testing.T) {
+		full := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Type: "Ascend910B3",
+			Used: 1, Count: 8,
+			Usedmem: 8192, Totalmem: 65536,
+			Usedcores: 100, Totalcore: 100,
+			Health: true,
+		}}
+		zeroCore := device.ContainerDeviceRequest{
+			Nums: 1, Type: "Ascend910B3",
+			Memreq: 1024, MemPercentagereq: 0, Coresreq: 0,
+		}
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit(full, zeroCore, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected a full card to reject the request")
+		}
+		if reason != "1/1 CardComputeUnitsExhausted" {
+			t.Fatalf("expected CardComputeUnitsExhausted without oversell, got %s", reason)
+		}
+	})
 	t.Run("advertised 150 admits a second tenant below the exclusive threshold", func(t *testing.T) {
 		partial := []*device.DeviceUsage{{
 			ID: "dev-0", Index: 0, Type: "Ascend910B3",

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -2553,6 +2553,131 @@ func TestDevices_Fit(t *testing.T) {
 	}
 }
 
+func TestDevices_Fit_HamiCoreOversell(t *testing.T) {
+	enableAscend = true
+	cfg := []VNPUConfig{{
+		CommonWord:         "Ascend910B3",
+		ChipName:           "910B3",
+		ResourceName:       "huawei.com/Ascend910B3",
+		ResourceMemoryName: "huawei.com/Ascend910B3-memory",
+		MemoryAllocatable:  65536,
+		Templates:          []Template{{Name: "vir05", Memory: 16384}},
+	}}
+	base := device.DeviceUsage{
+		ID: "dev-0", Index: 0, Type: "Ascend910B3",
+		Used: 3, Count: 4,
+		Usedmem: 3072, Totalmem: 65536,
+		Usedcores: 90, Health: true,
+	}
+	req := device.ContainerDeviceRequest{
+		Nums: 1, Type: "Ascend910B3",
+		Memreq: 1024, MemPercentagereq: 0, Coresreq: 20,
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		VNPUModeAnnotation: VNPUModeHamiCore,
+	}}}
+	nodeInfo := &device.NodeInfo{
+		ID: "node1",
+		Node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			VNPUNodeSelectorAnnotation: "true",
+		}}},
+	}
+
+	t.Run("physical aiCore 20 still admits Coresreq 30", func(t *testing.T) {
+		c := base
+		c.Used = 0
+		c.Usedmem = 0
+		c.Usedcores = 0
+		c.Totalcore = 20
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		req30 := req
+		req30.Coresreq = 30
+		fit, result, reason := dev.Fit([]*device.DeviceUsage{&c}, req30, pod, nodeInfo, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected admit against 100-point budget with physical Totalcore=20, got reason=%s", reason)
+		}
+		if len(result["Ascend910B3"]) != 1 || result["Ascend910B3"][0].UUID != "dev-0" {
+			t.Fatalf("unexpected result %#v", result)
+		}
+	})
+	t.Run("physical aiCore 20 still rejects 90+20", func(t *testing.T) {
+		c := base
+		c.Totalcore = 20
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit([]*device.DeviceUsage{&c}, req, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected reject at 110>100 with physical Totalcore=20, got fit reason=%s", reason)
+		}
+		if reason != "1/1 CardInsufficientCore" {
+			t.Fatalf("expected CardInsufficientCore, got %s", reason)
+		}
+	})
+	t.Run("plugin advertises 100 rejects 90+20", func(t *testing.T) {
+		c := base
+		c.Totalcore = 100
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit([]*device.DeviceUsage{&c}, req, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected reject at 110>100, got fit reason=%s", reason)
+		}
+		if reason != "1/1 CardInsufficientCore" {
+			t.Fatalf("expected CardInsufficientCore, got %s", reason)
+		}
+	})
+	t.Run("plugin advertises 150 admits 90+20", func(t *testing.T) {
+		c := base
+		c.Totalcore = 150
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, result, reason := dev.Fit([]*device.DeviceUsage{&c}, req, pod, nodeInfo, &device.PodDevices{})
+		if !fit {
+			t.Fatalf("expected admit at 110<=150, got reason=%s", reason)
+		}
+		if len(result["Ascend910B3"]) != 1 || result["Ascend910B3"][0].UUID != "dev-0" {
+			t.Fatalf("unexpected result %#v", result)
+		}
+	})
+	t.Run("advertised 150 exclusive occupant rejects later share", func(t *testing.T) {
+		exclusive := []*device.DeviceUsage{{
+			ID: "dev-0", Index: 0, Type: "Ascend910B3",
+			Used: 1, Count: 8,
+			Usedmem: 8192, Totalmem: 65536,
+			Usedcores: 100, Totalcore: 150,
+			Health: true,
+		}}
+		share := device.ContainerDeviceRequest{
+			Nums: 1, Type: "Ascend910B3",
+			Memreq: 8192, MemPercentagereq: 0, Coresreq: 50,
+		}
+		dev := InitDevices(VNPUs{HamiVnpuCore: true, Configs: cfg})[0]
+		fit, _, reason := dev.Fit(exclusive, share, pod, nodeInfo, &device.PodDevices{})
+		if fit {
+			t.Fatalf("expected exclusive occupant to reject 50-core share, got reason=%s", reason)
+		}
+		if reason != "1/1 ExclusiveDeviceAllocateConflict" {
+			t.Fatalf("expected ExclusiveDeviceAllocateConflict, got %s", reason)
+		}
+	})
+}
+
+func TestHamiCoreFitBudget(t *testing.T) {
+	cases := []struct {
+		in   int32
+		want int32
+	}{
+		{0, 100},
+		{20, 100},
+		{32, 100},
+		{100, 100},
+		{150, 150},
+		{200, 200},
+	}
+	for _, tc := range cases {
+		if got := hamiCoreFitBudget(tc.in); got != tc.want {
+			t.Fatalf("hamiCoreFitBudget(%d)=%d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestDevices_Fit_910C(t *testing.T) {
 	configStr := `- chipName: Ascend910
   commonWord: Ascend910C


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Follow-up to #2902, coupled with https://github.com/Project-HAMi/ascend-device-plugin/pull/132.

#2902 removed the hami-core `effectiveTotalCore = 100` override and used `dev.Totalcore` directly. That is incorrect on Ascend: `Totalcore` is the physical AICore count (8/20/24/30) on existing deployments, not a 0-100 percentage. Dropping the override would change `Coresreq` admission.

This PR keeps the 100-point percentage budget and only honors an oversold percentage advertised by the plugin:

- hami-core Fit budget = `100` when advertised `Totalcore <= 100` (physical AICore, or the default `Devcore=100`)
- hami-core Fit budget = advertised `Totalcore` when the plugin reports `Devcore > 100`
- scaling config is **not** added to HAMi Helm; it lives in the plugin as `hamiVnpuCore.deviceCoreScaling` (see the coupled PR)
- `Coresreq=100` stays exclusive for hami-core even when the budget is oversold
- a card already held by a single full-core occupant rejects every later request, whatever mode that request is in

Default deployments are unchanged: `-core: "30"` still fits against a 100-point budget even if `Totalcore` is 20.

**Which issue(s) this PR fixes**:
Fixes #2946

**Special notes for your reviewer**:

AI assistance: I used Cursor to draft the patch and this description. I reviewed every changed line and can explain the Fit budget and exclusive checks. Commit messages were written by me.

This is a new PR after #2902 was closed. The close reasons are addressed as follows:

1. `dev.Totalcore` is physical AICore — Fit no longer uses it as the hami-core percentage when it is `<= 100`.
2. Removing the 100 override would change existing admission — the 100-point budget stays the default.
3. HAMi Helm `deviceCoreScaling` wiring is intentionally absent — the knob is in ascend-device-plugin#132.

The second commit fixes a bug I found while re-reviewing this against the plugin PR. The exclusivity guard was scoped to the requesting pod's mode (`isHAMiCore && dev.Used == 1 && ...`), but `Fit` only rejects hami-core pods on non-hami-core nodes, not the reverse. A legacy vNPU pod therefore skipped the guard and could land on a card already held exclusively by a 100%-core occupant: under oversell neither the capacity check (`150 - 100 = 50` still passes) nor `CardComputeUnitsExhausted` (`100 != 150`) catches that any more. Both did catch it before oversell existed, which is why it only surfaces with the feature on.

`dev.Used == 1` has to stay in the guard. With two or more tenants the used cores are a sum of sub-100 shares, and rejecting those would break exactly the oversell case this PR adds. There is a test for that direction too.

Hardware validation (scheduler extender Fit path):
- Device: 8 × Ascend 910B3
- Driver / npu-smi: 25.5.0
- plugin `deviceCoreScaling=1.5` (advertised Devcore 150)
- 3 pods with `-core: "30"` plus 1 pod with `-core: "20"` on the same UUID
- Result: all four scheduled (110 ≤ 150). Default budget 100 rejects the fourth (`CardInsufficientCore`).
- Physical `Totalcore=20` still admits `-core: "30"`.

Unit validation: `go test ./pkg/device/...` passes across all 15 device packages, with no reason-string changes for pre-existing cases. I checked the new regression test against the previous commit, where it fails with an empty reason string, i.e. the pod is admitted.

**Does this PR introduce a user-facing change?**:

No HAMi Helm change. Behavior changes only when the coupled plugin advertises `Devcore > 100`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ascend device core allocation in Hami-core mode.
  * Accurately honors advertised core capacities above the standard 100-core budget.
  * Prevents allocations that exceed the available device capacity.
  * Strengthened exclusive allocation handling when a device is fully occupied.
  * Allows valid shared allocations on devices with sufficient advertised capacity while rejecting conflicting requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->