### PR TITLE
fix(ascend): do not overwrite ASCEND_VISIBLE_DEVICES for Ascend containers

### DIFF
--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -49,12 +49,13 @@ const (
 )
 
 type Devices struct {
-	config           VNPUConfig
-	nodeRegisterAnno string
-	useUUIDAnno      string
-	noUseUUIDAnno    string
-	handshakeAnno    string
-	hamiVnpuCore     bool
+	config                 VNPUConfig
+	nodeRegisterAnno       string
+	useUUIDAnno            string
+	noUseUUIDAnno          string
+	handshakeAnno          string
+	hamiVnpuCore           bool
+	allAscendResourceNames []corev1.ResourceName
 }
 
 type RuntimeInfo struct {
@@ -83,15 +84,20 @@ func InitDevices(vnpus VNPUs) []*Devices {
 	if !enableAscend {
 		return devs
 	}
+	allAscendResourceNames := make([]corev1.ResourceName, 0, len(vnpus.Configs))
+	for _, vnpu := range vnpus.Configs {
+		allAscendResourceNames = append(allAscendResourceNames, corev1.ResourceName(vnpu.ResourceName))
+	}
 	for _, vnpu := range vnpus.Configs {
 		commonWord := vnpu.CommonWord
 		dev := &Devices{
-			config:           vnpu,
-			nodeRegisterAnno: fmt.Sprintf("hami.io/node-register-%s", commonWord),
-			useUUIDAnno:      fmt.Sprintf("hami.io/use-%s-uuid", commonWord),
-			noUseUUIDAnno:    fmt.Sprintf("hami.io/no-use-%s-uuid", commonWord),
-			handshakeAnno:    fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
-			hamiVnpuCore:     vnpus.HamiVnpuCore,
+			config:                 vnpu,
+			nodeRegisterAnno:       fmt.Sprintf("hami.io/node-register-%s", commonWord),
+			useUUIDAnno:            fmt.Sprintf("hami.io/use-%s-uuid", commonWord),
+			noUseUUIDAnno:          fmt.Sprintf("hami.io/no-use-%s-uuid", commonWord),
+			handshakeAnno:          fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
+			hamiVnpuCore:           vnpus.HamiVnpuCore,
+			allAscendResourceNames: allAscendResourceNames,
 		}
 		sort.Slice(dev.config.Templates, func(i, j int) bool {
 			return dev.config.Templates[i].Memory < dev.config.Templates[j].Memory
@@ -116,10 +122,35 @@ func (dev *Devices) CommonWord() string {
 	return dev.config.CommonWord
 }
 
+func (dev *Devices) containerRequestsAnyAscendResource(ctr *corev1.Container) bool {
+	for _, name := range dev.allAscendResourceNames {
+		if _, ok := ctr.Resources.Limits[name]; ok {
+			return true
+		}
+		if _, ok := ctr.Resources.Requests[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func lastEnvValueEquals(env []corev1.EnvVar, name, value string) bool {
+	// kubelet will dedupes same-name env and the last one wins, so iterate backward
+	for _, e := range slices.Backward(env) {
+		if e.Name != name {
+			continue
+		}
+		// TODO: currently ignore the ValueFrom reference, because it's complicated to get the runtime value.
+		return e.ValueFrom == nil && e.Value == value
+	}
+	return false
+}
+
 func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceName)]
 	if !ok {
-		if dev.config.OverwriteEnv {
+		if dev.config.OverwriteEnv && !dev.containerRequestsAnyAscendResource(ctr) &&
+			!lastEnvValueEquals(ctr.Env, "ASCEND_VISIBLE_DEVICES", "") {
 			ctr.Env = append(ctr.Env, corev1.EnvVar{
 				Name:  "ASCEND_VISIBLE_DEVICES",
 				Value: "",

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -821,6 +821,169 @@ func Test_MutateAdmission_EmptyResourceMemoryName(t *testing.T) {
 	}
 }
 
+func Test_MutateAdmission_OverwriteEnvDoesNotOverrideAscendContainer(t *testing.T) {
+	// Regression: a container that requests an Ascend resource (here Ascend910B4) must
+	// NOT get an empty ASCEND_VISIBLE_DEVICES injected by a sibling chip's
+	// MutateAdmission. Previously each chip injected an empty value per-chip when
+	// !ok, and the empty pod-spec env overrode the real value injected later by the
+	// device plugin, so ascend-docker-runtime saw an empty value and skipped device
+	// mounting.
+	allResNames := []corev1.ResourceName{
+		"huawei.com/Ascend910A",
+		"huawei.com/Ascend910B4",
+	}
+	dev := Devices{
+		config: VNPUConfig{
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryAllocatable:  int64(32768),
+			MemoryCapacity:     int64(32768),
+			OverwriteEnv:       true,
+			Templates: []Template{
+				{Name: "vir08", Memory: int64(8738), AICore: int32(8)},
+			},
+		},
+		allAscendResourceNames: allResNames,
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"huawei.com/Ascend910B4":        resource.MustParse("1"),
+				"huawei.com/Ascend910B4-memory": resource.MustParse("8192"),
+			},
+		},
+	}
+	got, err := dev.MutateAdmission(&ctr, &corev1.Pod{})
+	assert.NilError(t, err)
+	assert.Equal(t, got, false) // 910A device: container did not request 910A
+	for _, e := range ctr.Env {
+		if e.Name == "ASCEND_VISIBLE_DEVICES" {
+			t.Fatalf("expected no ASCEND_VISIBLE_DEVICES env injected for ascend container, got %q", e.Value)
+		}
+	}
+}
+
+func Test_MutateAdmission_OverwriteEnvInjectsEmptyForNonAscendContainer(t *testing.T) {
+	// A container that requests NO Ascend resource should get exactly one empty
+	// ASCEND_VISIBLE_DEVICES injected (to clear image-baked values), even when
+	// multiple chips' MutateAdmission run in the webhook device loop.
+	allResNames := []corev1.ResourceName{
+		"huawei.com/Ascend910A",
+		"huawei.com/Ascend910B4",
+	}
+	mkDev := func(resourceName string) *Devices {
+		return &Devices{
+			config: VNPUConfig{
+				ResourceName:       resourceName,
+				ResourceMemoryName: resourceName + "-memory",
+				MemoryAllocatable:  int64(32768),
+				MemoryCapacity:     int64(32768),
+				OverwriteEnv:       true,
+				Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+			},
+			allAscendResourceNames: allResNames,
+		}
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
+		Env: []corev1.EnvVar{
+			{Name: "ASCEND_VISIBLE_DEVICES", Value: "2"}, // image-baked leak
+		},
+	}
+	// Simulate the webhook device loop: every chip's MutateAdmission runs.
+	for _, name := range allResNames {
+		_, err := mkDev(string(name)).MutateAdmission(&ctr, &corev1.Pod{})
+		assert.NilError(t, err)
+	}
+	emptyCount := 0
+	for _, e := range ctr.Env {
+		if e.Name == "ASCEND_VISIBLE_DEVICES" && e.Value == "" {
+			emptyCount++
+		}
+	}
+	assert.Equal(t, emptyCount, 1, "expected exactly one empty ASCEND_VISIBLE_DEVICES")
+}
+
+func Test_MutateAdmission_OverwriteEnvLastWinsInjectsAfterRealValue(t *testing.T) {
+	// Regression: kubelet dedupes same-name env vars last-wins, so an empty
+	// ASCEND_VISIBLE_DEVICES earlier in the list does NOT hide a real value that
+	// comes after it (["", "2"] resolves to "2"). The guard must check the LAST
+	// same-name entry and still inject, so the container ends up seeing "".
+	allResNames := []corev1.ResourceName{
+		"huawei.com/Ascend910A",
+		"huawei.com/Ascend910B4",
+	}
+	dev := &Devices{
+		config: VNPUConfig{
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryAllocatable:  int64(32768),
+			MemoryCapacity:     int64(32768),
+			OverwriteEnv:       true,
+			Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+		},
+		allAscendResourceNames: allResNames,
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
+		Env: []corev1.EnvVar{
+			{Name: "ASCEND_VISIBLE_DEVICES", Value: ""},  // e.g. injected by another webhook
+			{Name: "ASCEND_VISIBLE_DEVICES", Value: "2"}, // real value after the empty one
+		},
+	}
+	got, err := dev.MutateAdmission(&ctr, &corev1.Pod{})
+	assert.NilError(t, err)
+	assert.Equal(t, got, false)
+	last := ctr.Env[len(ctr.Env)-1]
+	assert.Equal(t, last.Name, "ASCEND_VISIBLE_DEVICES")
+	assert.Equal(t, last.Value, "", "expected an empty value injected after the real one")
+	assert.Assert(t, last.ValueFrom == nil, "injected entry must be a literal")
+}
+
+func Test_MutateAdmission_OverwriteEnvIgnoresValueFromEntry(t *testing.T) {
+	// An ASCEND_VISIBLE_DEVICES populated via ValueFrom must NOT be treated as an
+	// existing empty literal value: hasEnvWithValue skips ValueFrom entries so the
+	// safety injection still runs for a non-Ascend container.
+	allResNames := []corev1.ResourceName{
+		"huawei.com/Ascend910A",
+		"huawei.com/Ascend910B4",
+	}
+	dev := &Devices{
+		config: VNPUConfig{
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryAllocatable:  int64(32768),
+			MemoryCapacity:     int64(32768),
+			OverwriteEnv:       true,
+			Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+		},
+		allAscendResourceNames: allResNames,
+	}
+	ctr := corev1.Container{
+		Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
+		Env: []corev1.EnvVar{
+			{Name: "ASCEND_VISIBLE_DEVICES", ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "cm"},
+					Key:                  "devices",
+				},
+			}},
+		},
+	}
+	got, err := dev.MutateAdmission(&ctr, &corev1.Pod{})
+	assert.NilError(t, err)
+	assert.Equal(t, got, false)
+	// The ValueFrom entry must not block injection: an empty literal entry should be appended.
+	foundEmpty := false
+	for _, e := range ctr.Env {
+		if e.Name == "ASCEND_VISIBLE_DEVICES" && e.Value == "" && e.ValueFrom == nil {
+			foundEmpty = true
+			break
+		}
+	}
+	assert.Assert(t, foundEmpty, "expected an empty literal ASCEND_VISIBLE_DEVICES to be injected despite the ValueFrom entry")
+}
+
 func Test_MutateAdmission910C(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug in the ascend `overwriteEnv` injection (introduced in #1738):
when multiple Ascend chip types are registered, a container that requests one of them still gets `ASCEND_VISIBLE_DEVICES` clobbered by empty values injected by the *other* chip instances, so ascend-docker-runtime mounts no device at all.


**Which issue(s) this PR fixes**:

Fixes #2954

**Special notes for your reviewer**:

Each registered Ascend chip type has its own `Device` instance, and the scheduler webhook calls `MutateAdmission` once per instance. #1738 modeled the injection on the nvidia implementation, which has a single instance, so the per-instance aspect was missed: for a container that requests one chip, the other N-1 instances each take the `!ok` branch and each append an empty `ASCEND_VISIBLE_DEVICES` to `container.Env`.

Why that breaks mounting, based on #1738 and re-validation on a real Ascend
cluster — when Kubernetes starts a container, env entries are appended to
`Config.Env` in this order:

- variables from the original image;
- variables injected by the device plugin via kubelet;
- variables defined in `pod.spec.containers[].env`.

ascend-docker-runtime then interprets them as follows:

- `ASCEND_VISIBLE_DEVICES`: parsed from the end backwards — a later value  overrides an earlier one;
- all other variables (including `ASCEND_VNPU_SPECS`): parsed from the beginning — values defined in the image win.

So the extra empty `ASCEND_VISIBLE_DEVICES` entries from the other Ascend instances override the device plugin's real value: the pod still schedules, but ascend-docker-runtime does not actually mount the Ascend devices.

The fix (two guards in the `!ok` branch):

1. skip the injection when the container requests *any* registered Ascend resource (limits or requests) — the clearing value is only meant for containers that request nothing;
2. make the injection idempotent: skip it when the last `ASCEND_VISIBLE_DEVICES` entry already equals the value we would inject, so even a multi-instance loop appends at most one entry.

Containers that request no Ascend resource still get exactly one empty `ASCEND_VISIBLE_DEVICES` — that is the intended `overwriteEnv` behavior, unchanged by this PR.

Hardware validation:

- Huawei Ascend 910B4 (single physical card), ascend-docker-runtime, k3s  v1.33.4, containerd 2.0.5, 7 chip types registered with `overwriteEnv: true`.
- Before: a pod requesting `huawei.com/Ascend910B4: 1` + `Ascend910B4-memory: 8192` (vNPU slice `vir05_1c_8g`) schedules and runs, pod spec carries 6 empty `ASCEND_VISIBLE_DEVICES` entries, container env  shows `ASCEND_VNPU_SPECS=vir05_1c_8g` but empty  `ASCEND_VISIBLE_DEVICES`, and no `/dev/davinci*` is mounted.
- After: same pod gets `ASCEND_VISIBLE_DEVICES=<phyid>` (single value,  no duplicates), `ASCEND_VNPU_SPECS=vir05_1c_8g`, and the assigned  `/dev/davinci*` is mounted.

<img width="1262" height="655" alt="image" src="https://github.com/user-attachments/assets/b9d3a3f2-0425-4cfc-8a62-e227cb354699" />

<img width="2604" height="260" alt="image" src="https://github.com/user-attachments/assets/473e43eb-3e43-4270-a646-0cf19213c41f" />


**Does this PR introduce a user-facing change?**:

Yes — with multiple Ascend chip types registered and `overwriteEnv: true`, containers that request an Ascend resource now correctly keep the device plugin's `ASCEND_VISIBLE_DEVICES` value and get their devices mounted.

---

AI assistance disclosure: this fix was developed with AI assistance for code editing and this description's English wording. The root-cause analysis, reproduction, and hardware validation on a real 910B cluster are my own work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ascend device environment handling during admission.
  * Prevented empty `ASCEND_VISIBLE_DEVICES` values from being injected when a container requests Ascend resources.
  * Ensured non-Ascend containers receive the expected empty value when overwrite is enabled.
  * Corrected handling of repeated environment entries and values supplied through references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->