### PR TITLE
fix(scheduler): clean annotationless pod deletes from cache

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -266,10 +266,8 @@ func (s *Scheduler) onDelPod(obj any) {
 		return
 	}
 
-	_, ok = pod.Annotations[util.AssignedNodeAnnotations]
-	if !ok {
-		return
-	}
+	// Delete notifications can contain incomplete Pod objects. The cached
+	// allocation, keyed by the immutable UID, is the cleanup source of truth.
 	if pi, ok := s.podManager.TakeAndDeletePod(pod); ok {
 		s.quotaManager.RmUsage(pod, pi.Devices)
 	}

--- a/pkg/scheduler/scheduler_pod_lifecycle_test.go
+++ b/pkg/scheduler/scheduler_pod_lifecycle_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
@@ -115,4 +116,96 @@ func Test_onUpdatePod_TerminatingPodMissingFromCache(t *testing.T) {
 	assert.Equal(t, pi.Devices[nvidia.NvidiaGPUDevice][0][0].UUID, "GPU0")
 	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpumem"), int64(20000))
 	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpucores"), int64(100))
+}
+
+// An informer delete notification is only an identity signal. The final Pod
+// object may no longer carry the scheduler annotations that were present when
+// its allocation was cached, so cleanup must use the UID-keyed PodManager
+// entry instead of depending on the delete object's annotations.
+func Test_onDelPod_CleansCachedAllocationWithoutAnnotations(t *testing.T) {
+	initReplayDevices(t)
+	s := NewScheduler()
+	pod := newTerminatingAllocatedPod(
+		"annotationless-delete-uid",
+		"annotationless-delete",
+		"annotationless-delete-ns",
+	)
+	t.Cleanup(func() { s.onDelPod(pod) })
+
+	s.onAddPod(pod)
+	deletedPod := pod.DeepCopy()
+	deletedPod.Annotations = nil
+
+	s.onDelPod(deletedPod)
+
+	_, cached := s.podManager.GetPod(pod)
+	assert.Equal(
+		t,
+		cached,
+		false,
+		"delete must evict the allocation by UID even without annotations",
+	)
+	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpumem"), int64(0))
+	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpucores"), int64(0))
+}
+
+func Test_onDelPod_CleansAnnotationlessTombstoneAndIsIdempotent(t *testing.T) {
+	initReplayDevices(t)
+	s := NewScheduler()
+	pod := newTerminatingAllocatedPod(
+		"annotationless-tombstone-uid",
+		"annotationless-tombstone",
+		"annotationless-tombstone-ns",
+	)
+	t.Cleanup(func() { s.onDelPod(pod) })
+
+	s.onAddPod(pod)
+	deletedPod := pod.DeepCopy()
+	deletedPod.Annotations = nil
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: deletedPod.Namespace + "/" + deletedPod.Name,
+		Obj: deletedPod,
+	}
+
+	s.onDelPod(tombstone)
+	s.onDelPod(tombstone)
+
+	_, cached := s.podManager.GetPod(pod)
+	assert.Equal(t, cached, false)
+	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpumem"), int64(0))
+	assert.Equal(t, replayQuotaUsage(s, pod.Namespace, "hami.io/gpucores"), int64(0))
+}
+
+func Test_onDelPod_AnnotationlessOldUIDDoesNotDeleteReplacement(t *testing.T) {
+	initReplayDevices(t)
+	s := NewScheduler()
+	oldPod := newTerminatingAllocatedPod(
+		"old-uid",
+		"replaced-pod",
+		"replacement-delete-ns",
+	)
+	newPod := newTerminatingAllocatedPod("new-uid", oldPod.Name, oldPod.Namespace)
+	t.Cleanup(func() {
+		s.onDelPod(oldPod)
+		s.onDelPod(newPod)
+	})
+
+	s.onAddPod(oldPod)
+	s.onAddPod(newPod)
+	deletedOldPod := oldPod.DeepCopy()
+	deletedOldPod.Annotations = nil
+
+	s.onDelPod(deletedOldPod)
+
+	_, oldCached := s.podManager.GetPod(oldPod)
+	_, newCached := s.podManager.GetPod(newPod)
+	assert.Equal(t, oldCached, false)
+	assert.Equal(
+		t,
+		newCached,
+		true,
+		"a stale delete must not evict the same-name replacement UID",
+	)
+	assert.Equal(t, replayQuotaUsage(s, oldPod.Namespace, "hami.io/gpumem"), int64(20000))
+	assert.Equal(t, replayQuotaUsage(s, oldPod.Namespace, "hami.io/gpucores"), int64(100))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A Pod delete notification is an identity signal, but the final object delivered by an informer can be incomplete or can have lost HAMi's scheduler annotations. The scheduler currently returns early when `hami.io/vgpu-node` is absent, even if `PodManager` still owns an allocation for the immutable Pod UID. That leaves both the cached devices and quota usage behind.

This change:

- uses the UID-keyed cached allocation as the delete source of truth;
- releases quota from the cached device snapshot rather than from delete-object annotations;
- keeps repeated direct or tombstone deletes idempotent; and
- proves that a stale delete for an old UID cannot remove a same-name replacement Pod.

PR #1459 added `DeletedFinalStateUnknown` handling for #1458. It still retains the annotation gate, so this is an adjacent hardening case rather than a duplicate. Related context: #2923. This PR does not claim to close #2923 because the reported v2.7.1 missing-delete problem is already fixed in v2.8.0 by #1459.

**Test-first reproduction**:

With only the three new tests applied to current master `f47cd28`, all three fail because the cached UID remains present:

```text
Test_onDelPod_CleansCachedAllocationWithoutAnnotations: cached=true, want false
Test_onDelPod_CleansAnnotationlessTombstoneAndIsIdempotent: cached=true, want false
Test_onDelPod_AnnotationlessOldUIDDoesNotDeleteReplacement: oldCached=true, want false
```

**Validation at final commit `0331aafb983c9865a82a64a75676669e5b678d24`**:

```bash
go test ./pkg/scheduler -count=1
go test -race ./pkg/scheduler \
  -run 'Test_onDelPod_(CleansCachedAllocationWithoutAnnotations|CleansAnnotationlessTombstoneAndIsIdempotent|AnnotationlessOldUIDDoesNotDeleteReplacement)$' \
  -count=1
PATH=/Users/0z5a/go/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin make verify
```

```text
pkg/scheduler: PASS (14.234s)
targeted race run: PASS (2.020s)
make verify: PASS
```

The combined raw log has 64 lines and SHA-256 `0210a9d2833a8aed059b5ece9c5a777c1844c90466496299e5ae2e088e816a46`.

This is scheduler-extender bookkeeping and uses deterministic unit tests; it does not alter device allocation or in-container isolation, so no GPU hardware path is involved. The commands above are the direct reviewer-runnable reproduction; a notebook would only wrap the same Go commands.

**Non-goals**:

- changing informer resync behavior;
- reconciling arbitrary missing delete events;
- deleting allocations by namespace/name instead of UID;
- changing device allocation or isolation behavior.

**AI assistance disclosure**:

AI assistance was used for codebase inspection, implementation support, test construction, and PR formatting. I reviewed the final diff and personally supplied the commit rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when Pods are deleted without assignment metadata.
  * Ensured cleanup remains reliable for incomplete deletion events and repeated notifications.
  * Prevented stale deletion events from removing allocations belonging to replacement Pods.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->