### PR TITLE
docs: correct protocol.md handshake expiry, register format and timestamps

### DIFF
--- a/docs/develop/protocol.md
+++ b/docs/develop/protocol.md
@@ -11,32 +11,68 @@ hami.io/node-handshake-{device-type}: Reported_{device_node_current_timestamp}
 hami.io/node-{device-type}-register: {Device 1}:{Device2}:...:{Device N}
 ```
 
-The definition of each device is in the following format:
+The definition of each device is nine comma-separated fields:
 
 ```text
-{Device UUID},{device split count},{device memory limit},{device core limit},{device type},{device numa},{healthy}
+{Device UUID},{device split count},{device memory limit},{device core limit},{device type},{device numa},{healthy},{device index},{mode}
 ```
+
+The last two fields are:
+
+| Field            | Meaning                                                        |
+|------------------|----------------------------------------------------------------|
+| `{device index}` | The device's index on the node. Must not be negative.          |
+| `{mode}`         | The device's virtualization mode: `hami-core`, `mig` or `mps`. |
+
+For backward compatibility the scheduler also accepts the older seven-field form,
+which omits `{device index}` and `{mode}`. In that case it defaults the index to
+`0` and the mode to `hami-core`, so a plugin registering with the seven-field
+form can never have its devices scheduled as MIG. New plugins should write all
+nine fields.
 
 An example is shown below:
 
 ```text
-hami.io/node-handshake-nvidia: Reported 2024-01-23 04:30:04.434037031 +0000 UTC m=+1104711.777756895
-hami.io/node-handshake-mlu: Requesting_2024.01.10 04:06:57
-hami.io/node-mlu-register: MLU-45013011-2257-0000-0000-000000000000,10,23308,0,MLU-MLU370-X4,0,false:MLU-54043011-2257-0000-0000-000000000000,10,23308,0,
-hami.io/node-nvidia-register: GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true:GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true:
+hami.io/node-handshake-nvidia: Reported_2024-01-23 04:30:04
+hami.io/node-handshake-mlu: Requesting_2024-01-10 04:06:57
+hami.io/node-mlu-register: MLU-45013011-2257-0000-0000-000000000000,10,23308,0,MLU-MLU370-X4,0,false,0,hami-core:MLU-54043011-2257-0000-0000-000000000000,10,23308,0,MLU-MLU370-X4,0,true,1,hami-core:
+hami.io/node-nvidia-register: GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true,0,hami-core:GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,10,32768,100,NVIDIA-Tesla V100-PCIE-32GB,0,true,1,hami-core:
 ```
 
 In this example, this node has two different AI devices, 2 Nvidia-V100 GPUs, and 2 Cambricon 370-X4 MLUs
 
-Note that a device node may become unavailable due to hardware or network failure, if a node hasn't registered in last 5 minutes, scheduler will mark that node as 'unavailable'.
+A device node may become unavailable due to hardware or network failure. The
+scheduler detects this with a handshake rather than by trusting the node's own
+clock, since the system clocks on the scheduler node and the device node may not
+align.
 
-Since system clock on scheduler node and 'device' node may not align properly, scheduler node will patch the following device node annotations every 30s
+Whenever the handshake annotation does not already hold a `Requesting_` value,
+the scheduler overwrites it with its own timestamp:
 
 ```text
 hami.io/node-handshake-{device-type}: Requesting_{scheduler_node_current_timestamp}
 ```
 
-If hami.io/node-handshake annotations remains in "Requesting_xxxx" and {scheduler current timestamp} > 5 mins + {scheduler timestamp in annotations}, then this device on that node will be marked "unavailable" in scheduler.
+This happens on each registration cycle, which runs every 15 seconds and also
+whenever a node is added or deleted. The timestamp is written and parsed as
+`2006-01-02 15:04:05` (Go's `time.DateTime`) in the scheduler's local timezone.
+A value the scheduler cannot parse leaves the devices registered but never
+refreshed, so a plugin must reproduce this layout exactly.
+
+The device-plugin answers by overwriting the annotation with its own `Reported_`
+value. The scheduler only parses the `Requesting_` form; any other value is read
+as "the plugin has answered".
+
+If `hami.io/node-handshake-{device-type}` remains in `Requesting_xxxx` and
+{scheduler current timestamp} > 60 seconds + {scheduler timestamp in
+annotations}, then the devices of that type on that node are marked
+"unavailable" and removed from the scheduler's cache.
+
+There is one exception. If the node still advertises the device type's count
+resource in `.status.allocatable` with a value greater than zero, the scheduler
+keeps the devices and skips the cleanup even though the handshake has expired.
+This avoids dropping a node whose plugin is briefly unreachable while the kubelet
+still reports its devices.
  
 
 ## Schedule Decision


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Updates `docs/develop/protocol.md` to match the current implementation.

The documentation had a few outdated details:

* Handshake timeout was documented as **5 minutes**, while the code uses **60 seconds**.
* Device registration was documented with **7 fields**, while the current format supports **9 fields** including `index` and `mode`.
* The `Requesting_` timestamp example used the wrong format.
* The documentation did not mention the `Allocatable` fallback when a handshake expires.

This PR corrects these details and updates the examples so vendors can implement HAMi-compatible device plugins correctly.

**Which issue(s) this PR fixes**:

Fixes #2945

**AI assistance disclosure:**

I used AI assistance to cross-check the documentation against the code and help update the examples. I reviewed the changes and verified the updated documentation.

**Validation:**
Verified the updated examples against the current device decoding and timestamp formats.

**Scope:**
Documentation only. No code or behavior changes.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated device registration protocol examples to support device indexes and operating modes.
  * Documented continued compatibility with the legacy seven-field device format.
  * Clarified scheduler-driven registration, timestamp handling, and device availability timing.
  * Added guidance for retaining devices when the corresponding count resource remains available.
  * Updated annotation and reported/requesting value examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->