### PR TITLE
fix(chart): keep scheduler livenessProbe inside the kubeScheduler container guard

### DIFF
--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -63,7 +63,6 @@ spec:
           volumeMounts:
             - name: scheduler-config
               mountPath: /config
-        {{- end }}
           {{- if .Values.scheduler.livenessProbe }}
           livenessProbe:
             failureThreshold: 8
@@ -76,6 +75,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 15
           {{- end }}
+        {{- end }}
         - name: vgpu-scheduler-extender
           image: {{ include "hami.scheduler.extender.image" . }}
           imagePullPolicy: {{ .Values.scheduler.extender.image.pullPolicy }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The scheduler deployment template renders the `livenessProbe` block after the `{{- end }}` that closes the `kubeScheduler.enabled` guard, so it's indented as if still part of the `kube-scheduler` container but has no container list item above it when `kubeScheduler.enabled` is false. With `scheduler.livenessProbe=true` and `scheduler.kubeScheduler.enabled=false`, `helm template` fails with a YAML parse error instead of rendering a valid manifest. This moves the block back inside the guard so the probe only renders when the container it targets exists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Verified with `helm template hami charts/hami --set scheduler.livenessProbe=true --set scheduler.kubeScheduler.enabled=false` before and after: before, the command fails with `yaml: line 44: did not find expected key`; after, it renders successfully. Also verified with both flags true that the probe still nests correctly under the `kube-scheduler` container, and `helm lint` passes. No open issue or PR found covering this.

**Does this PR introduce a user-facing change?**:
Fixes a chart render failure when `scheduler.kubeScheduler.enabled=false` and `scheduler.livenessProbe=true` are combined; no behavior change at default values.

---
This PR was written primarily by Claude Code, an AI assistant, under my direction and review. I verified the fix by reproducing the render failure and confirming it is resolved, and reviewed the diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected scheduler deployment configuration so kube-scheduler health checks are applied only when kube-scheduler is enabled.
  - Prevented health-check settings from being incorrectly assigned to the vGPU scheduler extender when kube-scheduler is disabled.
  - Improved reliability for deployments using the alternate scheduler configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->