### PR TITLE
test(util): cover MarkAnnotationsToDelete

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1131,3 +1131,34 @@ func TestGetNode(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkAnnotationsToDelete(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Annotations: map[string]string{
+				"hami.io/nvidia": "handshake",
+			},
+		},
+	}
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+	client.KubeClient = fake.NewClientset(node)
+
+	err := MarkAnnotationsToDelete("hami.io/nvidia", "test-node")
+	assert.NilError(t, err)
+
+	updated, err := client.KubeClient.CoreV1().Nodes().Get(context.TODO(), "test-node", metav1.GetOptions{})
+	assert.NilError(t, err)
+	_, hasAnno := updated.Annotations["hami.io/nvidia"]
+	assert.Assert(t, !hasAnno)
+}
+
+func TestMarkAnnotationsToDelete_NodeNotFound(t *testing.T) {
+	oldClient := client.KubeClient
+	t.Cleanup(func() { client.KubeClient = oldClient })
+	client.KubeClient = fake.NewClientset()
+
+	err := MarkAnnotationsToDelete("hami.io/nvidia", "missing-node")
+	assert.ErrorContains(t, err, "not found")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`util.MarkAnnotationsToDelete` is the only exported function in `pkg/util/util.go` without a direct unit test. It's a thin wrapper over `GetNode` and `RemoveNodeAnnotation`, both already tested individually, but its own composition and error-propagation path (when `GetNode` fails) were untested. Adds `TestMarkAnnotationsToDelete` and `TestMarkAnnotationsToDelete_NodeNotFound` following the existing fake-clientset pattern used by the neighboring `GetNode`/`RemoveNodeAnnotation` tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test-only change, no production code touched. Ran `go test ./pkg/util/... -run TestMarkAnnotationsToDelete -v --race -count=1`, both new tests pass.

**Does this PR introduce a user-facing change?**:
NONE

---
This PR was written primarily by Claude Code, an AI assistant, under my direction and review. I verified the tests by running them locally and reviewed the diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for successfully removing node annotations.
  - Added coverage for handling cases where the specified annotation is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->