### PR TITLE
fix(chart): target device plugin monitor port by name

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -197,6 +197,7 @@ become ready and restart the HAMi device plugin DaemonSet.
 |-----------|-------------|---------------|
 | `devicePlugin.service.type` | Service type | `NodePort` |
 | `devicePlugin.service.httpPort` | HTTP port | `31992` |
+| `devicePlugin.service.monitorTargetPort` | Monitor target port | `metrics` |
 
 ### Device Plugin Deployment Configuration
 

--- a/charts/hami/templates/device-plugin/monitorservice.yaml
+++ b/charts/hami/templates/device-plugin/monitorservice.yaml
@@ -18,7 +18,7 @@ spec:
   ports:
     - name: monitorport
       port: {{ .Values.devicePlugin.service.httpPort | default 31992 }}  # Default HTTP port is 31992
-      targetPort: 9394
+      targetPort: {{ .Values.devicePlugin.service.monitorTargetPort | default "metrics" }}
       {{- if eq (.Values.devicePlugin.service.type | default "NodePort") "NodePort" }}  # If type is NodePort, set nodePort
       nodePort: {{ .Values.devicePlugin.service.httpPort | default 31992 }}
       {{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -438,6 +438,7 @@ devicePlugin:
   service:
     type: NodePort  # Default type is NodePort, can be changed to ClusterIP
     httpPort: 31992
+    monitorTargetPort: metrics  # Name of the container port, so it follows the monitor's containerPort name
     labels: {}
     annotations: {}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The device plugin monitor Service hardcodes `targetPort: 9394` instead of targeting the container port by name, unlike the scheduler's equivalent monitor Service (fixed in #2895) which targets by name to avoid drift if the container port number ever changes. This applies the same fix here: adds `devicePlugin.service.monitorTargetPort` (default `metrics`) to `values.yaml`, uses it in `monitorservice.yaml`, and documents it in the chart README, mirroring #2895's pattern exactly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Confirmed via grep that this was the only remaining hardcoded `targetPort` of this kind in the chart. Verified rendered output is functionally identical at default values (`helm template` diff shows only the port field changing from the numeric literal to the equivalent name), and `helm lint` passes.

**Does this PR introduce a user-facing change?**:
No behavior change at default values; adds a new `devicePlugin.service.monitorTargetPort` value for consistency with the scheduler service.

---
This PR was written primarily by Claude Code, an AI assistant, under my direction and review. I verified the change by comparing rendered chart output before and after, and reviewed the diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the device plugin monitor service’s target port.
  * The target port defaults to the named `metrics` port and can be customized through Helm values.

* **Documentation**
  * Updated the Helm chart configuration reference with the new monitor target port setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->