### PR TITLE
fix(chart): honor kube-scheduler image pull secrets

### DIFF
--- a/charts/hami/templates/_helpers.tpl
+++ b/charts/hami/templates/_helpers.tpl
@@ -159,7 +159,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "hami.scheduler.extender.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.scheduler.extender.image) "global" .Values.global) }}
+{{- $images := list .Values.scheduler.extender.image -}}
+{{- if .Values.scheduler.kubeScheduler.enabled -}}
+{{- $images = append $images .Values.scheduler.kubeScheduler.image -}}
+{{- end -}}
+{{ include "common.images.pullSecrets" (dict "images" $images "global" .Values.global) }}
 {{- end -}}
 
 {{- define "hami.devicePlugin.imagePullSecrets" -}}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The scheduler Pod currently includes global and extender image pull secrets but ignores `scheduler.kubeScheduler.image.pullSecrets`. This can prevent a private kube-scheduler image from being pulled.

Update the existing `hami.scheduler.extender.imagePullSecrets` helper to include kube-scheduler pull secrets when its container is enabled, while retaining global and extender secrets.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

- Rendered YAML was also parsed to verify Pod-level secret references, private image names, and kube-scheduler container presence. No live private-registry pull was tested.
- AI disclosure: Codex generated the code changes, ran validation, and prepared this PR description.

**Does this PR introduce a user-facing change?**:

Yes. `scheduler.kubeScheduler.image.pullSecrets` now contributes to the scheduler Pod's `imagePullSecrets` when kube-scheduler is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image pull secrets now account for both the scheduler extender image and the optional kube-scheduler image when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->