### PR TITLE
Feat: pod level and container level overwrite env

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -113,6 +113,8 @@ data:
       resourceCountName: {{ .Values.birenResourceName }}
     vnpus:
       hamiVnpuCore: {{ .Values.devices.ascend.hamiVnpuCore | default false }}
+      overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
+      runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
       configs:
       - chipName: 910A
         commonWord: Ascend910A
@@ -123,8 +125,6 @@ data:
         memoryCapacity: 32768
         memoryFactor: 1
         aiCore: 30
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir02
             memory: 2184
@@ -148,8 +148,6 @@ data:
         memoryFactor: 1
         aiCore: 24
         aiCPU: 6
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir03_1c_8g
             memory: 8192
@@ -173,8 +171,6 @@ data:
         memoryFactor: 1
         aiCore: 20
         aiCPU: 7
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir05_1c_16g
             memory: 16384
@@ -194,8 +190,6 @@ data:
         memoryFactor: 1
         aiCore: 20
         aiCPU: 7
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir05_1c_16g
             memory: 16384
@@ -215,8 +209,6 @@ data:
         memoryFactor: 1
         aiCore: 20
         aiCPU: 7
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir05_1c_8g
             memory: 8192
@@ -236,8 +228,6 @@ data:
         memoryFactor: 1
         aiCore: 8
         aiCPU: 7
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         templates:
           - name: vir01
             memory: 3072
@@ -260,8 +250,6 @@ data:
         memoryCapacity: 65536
         aiCore: 20
         aiCPU: 7
-        runtimeClassName: "{{ .Values.devices.ascend.runtimeClassName }}"
-        overwriteEnv: {{ .Values.scheduler.overwriteEnv | default "false" }}
         superPod: true
         templates:
           - name: vir05_1c_16g

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -159,9 +159,11 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		}
 		// The container-level JSON is decoded once and cached.
 		podMode, _ := util.ParsePodOverwriteEnv(p.Annotations[util.OverwriteEnvAnnotationKey])
-		entries := cachedContainerOverwriteEnv(p.Annotations[util.OverwriteEnvContainersAnnotationKey])
+		if ctrMode, listed := cachedContainerOverwriteEnv(p.Annotations[util.OverwriteEnvContainersAnnotationKey], ctr.Name); listed {
+			podMode = ctrMode
+		}
 		inject := false
-		switch util.ResolveOverwriteEnv(podMode, entries, ctr) {
+		switch podMode {
 		case util.OverwriteEnvOn:
 			inject = true
 		case util.OverwriteEnvOff:

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -153,8 +153,11 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		if dev.containerRequestsAnyAscendResource(ctr) {
 			return false, nil
 		}
+		// The container-level JSON is decoded once and cached.
+		podMode := cachedPodOverwriteEnv(p.Annotations[util.OverwriteEnvAnnotationKey])
+		entries := cachedContainerOverwriteEnv(p.Annotations[util.OverwriteEnvContainersAnnotationKey])
 		inject := false
-		switch util.OverwriteEnvDecision(p, ctr) {
+		switch util.ResolveOverwriteEnv(podMode, entries, ctr) {
 		case util.OverwriteEnvOn:
 			inject = true
 		case util.OverwriteEnvOff:

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -154,7 +154,7 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 			return false, nil
 		}
 		// The container-level JSON is decoded once and cached.
-		podMode := cachedPodOverwriteEnv(p.Annotations[util.OverwriteEnvAnnotationKey])
+		podMode, _ := util.ParsePodOverwriteEnv(p.Annotations[util.OverwriteEnvAnnotationKey])
 		entries := cachedContainerOverwriteEnv(p.Annotations[util.OverwriteEnvContainersAnnotationKey])
 		inject := false
 		switch util.ResolveOverwriteEnv(podMode, entries, ctr) {

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -56,6 +56,8 @@ type Devices struct {
 	noUseUUIDAnno          string
 	handshakeAnno          string
 	hamiVnpuCore           bool
+	overwriteEnv           bool
+	runtimeClassName       string
 	allAscendResourceNames []corev1.ResourceName
 }
 
@@ -98,6 +100,8 @@ func InitDevices(vnpus VNPUs) []*Devices {
 			noUseUUIDAnno:          fmt.Sprintf("hami.io/no-use-%s-uuid", commonWord),
 			handshakeAnno:          fmt.Sprintf("hami.io/node-handshake-%s", commonWord),
 			hamiVnpuCore:           vnpus.HamiVnpuCore,
+			overwriteEnv:           vnpus.OverwriteEnv,
+			runtimeClassName:       vnpus.RuntimeClassName,
 			allAscendResourceNames: allAscendResourceNames,
 		}
 		sort.Slice(dev.config.Templates, func(i, j int) bool {
@@ -163,7 +167,7 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 		case util.OverwriteEnvOff:
 			inject = false
 		default:
-			inject = dev.config.OverwriteEnv
+			inject = dev.overwriteEnv
 		}
 		if inject && !lastEnvValueEquals(ctr.Env, "ASCEND_VISIBLE_DEVICES", "") {
 			ctr.Env = append(ctr.Env, corev1.EnvVar{
@@ -247,8 +251,8 @@ func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool,
 	}
 
 	// Set runtime class name if it is not set by user and the runtime class name is configured
-	if p.Spec.RuntimeClassName == nil && dev.config.RuntimeClassName != "" {
-		p.Spec.RuntimeClassName = &dev.config.RuntimeClassName
+	if p.Spec.RuntimeClassName == nil && dev.runtimeClassName != "" {
+		p.Spec.RuntimeClassName = &dev.runtimeClassName
 	}
 	return true, nil
 }

--- a/pkg/device/ascend/device.go
+++ b/pkg/device/ascend/device.go
@@ -150,8 +150,19 @@ func lastEnvValueEquals(env []corev1.EnvVar, name, value string) bool {
 func (dev *Devices) MutateAdmission(ctr *corev1.Container, p *corev1.Pod) (bool, error) {
 	count, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourceName)]
 	if !ok {
-		if dev.config.OverwriteEnv && !dev.containerRequestsAnyAscendResource(ctr) &&
-			!lastEnvValueEquals(ctr.Env, "ASCEND_VISIBLE_DEVICES", "") {
+		if dev.containerRequestsAnyAscendResource(ctr) {
+			return false, nil
+		}
+		inject := false
+		switch util.OverwriteEnvDecision(p, ctr) {
+		case util.OverwriteEnvOn:
+			inject = true
+		case util.OverwriteEnvOff:
+			inject = false
+		default:
+			inject = dev.config.OverwriteEnv
+		}
+		if inject && !lastEnvValueEquals(ctr.Env, "ASCEND_VISIBLE_DEVICES", "") {
 			ctr.Env = append(ctr.Env, corev1.EnvVar{
 				Name:  "ASCEND_VISIBLE_DEVICES",
 				Value: "",

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -147,6 +147,40 @@ func Test_InitDevices(t *testing.T) {
 			},
 			want: []*Devices{},
 		},
+		{
+			// Multi-chip config: allAscendResourceNames must be collected from every
+			// chip and shared across all returned Devices instances, so a container
+			// requesting one chip's resource is recognized as an Ascend container by
+			// every other chip's MutateAdmission.
+			name:         "multi-chip shares allAscendResourceNames",
+			enableAscend: true,
+			args: []VNPUConfig{
+				{
+					ChipName:           "910A",
+					CommonWord:         "Ascend910A",
+					ResourceName:       "huawei.com/Ascend910A",
+					ResourceMemoryName: "huawei.com/Ascend910A-memory",
+					MemoryAllocatable:  int64(32768),
+					MemoryCapacity:     int64(32768),
+					AICore:             int32(30),
+					Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+				},
+				{
+					ChipName:           "910B4",
+					CommonWord:         "Ascend910B4",
+					ResourceName:       "huawei.com/Ascend910B4",
+					ResourceMemoryName: "huawei.com/Ascend910B4-memory",
+					MemoryAllocatable:  int64(32768),
+					MemoryCapacity:     int64(32768),
+					AICore:             int32(20),
+					Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+				},
+			},
+			want: []*Devices{
+				{config: VNPUConfig{ChipName: "910A", CommonWord: "Ascend910A", ResourceName: "huawei.com/Ascend910A", ResourceMemoryName: "huawei.com/Ascend910A-memory", MemoryAllocatable: int64(32768), MemoryCapacity: int64(32768), AICore: int32(30), Templates: []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}}}},
+				{config: VNPUConfig{ChipName: "910B4", CommonWord: "Ascend910B4", ResourceName: "huawei.com/Ascend910B4", ResourceMemoryName: "huawei.com/Ascend910B4-memory", MemoryAllocatable: int64(32768), MemoryCapacity: int64(32768), AICore: int32(20), Templates: []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}}}},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -157,9 +191,20 @@ func Test_InitDevices(t *testing.T) {
 				for k, v := range devices {
 					assert.Equal(t, v, devices[k], "load ascend vnpu config %s: %v", devices[k].config.CommonWord, devices[k].config)
 				}
+				// Multi-chip: every Devices instance must share the full resource-name
+				// list collected from all chips, so containerRequestsAnyAscendResource
+				// works across sibling chips in the webhook loop.
+				if len(test.args) > 1 {
+					wantNames := []corev1.ResourceName{"huawei.com/Ascend910A", "huawei.com/Ascend910B4"}
+					for _, d := range devices {
+						assert.DeepEqual(t, d.allAscendResourceNames, wantNames)
+					}
+				}
 				assert.Equal(t, "hami.io/Ascend910A-devices-to-allocate", device.InRequestDevices[test.args[0].CommonWord])
 				assert.Equal(t, "hami.io/Ascend910A-devices-allocated", device.SupportDevices[test.args[0].CommonWord])
-				assert.Equal(t, test.want[0].handshakeAnno, util.HandshakeAnnos[test.args[0].CommonWord])
+				if len(test.args) == 1 && len(test.want) > 0 {
+					assert.Equal(t, test.want[0].handshakeAnno, util.HandshakeAnnos[test.args[0].CommonWord])
+				}
 			}
 		})
 	}
@@ -1011,6 +1056,117 @@ func Test_MutateAdmission_OverwriteEnvIgnoresValueFromEntry(t *testing.T) {
 		}
 	}
 	assert.Assert(t, foundEmpty, "expected an empty literal ASCEND_VISIBLE_DEVICES to be injected despite the ValueFrom entry")
+}
+
+// hasInjectedEmptyAVD reports whether ctr.Env contains a literal empty
+// ASCEND_VISIBLE_DEVICES entry (the clearing injection).
+func hasInjectedEmptyAVD(env []corev1.EnvVar) bool {
+	for _, e := range env {
+		if e.Name == "ASCEND_VISIBLE_DEVICES" && e.ValueFrom == nil && e.Value == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_MutateAdmission_OverwriteEnvOptOut covers the universal opt-out annotation
+// (hami.io/overwrite-env pod-level + hami.io/overwrite-env-containers JSON container-level)
+// resolved via util.OverwriteEnvDecision, with the backend's dev.config.OverwriteEnv
+// as the Unset fallback. The three-state decision: On forces injection, Off skips,
+// Unset falls back to config. Container-level overrides pod-level (both directions).
+func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
+	allResNames := []corev1.ResourceName{
+		"huawei.com/Ascend910A",
+		"huawei.com/Ascend910B4",
+	}
+	mkDev := func(overwriteEnv bool) *Devices {
+		return &Devices{
+			config: VNPUConfig{
+				ResourceName:       "huawei.com/Ascend910A",
+				ResourceMemoryName: "huawei.com/Ascend910A-memory",
+				MemoryAllocatable:  int64(32768),
+				MemoryCapacity:     int64(32768),
+				OverwriteEnv:       overwriteEnv,
+				Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
+			},
+			allAscendResourceNames: allResNames,
+		}
+	}
+	mkPod := func(ann map[string]string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: ann}}
+	}
+	// nonAscendCtr requests no Ascend resource → eligible for the clearing injection.
+	nonAscendCtr := func() corev1.Container {
+		return corev1.Container{
+			Name:      "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
+		}
+	}
+
+	type tc struct {
+		name        string
+		configOn    bool // dev.config.OverwriteEnv
+		annotations map[string]string
+		wantInject  bool
+	}
+	cases := []tc{
+		// Unset (no annotations) → fall back to config.
+		{name: "unset config true injects", configOn: true, wantInject: true},
+		{name: "unset config false skips", configOn: false, wantInject: false},
+		// Pod-level annotation forces the decision regardless of config.
+		{name: "pod false skips despite config true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false"}, wantInject: false},
+		{name: "pod true injects despite config false", configOn: false, annotations: map[string]string{"hami.io/overwrite-env": "true"}, wantInject: true},
+		// Container-level overrides pod-level (both directions).
+		{name: "container false overrides pod true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "true", "hami.io/overwrite-env-containers": `{"main":"false"}`}, wantInject: false},
+		{name: "container true reverse-overrides pod false", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false", "hami.io/overwrite-env-containers": `{"main":"true"}`}, wantInject: true},
+		// Invalid annotation value is treated as absent → falls back to lower layer.
+		{name: "invalid pod value falls back to config true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "yes"}, wantInject: true},
+		{name: "invalid container value falls back to pod false", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false", "hami.io/overwrite-env-containers": `{"main":"maybe"}`}, wantInject: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dev := mkDev(c.configOn)
+			ctr := nonAscendCtr()
+			_, err := dev.MutateAdmission(&ctr, mkPod(c.annotations))
+			assert.NilError(t, err)
+			assert.Equal(t, hasInjectedEmptyAVD(ctr.Env), c.wantInject)
+		})
+	}
+
+	// Ascend container opt-out is a no-op: a container requesting an Ascend resource
+	// never enters the injection branch, so opt-out annotations have no effect.
+	t.Run("ascend container opt-out is no-op regardless of annotation", func(t *testing.T) {
+		dev := mkDev(true)
+		ctr := corev1.Container{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+				"huawei.com/Ascend910B4": resource.MustParse("1"),
+			}},
+		}
+		// 910A device sees !ok for a 910B4 container; opt-out true would force inject
+		// for a non-ascend container, but an ascend container must be left untouched.
+		_, err := dev.MutateAdmission(&ctr, mkPod(map[string]string{"hami.io/overwrite-env": "true"}))
+		assert.NilError(t, err)
+		assert.Equal(t, hasInjectedEmptyAVD(ctr.Env), false, "ascend container must not be injected even with opt-out true")
+	})
+
+	// Requests-only (no Limits) Ascend container is still recognized as an Ascend
+	// container and must not be injected (containerRequestsAnyAscendResource checks
+	// both Limits and Requests).
+	t.Run("requests-only ascend container is not injected", func(t *testing.T) {
+		dev := mkDev(true)
+		ctr := corev1.Container{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"huawei.com/Ascend910B4": resource.MustParse("1"),
+				},
+			},
+		}
+		_, err := dev.MutateAdmission(&ctr, mkPod(nil))
+		assert.NilError(t, err)
+		assert.Equal(t, hasInjectedEmptyAVD(ctr.Env), false, "requests-only ascend container must not be injected")
+	})
 }
 
 func Test_MutateAdmission910C(t *testing.T) {

--- a/pkg/device/ascend/device_test.go
+++ b/pkg/device/ascend/device_test.go
@@ -912,11 +912,11 @@ func Test_MutateAdmission_OverwriteEnvDoesNotOverrideAscendContainer(t *testing.
 			ResourceMemoryName: "huawei.com/Ascend910A-memory",
 			MemoryAllocatable:  int64(32768),
 			MemoryCapacity:     int64(32768),
-			OverwriteEnv:       true,
 			Templates: []Template{
 				{Name: "vir08", Memory: int64(8738), AICore: int32(8)},
 			},
 		},
+		overwriteEnv:           true,
 		allAscendResourceNames: allResNames,
 	}
 	ctr := corev1.Container{
@@ -952,9 +952,9 @@ func Test_MutateAdmission_OverwriteEnvInjectsEmptyForNonAscendContainer(t *testi
 				ResourceMemoryName: resourceName + "-memory",
 				MemoryAllocatable:  int64(32768),
 				MemoryCapacity:     int64(32768),
-				OverwriteEnv:       true,
 				Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
 			},
+			overwriteEnv:           true,
 			allAscendResourceNames: allResNames,
 		}
 	}
@@ -993,9 +993,9 @@ func Test_MutateAdmission_OverwriteEnvLastWinsInjectsAfterRealValue(t *testing.T
 			ResourceMemoryName: "huawei.com/Ascend910A-memory",
 			MemoryAllocatable:  int64(32768),
 			MemoryCapacity:     int64(32768),
-			OverwriteEnv:       true,
 			Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
 		},
+		overwriteEnv:           true,
 		allAscendResourceNames: allResNames,
 	}
 	ctr := corev1.Container{
@@ -1028,9 +1028,9 @@ func Test_MutateAdmission_OverwriteEnvIgnoresValueFromEntry(t *testing.T) {
 			ResourceMemoryName: "huawei.com/Ascend910A-memory",
 			MemoryAllocatable:  int64(32768),
 			MemoryCapacity:     int64(32768),
-			OverwriteEnv:       true,
 			Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
 		},
+		overwriteEnv:           true,
 		allAscendResourceNames: allResNames,
 	}
 	ctr := corev1.Container{
@@ -1071,7 +1071,7 @@ func hasInjectedEmptyAVD(env []corev1.EnvVar) bool {
 
 // Test_MutateAdmission_OverwriteEnvOptOut covers the universal opt-out annotation
 // (hami.io/overwrite-env pod-level + hami.io/overwrite-env-containers JSON container-level)
-// resolved via util.OverwriteEnvDecision, with the backend's dev.config.OverwriteEnv
+// resolved via util.OverwriteEnvDecision, with the backend's dev.overwriteEnv
 // as the Unset fallback. The three-state decision: On forces injection, Off skips,
 // Unset falls back to config. Container-level overrides pod-level (both directions).
 func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
@@ -1086,9 +1086,9 @@ func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
 				ResourceMemoryName: "huawei.com/Ascend910A-memory",
 				MemoryAllocatable:  int64(32768),
 				MemoryCapacity:     int64(32768),
-				OverwriteEnv:       overwriteEnv,
 				Templates:          []Template{{Name: "vir08", Memory: int64(8738), AICore: int32(8)}},
 			},
+			overwriteEnv:           overwriteEnv,
 			allAscendResourceNames: allResNames,
 		}
 	}
@@ -1105,7 +1105,7 @@ func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
 
 	type tc struct {
 		name        string
-		configOn    bool // dev.config.OverwriteEnv
+		configOn    bool // dev.overwriteEnv
 		annotations map[string]string
 		wantInject  bool
 	}
@@ -3458,4 +3458,27 @@ func TestFit_CoresValidation(t *testing.T) {
 		assert.Equal(t, ok, false)
 		assert.Equal(t, reason, "core limit out of range")
 	})
+}
+
+// Test_InitDevices_GlobalOverwriteEnvPropagation verifies the global vnpus
+// overwriteEnv and runtimeClassName settings reach every Devices instance.
+func Test_InitDevices_GlobalOverwriteEnvPropagation(t *testing.T) {
+	chip := VNPUConfig{
+		ChipName:           "910A",
+		CommonWord:         "Ascend910A",
+		ResourceName:       "huawei.com/Ascend910A",
+		ResourceMemoryName: "huawei.com/Ascend910A-memory",
+	}
+	enable := true
+	defer func() { enableAscend = enable }()
+	enableAscend = true
+
+	devs := InitDevices(VNPUs{
+		OverwriteEnv:     true,
+		RuntimeClassName: "ascend-rc",
+		Configs:          []VNPUConfig{chip},
+	})
+	assert.Assert(t, len(devs) == 1, "expected one device")
+	assert.Equal(t, devs[0].overwriteEnv, true)
+	assert.Equal(t, devs[0].runtimeClassName, "ascend-rc")
 }

--- a/pkg/device/ascend/overwrite_env_cache.go
+++ b/pkg/device/ascend/overwrite_env_cache.go
@@ -26,42 +26,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/cache"
 )
 
-// overwriteEnv decode caches. The webhook calls MutateAdmission once per
-// registered Ascend chip (7 on a typical node), so without these caches the
-// same pod-level value and container-level JSON would be re-parsed 7× per
-// non-Ascend container — and, for invalid inputs, the same klog warning would
-// fire 7×.
+// overwriteEnvEntriesCache memoizes the decoded container-level OverwriteEnv
+// JSON (hami.io/overwrite-env-containers). The webhook calls MutateAdmission
+// once per registered Ascend chip (7 on a typical node), so without the cache
+// the same JSON would be decoded 7× per container — and, for a malformed
+// value, its warning logged 7×. The pod-level annotation is deliberately not
+// cached: strconv.ParseBool is cheaper than a cache lookup, so an invalid
+// pod-level value may log its warning per chip.
 //
-// Keys are the raw annotation content (not a pod identity): identical values
-// across pods share one entry, a changed annotation is a different key (no
-// stale risk, no TTL needed), and the LRU capacity bounds memory. Entries
-// never expire (ttl = math.MaxInt64). Error results (nil) are cached too, so a
-// malformed JSON is decoded and logged exactly once per distinct value.
-var (
-	overwriteEnvPodCache     = cache.NewLRUExpireCache(256)
-	overwriteEnvEntriesCache = cache.NewLRUExpireCache(256)
-)
+// The key is the raw JSON content (not a pod identity): identical values
+// across pods share one entry, and a changed annotation is a different key —
+// the same key always decodes to the same result, so expiry cannot improve
+// correctness and the LRU capacity is the only bound needed. The TTL is the
+// maximum duration solely because LRUExpireCache's API requires one. Error
+// results (nil) are cached too, so a malformed JSON is decoded and logged
+// exactly once per distinct value.
+var overwriteEnvEntriesCache = cache.NewLRUExpireCache(256)
 
 const overwriteEnvCacheTTL = time.Duration(math.MaxInt64)
-
-// cachedPodOverwriteEnv parses the pod-level annotation value once and caches
-// the result (including Unset for an invalid value) by the raw string, so the
-// 7× per-chip calls don't re-parse or re-warn. strconv.ParseBool is cheap, but
-// an invalid value would otherwise log the same warning 7×.
-func cachedPodOverwriteEnv(podVal string) util.OverwriteEnvMode {
-	if podVal == "" {
-		return util.OverwriteEnvUnset
-	}
-	if v, ok := overwriteEnvPodCache.Get(podVal); ok {
-		if mode, ok := v.(util.OverwriteEnvMode); ok {
-			return mode
-		}
-		// Wrong type stored: unreachable, but recompute rather than panic.
-	}
-	mode, _ := util.ParsePodOverwriteEnv(podVal)
-	overwriteEnvPodCache.Add(podVal, mode, overwriteEnvCacheTTL)
-	return mode
-}
 
 // cachedContainerOverwriteEnv decodes the container-level JSON once and caches
 // the result (including nil for a malformed JSON) by the raw string, so the 7×

--- a/pkg/device/ascend/overwrite_env_cache.go
+++ b/pkg/device/ascend/overwrite_env_cache.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ascend
+
+import (
+	"maps"
+	"math"
+	"time"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
+
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+// overwriteEnv decode caches. The webhook calls MutateAdmission once per
+// registered Ascend chip (7 on a typical node), so without these caches the
+// same pod-level value and container-level JSON would be re-parsed 7× per
+// non-Ascend container — and, for invalid inputs, the same klog warning would
+// fire 7×.
+//
+// Keys are the raw annotation content (not a pod identity): identical values
+// across pods share one entry, a changed annotation is a different key (no
+// stale risk, no TTL needed), and the LRU capacity bounds memory. Entries
+// never expire (ttl = math.MaxInt64). Error results (nil) are cached too, so a
+// malformed JSON is decoded and logged exactly once per distinct value.
+var (
+	overwriteEnvPodCache     = cache.NewLRUExpireCache(256)
+	overwriteEnvEntriesCache = cache.NewLRUExpireCache(256)
+)
+
+const overwriteEnvCacheTTL = time.Duration(math.MaxInt64)
+
+// cachedPodOverwriteEnv parses the pod-level annotation value once and caches
+// the result (including Unset for an invalid value) by the raw string, so the
+// 7× per-chip calls don't re-parse or re-warn. strconv.ParseBool is cheap, but
+// an invalid value would otherwise log the same warning 7×.
+func cachedPodOverwriteEnv(podVal string) util.OverwriteEnvMode {
+	if podVal == "" {
+		return util.OverwriteEnvUnset
+	}
+	if v, ok := overwriteEnvPodCache.Get(podVal); ok {
+		if mode, ok := v.(util.OverwriteEnvMode); ok {
+			return mode
+		}
+		// Wrong type stored: unreachable, but recompute rather than panic.
+	}
+	mode, _ := util.ParsePodOverwriteEnv(podVal)
+	overwriteEnvPodCache.Add(podVal, mode, overwriteEnvCacheTTL)
+	return mode
+}
+
+// cachedContainerOverwriteEnv decodes the container-level JSON once and caches
+// the result (including nil for a malformed JSON) by the raw string, so the 7×
+// per-chip calls don't re-decode or re-warn. An empty rawJSON returns nil
+// without touching the cache (no entry for "no annotation"). A shallow copy of
+// the decoded map is returned so callers cannot mutate the cached entry.
+func cachedContainerOverwriteEnv(rawJSON string) map[string]util.OverwriteEnvMode {
+	if rawJSON == "" {
+		return nil
+	}
+	if v, ok := overwriteEnvEntriesCache.Get(rawJSON); ok {
+		if entries, ok := v.(map[string]util.OverwriteEnvMode); ok {
+			return entries
+		}
+		// Wrong type stored: unreachable, but recompute rather than panic.
+	}
+	entries, err := util.DecodeContainerOverwriteEnvJSON(rawJSON)
+	if err != nil {
+		// DecodeContainerOverwriteEnvJSON already logged the warning. Cache nil
+		// so the remaining per-chip calls don't re-decode and re-log.
+		overwriteEnvEntriesCache.Add(rawJSON, map[string]util.OverwriteEnvMode(nil), overwriteEnvCacheTTL)
+		return nil
+	}
+	// Return a shallow copy so callers cannot mutate the cached shared map.
+	cp := make(map[string]util.OverwriteEnvMode, len(entries))
+	maps.Copy(cp, entries)
+	overwriteEnvEntriesCache.Add(rawJSON, entries, overwriteEnvCacheTTL)
+	return cp
+}

--- a/pkg/device/ascend/overwrite_env_cache.go
+++ b/pkg/device/ascend/overwrite_env_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ascend
 
 import (
-	"maps"
 	"math"
 	"time"
 
@@ -39,29 +38,26 @@ var overwriteEnvEntriesCache = cache.NewLRUExpireCache(256)
 
 const overwriteEnvCacheTTL = time.Duration(math.MaxInt64)
 
-// cachedContainerOverwriteEnv decodes rawJSON once and caches the result by
-// the raw string. A shallow copy is returned so callers cannot mutate the
-// cached entry.
-func cachedContainerOverwriteEnv(rawJSON string) map[string]util.OverwriteEnvMode {
+// cachedContainerOverwriteEnv resolves ctrName's mode from the container-level
+// JSON. The decoded map never leaves the cache layer. listed is false when the
+// JSON is empty or malformed, or the container has no entry — the caller falls
+// back to the pod-level value.
+func cachedContainerOverwriteEnv(rawJSON, ctrName string) (mode util.OverwriteEnvMode, listed bool) {
 	if rawJSON == "" {
-		return nil
+		return util.OverwriteEnvUnset, false
 	}
-	if v, ok := overwriteEnvEntriesCache.Get(rawJSON); ok {
-		if entries, ok := v.(map[string]util.OverwriteEnvMode); ok {
-			return entries
+	v, ok := overwriteEnvEntriesCache.Get(rawJSON)
+	if !ok {
+		entries, err := util.DecodeContainerOverwriteEnvJSON(rawJSON)
+		if err != nil {
+			// Cache nil so per-chip calls don't re-decode or re-warn.
+			overwriteEnvEntriesCache.Add(rawJSON, map[string]util.OverwriteEnvMode(nil), overwriteEnvCacheTTL)
+			return util.OverwriteEnvUnset, false
 		}
-		// Wrong type stored: unreachable, but recompute rather than panic.
+		overwriteEnvEntriesCache.Add(rawJSON, entries, overwriteEnvCacheTTL)
+		v = entries
 	}
-	entries, err := util.DecodeContainerOverwriteEnvJSON(rawJSON)
-	if err != nil {
-		// DecodeContainerOverwriteEnvJSON already logged the warning. Cache nil
-		// so the remaining per-chip calls don't re-decode and re-log.
-		overwriteEnvEntriesCache.Add(rawJSON, map[string]util.OverwriteEnvMode(nil), overwriteEnvCacheTTL)
-		return nil
-	}
-	// Return a shallow copy so callers cannot mutate the cached shared map.
-	cp := make(map[string]util.OverwriteEnvMode, len(entries))
-	maps.Copy(cp, entries)
-	overwriteEnvEntriesCache.Add(rawJSON, entries, overwriteEnvCacheTTL)
-	return cp
+	entries, _ := v.(map[string]util.OverwriteEnvMode) // nil map is safe to index
+	mode, listed = entries[ctrName]
+	return mode, listed
 }

--- a/pkg/device/ascend/overwrite_env_cache.go
+++ b/pkg/device/ascend/overwrite_env_cache.go
@@ -27,29 +27,21 @@ import (
 )
 
 // overwriteEnvEntriesCache memoizes the decoded container-level OverwriteEnv
-// JSON (hami.io/overwrite-env-containers). The webhook calls MutateAdmission
-// once per registered Ascend chip (7 on a typical node), so without the cache
-// the same JSON would be decoded 7× per container — and, for a malformed
-// value, its warning logged 7×. The pod-level annotation is deliberately not
-// cached: strconv.ParseBool is cheaper than a cache lookup, so an invalid
-// pod-level value may log its warning per chip.
-//
-// The key is the raw JSON content (not a pod identity): identical values
-// across pods share one entry, and a changed annotation is a different key —
-// the same key always decodes to the same result, so expiry cannot improve
-// correctness and the LRU capacity is the only bound needed. The TTL is the
-// maximum duration solely because LRUExpireCache's API requires one. Error
-// results (nil) are cached too, so a malformed JSON is decoded and logged
-// exactly once per distinct value.
+// JSON: the webhook calls MutateAdmission once per chip (7 on a typical node),
+// so without it the same JSON would be decoded 7× per container. The key is
+// the raw JSON content (not a pod identity), so the same key always decodes to
+// the same result — expiry cannot improve correctness and the LRU capacity is
+// the only bound needed; the TTL is the max duration solely because the API
+// requires one. Error results (nil) are cached too, so a malformed JSON is
+// decoded and logged exactly once per distinct value. The pod-level annotation
+// is not cached: strconv.ParseBool is cheaper than a cache lookup.
 var overwriteEnvEntriesCache = cache.NewLRUExpireCache(256)
 
 const overwriteEnvCacheTTL = time.Duration(math.MaxInt64)
 
-// cachedContainerOverwriteEnv decodes the container-level JSON once and caches
-// the result (including nil for a malformed JSON) by the raw string, so the 7×
-// per-chip calls don't re-decode or re-warn. An empty rawJSON returns nil
-// without touching the cache (no entry for "no annotation"). A shallow copy of
-// the decoded map is returned so callers cannot mutate the cached entry.
+// cachedContainerOverwriteEnv decodes rawJSON once and caches the result by
+// the raw string. A shallow copy is returned so callers cannot mutate the
+// cached entry.
 func cachedContainerOverwriteEnv(rawJSON string) map[string]util.OverwriteEnvMode {
 	if rawJSON == "" {
 		return nil

--- a/pkg/device/ascend/overwrite_env_cache_test.go
+++ b/pkg/device/ascend/overwrite_env_cache_test.go
@@ -25,28 +25,6 @@ import (
 	"github.com/Project-HAMi/HAMi/pkg/util"
 )
 
-// Test_cachedPodOverwriteEnv covers hit/miss, invalid-value caching, and empty
-// short-circuit. The cache is package-global, so each case uses a distinct
-// input to avoid cross-case interference.
-func Test_cachedPodOverwriteEnv(t *testing.T) {
-	// miss → parse + cache
-	got := cachedPodOverwriteEnv("true")
-	assert.Equal(t, got, util.OverwriteEnvOn)
-	// hit (same value) → returns cached without re-parse
-	got = cachedPodOverwriteEnv("true")
-	assert.Equal(t, got, util.OverwriteEnvOn)
-
-	// invalid value caches Unset so repeated calls don't re-warn
-	got = cachedPodOverwriteEnv("not-a-bool")
-	assert.Equal(t, got, util.OverwriteEnvUnset)
-	got = cachedPodOverwriteEnv("not-a-bool") // hit
-	assert.Equal(t, got, util.OverwriteEnvUnset)
-
-	// empty short-circuits (no cache entry)
-	got = cachedPodOverwriteEnv("")
-	assert.Equal(t, got, util.OverwriteEnvUnset)
-}
-
 // Test_cachedContainerOverwriteEnv covers hit/miss, malformed-JSON nil caching,
 // and empty short-circuit. Distinct JSON per case avoids cross-case sharing.
 func Test_cachedContainerOverwriteEnv(t *testing.T) {
@@ -76,7 +54,7 @@ func Test_cachedContainerOverwriteEnv(t *testing.T) {
 }
 
 // Test_cachedOverwriteEnv_DecisionEquivalence confirms the cached ascend path
-// (cachedPodOverwriteEnv + cachedContainerOverwriteEnv + ResolveOverwriteEnv)
+// (util.ParsePodOverwriteEnv + cachedContainerOverwriteEnv + ResolveOverwriteEnv)
 // produces the same decision as the uncached util.OverwriteEnvDecision for
 // representative inputs.
 func Test_cachedOverwriteEnv_DecisionEquivalence(t *testing.T) {
@@ -105,7 +83,7 @@ func Test_cachedOverwriteEnv_DecisionEquivalence(t *testing.T) {
 			}
 			ctr := &corev1.Container{Name: c.ctrName}
 			want := util.OverwriteEnvDecision(pod, ctr)
-			podMode := cachedPodOverwriteEnv(c.podVal)
+			podMode, _ := util.ParsePodOverwriteEnv(c.podVal)
 			entries := cachedContainerOverwriteEnv(c.rawJSON)
 			got := util.ResolveOverwriteEnv(podMode, entries, ctr)
 			assert.Equal(t, got, want, "cached path must match uncached decision")

--- a/pkg/device/ascend/overwrite_env_cache_test.go
+++ b/pkg/device/ascend/overwrite_env_cache_test.go
@@ -28,33 +28,33 @@ import (
 // Test_cachedContainerOverwriteEnv covers hit/miss, malformed-JSON nil caching,
 // and empty short-circuit. Distinct JSON per case avoids cross-case sharing.
 func Test_cachedContainerOverwriteEnv(t *testing.T) {
-	// miss → decode + cache
-	got := cachedContainerOverwriteEnv(`{"main":"true"}`)
-	assert.Equal(t, len(got), 1)
-	assert.Equal(t, got["main"], util.OverwriteEnvOn)
-	// hit (same JSON) → returns cached map
-	got = cachedContainerOverwriteEnv(`{"main":"true"}`)
-	assert.Equal(t, got["main"], util.OverwriteEnvOn)
+	// miss → decode + cache, lookup by container name
+	mode, listed := cachedContainerOverwriteEnv(`{"main":"true"}`, "main")
+	assert.Equal(t, mode, util.OverwriteEnvOn)
+	assert.Assert(t, listed)
+	// hit (same JSON) → same answer, no re-decode
+	mode, listed = cachedContainerOverwriteEnv(`{"main":"true"}`, "main")
+	assert.Equal(t, mode, util.OverwriteEnvOn)
+	assert.Assert(t, listed)
+	// unlisted container
+	mode, listed = cachedContainerOverwriteEnv(`{"main":"true"}`, "sidecar")
+	assert.Equal(t, mode, util.OverwriteEnvUnset)
+	assert.Assert(t, !listed)
 
 	// malformed JSON caches nil so repeated calls don't re-decode/re-warn
-	got = cachedContainerOverwriteEnv("not-json")
-	assert.Assert(t, got == nil, "malformed JSON must return nil")
-	got = cachedContainerOverwriteEnv("not-json") // hit, no re-warn
-	assert.Assert(t, got == nil)
+	mode, listed = cachedContainerOverwriteEnv("not-json", "main")
+	assert.Equal(t, mode, util.OverwriteEnvUnset)
+	assert.Assert(t, !listed)
+	_, listed = cachedContainerOverwriteEnv("not-json", "main") // hit, no re-warn
+	assert.Assert(t, !listed)
 
 	// empty short-circuits (no cache entry)
-	got = cachedContainerOverwriteEnv("")
-	assert.Assert(t, got == nil)
-
-	// multi-container JSON
-	got = cachedContainerOverwriteEnv(`{"main":"true","sidecar":"false"}`)
-	assert.Equal(t, len(got), 2)
-	assert.Equal(t, got["main"], util.OverwriteEnvOn)
-	assert.Equal(t, got["sidecar"], util.OverwriteEnvOff)
+	_, listed = cachedContainerOverwriteEnv("", "main")
+	assert.Assert(t, !listed)
 }
 
 // Test_cachedOverwriteEnv_DecisionEquivalence confirms the cached ascend path
-// (util.ParsePodOverwriteEnv + cachedContainerOverwriteEnv + ResolveOverwriteEnv)
+// (util.ParsePodOverwriteEnv + cachedContainerOverwriteEnv) with the inline
 // produces the same decision as the uncached util.OverwriteEnvDecision for
 // representative inputs.
 func Test_cachedOverwriteEnv_DecisionEquivalence(t *testing.T) {
@@ -84,9 +84,10 @@ func Test_cachedOverwriteEnv_DecisionEquivalence(t *testing.T) {
 			ctr := &corev1.Container{Name: c.ctrName}
 			want := util.OverwriteEnvDecision(pod, ctr)
 			podMode, _ := util.ParsePodOverwriteEnv(c.podVal)
-			entries := cachedContainerOverwriteEnv(c.rawJSON)
-			got := util.ResolveOverwriteEnv(podMode, entries, ctr)
-			assert.Equal(t, got, want, "cached path must match uncached decision")
+			if ctrMode, listed := cachedContainerOverwriteEnv(c.rawJSON, c.ctrName); listed {
+				podMode = ctrMode
+			}
+			assert.Equal(t, podMode, want, "cached path must match uncached decision")
 		})
 	}
 }

--- a/pkg/device/ascend/overwrite_env_cache_test.go
+++ b/pkg/device/ascend/overwrite_env_cache_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ascend
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/util"
+)
+
+// Test_cachedPodOverwriteEnv covers hit/miss, invalid-value caching, and empty
+// short-circuit. The cache is package-global, so each case uses a distinct
+// input to avoid cross-case interference.
+func Test_cachedPodOverwriteEnv(t *testing.T) {
+	// miss → parse + cache
+	got := cachedPodOverwriteEnv("true")
+	assert.Equal(t, got, util.OverwriteEnvOn)
+	// hit (same value) → returns cached without re-parse
+	got = cachedPodOverwriteEnv("true")
+	assert.Equal(t, got, util.OverwriteEnvOn)
+
+	// invalid value caches Unset so repeated calls don't re-warn
+	got = cachedPodOverwriteEnv("not-a-bool")
+	assert.Equal(t, got, util.OverwriteEnvUnset)
+	got = cachedPodOverwriteEnv("not-a-bool") // hit
+	assert.Equal(t, got, util.OverwriteEnvUnset)
+
+	// empty short-circuits (no cache entry)
+	got = cachedPodOverwriteEnv("")
+	assert.Equal(t, got, util.OverwriteEnvUnset)
+}
+
+// Test_cachedContainerOverwriteEnv covers hit/miss, malformed-JSON nil caching,
+// and empty short-circuit. Distinct JSON per case avoids cross-case sharing.
+func Test_cachedContainerOverwriteEnv(t *testing.T) {
+	// miss → decode + cache
+	got := cachedContainerOverwriteEnv(`{"main":"true"}`)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got["main"], util.OverwriteEnvOn)
+	// hit (same JSON) → returns cached map
+	got = cachedContainerOverwriteEnv(`{"main":"true"}`)
+	assert.Equal(t, got["main"], util.OverwriteEnvOn)
+
+	// malformed JSON caches nil so repeated calls don't re-decode/re-warn
+	got = cachedContainerOverwriteEnv("not-json")
+	assert.Assert(t, got == nil, "malformed JSON must return nil")
+	got = cachedContainerOverwriteEnv("not-json") // hit, no re-warn
+	assert.Assert(t, got == nil)
+
+	// empty short-circuits (no cache entry)
+	got = cachedContainerOverwriteEnv("")
+	assert.Assert(t, got == nil)
+
+	// multi-container JSON
+	got = cachedContainerOverwriteEnv(`{"main":"true","sidecar":"false"}`)
+	assert.Equal(t, len(got), 2)
+	assert.Equal(t, got["main"], util.OverwriteEnvOn)
+	assert.Equal(t, got["sidecar"], util.OverwriteEnvOff)
+}
+
+// Test_cachedOverwriteEnv_DecisionEquivalence confirms the cached ascend path
+// (cachedPodOverwriteEnv + cachedContainerOverwriteEnv + ResolveOverwriteEnv)
+// produces the same decision as the uncached util.OverwriteEnvDecision for
+// representative inputs.
+func Test_cachedOverwriteEnv_DecisionEquivalence(t *testing.T) {
+	cases := []struct {
+		name    string
+		podVal  string
+		rawJSON string
+		ctrName string
+	}{
+		{"pod-only-true", "true", "", "main"},
+		{"pod-only-false", "false", "", "main"},
+		{"container-overrides-pod", "false", `{"main":"true"}`, "main"},
+		{"unlisted-container-falls-back", "true", `{"other":"false"}`, "main"},
+		{"malformed-json-falls-back", "true", "not-json", "main"},
+		{"no-annotations", "", "", "main"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			pod.Annotations = map[string]string{}
+			if c.podVal != "" {
+				pod.Annotations[util.OverwriteEnvAnnotationKey] = c.podVal
+			}
+			if c.rawJSON != "" {
+				pod.Annotations[util.OverwriteEnvContainersAnnotationKey] = c.rawJSON
+			}
+			ctr := &corev1.Container{Name: c.ctrName}
+			want := util.OverwriteEnvDecision(pod, ctr)
+			podMode := cachedPodOverwriteEnv(c.podVal)
+			entries := cachedContainerOverwriteEnv(c.rawJSON)
+			got := util.ResolveOverwriteEnv(podMode, entries, ctr)
+			assert.Equal(t, got, want, "cached path must match uncached decision")
+		})
+	}
+}

--- a/pkg/device/ascend/vnpu.go
+++ b/pkg/device/ascend/vnpu.go
@@ -34,15 +34,17 @@ type VNPUConfig struct {
 	MemoryFactor       int32      `yaml:"memoryFactor"`
 	AICore             int32      `yaml:"aiCore"`
 	AICPU              int32      `yaml:"aiCPU"`
-	RuntimeClassName   string     `yaml:"runtimeClassName"`
-	OverwriteEnv       bool       `yaml:"overwriteEnv"`
 	Templates          []Template `yaml:"templates"`
 	SuperPod           bool       `yaml:"superPod"`
 }
 
 // VNPUs holds the global Ascend VNPU configuration, including a flag to enable
 // hami-vnpu-core soft-partitioning for all nodes and the per-chip config list.
+// OverwriteEnv and RuntimeClassName apply to every chip identically, so they
+// live here rather than on each VNPUConfig.
 type VNPUs struct {
-	HamiVnpuCore bool         `yaml:"hamiVnpuCore"`
-	Configs      []VNPUConfig `yaml:"configs"`
+	HamiVnpuCore     bool         `yaml:"hamiVnpuCore"`
+	OverwriteEnv     bool         `yaml:"overwriteEnv"`
+	RuntimeClassName string       `yaml:"runtimeClassName"`
+	Configs          []VNPUConfig `yaml:"configs"`
 }

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -367,11 +367,30 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 		}
 	}
 
-	if !hasResource && dev.config.OverwriteEnv {
-		ctr.Env = append(ctr.Env, corev1.EnvVar{
-			Name:  "NVIDIA_VISIBLE_DEVICES",
-			Value: "none",
-		})
+	if !hasResource {
+		// opt-out: On forces NVIDIA_VISIBLE_DEVICES=none, Off skips, Unset falls
+		// back to dev.config.OverwriteEnv.
+		//
+		// PREREQUISITE: GetDevices() contains at most one Nvidia entry; otherwise
+		// MutateAdmission runs multiple times per container and duplicate
+		// NVIDIA_VISIBLE_DEVICES=none entries would accumulate (functionally
+		// harmless via kubelet last-wins, but noisy). If multi-config Nvidia
+		// support is added, add a lastEnvValueEquals guard like Ascend.
+		inject := false
+		switch util.OverwriteEnvDecision(p, ctr) {
+		case util.OverwriteEnvOn:
+			inject = true
+		case util.OverwriteEnvOff:
+			inject = false
+		default:
+			inject = dev.config.OverwriteEnv
+		}
+		if inject {
+			ctr.Env = append(ctr.Env, corev1.EnvVar{
+				Name:  "NVIDIA_VISIBLE_DEVICES",
+				Value: "none",
+			})
+		}
 	}
 	return hasResource, nil
 }

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -368,10 +368,7 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 	}
 
 	if !hasResource {
-		// opt-out: On forces NVIDIA_VISIBLE_DEVICES=none, Off skips, Unset falls
-		// back to dev.config.OverwriteEnv. Assumes GetDevices() has at most one
-		// Nvidia entry; multi-config support would need a lastEnvValueEquals
-		// guard like Ascend.
+		// Unset falls back to dev.config.OverwriteEnv.
 		inject := false
 		switch util.OverwriteEnvDecision(p, ctr) {
 		case util.OverwriteEnvOn:
@@ -381,7 +378,8 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 		default:
 			inject = dev.config.OverwriteEnv
 		}
-		if inject {
+		// Idempotent on webhook reinvocation (reinvocationPolicy: IfNeeded).
+		if inject && !hasEnvVarWithValue(ctr.Env, "NVIDIA_VISIBLE_DEVICES", "none") {
 			ctr.Env = append(ctr.Env, corev1.EnvVar{
 				Name:  "NVIDIA_VISIBLE_DEVICES",
 				Value: "none",
@@ -389,6 +387,18 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 		}
 	}
 	return hasResource, nil
+}
+
+// hasEnvVarWithValue matches the last entry with the given name, because
+// kubelet lets the last same-name env entry win.
+func hasEnvVarWithValue(env []corev1.EnvVar, name, value string) bool {
+	for _, e := range slices.Backward(env) {
+		if e.Name != name {
+			continue
+		}
+		return e.ValueFrom == nil && e.Value == value
+	}
+	return false
 }
 
 func (dev *NvidiaGPUDevices) validateMemoryPercentage(ctr *corev1.Container) error {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -369,13 +369,9 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 
 	if !hasResource {
 		// opt-out: On forces NVIDIA_VISIBLE_DEVICES=none, Off skips, Unset falls
-		// back to dev.config.OverwriteEnv.
-		//
-		// PREREQUISITE: GetDevices() contains at most one Nvidia entry; otherwise
-		// MutateAdmission runs multiple times per container and duplicate
-		// NVIDIA_VISIBLE_DEVICES=none entries would accumulate (functionally
-		// harmless via kubelet last-wins, but noisy). If multi-config Nvidia
-		// support is added, add a lastEnvValueEquals guard like Ascend.
+		// back to dev.config.OverwriteEnv. Assumes GetDevices() has at most one
+		// Nvidia entry; multi-config support would need a lastEnvValueEquals
+		// guard like Ascend.
 		inject := false
 		switch util.OverwriteEnvDecision(p, ctr) {
 		case util.OverwriteEnvOn:

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -127,6 +127,65 @@ func Test_MutateAdmission(t *testing.T) {
 	}
 }
 
+func hasInjectedNVDnone(env []corev1.EnvVar) bool {
+	for _, e := range env {
+		if e.Name == "NVIDIA_VISIBLE_DEVICES" && e.Value == "none" {
+			return true
+		}
+	}
+	return false
+}
+
+func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
+	mkDev := func(overwriteEnv bool) *NvidiaGPUDevices {
+		return &NvidiaGPUDevices{
+			config: NvidiaConfig{
+				ResourceCountName:            "nvidia.com/gpu",
+				ResourceMemoryName:           "nvidia.com/gpumem",
+				ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+				ResourceCoreName:             "nvidia.com/gpucores",
+				DefaultGPUNum:                int32(1),
+				OverwriteEnv:                 overwriteEnv,
+			},
+		}
+	}
+	mkPod := func(ann map[string]string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: ann}}
+	}
+	nonGPUCtr := func() corev1.Container {
+		return corev1.Container{
+			Name:      "main",
+			Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
+		}
+	}
+
+	type tc struct {
+		name        string
+		configOn    bool
+		annotations map[string]string
+		wantInject  bool
+	}
+	cases := []tc{
+		{name: "unset config true injects none", configOn: true, wantInject: true},
+		{name: "unset config false skips", configOn: false, wantInject: false},
+		{name: "pod false skips despite config true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false"}, wantInject: false},
+		{name: "pod true injects despite config false", configOn: false, annotations: map[string]string{"hami.io/overwrite-env": "true"}, wantInject: true},
+		{name: "container false overrides pod true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "true", "hami.io/overwrite-env-containers": `{"main":"false"}`}, wantInject: false},
+		{name: "container true reverse-overrides pod false", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false", "hami.io/overwrite-env-containers": `{"main":"true"}`}, wantInject: true},
+		{name: "invalid pod value falls back to config true", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "yes"}, wantInject: true},
+		{name: "invalid container value falls back to pod false", configOn: true, annotations: map[string]string{"hami.io/overwrite-env": "false", "hami.io/overwrite-env-containers": `{"main":"maybe"}`}, wantInject: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dev := mkDev(c.configOn)
+			ctr := nonGPUCtr()
+			_, err := dev.MutateAdmission(&ctr, mkPod(c.annotations))
+			assert.NilError(t, err)
+			assert.Equal(t, hasInjectedNVDnone(ctr.Env), c.wantInject)
+		})
+	}
+}
+
 func Test_MutateAdmission_MemoryPercentageValidation(t *testing.T) {
 	gpuDevices := &NvidiaGPUDevices{
 		config: NvidiaConfig{

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -136,6 +136,25 @@ func hasInjectedNVDnone(env []corev1.EnvVar) bool {
 	return false
 }
 
+func Test_MutateAdmission_OverwriteEnvIdempotent(t *testing.T) {
+	// Webhook reinvocation (reinvocationPolicy: IfNeeded) must not append
+	// a duplicate entry.
+	dev := &NvidiaGPUDevices{config: NvidiaConfig{OverwriteEnv: true}}
+	ctr := &corev1.Container{Name: "main"}
+	pod := &corev1.Pod{}
+	for range 3 { // simulate multiple invocations
+		_, err := dev.MutateAdmission(ctr, pod)
+		assert.NilError(t, err)
+	}
+	count := 0
+	for _, e := range ctr.Env {
+		if e.Name == "NVIDIA_VISIBLE_DEVICES" && e.Value == "none" {
+			count++
+		}
+	}
+	assert.Equal(t, count, 1, "expected exactly one NVIDIA_VISIBLE_DEVICES=none")
+}
+
 func Test_MutateAdmission_OverwriteEnvOptOut(t *testing.T) {
 	mkDev := func(overwriteEnv bool) *NvidiaGPUDevices {
 		return &NvidiaGPUDevices{

--- a/pkg/util/overwrite_env.go
+++ b/pkg/util/overwrite_env.go
@@ -54,12 +54,10 @@ func (m OverwriteEnvMode) String() string {
 	}
 }
 
-// parseOverwriteEnvAnnotation parses an annotation value into a mode using
+// parseOverwriteEnvValue parses a single annotation value into a mode using
 // strconv.ParseBool semantics (accepts true/True/1/t/T and false/False/0/f/F).
-// The second return is false when the value is not a valid bool, so callers
-// can decide whether to fall back to a lower-priority layer or treat the
-// annotation as absent.
-func parseOverwriteEnvAnnotation(val string) (OverwriteEnvMode, bool) {
+// The second return is false when the value is not a valid bool.
+func parseOverwriteEnvValue(val string) (OverwriteEnvMode, bool) {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
 		return OverwriteEnvUnset, false
@@ -70,18 +68,75 @@ func parseOverwriteEnvAnnotation(val string) (OverwriteEnvMode, bool) {
 	return OverwriteEnvOff, true
 }
 
-// OverwriteEnvDecision resolves the OverwriteEnv opt-out for a container by
-// inspecting pod-level (hami.io/overwrite-env) and container-level
-// (hami.io/overwrite-env-containers) annotations. Priority: container-level JSON
-// entry > pod-level single value > Unset (the caller falls back to
-// dev.config.OverwriteEnv). A container listed in the JSON overrides the pod
-// level for that container only; unlisted containers fall back to the pod level.
-// There is NO wildcard — "*" is a literal container name, not "all containers".
+// ParsePodOverwriteEnv parses the pod-level annotation value (hami.io/overwrite-env)
+// into a mode. An empty or absent value returns (Unset, false). An invalid value
+// returns (Unset, false) and is logged so a typo doesn't silently no-op.
+// Exported so backends that cache decoded annotations (ascend's per-chip loop)
+// can parse the pod-level value once and reuse it across chips.
+func ParsePodOverwriteEnv(podVal string) (OverwriteEnvMode, bool) {
+	mode, parsed := parseOverwriteEnvValue(podVal)
+	if podVal != "" && !parsed {
+		klog.Warningf("OverwriteEnv: invalid pod-level annotation value %q, falling back to global config", podVal)
+	}
+	return mode, parsed
+}
+
+// DecodeContainerOverwriteEnvJSON decodes the container-level annotation
+// (hami.io/overwrite-env-containers) into a name→mode map. Each JSON value is
+// parsed with strconv.ParseBool; invalid values are skipped (that container
+// falls back to pod-level) and logged. The empty string returns (nil, nil).
+// A malformed JSON is logged here and returns (nil, err) so the caller can
+// decide its fallback; the warning lives in this single place so the cached
+// and uncached paths cannot diverge.
 //
-// Value vocabulary is strconv.ParseBool at both levels (true/false/1/0/t/f).
-// A malformed JSON or an invalid bool value is logged (klog warning) and treated
-// as absent — the affected container falls back to the lower layer. Admission is
-// never denied for a malformed annotation.
+// Backends that the webhook calls multiple times per pod (ascend's per-chip
+// loop) should cache this by the raw JSON string to avoid re-decoding 7×.
+func DecodeContainerOverwriteEnvJSON(rawJSON string) (map[string]OverwriteEnvMode, error) {
+	if rawJSON == "" {
+		return nil, nil
+	}
+	raw := map[string]string{}
+	if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
+		klog.Warningf("OverwriteEnv: could not parse container-level annotation %q as JSON map[string]string (values must be quoted bool strings like \"true\"), falling back to pod-level decision: %v", rawJSON, err)
+		return nil, err
+	}
+	entries := make(map[string]OverwriteEnvMode, len(raw))
+	for name, val := range raw {
+		mode, parsed := parseOverwriteEnvValue(val)
+		if !parsed {
+			klog.Warningf("OverwriteEnv: invalid container-level value %q for container %q, falling back to pod-level decision", val, name)
+			continue
+		}
+		entries[name] = mode
+	}
+	return entries, nil
+}
+
+// ResolveOverwriteEnv combines a pod-level mode with a (possibly nil) decoded
+// container-level entries map for a specific container. A listed container
+// overrides the pod level; an unlisted one keeps the pod level. There is no
+// wildcard — "*" is a literal container name. This is a pure lookup with no
+// logging (warnings are emitted during DecodeContainerOverwriteEnvJSON).
+func ResolveOverwriteEnv(podMode OverwriteEnvMode, entries map[string]OverwriteEnvMode, ctr *corev1.Container) OverwriteEnvMode {
+	if entries == nil || ctr == nil {
+		return podMode
+	}
+	if mode, ok := entries[ctr.Name]; ok {
+		return mode
+	}
+	return podMode
+}
+
+// OverwriteEnvDecision is the composed (uncached) resolver for backends that
+// call once per container (nvidia). Ascend, which the webhook calls once per
+// chip, should cache DecodeContainerOverwriteEnvJSON + ParsePodOverwriteEnv and
+// call ResolveOverwriteEnv to avoid re-decoding the same JSON 7×.
+//
+// Priority: container-level JSON entry > pod-level single value > Unset (the
+// caller falls back to dev.config.OverwriteEnv). Value vocabulary is
+// strconv.ParseBool at both levels. A malformed JSON or invalid value is logged
+// (klog warning) and treated as absent — the affected container falls back to
+// the lower layer. Admission is never denied for a malformed annotation.
 //
 // Nil pod / nil ctr / nil Annotations are all treated as "no annotations"
 // and return Unset.
@@ -89,29 +144,11 @@ func OverwriteEnvDecision(pod *corev1.Pod, ctr *corev1.Container) OverwriteEnvMo
 	if pod == nil || ctr == nil || pod.Annotations == nil {
 		return OverwriteEnvUnset
 	}
-	// An invalid pod-level value is intentionally treated as Unset (the caller
-	// then applies its global config); warn so a typo doesn't silently no-op.
-	podVal := pod.Annotations[OverwriteEnvAnnotationKey]
-	podMode, podParsed := parseOverwriteEnvAnnotation(podVal)
-	if podVal != "" && !podParsed {
-		klog.Warningf("OverwriteEnv: invalid pod-level annotation value %q, falling back to global config", podVal)
+	podMode, _ := ParsePodOverwriteEnv(pod.Annotations[OverwriteEnvAnnotationKey])
+	rawJSON := pod.Annotations[OverwriteEnvContainersAnnotationKey]
+	entries, err := DecodeContainerOverwriteEnvJSON(rawJSON)
+	if err != nil {
+		return podMode
 	}
-	mode := podMode
-	// Container-level JSON overrides pod-level for listed containers only.
-	rawJSON, hasContainerAnno := pod.Annotations[OverwriteEnvContainersAnnotationKey]
-	if hasContainerAnno {
-		entries := map[string]string{}
-		if err := json.Unmarshal([]byte(rawJSON), &entries); err != nil {
-			klog.Warningf("OverwriteEnv: could not parse container-level annotation %q as JSON map[string]string (values must be quoted bool strings like \"true\"), falling back to pod-level decision: %v", rawJSON, err)
-			return mode
-		}
-		if val, ok := entries[ctr.Name]; ok {
-			if ctrMode, parsed := parseOverwriteEnvAnnotation(val); parsed {
-				mode = ctrMode
-			} else {
-				klog.Warningf("OverwriteEnv: invalid container-level value %q for container %q, falling back to pod-level decision", val, ctr.Name)
-			}
-		}
-	}
-	return mode
+	return ResolveOverwriteEnv(podMode, entries, ctr)
 }

--- a/pkg/util/overwrite_env.go
+++ b/pkg/util/overwrite_env.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// Annotation keys for the OverwriteEnv opt-out (ADR 0002). Pod-level is a single
+// bool string; container-level is a JSON map of container-name -> bool-string.
+const (
+	OverwriteEnvAnnotationKey           = "hami.io/overwrite-env"
+	OverwriteEnvContainersAnnotationKey = "hami.io/overwrite-env-containers"
+)
+
+// OverwriteEnvMode is the three-state decision returned by OverwriteEnvDecision.
+// Backends switch on it: Unset falls back to their global config, On forces
+// injection, Off leaves any existing *_VISIBLE_DEVICES untouched.
+type OverwriteEnvMode int
+
+const (
+	OverwriteEnvUnset OverwriteEnvMode = iota // no annotation — fall back to global config
+	OverwriteEnvOn                            // force inject the clearing env var
+	OverwriteEnvOff                           // do not touch existing env var
+)
+
+// String renders the mode for logs and debugging.
+func (m OverwriteEnvMode) String() string {
+	switch m {
+	case OverwriteEnvOn:
+		return "On"
+	case OverwriteEnvOff:
+		return "Off"
+	default:
+		return "Unset"
+	}
+}
+
+// parseOverwriteEnvAnnotation parses an annotation value into a mode using
+// strconv.ParseBool semantics (accepts true/True/1/t/T and false/False/0/f/F).
+// The second return is false when the value is not a valid bool, so callers
+// can decide whether to fall back to a lower-priority layer or treat the
+// annotation as absent.
+func parseOverwriteEnvAnnotation(val string) (OverwriteEnvMode, bool) {
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return OverwriteEnvUnset, false
+	}
+	if b {
+		return OverwriteEnvOn, true
+	}
+	return OverwriteEnvOff, true
+}
+
+// OverwriteEnvDecision resolves the OverwriteEnv opt-out for a container by
+// inspecting pod-level (hami.io/overwrite-env) and container-level
+// (hami.io/overwrite-env-containers) annotations. Priority: container-level JSON
+// entry > pod-level single value > Unset (the caller falls back to
+// dev.config.OverwriteEnv). A container listed in the JSON overrides the pod
+// level for that container only; unlisted containers fall back to the pod level.
+// There is NO wildcard — "*" is a literal container name, not "all containers".
+//
+// Value vocabulary is strconv.ParseBool at both levels (true/false/1/0/t/f).
+// A malformed JSON or an invalid bool value is logged (klog warning) and treated
+// as absent — the affected container falls back to the lower layer. Admission is
+// never denied for a malformed annotation.
+//
+// Nil pod / nil ctr / nil Annotations are all treated as "no annotations"
+// and return Unset.
+func OverwriteEnvDecision(pod *corev1.Pod, ctr *corev1.Container) OverwriteEnvMode {
+	if pod == nil || ctr == nil || pod.Annotations == nil {
+		return OverwriteEnvUnset
+	}
+	// An invalid pod-level value is intentionally treated as Unset (the caller
+	// then applies its global config); warn so a typo doesn't silently no-op.
+	podVal := pod.Annotations[OverwriteEnvAnnotationKey]
+	podMode, podParsed := parseOverwriteEnvAnnotation(podVal)
+	if podVal != "" && !podParsed {
+		klog.Warningf("OverwriteEnv: invalid pod-level annotation value %q, falling back to global config", podVal)
+	}
+	mode := podMode
+	// Container-level JSON overrides pod-level for listed containers only.
+	rawJSON, hasContainerAnno := pod.Annotations[OverwriteEnvContainersAnnotationKey]
+	if hasContainerAnno {
+		entries := map[string]string{}
+		if err := json.Unmarshal([]byte(rawJSON), &entries); err != nil {
+			klog.Warningf("OverwriteEnv: could not parse container-level annotation %q as JSON map[string]string (values must be quoted bool strings like \"true\"), falling back to pod-level decision: %v", rawJSON, err)
+			return mode
+		}
+		if val, ok := entries[ctr.Name]; ok {
+			if ctrMode, parsed := parseOverwriteEnvAnnotation(val); parsed {
+				mode = ctrMode
+			} else {
+				klog.Warningf("OverwriteEnv: invalid container-level value %q for container %q, falling back to pod-level decision", val, ctr.Name)
+			}
+		}
+	}
+	return mode
+}

--- a/pkg/util/overwrite_env.go
+++ b/pkg/util/overwrite_env.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Annotation keys for the OverwriteEnv opt-out (ADR 0002). Pod-level is a single
-// bool string; container-level is a JSON map of container-name -> bool-string.
+// Annotation keys for the OverwriteEnv opt-out. Pod-level is a single bool
+// string; container-level is a JSON map of container-name -> bool-string.
 const (
 	OverwriteEnvAnnotationKey           = "hami.io/overwrite-env"
 	OverwriteEnvContainersAnnotationKey = "hami.io/overwrite-env-containers"
@@ -54,9 +54,7 @@ func (m OverwriteEnvMode) String() string {
 	}
 }
 
-// parseOverwriteEnvValue parses a single annotation value into a mode using
-// strconv.ParseBool semantics (accepts true/True/1/t/T and false/False/0/f/F).
-// The second return is false when the value is not a valid bool.
+// parseOverwriteEnvValue parses a single bool-string annotation value.
 func parseOverwriteEnvValue(val string) (OverwriteEnvMode, bool) {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
@@ -68,11 +66,7 @@ func parseOverwriteEnvValue(val string) (OverwriteEnvMode, bool) {
 	return OverwriteEnvOff, true
 }
 
-// ParsePodOverwriteEnv parses the pod-level annotation value (hami.io/overwrite-env)
-// into a mode. An empty or absent value returns (Unset, false). An invalid value
-// returns (Unset, false) and is logged so a typo doesn't silently no-op.
-// Exported so backends that cache decoded annotations (ascend's per-chip loop)
-// can parse the pod-level value once and reuse it across chips.
+// ParsePodOverwriteEnv parses the pod-level annotation; an empty or invalid value returns (Unset, false).
 func ParsePodOverwriteEnv(podVal string) (OverwriteEnvMode, bool) {
 	mode, parsed := parseOverwriteEnvValue(podVal)
 	if podVal != "" && !parsed {
@@ -81,16 +75,8 @@ func ParsePodOverwriteEnv(podVal string) (OverwriteEnvMode, bool) {
 	return mode, parsed
 }
 
-// DecodeContainerOverwriteEnvJSON decodes the container-level annotation
-// (hami.io/overwrite-env-containers) into a name→mode map. Each JSON value is
-// parsed with strconv.ParseBool; invalid values are skipped (that container
-// falls back to pod-level) and logged. The empty string returns (nil, nil).
-// A malformed JSON is logged here and returns (nil, err) so the caller can
-// decide its fallback; the warning lives in this single place so the cached
-// and uncached paths cannot diverge.
-//
-// Backends that the webhook calls multiple times per pod (ascend's per-chip
-// loop) should cache this by the raw JSON string to avoid re-decoding 7×.
+// DecodeContainerOverwriteEnvJSON decodes the container-level annotation into
+// a name→mode map; malformed JSON and invalid values are logged and skipped.
 func DecodeContainerOverwriteEnvJSON(rawJSON string) (map[string]OverwriteEnvMode, error) {
 	if rawJSON == "" {
 		return nil, nil
@@ -112,11 +98,8 @@ func DecodeContainerOverwriteEnvJSON(rawJSON string) (map[string]OverwriteEnvMod
 	return entries, nil
 }
 
-// ResolveOverwriteEnv combines a pod-level mode with a (possibly nil) decoded
-// container-level entries map for a specific container. A listed container
-// overrides the pod level; an unlisted one keeps the pod level. There is no
-// wildcard — "*" is a literal container name. This is a pure lookup with no
-// logging (warnings are emitted during DecodeContainerOverwriteEnvJSON).
+// ResolveOverwriteEnv returns the container's mode: a listed container
+// overrides the pod level. "*" is a literal container name, not a wildcard.
 func ResolveOverwriteEnv(podMode OverwriteEnvMode, entries map[string]OverwriteEnvMode, ctr *corev1.Container) OverwriteEnvMode {
 	if entries == nil || ctr == nil {
 		return podMode
@@ -127,19 +110,10 @@ func ResolveOverwriteEnv(podMode OverwriteEnvMode, entries map[string]OverwriteE
 	return podMode
 }
 
-// OverwriteEnvDecision is the composed (uncached) resolver for backends that
-// call once per container (nvidia). Ascend, which the webhook calls once per
-// chip, should cache DecodeContainerOverwriteEnvJSON + ParsePodOverwriteEnv and
-// call ResolveOverwriteEnv to avoid re-decoding the same JSON 7×.
-//
-// Priority: container-level JSON entry > pod-level single value > Unset (the
-// caller falls back to dev.config.OverwriteEnv). Value vocabulary is
-// strconv.ParseBool at both levels. A malformed JSON or invalid value is logged
-// (klog warning) and treated as absent — the affected container falls back to
-// the lower layer. Admission is never denied for a malformed annotation.
-//
-// Nil pod / nil ctr / nil Annotations are all treated as "no annotations"
-// and return Unset.
+// OverwriteEnvDecision is the composed resolver for backends that call once
+// per container (nvidia); backends invoked once per chip (ascend) should use
+// the split functions plus a cache instead. Priority: container entry >
+// pod value > Unset; a malformed annotation never denies admission.
 func OverwriteEnvDecision(pod *corev1.Pod, ctr *corev1.Container) OverwriteEnvMode {
 	if pod == nil || ctr == nil || pod.Annotations == nil {
 		return OverwriteEnvUnset

--- a/pkg/util/overwrite_env_bench_test.go
+++ b/pkg/util/overwrite_env_bench_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Benchmark_OverwriteEnvDecision_NoAnnotations measures the baseline cost when
+// no opt-out annotations are set (the common case): the function returns Unset
+// after two map lookups + one ParseBool("") that fails fast.
+func Benchmark_OverwriteEnvDecision_NoAnnotations(b *testing.B) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: nil}}
+	ctr := &corev1.Container{Name: "main"}
+	b.ResetTimer()
+	for range b.N {
+		OverwriteEnvDecision(pod, ctr)
+	}
+}
+
+// Benchmark_OverwriteEnvDecision_PodLevelOnly measures the cost when only the
+// pod-level single-value annotation is set (no JSON to parse).
+func Benchmark_OverwriteEnvDecision_PodLevelOnly(b *testing.B) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		OverwriteEnvAnnotationKey: "true",
+	}}}
+	ctr := &corev1.Container{Name: "main"}
+	b.ResetTimer()
+	for range b.N {
+		OverwriteEnvDecision(pod, ctr)
+	}
+}
+
+// Benchmark_OverwriteEnvDecision_ContainerJSON measures a single call with the
+// container-level JSON annotation set (the case that pays the json.Unmarshal).
+// The JSON has 3 containers, a realistic pod size.
+func Benchmark_OverwriteEnvDecision_ContainerJSON(b *testing.B) {
+	entries := map[string]string{"main": "true", "sidecar": "false", "worker": "0"}
+	raw, _ := json.Marshal(entries)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		OverwriteEnvAnnotationKey:           "false",
+		OverwriteEnvContainersAnnotationKey: string(raw),
+	}}}
+	ctr := &corev1.Container{Name: "main"}
+	b.ResetTimer()
+	for range b.N {
+		OverwriteEnvDecision(pod, ctr)
+	}
+}
+
+// Benchmark_OverwriteEnvDecision_WebhookLoop simulates the real webhook path:
+// the webhook iterates device.GetDevices() and calls MutateAdmission (→
+// OverwriteEnvDecision) once per registered ascend chip (7 on the arm231
+// cluster). This is the number to compare against a cached implementation.
+func Benchmark_OverwriteEnvDecision_WebhookLoop(b *testing.B) {
+	entries := map[string]string{"main": "true", "sidecar": "false", "worker": "0"}
+	raw, _ := json.Marshal(entries)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		OverwriteEnvAnnotationKey:           "false",
+		OverwriteEnvContainersAnnotationKey: string(raw),
+	}}}
+	ctr := &corev1.Container{Name: "main"}
+	const numChips = 7
+	b.ResetTimer()
+	for range b.N {
+		for range numChips {
+			OverwriteEnvDecision(pod, ctr)
+		}
+	}
+}
+
+// Benchmark_OverwriteEnvDecision_WebhookLoop_Cached simulates the cached path
+// the Ascend backend uses: the container-level JSON is decoded once (first chip)
+// and served from the LRU cache for the remaining 6 chips. It measures the
+// util-level resolve (ParsePodOverwriteEnv + DecodeContainerOverwriteEnvJSON once
+// + ResolveOverwriteEnv 7×) to show the ceiling the ascend cache achieves; the
+// actual ascend cache helper is exercised by the ascend package tests.
+func Benchmark_OverwriteEnvDecision_WebhookLoop_Cached(b *testing.B) {
+	entries := map[string]string{"main": "true", "sidecar": "false", "worker": "0"}
+	raw, _ := json.Marshal(entries)
+	rawJSON := string(raw)
+	podMode, _ := ParsePodOverwriteEnv("false")
+	ctr := &corev1.Container{Name: "main"}
+	const numChips = 7
+	b.ResetTimer()
+	for range b.N {
+		cachedEntries, _ := DecodeContainerOverwriteEnvJSON(rawJSON)
+		for range numChips {
+			ResolveOverwriteEnv(podMode, cachedEntries, ctr)
+		}
+	}
+}

--- a/pkg/util/overwrite_env_bench_test.go
+++ b/pkg/util/overwrite_env_bench_test.go
@@ -67,9 +67,9 @@ func Benchmark_OverwriteEnvDecision_ContainerJSON(b *testing.B) {
 }
 
 // Benchmark_OverwriteEnvDecision_WebhookLoop simulates the real webhook path:
-// the webhook iterates device.GetDevices() and calls MutateAdmission (→
-// OverwriteEnvDecision) once per registered ascend chip (7 on the arm231
-// cluster). This is the number to compare against a cached implementation.
+// the webhook calls MutateAdmission (→ OverwriteEnvDecision) once per
+// registered Ascend chip (7 on a typical node). Compare against a cached
+// implementation.
 func Benchmark_OverwriteEnvDecision_WebhookLoop(b *testing.B) {
 	entries := map[string]string{"main": "true", "sidecar": "false", "worker": "0"}
 	raw, _ := json.Marshal(entries)

--- a/pkg/util/overwrite_env_test.go
+++ b/pkg/util/overwrite_env_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func podWithAnnos(annos map[string]string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annos}}
+}
+
+func ctrNamed(name string) *corev1.Container {
+	return &corev1.Container{Name: name}
+}
+
+// containerJSON builds the JSON value for hami.io/overwrite-env-containers.
+func containerJSON(t *testing.T, m map[string]string) string {
+	t.Helper()
+	b, err := json.Marshal(m)
+	assert.NilError(t, err)
+	return string(b)
+}
+
+func Test_OverwriteEnvDecision_BothUnset(t *testing.T) {
+	got := OverwriteEnvDecision(podWithAnnos(nil), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvUnset)
+}
+
+func Test_OverwriteEnvDecision_PodLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want OverwriteEnvMode
+	}{
+		{"true", "true", OverwriteEnvOn},
+		{"True", "True", OverwriteEnvOn},
+		{"1", "1", OverwriteEnvOn},
+		{"t", "t", OverwriteEnvOn},
+		{"false", "false", OverwriteEnvOff},
+		{"0", "0", OverwriteEnvOff},
+		{"f", "f", OverwriteEnvOff},
+		{"invalid-yes", "yes", OverwriteEnvUnset},
+		{"invalid-maybe", "maybe", OverwriteEnvUnset},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := OverwriteEnvDecision(
+				podWithAnnos(map[string]string{OverwriteEnvAnnotationKey: tc.val}),
+				ctrNamed("main"))
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+func Test_OverwriteEnvDecision_ContainerOverridesPod(t *testing.T) {
+	tests := []struct {
+		name   string
+		podVal string
+		ctrVal string
+		want   OverwriteEnvMode
+	}{
+		{"reverse-pod-false-ctr-true", "false", "true", OverwriteEnvOn},
+		{"reverse-pod-true-ctr-false", "true", "false", OverwriteEnvOff},
+		{"same-pod-true-ctr-true", "true", "true", OverwriteEnvOn},
+		{"same-pod-false-ctr-false", "false", "false", OverwriteEnvOff},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			annos := map[string]string{
+				OverwriteEnvAnnotationKey:           tc.podVal,
+				OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{"main": tc.ctrVal}),
+			}
+			got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+func Test_OverwriteEnvDecision_ContainerOnly(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{"main": "true"}),
+	}
+	got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvOn)
+}
+
+func Test_OverwriteEnvDecision_NilSafety(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		ctr  *corev1.Container
+	}{
+		{"nil-pod", nil, ctrNamed("main")},
+		{"nil-ctr", podWithAnnos(nil), nil},
+		{"nil-annotations", &corev1.Pod{}, ctrNamed("main")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := OverwriteEnvDecision(tc.pod, tc.ctr)
+			assert.Equal(t, got, OverwriteEnvUnset)
+		})
+	}
+}
+
+func Test_OverwriteEnvDecision_InvalidContainerValueFallsBackToPod(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvAnnotationKey:           "false",
+		OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{"main": "yes"}),
+	}
+	got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvOff)
+}
+
+func Test_OverwriteEnvDecision_MalformedJSONFallsBackToPod(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvAnnotationKey:           "true",
+		OverwriteEnvContainersAnnotationKey: "not-json",
+	}
+	got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvOn)
+}
+
+func Test_OverwriteEnvDecision_UnlistedContainerFallsBackToPod(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvAnnotationKey:           "false",
+		OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{"other": "true"}),
+	}
+	got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvOff)
+}
+
+func Test_OverwriteEnvDecision_MultiContainerJSON(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{
+			"main":    "true",
+			"sidecar": "false",
+		}),
+	}
+	assert.Equal(t, OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main")), OverwriteEnvOn)
+	assert.Equal(t, OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("sidecar")), OverwriteEnvOff)
+}
+
+// Test_OverwriteEnvDecision_NoWildcard confirms "*" is a literal container name,
+// not a wildcard — a container named "main" does not inherit a "*" entry.
+func Test_OverwriteEnvDecision_NoWildcard(t *testing.T) {
+	annos := map[string]string{
+		OverwriteEnvContainersAnnotationKey: containerJSON(t, map[string]string{"*": "true"}),
+	}
+	got := OverwriteEnvDecision(podWithAnnos(annos), ctrNamed("main"))
+	assert.Equal(t, got, OverwriteEnvUnset)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds pod-level and container-level opt-in/out annotations for the `overwriteEnv` clearing injection, on top of #2953

Currently `overwriteEnv` is a scheduler global device config. There is no per-pod or per-container control. These annotations give pod authors that control:

- `hami.io/overwrite-env` (pod-level, single value): overrides the device config default for all containers in the pod.
- `hami.io/overwrite-env-containers` (container-level, JSON map of container name to value): overrides the pod-level value for specific containers.

Values use `strconv.ParseBool` vocabulary (`true`/`false`/`1`/`0`/`t`/`f`).

Resolution order: container-level entry > pod-level value > device config.

For ascend, since each each container of each pod will go through the `dev.MutateAdmission` (currently 7 times for all ascend chip type), its might be a bottlenect to decode json multiple time for the same anno. So we use a LRU cache with TTL to cache the decoded container-level JSON by itsraw content.

Benchmark (7-chip webhook loop, 3-container JSON): 19667 ns/op / 119 allocs uncached → 723 ns/op / 0 allocs cached.

**Which issue(s) this PR fixes**:

Depends on #2953.

**Special notes for your reviewer**:

- The nvidia integration keeps the single `NvidiaConfig` assumption (one entry in `GetDevices()`), same as before.
- Hardware validated on the same Ascend 910B cluster as #2953: pod-level on/off, container-level JSON overrides, malformed-JSON fallback all behave as described.

**Does this PR introduce a user-facing change?**:

Yes — new annotations `hami.io/overwrite-env` and `hami.io/overwrite-env-containers` control the `overwriteEnv` clearing
injection per pod / per container.

---

AI assistance disclosure: this feature was developed with AI assistance for code editing and this description's English wording. The design decisions, hardware validation, and benchmarking on a real 910B cluster are my own work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pod- and container-level controls for environment-variable injection through overwrite annotations.
  - Ascend and NVIDIA device injection now respects explicit overwrite settings, including opt-out behavior.
  - Ascend device handling now supports shared multi-chip resource configuration.
  - Added configurable Ascend runtime class and environment-injection settings at the shared device level.
  - Added a streamlined NVIDIA MIG profile allowlist configuration.

- **Bug Fixes**
  - Prevented incorrect empty `ASCEND_VISIBLE_DEVICES` injection for Ascend containers.
  - Improved handling of existing environment variables and duplicate injection scenarios.
  - Invalid overwrite annotations now safely fall back without blocking admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->