### PR TITLE
fix(chart): add standard labels to webhook, monitor role, and runtime class

### DIFF
--- a/charts/hami/templates/device-plugin/monitorrole.yaml
+++ b/charts/hami/templates/device-plugin/monitorrole.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name:  {{ include "hami-vgpu.device-plugin" . }}-monitor
+  labels:
+    app.kubernetes.io/component: "hami-device-plugin"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/hami/templates/device-plugin/runtime-class.yaml
+++ b/charts/hami/templates/device-plugin/runtime-class.yaml
@@ -4,6 +4,9 @@ apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: {{ .Values.devicePlugin.runtimeClassName }}
+  labels:
+    app.kubernetes.io/component: "hami-device-plugin"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
 handler: nvidia

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -7,6 +7,9 @@ metadata:
     cert-manager.io/inject-ca-from: {{ include "hami-vgpu.namespace" . }}/{{ include "hami-vgpu.scheduler" . }}-serving-cert
   {{- end }}
   name: {{ include "hami-vgpu.scheduler.webhook" . }}
+  labels:
+    app.kubernetes.io/component: "hami-scheduler"
+    {{- include "hami-vgpu.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1beta1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`MutatingWebhookConfiguration` (charts/hami/templates/scheduler/webhook.yaml), the device plugin monitor `ClusterRole` (charts/hami/templates/device-plugin/monitorrole.yaml), and the `RuntimeClass` (charts/hami/templates/device-plugin/runtime-class.yaml) had no labels at all, unlike nearly every other resource in the chart, including other cluster scoped ones like the scheduler ClusterRole and the device plugin ClusterRoleBinding. This adds the same standard labels those already have. The webhook config in particular is the most operationally significant resource in the chart, so missing labels there makes it harder to find with label selector based tooling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Verified with `helm lint` and `helm template --show-only` on all three files: labels render correctly, no other output changed.

**Does this PR introduce a user-facing change?**:
No behavior change; adds standard `app.kubernetes.io/*` and `helm.sh/chart` labels to three resources that previously had none.

---
This PR was written primarily by Claude Code, an AI assistant, under my direction and review. I verified the change with helm lint and helm template and reviewed the diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added standard Kubernetes metadata labels to device plugin monitoring, runtime class, and scheduler webhook resources.
  * Improved resource identification and consistency across deployed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->