### PR TITLE
fix(nvidia): guard Allocate against empty DevicesIds requests

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -873,6 +873,11 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	}
 
 	for idx, req := range reqs.ContainerRequests {
+		if len(req.DevicesIds) == 0 {
+			PodAllocationFailed(nodename, current, NodeLockNvidia)
+			return nil, fmt.Errorf("invalid allocation request with no devices requested")
+		}
+
 		// If the devices being allocated are replicas, then (conditionally)
 		// error out if more than one resource is being allocated.
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server_test.go
@@ -1048,3 +1048,61 @@ func TestListAndWatchSendError(t *testing.T) {
 		require.Len(t, server.sent, 2)
 	})
 }
+
+// TestAllocateRejectsEmptyDeviceIDs guards against a regression of the
+// index-out-of-range panic in Allocate when kubelet sends a container
+// request with an empty DevicesIds list (upstream k8s-device-plugin has
+// the same guard).
+func TestAllocateRejectsEmptyDeviceIDs(t *testing.T) {
+	plugin := &NvidiaDevicePlugin{
+		config: &nvidia.DeviceConfig{
+			Config: &v1.Config{
+				Flags: v1.Flags{
+					CommandLineFlags: v1.CommandLineFlags{
+						Plugin: &v1.PluginCommandLineFlags{
+							DeviceIDStrategy: ptr(v1.DeviceIDStrategyUUID),
+						},
+					},
+				},
+			},
+		},
+		deviceListStrategies: func() v1.DeviceListStrategies {
+			s, _ := v1.NewDeviceListStrategies([]string{"envvar"})
+			return s
+		}(),
+	}
+
+	previousInRequestDevice := device.InRequestDevices[nvidia.NvidiaGPUDevice]
+	device.InRequestDevices[nvidia.NvidiaGPUDevice] = "hami.io/vgpu-devices-to-allocate"
+	defer func() { device.InRequestDevices[nvidia.NvidiaGPUDevice] = previousInRequestDevice }()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-annotated-a,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+	}
+
+	previousGetPendingPod := getPendingPod
+	getPendingPod = func(context.Context, string) (*corev1.Pod, error) { return pod, nil }
+	defer func() { getPendingPod = previousGetPendingPod }()
+
+	previousPodAllocationFailed := podAllocationFailed
+	podAllocationFailed = func(string, *corev1.Pod, string) {}
+	defer func() { podAllocationFailed = previousPodAllocationFailed }()
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{{
+			DevicesIds: []string{},
+		}},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.Nil(t, response)
+	require.ErrorContains(t, err, "invalid allocation request with no devices requested")
+}


### PR DESCRIPTION
## What this PR does / why we need it

The NVIDIA device plugin's `Allocate()` handler indexes `req.DevicesIds[0]`
at the top of the container-request loop without a length check:

```go
for idx, req := range reqs.ContainerRequests {
    if strings.Contains(req.DevicesIds[0], "MIG") {
```

If any `ContainerAllocateRequest` in the batch arrives with an empty
`DevicesIds` slice, this panics with `index out of range [0] with length 0`.
There is no panic-recovery interceptor on this gRPC server, so the panic
crashes the whole device-plugin pod and blocks GPU allocation for every
workload on the node until the container restarts.

The kubelet device-plugin API does not guarantee non-empty `DevicesIds`, and
the upstream NVIDIA k8s-device-plugin guards against exactly this case first
thing in its `Allocate` (`"invalid allocation request with no devices
requested"`); the check was dropped when the handler was ported to HAMi.

This PR adds the missing guard at the top of the loop, releasing the node
lock via `PodAllocationFailed` like the other error paths, and a regression
test `TestAllocateRejectsEmptyDeviceIDs`. The test panics with
`index out of range [0] with length 0` against the old code and passes with
the fix (verified by running the test against the pre-fix tree).

Fixes #2414
Fixes #2405

## AI Assistance Disclosure

This PR was written with AI assistance (Claude) for bug identification; the
analysis (empty-list panic path, missing upstream guard, blast radius) was
verified against the code, and the fix and test design were reviewed and
understood by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid allocation requests with no device IDs are now rejected with a clear error instead of causing a runtime failure.
  * Allocation failure handling now reports the request as unsuccessful when no devices are specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->