### PR TITLE
fix(device-plugin): skip ld.so.preload for sandboxed runtime classes

### DIFF
--- a/charts/hami/README.md
+++ b/charts/hami/README.md
@@ -240,6 +240,7 @@ become ready and restart the HAMi device plugin DaemonSet.
 |-----------|-------------|---------------|
 | `devices.nvidia.gpuCorePolicy` | GPU core policy | `default` |
 | `devices.nvidia.libCudaLogLevel` | CUDA library log level | `1` |
+| `devices.nvidia.sandboxRuntimeClassNames` | RuntimeClass names whose sandbox does not provide the `libcuda.so.1` that `libvgpu.so` links against (gVisor); pods using them skip the preload injection, and vGPU limits are not enforced. Empty means the defaults `gvisor` and `runsc` | `[]` |
 
 ### Huawei Ascend
 | Parameter | Description | Default Value |

--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -32,6 +32,10 @@ data:
       gpuCorePolicy: {{ .Values.devices.nvidia.gpuCorePolicy }}
       libCudaLogLevel: {{ .Values.devices.nvidia.libCudaLogLevel }}
       runtimeClassName: "{{ .Values.devicePlugin.runtimeClassName }}"
+      {{- with .Values.devices.nvidia.sandboxRuntimeClassNames }}
+      sandboxRuntimeClassNames:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       migProfileAllowlist:
       - models: [ "A30" ]
         profiles: [ "1g.6gb", "2g.12gb", "4g.24gb" ]

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -531,6 +531,11 @@ devices:
   nvidia:
     gpuCorePolicy: default
     libCudaLogLevel: 1
+    # RuntimeClass names, gVisor for example, whose sandbox does not provide the
+    # libcuda.so.1 that libvgpu.so links against. Pods using one of these skip the preload
+    # injection so the container can start; memory and core limits are not enforced in them.
+    # Leave empty for the built-in defaults: gvisor and runsc.
+    sandboxRuntimeClassNames: []
   ascend:
     enabled: false
     image: ""

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_sandbox_runtime_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/alloc_sandbox_runtime_test.go
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026, HAMi.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func hasLibvgpuMount(mounts []*kubeletdevicepluginv1beta1.Mount) bool {
+	for _, m := range mounts {
+		if m.ContainerPath == fmt.Sprintf("%s/vgpu/libvgpu.so", hostHookPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIsSandboxedRuntimeClass(t *testing.T) {
+	tests := []struct {
+		name         string
+		runtimeClass *string
+		configured   []string
+		want         bool
+	}{
+		{
+			name:         "NoRuntimeClass",
+			runtimeClass: nil,
+			want:         false,
+		},
+		{
+			name:         "EmptyRuntimeClass",
+			runtimeClass: ptr(""),
+			want:         false,
+		},
+		{
+			name:         "NvidiaRuntimeClass",
+			runtimeClass: ptr("nvidia"),
+			want:         false,
+		},
+		{
+			name:         "DefaultGvisorName",
+			runtimeClass: ptr("gvisor"),
+			want:         true,
+		},
+		{
+			name:         "DefaultRunscName",
+			runtimeClass: ptr("runsc"),
+			want:         true,
+		},
+		{
+			name:         "NameMatchIsCaseInsensitiveAndTrimmed",
+			runtimeClass: ptr(" gVisor "),
+			want:         true,
+		},
+		{
+			name:         "ConfiguredListReplacesDefaults",
+			runtimeClass: ptr("gvisor"),
+			configured:   []string{"sandboxed"},
+			want:         false,
+		},
+		{
+			name:         "ConfiguredListMatches",
+			runtimeClass: ptr("sandboxed"),
+			configured:   []string{"sandboxed", "gvisor"},
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Spec: corev1.PodSpec{RuntimeClassName: tt.runtimeClass}}
+			require.Equal(t, tt.want, isSandboxedRuntimeClass(pod, tt.configured))
+		})
+	}
+}
+
+func TestIsSandboxedRuntimeClass_NilPod(t *testing.T) {
+	require.False(t, isSandboxedRuntimeClass(nil, nil))
+}
+
+// allocateWithRuntimeClass runs a single container Allocate for a pod pinned to runtimeClass.
+func allocateWithRuntimeClass(t *testing.T, runtimeClass string, configured []string) *kubeletdevicepluginv1beta1.ContainerAllocateResponse {
+	t.Helper()
+	setupInRequestDevices(t)
+	plugin := newTestPlugin(t)
+	plugin.schedulerConfig.SandboxRuntimeClassNames = configured
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				"hami.io/vgpu-devices-to-allocate": "GPU-aaa,NVIDIA,3000,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClass,
+			Containers:       []corev1.Container{{Name: "c0"}},
+		},
+	}
+	setupFakeClient(t, pod)
+	mockAllocateGlobals(t, pod)
+
+	request := &kubeletdevicepluginv1beta1.AllocateRequest{
+		ContainerRequests: []*kubeletdevicepluginv1beta1.ContainerAllocateRequest{
+			{DevicesIds: []string{"GPU-aaa-0"}},
+		},
+	}
+
+	response, err := plugin.Allocate(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, response.ContainerResponses, 1)
+	return response.ContainerResponses[0]
+}
+
+func TestAllocate_GvisorRuntimeClassSkipsLdSoPreload(t *testing.T) {
+	containerResponse := allocateWithRuntimeClass(t, "gvisor", nil)
+
+	require.False(t, hasLdSoPreloadMount(containerResponse.Mounts),
+		"mounting the preload makes every binary fail on libvgpu.so's libcuda.so.1 dependency")
+	// The allocation is otherwise untouched: the device is still handed to the container.
+	require.True(t, hasLibvgpuMount(containerResponse.Mounts))
+	require.Equal(t, "3000m", containerResponse.Envs["CUDA_DEVICE_MEMORY_LIMIT_0"])
+	require.Equal(t, "50", containerResponse.Envs["CUDA_DEVICE_SM_LIMIT"])
+}
+
+func TestAllocate_NvidiaRuntimeClassKeepsLdSoPreload(t *testing.T) {
+	containerResponse := allocateWithRuntimeClass(t, "nvidia", nil)
+
+	require.True(t, hasLdSoPreloadMount(containerResponse.Mounts),
+		"runc based runtime classes must keep the libvgpu preload injection")
+}
+
+func TestAllocate_ConfiguredSandboxRuntimeClassSkipsLdSoPreload(t *testing.T) {
+	containerResponse := allocateWithRuntimeClass(t, "gvisor-nvidia", []string{"gvisor-nvidia"})
+
+	require.False(t, hasLdSoPreloadMount(containerResponse.Mounts))
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -866,6 +866,13 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 	}
 	klog.Infof("Allocate pod name is %s/%s, annotation is %+v", current.Namespace, current.Name, current.Annotations)
 
+	sandboxedRuntime := isSandboxedRuntimeClass(current, plugin.schedulerConfig.SandboxRuntimeClassNames)
+	if sandboxedRuntime {
+		klog.Warningf("Pod %s/%s uses runtimeClass %q: skipping the libvgpu.so preload injection, "+
+			"device memory and core limits are not enforced in this pod",
+			current.Namespace, current.Name, *current.Spec.RuntimeClassName)
+	}
+
 	podSingleDev, err := decodePodSingleDevice(nvidia.NvidiaGPUDevice, current)
 	if err != nil {
 		PodAllocationFailed(nodename, current, NodeLockNvidia)
@@ -988,7 +995,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *kubeletdev
 						break
 					}
 				}
-				if !found {
+				if !found && !sandboxedRuntime {
 					response.Mounts = append(response.Mounts, &kubeletdevicepluginv1beta1.Mount{ContainerPath: "/etc/ld.so.preload",
 						HostPath: hostHookPath + "/vgpu/ld.so.preload",
 						ReadOnly: true},

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -453,3 +453,26 @@ func createSpecFile(outputPath string) error {
 	}
 	return nil
 }
+
+// isSandboxedRuntimeClass reports whether the pod runs under one of the configured sandbox
+// runtime classes. libvgpu.so carries a DT_NEEDED on libcuda.so.1, which those sandboxes do
+// not provide, so preloading it makes every binary in the container fail to start.
+func isSandboxedRuntimeClass(pod *corev1.Pod, configured []string) bool {
+	if pod == nil || pod.Spec.RuntimeClassName == nil {
+		return false
+	}
+	runtimeClass := strings.TrimSpace(*pod.Spec.RuntimeClassName)
+	if runtimeClass == "" {
+		return false
+	}
+	names := configured
+	if len(names) == 0 {
+		names = nvidia.DefaultSandboxRuntimeClassNames
+	}
+	for _, name := range names {
+		if strings.EqualFold(strings.TrimSpace(name), runtimeClass) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -112,7 +112,14 @@ type NvidiaConfig struct {
 	GPUCorePolicy GPUCoreUtilizationPolicy `yaml:"gpuCorePolicy"`
 	// RuntimeClassName is the name of the runtime class to be added to pod.spec.runtimeClassName
 	RuntimeClassName string `yaml:"runtimeClassName"`
+	// SandboxRuntimeClassNames lists the runtime classes that skip the libvgpu.so preload
+	// injection. Empty means DefaultSandboxRuntimeClassNames.
+	SandboxRuntimeClassNames []string `yaml:"sandboxRuntimeClassNames"`
 }
+
+// DefaultSandboxRuntimeClassNames are the gVisor runtime class names: "gvisor" is the
+// conventional RuntimeClass name, "runsc" the handler it registers.
+var DefaultSandboxRuntimeClassNames = []string{"gvisor", "runsc"}
 
 // These configs can be specified for each node by using Nodeconfig.
 type NodeDefaultConfig struct {

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -229,6 +229,44 @@ func Test_LoadConfig(t *testing.T) {
 	assert.DeepEqual(t, configData.IluvatarConfig, expectedIluvatars)
 }
 
+// Test_LoadConfig_SandboxRuntimeClassNames pins the yaml key the Helm chart renders for the
+// runtime classes that skip the preload injection.
+func Test_LoadConfig_SandboxRuntimeClassNames(t *testing.T) {
+	testCases := []struct {
+		name     string
+		yamlData string
+		expected []string
+	}{
+		{
+			name: "AbsentKeyLeavesTheListEmpty",
+			yamlData: `
+nvidia:
+  resourceCountName: nvidia.com/gpu
+`,
+			expected: nil,
+		},
+		{
+			name: "ListIsParsed",
+			yamlData: `
+nvidia:
+  sandboxRuntimeClassNames:
+  - gvisor
+  - my-sandbox
+`,
+			expected: []string{"gvisor", "my-sandbox"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var configData Config
+			err := yaml.Unmarshal([]byte(testCase.yamlData), &configData)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, testCase.expected, configData.NvidiaConfig.SandboxRuntimeClassNames)
+		})
+	}
+}
+
 func createNvidiaConfig() nvidia.NvidiaConfig {
 	return nvidia.NvidiaConfig{
 		ResourceCountName:            "nvidia.com/gpu",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Allocate()` mounts `/etc/ld.so.preload` into every non-MIG container unless the container sets `CUDA_DISABLE_CONTROL=true`. The file points at `libvgpu.so`, which is linked with `-lcuda -lnvidia-ml`:

```
$ readelf -d libvgpu.so.v2.9.0 | grep NEEDED
 (NEEDED)  Shared library: [libcuda.so.1]
```

That is a load-time dependency, so every process in the container has to resolve `libcuda.so.1` before it starts. Under `runtimeClassName: gvisor` it cannot, so every binary fails, including bash:

```
bash: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory
```

The pod never starts. HAMi also cannot enforce limits in it, because `libvgpu.so` is what does the enforcement.

This PR checks the pod's runtimeClassName in `Allocate()` and skips the `ld.so.preload` mount for sandbox runtimes, with a warning in the log saying limits are not enforced. Nothing else in the allocation changes. The device, the `CUDA_DEVICE_MEMORY_LIMIT_*` and `CUDA_DEVICE_SM_LIMIT` envs, the `libvgpu.so` mount, the cache directory and
`/tmp/vgpulock` are all still set.

The default list is `gvisor` and `runsc`. It can be changed with `sandboxRuntimeClassNames` in the device config. Existing installs get the fix without editing config.

**Which issue(s) this PR fixes**:

Fixes #2581

**Special notes for your reviewer**:

I match on the RuntimeClass name instead of reading the RuntimeClass object's handler. Reading the object would be exact, but it needs a `node.k8s.io` read added to the device plugin RBAC and an API call during allocation. I can switch it if you would rather have that.

The issue says gVisor does not honour `/etc/ld.so.preload`. I do not think that is what happened. Only two things can put `libvgpu.so` into bash's dependency list: the `LD_PRELOAD` env var, or `/etc/ld.so.preload`. HAMi never sets `LD_PRELOAD` anywhere, and `vgpu-init.sh` only rewrites the preload file, so the file must have been read. If `libcuda.so.1` had been in the sandbox it would have resolved and there would be no error. So the preload was honoured, and the driver libraries that the NVIDIA container runtime puts into a runc container are not there under `runsc`.

If those libraries were injected, `libvgpu.so` might load and enforcement might work under nvproxy. That is option 1 in the issue and I have not tried it. I did option 2 because the issue asks for it as a minimum, and because HAMi should not mount a preload whose dependency it cannot satisfy either way.

**Does this PR introduce a user-facing change?**:

Yes. A pod with `runtimeClassName` of `gvisor` or `runsc` no longer gets the `/etc/ld.so.preload` mount, so it starts instead of failing on `libcuda.so.1`. Memory and core limits are not enforced inside it. The scheduler still counts the request. The device
plugin logs a warning on each such allocation. Other runtime classes are not affected.

## Validation

Linux x86_64 (WSL2, Ubuntu), Go 1.27.0, CGO enabled:

* `go test ./pkg/device-plugin/... ./pkg/scheduler/config/... ./pkg/device/nvidia/... -count=1` — pass
* `make verify` — exit 0, 0 lint issues
* `make -C charts validate` and `hack/verify-chart-version.sh` with Helm v3.21.4 — pass
* Reverted the new condition and re-ran the two Allocate tests to check they fail against the
  unfixed code

For the root cause I extracted `ld.so.preload` and `libvgpu.so` from `projecthami/hami:v2.9.0` and checked the `DT_NEEDED`. I then built a library with the same shape, with a `DT_NEEDED` that cannot be resolved, and preloaded it: bash, ls, cat and id all
fail with the same error. With the dependency resolvable the same preload does nothing.

**Hardware:** I do not have a GPU node or a gVisor cluster. I have not reproduced the original crash or checked that a gVisor pod starts with this change, so gate 2 is not met. The runc path is covered by the repo's `e2e_test (nvidia, tesla-p4)` job, which starts a vGPU pod and runs a CUDA sample, and that needs the preload to be in place.

@marcellvasanczki-sap if you can run this on the cluster from the issue, the check is whether a pod with `runtimeClassName: gvisor` and `nvidia.com/gpumem` starts now. This also shows the driver libraries are missing in the sandbox, which is what the diagnosis rests on:

```
kubectl exec <gvisor-pod> -- ldconfig -p | grep -E "libcuda|libnvidia-ml"
```

## AI Assistance Disclosure
This PR was written with AI assistance (Claude Code), covering the codebase investigation, implementation, and tests. I reviewed the change against the existing code and ran the validation listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for sandboxed runtime classes, including gVisor and runsc by default.
  * Pods using configured sandboxed runtimes can start without the NVIDIA preload injection.
  * Added Helm chart values and documentation for configuring sandbox runtime classes.

* **Behavior Changes**
  * Memory and core limits are not enforced for pods using sandboxed runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->