### PR TITLE
fix(scheduler): remove duplicated effectivePodDeviceUsage declaration

### DIFF
--- a/pkg/scheduler/numa_refit_handler.go
+++ b/pkg/scheduler/numa_refit_handler.go
@@ -342,14 +342,6 @@ func containerNameAt(pod *corev1.Pod, index int) (string, bool) {
 	return "", false
 }
 
-// effectivePodDeviceUsage mirrors the accounting shape stored by PodManager.
-func effectivePodDeviceUsage(pod *corev1.Pod, raw device.PodDevices, initReleased bool) device.PodDevices {
-	if initReleased {
-		return device.SteadyStateDeviceUsage(pod, raw)
-	}
-	return device.CollapseInitContainerUsage(pod, raw)
-}
-
 // aggregateDeviceUsage returns one usage total per physical device.
 func aggregateDeviceUsage(single device.PodSingleDevice) map[string]device.ContainerDevice {
 	usage := make(map[string]device.ContainerDevice)


### PR DESCRIPTION
**What this PR does / why we need it:**

PR #2836 (300800c) and PR #2868 (4d45ace) both introduced an identical `effectivePodDeviceUsage` helper at different positions in `pkg/scheduler/numa_refit_handler.go`. Git auto-merged the two without a textual conflict, leaving two declarations of the same function in one file. Since 300800c landed, `pkg/scheduler` fails to compile:

```
pkg/scheduler/numa_refit_handler.go:346:6: effectivePodDeviceUsage redeclared in this block
	pkg/scheduler/numa_refit_handler.go:310:6: other declaration of effectivePodDeviceUsage
```

This breaks the lint CI job (typecheck) for **every** PR opened against master, e.g. #2956.

This PR removes the second declaration and keeps the one carrying the full doc comment. `go build ./...` and `golangci-lint` (v2.13.1, repo config) both pass after the change.

**Which issue(s) this PR fixes:**

Fixes none directly; unblocks the broken master build.

**Special notes for reviewers:**

Pure deletion (8 lines), no behavior change.

Assisted-by: AI coding tool (Trae), reviewed and verified by the contributor.

Signed-off-by: Woolgathererer <waterrulerule@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a duplicate internal helper definition.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->