### PR TITLE
perf(scheduler): stop deep-copying whole Pods into the usage snapshot

### DIFF
--- a/pkg/device/devices.go
+++ b/pkg/device/devices.go
@@ -256,6 +256,8 @@ func init() {
 	SupportDevices = make(map[string]string)
 }
 
+// DeepCopy returns a copy of DeviceUsage. It clones the PodInfos slice but
+// shares its read-only PodInfo entries, which callers must not mutate.
 func (d *DeviceUsage) DeepCopy() *DeviceUsage {
 	if d == nil {
 		return nil
@@ -291,12 +293,8 @@ func (d *DeviceUsage) DeepCopy() *DeviceUsage {
 	}
 	dup.MigUsage = d.MigUsage.DeepCopy()
 
-	if d.PodInfos != nil {
-		dup.PodInfos = make([]*PodInfo, len(d.PodInfos))
-		for i, pi := range d.PodInfos {
-			dup.PodInfos[i] = pi.DeepCopy()
-		}
-	}
+	// Copy the slice while sharing its read-only PodInfo snapshots.
+	dup.PodInfos = slices.Clone(d.PodInfos)
 
 	if d.CustomInfo != nil {
 		dup.CustomInfo = make(map[string]any, len(d.CustomInfo))

--- a/pkg/device/devices_test.go
+++ b/pkg/device/devices_test.go
@@ -1989,9 +1989,10 @@ func TestDeviceUsageDeepCopy(t *testing.T) {
 			}
 
 			if len(copy.PodInfos) > 0 {
-				originalNodeID := tt.original.PodInfos[0].NodeID
-				copy.PodInfos[0].NodeID = "mutated-node"
-				assert.Equal(t, tt.original.PodInfos[0].NodeID, originalNodeID)
+				assert.Assert(t, tt.original.PodInfos[0] == copy.PodInfos[0], "PodInfos entries should be shared with the copy")
+				originalEntry := tt.original.PodInfos[0]
+				copy.PodInfos[0] = &PodInfo{NodeID: "replacement-node"}
+				assert.Assert(t, tt.original.PodInfos[0] == originalEntry, "replacing a copied slice entry must not affect the original")
 			}
 
 			if copy.CustomInfo != nil {

--- a/pkg/device/pod_test.go
+++ b/pkg/device/pod_test.go
@@ -486,7 +486,7 @@ func TestUpdatePod(t *testing.T) {
 	}
 }
 
-func TestPodInfoDeepCopy(t *testing.T) {
+func TestPodInfoSnapshot(t *testing.T) {
 	tests := []struct {
 		name     string
 		original *PodInfo
@@ -523,7 +523,7 @@ func TestPodInfoDeepCopy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			copy := tt.original.DeepCopy()
+			copy := tt.original.Snapshot()
 
 			if tt.original == nil {
 				if copy != nil {
@@ -532,19 +532,17 @@ func TestPodInfoDeepCopy(t *testing.T) {
 				return
 			}
 
-			// 1. Copy must be deeply equal to original.
 			assert.Equal(t, tt.original.NodeID, copy.NodeID)
 			assert.Equal(t, tt.original.Devices, copy.Devices)
 			if tt.original.Pod != nil {
 				assert.Equal(t, tt.original.Name, copy.Name)
 			}
 
-			// 2. Mutating the copy must not affect the original.
-			if copy.Pod != nil {
-				originalPodName := tt.original.Name
-				copy.Name = "mutated-pod"
-				assert.Equal(t, tt.original.Name, originalPodName)
+			if tt.original.Pod != nil {
+				assert.Same(t, tt.original.Pod, copy.Pod, "Pod pointer should be shared with the snapshot")
 			}
+
+			// Manager-owned fields remain independent of the snapshot.
 			originalNodeID := tt.original.NodeID
 			copy.NodeID = "mutated-node"
 			assert.Equal(t, tt.original.NodeID, originalNodeID)
@@ -647,7 +645,7 @@ func TestContainerDeviceDeepCopy(t *testing.T) {
 	assert.False(t, exists, "original CustomInfo should not have key2")
 }
 
-func TestListPodsInfoReturnsDeepCopy(t *testing.T) {
+func TestListPodsInfoReturnsSnapshot(t *testing.T) {
 	pm := NewPodManager()
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "p", Namespace: "ns"}}
 	pm.AddPod(pod, "node-1", PodDevices{"dev": {{{UUID: "GPU-0"}}}})
@@ -729,7 +727,7 @@ func TestGetScheduledPodsCopiesEntries(t *testing.T) {
 	wg.Wait()
 }
 
-// A caller must not be able to reach into the manager through what it hands back.
+// Mutating snapshot accounting fields must not affect the manager.
 func TestGetScheduledPodsReturnsDetachedEntries(t *testing.T) {
 	pm := NewPodManager()
 	pod := &corev1.Pod{

--- a/pkg/device/pods.go
+++ b/pkg/device/pods.go
@@ -109,13 +109,14 @@ func (m *PodManager) UpdatePod(pod *corev1.Pod) {
 	}
 }
 
-// DeepCopy must include the new field.
-func (p *PodInfo) DeepCopy() *PodInfo {
+// Snapshot copies manager-owned state and shares the read-only Pod.
+// Callers must not mutate the shared Pod.
+func (p *PodInfo) Snapshot() *PodInfo {
 	if p == nil {
 		return nil
 	}
 	return &PodInfo{
-		Pod:                           p.Pod.DeepCopy(),
+		Pod:                           p.Pod,
 		NodeID:                        p.NodeID,
 		Devices:                       p.Devices.DeepCopy(),
 		InitContainerResourceReleased: p.InitContainerResourceReleased,
@@ -140,8 +141,8 @@ func (m *PodManager) DelPod(pod *corev1.Pod) {
 	}
 }
 
-// GetPod returns a copy. AddPod and UpdatePod write to the stored PodInfo in
-// place, so handing out the pointer would let the caller read it while the
+// GetPod returns a snapshot. AddPod and UpdatePod write to the stored PodInfo
+// in place, so handing out the pointer would let the caller read it while the
 // informer is rewriting it.
 func (m *PodManager) GetPod(pod *corev1.Pod) (*PodInfo, bool) {
 	m.mutex.RLock()
@@ -151,7 +152,7 @@ func (m *PodManager) GetPod(pod *corev1.Pod) (*PodInfo, bool) {
 	if !ok {
 		return nil, false
 	}
-	return pi.DeepCopy(), true
+	return pi.Snapshot(), true
 }
 
 func (m *PodManager) TakeAndDeletePod(pod *corev1.Pod) (*PodInfo, bool) {
@@ -224,7 +225,7 @@ func (m *PodManager) ListPodsInfo() []*PodInfo {
 
 	pods := make([]*PodInfo, 0, len(m.pods))
 	for _, pod := range m.pods {
-		pods = append(pods, pod.DeepCopy())
+		pods = append(pods, pod.Snapshot())
 		klog.V(5).InfoS("Pod info",
 			"pod", klog.KRef(pod.Namespace, pod.Name),
 			"nodeID", pod.NodeID,
@@ -301,7 +302,7 @@ func (m *PodManager) GetScheduledPods() (map[k8stypes.UID]*PodInfo, error) {
 	// over Devices after this returns, by which point the read lock is gone.
 	podsCopy := make(map[k8stypes.UID]*PodInfo, podCount)
 	for uid, pi := range m.pods {
-		podsCopy[uid] = pi.DeepCopy()
+		podsCopy[uid] = pi.Snapshot()
 	}
 	return podsCopy, nil
 }

--- a/pkg/device/pods_bench_test.go
+++ b/pkg/device/pods_bench_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// newBenchmarkCachedPod includes nested fields to exercise Pod copying costs.
+func newBenchmarkCachedPod(index int) *corev1.Pod {
+	envs := make([]corev1.EnvVar, 0, 20)
+	for i := range 20 {
+		envs = append(envs, corev1.EnvVar{Name: fmt.Sprintf("ENV_%d", i), Value: fmt.Sprintf("value-%d-%d", index, i)})
+	}
+	mounts := make([]corev1.VolumeMount, 0, 6)
+	for i := range 6 {
+		mounts = append(mounts, corev1.VolumeMount{Name: fmt.Sprintf("vol-%d", i), MountPath: fmt.Sprintf("/mnt/%d", i)})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("cached-pod-%d", index),
+			Namespace: "default",
+			UID:       k8stypes.UID(fmt.Sprintf("cached-uid-%d", index)),
+			Labels:    map[string]string{"app": "train", "release": "v1", "team": "ml"},
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-allocated": "GPU-0,NVIDIA,1024,10:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-0",
+			Containers: []corev1.Container{{Name: "main", Image: "example.com/train:v1", Env: envs, VolumeMounts: mounts}},
+			Volumes:    []corev1.Volume{{Name: "vol-0"}, {Name: "vol-1"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "main", Image: "example.com/train:v1", Ready: true}},
+		},
+	}
+}
+
+// newBenchmarkPodManager returns a manager holding podCount cached pods, each
+// with a single-device allocation.
+func newBenchmarkPodManager(podCount int) *PodManager {
+	manager := NewPodManager()
+	for i := range podCount {
+		manager.AddPod(newBenchmarkCachedPod(i), "node-0", PodDevices{
+			"NVIDIA": PodSingleDevice{
+				ContainerDevices{{UUID: "GPU-0", Type: "NVIDIA", Usedmem: 1024, Usedcores: 10}},
+			},
+		})
+	}
+	return manager
+}
+
+// BenchmarkListPodsInfo measures the cache snapshot taken once per Filter
+// across different cached Pod counts. AddPod logs at Info level, so klog is
+// silenced for the whole benchmark. SetOutput alone is not enough: klog
+// defaults to logtostderr, which writes to stderr directly and never consults
+// the configured output.
+func BenchmarkListPodsInfo(b *testing.B) {
+	klog.LogToStderr(false)
+	klog.SetOutput(io.Discard)
+	b.Cleanup(func() {
+		klog.SetOutput(os.Stderr)
+		klog.LogToStderr(true)
+	})
+
+	for _, podCount := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("pods=%d", podCount), func(b *testing.B) {
+			manager := newBenchmarkPodManager(podCount)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if got := len(manager.ListPodsInfo()); got != podCount {
+					b.Fatalf("ListPodsInfo returned %d pods, want %d", got, podCount)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/score_bench_test.go
+++ b/pkg/scheduler/score_bench_test.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -52,13 +53,18 @@ const (
 )
 
 // quietKlog silences klog for the duration of a benchmark. Fit logs once per
-// container request at Info level, so writing those lines to stderr would
-// otherwise dominate both the timing and the allocation counts. Uses the same
-// SetOutput and restore pattern as routes/route_test.go.
+// container request at Info level, so writing those lines out would otherwise
+// dominate both the timing and the allocation counts. SetOutput alone is not
+// enough: klog defaults to logtostderr, which writes to stderr directly and
+// never consults the configured output.
 func quietKlog(b *testing.B) {
 	b.Helper()
+	klog.LogToStderr(false)
 	klog.SetOutput(io.Discard)
-	b.Cleanup(func() { klog.SetOutput(os.Stderr) })
+	b.Cleanup(func() {
+		klog.SetOutput(os.Stderr)
+		klog.LogToStderr(true)
+	})
 }
 
 // newBenchmarkNodes builds nodeCount nodes carrying gpusPerNode idle NVIDIA
@@ -191,6 +197,88 @@ func BenchmarkScoreNode(b *testing.B) {
 				b.StopTimer()
 				nodes := *newBenchmarkNodes(1, 8)
 				node := nodes["node-0"]
+				b.StartTimer()
+
+				result := scheduler.scoreNode("node-0", node, requests, pod, nodePolicy, weights)
+				if result.err != nil {
+					b.Fatalf("scoreNode returned an error: %v", result.err)
+				}
+				if result.score == nil {
+					b.Fatalf("scoreNode did not fit the pod: %s", result.reason)
+				}
+			}
+		})
+	}
+}
+
+// benchTenantPod includes nested fields to exercise Pod copying costs.
+func benchTenantPod(index int) *corev1.Pod {
+	envs := make([]corev1.EnvVar, 0, 20)
+	for i := range 20 {
+		envs = append(envs, corev1.EnvVar{Name: fmt.Sprintf("ENV_%d", i), Value: fmt.Sprintf("value-%d-%d", index, i)})
+	}
+	mounts := make([]corev1.VolumeMount, 0, 6)
+	for i := range 6 {
+		mounts = append(mounts, corev1.VolumeMount{Name: fmt.Sprintf("vol-%d", i), MountPath: fmt.Sprintf("/mnt/%d", i)})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("tenant-pod-%d", index),
+			Namespace:   "default",
+			UID:         k8stypes.UID(fmt.Sprintf("tenant-uid-%d", index)),
+			Labels:      map[string]string{"app": "train", "release": "v1", "team": "ml"},
+			Annotations: map[string]string{util.AssignedNodeAnnotations: "node-0"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-0",
+			Containers: []corev1.Container{{Name: "main", Image: "example.com/train:v1", Env: envs, VolumeMounts: mounts}},
+			Volumes:    []corev1.Volume{{Name: "vol-0"}, {Name: "vol-1"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "main", Image: "example.com/train:v1", Ready: true}},
+		},
+	}
+}
+
+// occupyBenchmarkNode marks every device on the node as hosting podsPerGPU
+// tenants, the way getNodesUsage does when it replays cached allocations.
+func occupyBenchmarkNode(node *NodeUsage, podsPerGPU int) {
+	index := 0
+	for _, deviceList := range node.Devices.DeviceLists {
+		dev := deviceList.Device
+		for range podsPerGPU {
+			dev.PodInfos = append(dev.PodInfos, &device.PodInfo{Pod: benchTenantPod(index), NodeID: node.NodeInfo.ID})
+			dev.Used++
+			dev.Usedmem += benchMemreq
+			dev.Usedcores += benchCoresreq
+			index++
+		}
+	}
+}
+
+// BenchmarkScoreNodeOccupied measures one node whose devices already host
+// other pods. Their PodInfos ride along in the NodeUsage copy scoreNode
+// takes, so the spread across these cases is what resident pods cost per
+// candidate node.
+func BenchmarkScoreNodeOccupied(b *testing.B) {
+	quietKlog(b)
+
+	scheduler := &Scheduler{}
+	weights := util.DefaultDeviceScoringWeights()
+	nodePolicy := util.NodeSchedulerPolicyBinpack.String()
+	pod := newBenchmarkPod(0)
+	requests := newBenchmarkRequests(0)
+
+	for _, podsPerGPU := range []int{0, 2, 4} {
+		b.Run(fmt.Sprintf("podsPerGPU=%d", podsPerGPU), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				nodes := *newBenchmarkNodes(1, 8)
+				node := nodes["node-0"]
+				occupyBenchmarkNode(node, podsPerGPU)
 				b.StartTimer()
 
 				result := scheduler.scoreNode("node-0", node, requests, pod, nodePolicy, weights)


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

The HAMi scheduler deep-copies the entire Pod cache on every `Filter` call, even though it only ever reads annotations and identity fields off those Pods. This PR replaces the whole-Pod deep copy with pointer sharing, while still copying the fields the manager owns.

`getNodesUsage` calls `ListPodsInfo()` once per `Filter`. `ListPodsInfo` calls `PodInfo.DeepCopy()` for every cached GPU Pod, and that includes `corev1.Pod.DeepCopy()` — a full copy of the PodSpec, containers, env, volumes, status, and the `managedFields`/`FieldsV1` the API server generates.

`getNodesUsage` then attaches each `*PodInfo` to the matching device's `DeviceUsage.PodInfos`. When scoring runs per candidate node, `scoreNode` deep-copies the `NodeUsage` again — once for the app containers and once more per non-sidecar init container — and the old `DeviceUsage.DeepCopy` deep-copied every attached `PodInfo`, whole Pod included, **a second time**.

So one scheduling attempt performs roughly:

```
cached GPU pods × (1 + candidate nodes × (1 + non-sidecar init containers))
```

whole-Pod copies. The product grows with both cluster size and GPU Pod count. Nothing on the scheduling path mutates those Pods.

### The change

1. `PodInfo.DeepCopy` → `PodInfo.Snapshot`: still deep-copies `Devices` (`PodDevices`) and the scalar fields the manager owns and rewrites in place, but shares the `Pod` pointer.
2. `DeviceUsage.DeepCopy`: `slices.Clone(d.PodInfos)` replaces the per-element `PodInfo.DeepCopy()`. The copy gets its own slice header and shares the read-only `*PodInfo` entries.

Net production change is those two spots, about 10 lines.

## Performance validation

**Environment**: Apple M1 / 16 GiB / macOS 25.5.0 / Go 1.27.1 darwin/arm64

KWOK + [fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator) 

- **128 nodes × 8 fake H100 = 1,024 GPUs**, 10 shared slots each
- **4,096 resident Pods** (4 per GPU), loaded into the HAMi cache through the real API server and informers
- **500 new Pods** per round, 8 concurrent workers, each requesting 1 shared slot / 1,024 MiB / 10% cores
- `GOMAXPROCS=4` for both HAMi and kube-scheduler; HAMi with `kube-qps=200`, `kube-burst=400`, spread policy; kube-scheduler with `percentageOfNodesToScore: 100`
- New Pods traverse the full path: `API server → kube-scheduler → HAMi Filter/Score → HAMi Bind → API server → KWOK Running`
- Six interleaved rounds: `before-1 → after-1 → before-2 → after-2 → before-3 → after-3`. Each round deletes its own Pods and restarts HAMi; resident Pods and nodes stay put.

**Steady-state results** (3 rounds each, medians):

| Metric | before `aa6f39d` | after (this PR) | Change |
|---|---:|---:|---:|
| Wall time for 500 Pods | 34.89 s | 20.26 s | **−41.9%** |
| Successful throughput | 14.33 pod/s | 24.69 pod/s | **+72.2%** |
| End-to-end P50 | 545.5 ms | 343.4 ms | −37.1% |
| End-to-end P95 | 676.8 ms | 379.1 ms | −44.0% |
| End-to-end P99 | 862.4 ms | 396.8 ms | −54.0% |
| Process allocation / new Pod | 124.29 MiB | 9.49 MiB | **−92.4%** |
| Objects allocated (500-Pod window) | 284,416,706 | 50,336,234 | −82.3% |
| GC cycles | 356 | 65 | −81.7% |
| kube-scheduler scheduling-algorithm mean | 69.60 ms | 40.18 ms | −42.3% |

**pprof**:

|  | before `aa6f39d` | after (this PR) |
|---|---|---|
| **Allocation** `alloc_space`<br>60.84 GiB → 4.59 GiB | <img width="1478" height="400" alt="image" src="https://github.com/user-attachments/assets/5e4c1af3-ea7c-4f84-9bbd-0b9e963ce0a4" /> | <img width="1478" height="416" alt="image" src="https://github.com/user-attachments/assets/463c9a27-0965-4b62-8580-d611982c6744" /> |
| **CPU** 60 s window<br>68.69 → 10.03 CPU·s | <img width="1478" height="497" alt="image" src="https://github.com/user-attachments/assets/a9067730-7152-4a44-af60-3d6534485388" /> | <img width="1478" height="528" alt="image" src="https://github.com/user-attachments/assets/0ad2b521-2221-467e-80c1-5d498134aeed" /> |

**benchmark**:

| `BenchmarkListPodsInfo` (pkg/device) | sec/op | B/op | allocs/op |
|---|---|---|---|
| pods=100 | 195.6 µs → 31.4 µs (**−83.96%**) | 537.6 KiB → 67.3 KiB (−87.48%) | 1,902 → 802 (−57.83%) |
| pods=1000 | 2.019 ms → 310.8 µs (**−84.61%**) | 5,375 KiB → 672 KiB (−87.50%) | 19,003 → 8,003 (−57.89%) |
| pods=5000 | 13.040 ms → 1.901 ms (**−85.42%**) | 26.25 MiB → 3.28 MiB (−87.50%) | 95,003 → 40,003 (−57.89%) |

| `BenchmarkScoreNode*` (pkg/scheduler) | sec/op | B/op | allocs/op |
|---|---|---|---|
| `ScoreNodeOccupied` podsPerGPU=0 *(control)* | 10.36 µs → 10.49 µs (~, p=0.721) | 11.00 KiB → 11.00 KiB (~) | 154 → 154 (~) |
| `ScoreNodeOccupied` podsPerGPU=2 | 35.74 µs → 10.61 µs (**−70.31%**) | 87.47 KiB → 11.31 KiB (−87.07%) | 368 → 175 (−52.45%) |
| `ScoreNodeOccupied` podsPerGPU=4 | 61.08 µs → 11.28 µs (**−81.53%**) | 163.85 KiB → 11.56 KiB (−92.94%) | 562 → 177 (−68.51%) |
| `ScoreNode` initContainers=0/1/4 *(control, idle devices)* | ~ (p=0.743 / 0.314 / 0.328) | ~ | ~ (identical per sample) |


---

**AI assistance disclosure**

This PR was written with assistance from Claude Code, covering the code change, the benchmarks, and the setup and execution of the performance validation experiments. I have reviewed and understood every change line by line, and independently verified the correctness argument (the ownership boundary around the shared Pod and the read-only nature of each consumer).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Behavior Changes

* Pod information retrieval now returns lightweight snapshots that share read-only pod data while keeping manager-owned fields independent.
* Device usage copies duplicate the pod information list while sharing its read-only entries.

## Performance

* Reduced copying overhead for pod and device usage information.

## Tests

* Added benchmarks for pod snapshot generation and scoring nodes with existing workloads.
* Updated tests to verify snapshot isolation and shared read-only data semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->