### PR TITLE
enhance(device-plugin): pair NVML init and shutdown on the MIG manager session

### DIFF
--- a/docs/develop/mig-dynamic-deallocate.md
+++ b/docs/develop/mig-dynamic-deallocate.md
@@ -36,6 +36,26 @@ The scheduler owns placement policy. The device plugin owns hardware mutation. P
 
 A stable reservation key supports idempotent realization. Reconciliation aligns managed hardware with active workload reservations.
 
+## NVML session ownership
+
+Each Dynamic MIG plugin start cycle owns one NVML session through its
+`MigInstanceManager`. Construction does not initialize NVML. `Start` initializes
+it before the startup scan; MIG discovery, registration, topology scoring,
+allocation, adoption, and release borrow the configured instance.
+
+`Stop` cancels the cycle's registration and reconciliation loops, stops gRPC and
+waits for handlers (including allocation cleanup), and drains background workers
+before shutting down the manager. Manager shutdown rejects new operations and
+waits for admitted operations to finish. Startup failures use the same cleanup
+path; failed initialization is never paired with shutdown. Repeated shutdown is
+safe. A new start acquires a new session and rebuilds the in-memory allocation
+index from Pod annotations; shutdown itself does not destroy running instances.
+
+Initial resource discovery, health checking, non-MIG operation, and the separate
+monitor retain their independent session ownership. The one-init/one-shutdown
+invariant applies to the Dynamic MIG manager's session, not every NVML caller in
+the process. Forced process termination cannot run graceful cleanup.
+
 ## Architecture
 
 ```text

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_lifecycle_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_lifecycle_test.go
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, HAMi. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package plugin
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"google.golang.org/grpc"
+	kubelet "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
+	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
+)
+
+// Unix socket paths are limited to about 100 bytes, including the temporary
+// directory. macOS testing.TempDir paths may already exceed that limit.
+func lifecycleSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "hami-nvml-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	})
+	return dir
+}
+
+func lifecyclePlugin(t *testing.T) (*NvidiaDevicePlugin, *nvmlmock.Interface) {
+	t.Helper()
+	lib := &nvmlmock.Interface{
+		InitFunc:           func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc:       func() nvml.Return { return nvml.SUCCESS },
+		DeviceGetCountFunc: func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+	}
+	p := &NvidiaDevicePlugin{
+		ctx: context.Background(), operatingMode: nvidia.MigMode,
+		migMgr: newMigInstanceManager(lib), socket: filepath.Join(lifecycleSocketDir(t), "gpu.sock"),
+		rm: &rm.ResourceManagerMock{
+			ResourceFunc: func() spec.ResourceName { return "nvidia.com/gpu" },
+			DevicesFunc:  func() rm.Devices { return rm.Devices{} },
+			CheckHealthFunc: func(stop <-chan interface{}, _ chan<- *rm.Device) error {
+				<-stop
+				return nil
+			},
+		},
+	}
+	t.Cleanup(func() {
+		if err := p.Stop(); err != nil {
+			t.Error(err)
+		}
+	})
+	return p, lib
+}
+
+func TestMigPluginStartupRollback(t *testing.T) {
+	for _, stage := range []string{"init", "inventory", "serve", "register"} {
+		t.Run(stage, func(t *testing.T) {
+			p, lib := lifecyclePlugin(t)
+			kubeletSocket := ""
+			switch stage {
+			case "init":
+				lib.InitFunc = func() nvml.Return { return nvml.ERROR_LIBRARY_NOT_FOUND }
+			case "inventory":
+				lib.DeviceGetCountFunc = func() (int, nvml.Return) { return 0, nvml.ERROR_UNKNOWN }
+			case "serve":
+				p.socket = filepath.Join(t.TempDir(), "missing", "gpu.sock")
+			case "register":
+				kubeletSocket = filepath.Join(lifecycleSocketDir(t), "kubelet.sock")
+				listener, err := net.Listen("unix", kubeletSocket)
+				if err != nil {
+					t.Fatal(err)
+				}
+				server := grpc.NewServer()
+				// The default registration method returns Unimplemented.
+				kubelet.RegisterRegistrationServer(server, &kubelet.UnimplementedRegistrationServer{})
+				go func() { _ = server.Serve(listener) }()
+				t.Cleanup(server.Stop)
+			}
+			if err := p.Start(kubeletSocket); err == nil {
+				t.Fatal("expected startup error")
+			}
+			if p.server != nil || p.stop != nil || p.runCtx.Err() == nil {
+				t.Fatal("startup failure left cycle resources active")
+			}
+			wantShutdown := 1
+			if stage == "init" {
+				wantShutdown = 0
+			}
+			if len(lib.InitCalls()) != 1 || len(lib.ShutdownCalls()) != wantShutdown {
+				t.Fatal("startup failure leaked or over-released NVML")
+			}
+			if err := p.Stop(); err != nil {
+				t.Fatal(err)
+			}
+			if len(lib.ShutdownCalls()) != wantShutdown {
+				t.Fatal("repeated Stop released NVML")
+			}
+		})
+	}
+}
+
+func TestMigPluginStartStopRestart(t *testing.T) {
+	p, lib := lifecyclePlugin(t)
+	for cycle := 1; cycle <= 2; cycle++ {
+		if err := p.Start(""); err != nil {
+			t.Fatal(err)
+		}
+		ctx := p.runCtx
+		for i := 0; i < 3; i++ {
+			if _, err := p.getAPIDevices(); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := p.topologyScore(nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(lib.InitCalls()) != cycle || len(lib.ShutdownCalls()) != cycle-1 {
+			t.Fatal("registration or topology scoring changed session ownership")
+		}
+		if err := p.Stop(); err != nil {
+			t.Fatal(err)
+		}
+		if ctx.Err() == nil {
+			t.Fatal("old cycle context is still active")
+		}
+		if len(lib.ShutdownCalls()) != cycle {
+			t.Fatal("Stop did not release NVML")
+		}
+		if err := p.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMigPluginStopWaitsForWorkersDespiteSocketError(t *testing.T) {
+	p, lib := lifecyclePlugin(t)
+	p.initialize()
+	if err := p.migMgr.Init(); err != nil {
+		t.Fatal(err)
+	}
+	// A non-empty directory makes socket removal fail reliably, even as root.
+	p.socket = t.TempDir()
+	if err := os.WriteFile(filepath.Join(p.socket, "keep"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	workerCanceled, releaseWorker := make(chan struct{}), make(chan struct{})
+	p.workers.Add(1)
+	go func() {
+		defer p.workers.Done()
+		<-p.runCtx.Done()
+		close(workerCanceled)
+		<-releaseWorker
+	}()
+	stopped := make(chan error, 1)
+	go func() { stopped <- p.Stop() }()
+	select {
+	case <-workerCanceled:
+	case <-time.After(time.Second):
+		close(releaseWorker)
+		t.Fatal("worker was not canceled")
+	}
+	if len(lib.ShutdownCalls()) != 0 {
+		close(releaseWorker)
+		t.Fatal("NVML closed before worker finished")
+	}
+	close(releaseWorker)
+	select {
+	case err := <-stopped:
+		if err == nil {
+			t.Fatal("expected socket removal error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not finish")
+	}
+	if len(lib.ShutdownCalls()) != 1 || p.server != nil {
+		t.Fatal("socket error skipped cleanup")
+	}
+}
+
+func TestMigReconcilerStopsWithCycle(t *testing.T) {
+	p, _ := lifecyclePlugin(t)
+	p.initialize()
+	p.workers.Add(1)
+	go func() { defer p.workers.Done(); p.runMigAnnotationReconciler(time.Hour) }()
+	if err := p.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if p.ctx.Err() != nil {
+		t.Fatal("Stop canceled the parent context")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_lifecycle_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_lifecycle_test.go
@@ -19,7 +19,7 @@ import (
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"google.golang.org/grpc"
-	kubelet "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device-plugin/nvidiadevice/nvinternal/rm"
 	"github.com/Project-HAMi/HAMi/pkg/device/nvidia"
@@ -88,7 +88,7 @@ func TestMigPluginStartupRollback(t *testing.T) {
 				}
 				server := grpc.NewServer()
 				// The default registration method returns Unimplemented.
-				kubelet.RegisterRegistrationServer(server, &kubelet.UnimplementedRegistrationServer{})
+				kubeletdevicepluginv1beta1.RegisterRegistrationServer(server, &kubeletdevicepluginv1beta1.UnimplementedRegistrationServer{})
 				go func() { _ = server.Serve(listener) }()
 				t.Cleanup(server.Stop)
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/mig_startup.go
@@ -45,10 +45,10 @@ func sortedIntSetKeys(s map[int]struct{}) []int {
 // Failure to read Pod annotations is returned to the caller because startup
 // reset must not proceed without the authoritative allocation state. NVML
 // process detection is an additional safeguard and remains best effort.
-func collectInUseGPUs(ctx context.Context, nodeName string) (map[int]struct{}, error) {
+func (m *MigInstanceManager) collectInUseGPUs(ctx context.Context, nodeName string) (map[int]struct{}, error) {
 	out := make(map[int]struct{})
 
-	annotated, err := kubernetesAllocatedMigGPUs(ctx, nodeName)
+	annotated, err := m.kubernetesAllocatedMigGPUs(ctx, nodeName)
 	if err != nil {
 		return out, fmt.Errorf("list Kubernetes MIG allocations: %w", err)
 	}
@@ -56,7 +56,7 @@ func collectInUseGPUs(ctx context.Context, nodeName string) (map[int]struct{}, e
 		out[g] = struct{}{}
 	}
 
-	if busy, err := nvmlBusyGPUs(); err != nil {
+	if busy, err := m.nvmlBusyGPUs(); err != nil {
 		klog.InfoS("mig init: NVML busy-GPU detection skipped", "err", err)
 	} else {
 		for g := range busy {
@@ -90,7 +90,7 @@ func activeMigGPUUUIDs(pods []corev1.Pod) map[string]struct{} {
 	return out
 }
 
-func kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]struct{}, error) {
+func (m *MigInstanceManager) kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]struct{}, error) {
 	kubeClient := client.GetClient()
 	if kubeClient == nil {
 		return nil, fmt.Errorf("Kubernetes client is not initialized")
@@ -104,7 +104,7 @@ func kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]s
 
 	out := make(map[int]struct{})
 	for gpuUUID := range activeMigGPUUUIDs(pods.Items) {
-		idx, ok := gpuUUIDToIndex(gpuUUID)
+		idx, ok := m.gpuUUIDToIndex(gpuUUID)
 		if !ok {
 			return nil, fmt.Errorf("resolve GPU UUID %s", gpuUUID)
 		}
@@ -113,11 +113,13 @@ func kubernetesAllocatedMigGPUs(ctx context.Context, nodeName string) (map[int]s
 	return out, nil
 }
 
-func gpuUUIDToIndex(gpuUUID string) (int, bool) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
+func (m *MigInstanceManager) gpuUUIDToIndex(gpuUUID string) (int, bool) {
+	done, err := m.beginOperation()
+	if err != nil {
 		return 0, false
 	}
-	dev, ret := nvml.DeviceGetHandleByUUID(gpuUUID)
+	defer done()
+	dev, ret := m.nvmllib.DeviceGetHandleByUUID(gpuUUID)
 	if ret != nvml.SUCCESS {
 		return 0, false
 	}
@@ -128,18 +130,20 @@ func gpuUUIDToIndex(gpuUUID string) (int, bool) {
 // nvmlBusyGPUs returns the set of GPU indexes with at least one running
 // compute or graphics process. For MIG-enabled cards every live MIG instance
 // is inspected; for non-MIG cards the parent device is inspected directly.
-func nvmlBusyGPUs() (map[int]struct{}, error) {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return nil, fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+func (m *MigInstanceManager) nvmlBusyGPUs() (map[int]struct{}, error) {
+	done, err := m.beginOperation()
+	if err != nil {
+		return nil, err
 	}
-	count, ret := nvml.DeviceGetCount()
+	defer done()
+	count, ret := m.nvmllib.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("DeviceGetCount: %s", nvml.ErrorString(ret))
 	}
 
 	out := make(map[int]struct{})
 	for i := 0; i < count; i++ {
-		dev, ret := nvml.DeviceGetHandleByIndex(i)
+		dev, ret := m.nvmllib.DeviceGetHandleByIndex(i)
 		if ret != nvml.SUCCESS {
 			continue
 		}
@@ -183,4 +187,30 @@ func deviceHasProcesses(dev nvml.Device) bool {
 		return len(gprocs) > 0
 	}
 	return true
+}
+
+// deviceInventory borrows the manager session for the startup scan.
+func (m *MigInstanceManager) deviceInventory() (int, []string, error) {
+	done, err := m.beginOperation()
+	if err != nil {
+		return 0, nil, err
+	}
+	defer done()
+	count, ret := m.nvmllib.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return 0, nil, fmt.Errorf("get device count: %s", nvml.ErrorString(ret))
+	}
+	names := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		dev, ret := m.nvmllib.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			return 0, nil, fmt.Errorf("get device %d: %s", i, nvml.ErrorString(ret))
+		}
+		name, ret := dev.GetName()
+		if ret != nvml.SUCCESS {
+			return 0, nil, fmt.Errorf("get device %d name: %s", i, nvml.ErrorString(ret))
+		}
+		names = append(names, name)
+	}
+	return count, names, nil
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr.go
@@ -63,6 +63,13 @@ type migInstance struct {
 // Callers must invoke Init once before using other methods, and Shutdown
 // once when done; NVML is not re-initialized per call.
 type MigInstanceManager struct {
+	// sessionMu protects admission; operations finish before NVML is released.
+	sessionMu   sync.Mutex
+	operations  sync.WaitGroup
+	nvmllib     nvml.Interface
+	initialized bool
+	closing     chan struct{}
+
 	mu                  sync.Mutex
 	gpuLocks            map[int]*sync.Mutex
 	byAllocation        map[migAllocationKey]*migInstance
@@ -70,29 +77,83 @@ type MigInstanceManager struct {
 }
 
 func NewMigInstanceManager() *MigInstanceManager {
+	return newMigInstanceManager(nvml.New())
+}
+
+func newMigInstanceManager(lib nvml.Interface) *MigInstanceManager {
 	return &MigInstanceManager{
+		nvmllib:             lib,
 		gpuLocks:            make(map[int]*sync.Mutex),
 		byAllocation:        make(map[migAllocationKey]*migInstance),
 		byAllocationMigUUID: make(map[string]migAllocationKey),
 	}
 }
 
-// Init initializes NVML for this manager. It must be called exactly once,
-// before any other MigInstanceManager method, and paired with a single
-// later call to Shutdown.
+// Init acquires one NVML session for a plugin start cycle. Repeated calls
+// while running are harmless; initialization may be retried after failure.
 func (m *MigInstanceManager) Init() error {
-	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
-		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(nvret))
+	m.sessionMu.Lock()
+	defer m.sessionMu.Unlock()
+	if m.closing != nil {
+		return fmt.Errorf("MIG manager is shutting down")
 	}
+	if m.initialized {
+		return nil
+	}
+	if m.nvmllib == nil {
+		return fmt.Errorf("MIG manager NVML library is not configured")
+	}
+	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
+		return fmt.Errorf("nvml Init: %s", nvml.ErrorString(ret))
+	}
+	m.mu.Lock()
+	clear(m.byAllocation)
+	clear(m.byAllocationMigUUID)
+	m.mu.Unlock()
+	m.initialized = true
+	klog.V(4).InfoS("MIG manager NVML session initialized")
 	return nil
 }
 
-// Shutdown releases the NVML session acquired by Init. Safe to call once,
-// when the manager is no longer needed.
-func (m *MigInstanceManager) Shutdown() {
-	if nvret := nvml.Shutdown(); nvret != nvml.SUCCESS {
-		klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(nvret)), "nvml Shutdown failed")
+// beginOperation admits a complete operation, including error cleanup.
+// Internal helpers must not re-enter admission while an operation is active.
+func (m *MigInstanceManager) beginOperation() (func(), error) {
+	m.sessionMu.Lock()
+	defer m.sessionMu.Unlock()
+	if !m.initialized || m.closing != nil {
+		return nil, fmt.Errorf("MIG manager NVML session is not running")
 	}
+	m.operations.Add(1)
+	return m.operations.Done, nil
+}
+
+// Shutdown rejects new work, drains admitted operations, and releases exactly
+// the session acquired by Init. Concurrent/repeated calls are safe.
+func (m *MigInstanceManager) Shutdown() {
+	m.sessionMu.Lock()
+	if done := m.closing; done != nil {
+		m.sessionMu.Unlock()
+		<-done
+		return
+	}
+	if !m.initialized {
+		m.sessionMu.Unlock()
+		return
+	}
+	done := make(chan struct{})
+	m.closing = done
+	m.sessionMu.Unlock()
+	m.operations.Wait()
+	if ret := m.nvmllib.Shutdown(); ret != nvml.SUCCESS {
+		klog.ErrorS(fmt.Errorf("%s", nvml.ErrorString(ret)), "nvml Shutdown failed")
+	} else {
+		klog.V(4).InfoS("MIG manager NVML session shut down")
+	}
+	m.sessionMu.Lock()
+	m.initialized = false
+	m.closing = nil
+	close(done)
+	m.sessionMu.Unlock()
 }
 
 func (m *MigInstanceManager) gpuLock(gpuIndex int) *sync.Mutex {
@@ -117,6 +178,12 @@ func profileSliceKey(profile string) string {
 // through NVML. Busy GPUs are left untouched; idle GPUs
 // have MIG mode enabled and all existing GI/CI instances destroyed.
 func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct{}) ([]int, error) {
+	done, err := m.beginOperation()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
 	reset := []int{}
 	for gpuIndex := 0; gpuIndex < deviceCount; gpuIndex++ {
 		if _, busy := inUse[gpuIndex]; busy {
@@ -125,11 +192,11 @@ func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct
 
 		lk := m.gpuLock(gpuIndex)
 		lk.Lock()
-		if err := ensureMigModeEnabled(gpuIndex); err != nil {
+		if err := m.ensureMigModeEnabled(gpuIndex); err != nil {
 			lk.Unlock()
 			return reset, err
 		}
-		dev, err := deviceHandleByIndex(gpuIndex)
+		dev, err := m.deviceHandleByIndex(gpuIndex)
 		if err != nil {
 			lk.Unlock()
 			return reset, err
@@ -139,18 +206,7 @@ func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct
 			return reset, err
 		}
 
-		m.mu.Lock()
-		for key := range m.byAllocation {
-			if key.GPUIndex == gpuIndex {
-				delete(m.byAllocation, key)
-			}
-		}
-		for uuid, key := range m.byAllocationMigUUID {
-			if key.GPUIndex == gpuIndex {
-				delete(m.byAllocationMigUUID, uuid)
-			}
-		}
-		m.mu.Unlock()
+		m.clearAllocationsForGPU(gpuIndex)
 		lk.Unlock()
 		reset = append(reset, gpuIndex)
 	}
@@ -158,8 +214,23 @@ func (m *MigInstanceManager) ResetIdleGPUs(deviceCount int, inUse map[int]struct
 	return reset, nil
 }
 
-func deviceHandleByIndex(gpuIndex int) (nvml.Device, error) {
-	dev, ret := nvml.DeviceGetHandleByIndex(gpuIndex)
+func (m *MigInstanceManager) clearAllocationsForGPU(gpuIndex int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key := range m.byAllocation {
+		if key.GPUIndex == gpuIndex {
+			delete(m.byAllocation, key)
+		}
+	}
+	for uuid, key := range m.byAllocationMigUUID {
+		if key.GPUIndex == gpuIndex {
+			delete(m.byAllocationMigUUID, uuid)
+		}
+	}
+}
+
+func (m *MigInstanceManager) deviceHandleByIndex(gpuIndex int) (nvml.Device, error) {
+	dev, ret := m.nvmllib.DeviceGetHandleByIndex(gpuIndex)
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("nvml get handle by index %d: %s", gpuIndex, nvml.ErrorString(ret))
 	}
@@ -172,8 +243,8 @@ func deviceHandleByIndex(gpuIndex int) (nvml.Device, error) {
 //
 // SetMigMode may reset/unbind the device; callers must re-fetch the device
 // handle after this returns successfully before further NVML operations.
-func ensureMigModeEnabled(gpuIndex int) error {
-	dev, err := deviceHandleByIndex(gpuIndex)
+func (m *MigInstanceManager) ensureMigModeEnabled(gpuIndex int) error {
+	dev, err := m.deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
@@ -202,7 +273,7 @@ func ensureMigModeEnabled(gpuIndex int) error {
 		return fmt.Errorf("gpu %d activate mig mode: %s", gpuIndex, nvml.ErrorString(activation))
 	}
 
-	dev, err = deviceHandleByIndex(gpuIndex)
+	dev, err = m.deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
@@ -221,11 +292,11 @@ func ensureMigModeEnabled(gpuIndex int) error {
 
 // destroyMigInstance destroys the tracked GI+CI on hardware. Returns
 // nil when the instance is already gone or was destroyed successfully.
-func destroyMigInstance(gpuIndex int, inst *migInstance) error {
+func (m *MigInstanceManager) destroyMigInstance(gpuIndex int, inst *migInstance) error {
 	if inst == nil {
 		return nil
 	}
-	dev, err := deviceHandleByIndex(gpuIndex)
+	dev, err := m.deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
@@ -295,6 +366,12 @@ func destroyAllMigInstances(dev nvml.Device) error {
 
 // Release destroys the GI+CI bound to the given MIG UUID.
 func (m *MigInstanceManager) Release(migUUID string) error {
+	done, err := m.beginOperation()
+	if err != nil {
+		return err
+	}
+	defer done()
+
 	m.mu.Lock()
 	key, ok := m.byAllocationMigUUID[migUUID]
 	m.mu.Unlock()
@@ -311,7 +388,7 @@ func (m *MigInstanceManager) Release(migUUID string) error {
 	if inst == nil {
 		return nil
 	}
-	if err := destroyMigInstance(key.GPUIndex, inst); err != nil {
+	if err := m.destroyMigInstance(key.GPUIndex, inst); err != nil {
 		return err
 	}
 	m.mu.Lock()
@@ -330,6 +407,12 @@ func allocationKey(gpuIndex int, profile string, placement nvml.GpuInstancePlace
 // caller to roll back only its own partial allocation. It never retries
 // another placement.
 func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, placement nvml.GpuInstancePlacement) (string, bool, error) {
+	done, err := m.beginOperation()
+	if err != nil {
+		return "", false, err
+	}
+	defer done()
+
 	key := allocationKey(gpuIndex, profile, placement)
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
@@ -343,7 +426,7 @@ func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, plac
 	}
 	m.mu.Unlock()
 
-	if err := ensureMigModeEnabled(gpuIndex); err != nil {
+	if err := m.ensureMigModeEnabled(gpuIndex); err != nil {
 		return "", false, err
 	}
 	profileKey := profileSliceKey(profile)
@@ -355,7 +438,7 @@ func (m *MigInstanceManager) EnsureAllocation(gpuIndex int, profile string, plac
 	if !ok {
 		return "", false, fmt.Errorf("unsupported MIG compute profile %q", profile)
 	}
-	dev, err := deviceHandleByIndex(gpuIndex)
+	dev, err := m.deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return "", false, err
 	}
@@ -435,10 +518,16 @@ func (m *MigInstanceManager) AllocationRuntimeInfo(gpuIndex int, profile string,
 }
 
 func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID string, placement nvml.GpuInstancePlacement, gpuInstanceID, computeInstanceID uint32) error {
+	done, err := m.beginOperation()
+	if err != nil {
+		return err
+	}
+	defer done()
+
 	lk := m.gpuLock(gpuIndex)
 	lk.Lock()
 	defer lk.Unlock()
-	dev, err := deviceHandleByIndex(gpuIndex)
+	dev, err := m.deviceHandleByIndex(gpuIndex)
 	if err != nil {
 		return err
 	}
@@ -491,6 +580,12 @@ func (m *MigInstanceManager) AdoptAllocation(gpuIndex int, profile, migUUID stri
 }
 
 func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocationKey]struct{}) error {
+	done, err := m.beginOperation()
+	if err != nil {
+		return err
+	}
+	defer done()
+
 	m.mu.Lock()
 	keys := make([]migAllocationKey, 0, len(m.byAllocation))
 	for key := range m.byAllocation {
@@ -508,7 +603,7 @@ func (m *MigInstanceManager) ReconcileActiveAllocations(active map[migAllocation
 		m.mu.Unlock()
 		if inst != nil {
 			oldUUID := inst.MigUUID
-			if err := destroyMigInstance(key.GPUIndex, inst); err != nil {
+			if err := m.destroyMigInstance(key.GPUIndex, inst); err != nil {
 				lk.Unlock()
 				return err
 			}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr_lifecycle_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/migmgr_lifecycle_test.go
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026, HAMi. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package plugin
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+)
+
+func TestMigManagerLifecycle(t *testing.T) {
+	lib := &nvmlmock.Interface{
+		InitFunc:           func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc:       func() nvml.Return { return nvml.SUCCESS },
+		DeviceGetCountFunc: func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+	}
+	m := newMigInstanceManager(lib)
+	if len(lib.InitCalls()) != 0 {
+		t.Fatal("construction initialized NVML")
+	}
+	if _, _, err := m.deviceInventory(); err == nil {
+		t.Fatal("query before Init succeeded")
+	}
+	m.Shutdown()
+	for cycle := 1; cycle <= 2; cycle++ {
+		for i := 0; i < 2; i++ {
+			if err := m.Init(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for i := 0; i < 3; i++ {
+			if _, _, err := m.deviceInventory(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := m.nvmlBusyGPUs(); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.Release("unknown"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(lib.InitCalls()) != cycle || len(lib.ShutdownCalls()) != cycle-1 {
+			t.Fatal("operations changed NVML session ownership")
+		}
+		m.Shutdown()
+		m.Shutdown()
+		if len(lib.ShutdownCalls()) != cycle {
+			t.Fatal("shutdown was not paired exactly once")
+		}
+		if err := m.Release("unknown"); err == nil {
+			t.Fatal("operation after Shutdown succeeded")
+		}
+	}
+}
+
+func TestMigManagerInitFailureCanRetry(t *testing.T) {
+	attempt := 0
+	lib := &nvmlmock.Interface{
+		InitFunc: func() nvml.Return {
+			attempt++
+			if attempt == 1 {
+				return nvml.ERROR_LIBRARY_NOT_FOUND
+			}
+			return nvml.SUCCESS
+		},
+		ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+	}
+	m := newMigInstanceManager(lib)
+	if err := m.Init(); err == nil {
+		t.Fatal("expected init failure")
+	}
+	m.Shutdown()
+	if len(lib.ShutdownCalls()) != 0 {
+		t.Fatal("shutdown after failed Init")
+	}
+	if err := m.Init(); err != nil {
+		t.Fatal(err)
+	}
+	m.Shutdown()
+	if len(lib.ShutdownCalls()) != 1 {
+		t.Fatal("retry did not acquire a session")
+	}
+}
+
+func TestMigManagerShutdownDrainsQuery(t *testing.T) {
+	entered, unblock := make(chan struct{}), make(chan struct{})
+	var unblockOnce sync.Once
+	release := func() { unblockOnce.Do(func() { close(unblock) }) }
+	defer release()
+	lib := &nvmlmock.Interface{
+		InitFunc:     func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc: func() nvml.Return { return nvml.SUCCESS },
+		DeviceGetCountFunc: func() (int, nvml.Return) {
+			close(entered)
+			<-unblock
+			return 0, nvml.SUCCESS
+		},
+	}
+	m := newMigInstanceManager(lib)
+	if err := m.Init(); err != nil {
+		t.Fatal(err)
+	}
+	queryDone := make(chan error, 1)
+	go func() { _, _, err := m.deviceInventory(); queryDone <- err }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("query did not enter NVML")
+	}
+	closed := make(chan struct{})
+	go func() { m.Shutdown(); close(closed) }()
+	deadline := time.After(time.Second)
+	for {
+		m.sessionMu.Lock()
+		closing := m.closing != nil
+		m.sessionMu.Unlock()
+		if closing {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("shutdown did not close admission")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if err := m.Release("unknown"); err == nil {
+		t.Fatal("closing manager admitted new work")
+	}
+	if err := m.Init(); err == nil {
+		t.Fatal("Init succeeded while shutting down")
+	}
+	if len(lib.ShutdownCalls()) != 0 {
+		t.Fatal("NVML closed while query was active")
+	}
+	second := make(chan struct{})
+	go func() { m.Shutdown(); close(second) }()
+	release()
+	if err := <-queryDone; err != nil {
+		t.Fatal(err)
+	}
+	for _, done := range []chan struct{}{closed, second} {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Shutdown did not finish")
+		}
+	}
+	if len(lib.ShutdownCalls()) != 1 {
+		t.Fatal("concurrent Shutdown released twice")
+	}
+}
+
+// Exercise actual GI/CI creation, cache hits, adoption, and release through
+// the borrowed library, rather than only counting empty operations.
+func TestMigManagerAllocationUsesOneSession(t *testing.T) {
+	placement := nvml.GpuInstancePlacement{Start: 0, Size: 1}
+	ci := &nvmlmock.ComputeInstance{
+		GetInfoFunc: func() (nvml.ComputeInstanceInfo, nvml.Return) { return nvml.ComputeInstanceInfo{Id: 2}, nvml.SUCCESS },
+		DestroyFunc: func() nvml.Return { return nvml.SUCCESS },
+	}
+	gi := &nvmlmock.GpuInstance{
+		GetInfoFunc: func() (nvml.GpuInstanceInfo, nvml.Return) {
+			return nvml.GpuInstanceInfo{Id: 1, Placement: placement}, nvml.SUCCESS
+		},
+		GetComputeInstanceProfileInfoFunc: func(int, int) (nvml.ComputeInstanceProfileInfo, nvml.Return) {
+			return nvml.ComputeInstanceProfileInfo{}, nvml.SUCCESS
+		},
+		CreateComputeInstanceFunc:  func(*nvml.ComputeInstanceProfileInfo) (nvml.ComputeInstance, nvml.Return) { return ci, nvml.SUCCESS },
+		GetComputeInstanceByIdFunc: func(int) (nvml.ComputeInstance, nvml.Return) { return ci, nvml.SUCCESS },
+		GetComputeInstancesFunc: func(*nvml.ComputeInstanceProfileInfo) ([]nvml.ComputeInstance, nvml.Return) {
+			return []nvml.ComputeInstance{ci}, nvml.SUCCESS
+		},
+		DestroyFunc: func() nvml.Return { return nvml.SUCCESS },
+	}
+	migDev := &nvmlmock.Device{
+		GetGpuInstanceIdFunc: func() (int, nvml.Return) { return 1, nvml.SUCCESS },
+		GetUUIDFunc:          func() (string, nvml.Return) { return "MIG-test", nvml.SUCCESS },
+	}
+	dev := &nvmlmock.Device{
+		GetIndexFunc:   func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+		GetMigModeFunc: func() (int, int, nvml.Return) { return nvml.DEVICE_MIG_ENABLE, nvml.DEVICE_MIG_ENABLE, nvml.SUCCESS },
+		GetGpuInstanceProfileInfoFunc: func(int) (nvml.GpuInstanceProfileInfo, nvml.Return) {
+			return nvml.GpuInstanceProfileInfo{}, nvml.SUCCESS
+		},
+		GetGpuInstancePossiblePlacementsFunc: func(*nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstancePlacement, nvml.Return) {
+			return []nvml.GpuInstancePlacement{placement}, nvml.SUCCESS
+		},
+		CreateGpuInstanceWithPlacementFunc: func(*nvml.GpuInstanceProfileInfo, *nvml.GpuInstancePlacement) (nvml.GpuInstance, nvml.Return) {
+			return gi, nvml.SUCCESS
+		},
+		GetMaxMigDeviceCountFunc:      func() (int, nvml.Return) { return 1, nvml.SUCCESS },
+		GetMigDeviceHandleByIndexFunc: func(int) (nvml.Device, nvml.Return) { return migDev, nvml.SUCCESS },
+		GetGpuInstanceByIdFunc:        func(int) (nvml.GpuInstance, nvml.Return) { return gi, nvml.SUCCESS },
+		GetGpuInstancesFunc: func(*nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstance, nvml.Return) {
+			return []nvml.GpuInstance{gi}, nvml.SUCCESS
+		},
+	}
+	lib := &nvmlmock.Interface{
+		InitFunc:                   func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc:               func() nvml.Return { return nvml.SUCCESS },
+		DeviceGetHandleByIndexFunc: func(int) (nvml.Device, nvml.Return) { return dev, nvml.SUCCESS },
+		DeviceGetHandleByUUIDFunc:  func(string) (nvml.Device, nvml.Return) { return dev, nvml.SUCCESS },
+	}
+	m := newMigInstanceManager(lib)
+	if err := m.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Shutdown()
+	if index, ok := m.gpuUUIDToIndex("GPU-test"); !ok || index != 0 {
+		t.Fatal("UUID resolution failed")
+	}
+	for i := 0; i < 2; i++ {
+		uuid, created, err := m.EnsureAllocation(0, "1g.5gb", placement)
+		if err != nil || uuid != "MIG-test" || created != (i == 0) {
+			t.Fatalf("EnsureAllocation = %q, %v, %v", uuid, created, err)
+		}
+	}
+	if err := m.AdoptAllocation(0, "1g.5gb", "MIG-test", placement, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ReconcileActiveAllocations(map[migAllocationKey]struct{}{allocationKey(0, "1g.5gb", placement): {}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Release("MIG-test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(gi.DestroyCalls()) != 1 || len(ci.DestroyCalls()) != 1 {
+		t.Fatal("release did not destroy GI and CI")
+	}
+	if len(lib.InitCalls()) != 1 || len(lib.ShutdownCalls()) != 0 {
+		t.Fatal("allocation operations changed session ownership")
+	}
+	// Closing the session must never destroy an active allocation.
+	if _, _, err := m.EnsureAllocation(0, "1g.5gb", placement); err != nil {
+		t.Fatal(err)
+	}
+	m.Shutdown()
+	if len(gi.DestroyCalls()) != 1 || len(ci.DestroyCalls()) != 1 {
+		t.Fatal("Shutdown destroyed an allocation")
+	}
+	if len(lib.ShutdownCalls()) != 1 {
+		t.Fatal("NVML was not shut down once")
+	}
+}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -34,6 +34,7 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -95,12 +96,23 @@ var calculateGPUScore = nvidia.CalculateGPUScore
 func (plugin *NvidiaDevicePlugin) getAPIDevices() (*[]*device.DeviceInfo, error) {
 	devs := plugin.Devices()
 	klog.V(5).InfoS("getAPIDevices", "devices", devs)
-	if nvret := nvmlInit(); nvret != nvml.SUCCESS {
-		klog.Errorln("nvml Init err: ", nvret)
-		return nil, fmt.Errorf("nvml init failed: %v", nvret)
+	getHandle := nvml.DeviceGetHandleByUUID
+	if plugin.operatingMode == nvidia.MigMode {
+		if plugin.migMgr == nil {
+			return nil, fmt.Errorf("MIG manager is not configured")
+		}
+		done, err := plugin.migMgr.beginOperation()
+		if err != nil {
+			return nil, err
+		}
+		defer done()
+		getHandle = plugin.migMgr.nvmllib.DeviceGetHandleByUUID
+	} else {
+		if ret := nvmlInit(); ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("nvml init failed: %v", ret)
+		}
+		defer nvml.Shutdown()
 	}
-	// Shutdown is deferred only after Init succeeds, since calling it after a failed Init crashes the process.
-	defer nvml.Shutdown()
 	res := make([]*device.DeviceInfo, 0, len(devs))
 
 	// Log mode-related warnings once per scan instead of per device
@@ -110,7 +122,7 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices() (*[]*device.DeviceInfo, error)
 	}
 
 	for UUID := range devs {
-		ndev, ret := nvml.DeviceGetHandleByUUID(UUID)
+		ndev, ret := getHandle(UUID)
 		if ret != nvml.SUCCESS {
 			klog.Errorf("skipping device uuid=%s: nvml DeviceGetHandleByUUID failed: %v", UUID, ret)
 			continue
@@ -270,7 +282,7 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 	klog.V(5).InfoS("Device details", "devices", devices)
 
 	annos := make(map[string]string)
-	node, err := util.GetNode(util.NodeName)
+	node, err := util.GetNodeWithContext(plugin.operationContext(), util.NodeName)
 	if err != nil {
 		klog.Errorln("get node error", err.Error())
 		return false, err
@@ -283,7 +295,7 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 
 	var data []byte
 	if os.Getenv("ENABLE_TOPOLOGY_SCORE") == "true" {
-		gpuScore, hasAsymmetry, err := calculateGPUScore(device.GetDevicesUUIDList(*devices))
+		gpuScore, hasAsymmetry, err := plugin.topologyScore(device.GetDevicesUUIDList(*devices))
 		if err != nil {
 			klog.ErrorS(err, "calculate gpu topo score error")
 			return false, err
@@ -307,7 +319,7 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 	}
 	klog.Infof("Updating node annotations with %d device(s)", len(*devices))
 	klog.V(3).Infof("Annotation content: %v", annos)
-	err = util.PatchNodeAnnotations(node, annos)
+	err = util.PatchNodeAnnotationsWithContext(plugin.operationContext(), node, annos)
 	if err != nil {
 		klog.Errorln("patch node error", err.Error())
 		util.EmitNodeWarningEvent(node, "RegistrationFailed",
@@ -320,12 +332,15 @@ func (plugin *NvidiaDevicePlugin) RegisterInAnnotation() (bool, error) {
 }
 
 func (plugin *NvidiaDevicePlugin) WatchAndRegister(disableNVML <-chan bool, ackDisableWatchAndRegister chan<- bool) {
+	ctx := plugin.operationContext()
 	klog.Info("Starting WatchAndRegister")
 	errorSleepInterval := time.Second * 5
 	successSleepInterval := time.Second * 30
 	var disableWatchAndRegister bool
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case disable := <-disableNVML:
 			if disable {
 				// when received disableNVML signal, stop the watch and register all the time
@@ -341,21 +356,57 @@ func (plugin *NvidiaDevicePlugin) WatchAndRegister(disableNVML <-chan bool, ackD
 		}
 		if disableWatchAndRegister {
 			klog.V(3).Info("WatchAndRegister is disabled, sleeping")
-			ackDisableWatchAndRegister <- true
-			time.Sleep(successSleepInterval)
+			select {
+			case ackDisableWatchAndRegister <- true:
+			case <-ctx.Done():
+				return
+			}
+			if !waitForRegistration(ctx, successSleepInterval) {
+				return
+			}
 			continue
 		}
 		changed, err := plugin.RegisterInAnnotation()
 		if err != nil {
 			klog.Errorf("Failed to register annotation: %v. Retrying in %v...", err, errorSleepInterval)
-			time.Sleep(errorSleepInterval)
+			if !waitForRegistration(ctx, errorSleepInterval) {
+				return
+			}
 		} else {
 			if changed {
 				klog.Infof("Successfully updated node annotation. Next check in %v...", successSleepInterval)
 			} else {
 				klog.V(3).Infof("No device changes detected. Next check in %v...", successSleepInterval)
 			}
-			time.Sleep(successSleepInterval)
+			if !waitForRegistration(ctx, successSleepInterval) {
+				return
+			}
 		}
+	}
+}
+
+func (plugin *NvidiaDevicePlugin) topologyScore(available []string) (nvidia.ListDeviceScore, bool, error) {
+	if plugin.operatingMode != nvidia.MigMode {
+		return calculateGPUScore(available)
+	}
+	if plugin.migMgr == nil {
+		return nil, false, fmt.Errorf("MIG manager is not configured")
+	}
+	done, err := plugin.migMgr.beginOperation()
+	if err != nil {
+		return nil, false, err
+	}
+	defer done()
+	return nvidia.CalculateGPUScoreWithNVML(plugin.migMgr.nvmllib, available)
+}
+
+func waitForRegistration(ctx context.Context, interval time.Duration) bool {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -312,10 +313,14 @@ func TestWatchAndRegisterDisableSignal(t *testing.T) {
 
 	// Create a minimal plugin - WatchAndRegister will read the disable signal
 	// and send an ack, then sleep. We verify the ack arrives.
-	plugin := &NvidiaDevicePlugin{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	plugin := &NvidiaDevicePlugin{ctx: ctx}
+	exited := make(chan struct{})
 
 	done := make(chan struct{})
 	go func() {
+		defer close(exited)
 		plugin.WatchAndRegister(disableCh, ackCh)
 	}()
 
@@ -331,7 +336,12 @@ func TestWatchAndRegisterDisableSignal(t *testing.T) {
 	// Use a select with timeout to avoid hanging forever
 	select {
 	case <-done:
-		// Success: received the ack
+		cancel()
+		select {
+		case <-exited:
+		case <-time.After(time.Second):
+			t.Fatal("WatchAndRegister did not stop during its sleep")
+		}
 	case <-timeAfter(3 * time.Second):
 		t.Fatal("timed out waiting for disable ack from WatchAndRegister")
 	}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/server.go
@@ -93,6 +93,10 @@ func init() {
 type NvidiaDevicePlugin struct {
 	kubeletdevicepluginv1beta1.UnimplementedDevicePluginServer
 
+	lifecycleMu          sync.Mutex
+	runCtx               context.Context
+	cancelRun            context.CancelFunc
+	workers              sync.WaitGroup
 	ctx                  context.Context
 	rm                   rm.ResourceManager
 	config               *nvidia.DeviceConfig
@@ -115,7 +119,8 @@ type NvidiaDevicePlugin struct {
 
 	// migMgr tracks live MIG GI+CI instances so we can destroy and recreate
 	// them per-task rather than resharding the whole card. Only set when
-	// operatingMode == "mig".
+	// operatingMode == "mig". Construction does not initialize NVML; Start/Stop
+	// pair Init and Shutdown for that session.
 	migMgr *MigInstanceManager
 
 	imexChannels imex.Channels
@@ -190,10 +195,7 @@ func (o *options) devicePluginForResource(ctx context.Context, nvconfig *nvidia.
 	}
 	var migMgr *MigInstanceManager
 	if mode == "mig" {
-		migMgr = NewMigInstanceManager()
-		if err := migMgr.Init(); err != nil {
-			return nil, fmt.Errorf("init MIG instance manager: %w", err)
-		}
+		migMgr = newMigInstanceManager(o.nvmllib)
 	}
 	return o.newNvidiaDevicePlugin(ctx, resourceManager, deviceListStrategies, sConfig.NvidiaConfig, mode, migMgr), nil
 }
@@ -239,7 +241,13 @@ func (o *options) newNvidiaDevicePlugin(
 }
 
 func (plugin *NvidiaDevicePlugin) initialize() {
-	plugin.server = grpc.NewServer([]grpc.ServerOption{}...)
+	plugin.server = grpc.NewServer(grpc.WaitForHandlers(true))
+	parent := plugin.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	plugin.runCtx, plugin.cancelRun = context.WithCancel(parent)
+	plugin.deviceCache = ""
 	plugin.health = make(chan *rm.Device)
 	plugin.stop = make(chan any)
 	plugin.disableHealthChecks = make(chan bool, 1)
@@ -249,7 +257,6 @@ func (plugin *NvidiaDevicePlugin) initialize() {
 }
 
 func (plugin *NvidiaDevicePlugin) cleanup() {
-	close(plugin.stop)
 	plugin.server = nil
 	plugin.health = nil
 	plugin.stop = nil
@@ -265,15 +272,38 @@ func (plugin *NvidiaDevicePlugin) Devices() rm.Devices {
 }
 
 // Start starts the gRPC server, registers the device plugin with the Kubelet,and starts the device healthchecks.
-func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
+func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) (resultErr error) {
+	plugin.lifecycleMu.Lock()
+	defer plugin.lifecycleMu.Unlock()
+	if plugin.server != nil {
+		return fmt.Errorf("device plugin is already started")
+	}
 	plugin.initialize()
-
-	deviceNumbers, err := GetDeviceNums()
-	if err != nil {
-		return err
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, plugin.stopLocked())
+		}
+	}()
+	if plugin.operatingMode == nvidia.MigMode {
+		if plugin.migMgr == nil {
+			return fmt.Errorf("MIG manager is not configured")
+		}
+		if err := plugin.migMgr.Init(); err != nil {
+			return fmt.Errorf("init MIG instance manager: %w", err)
+		}
 	}
 
-	deviceNames, err := GetDeviceNames()
+	var deviceNumbers int
+	var deviceNames []string
+	var err error
+	if plugin.operatingMode == nvidia.MigMode {
+		deviceNumbers, deviceNames, err = plugin.migMgr.deviceInventory()
+	} else {
+		deviceNumbers, err = GetDeviceNums()
+		if err == nil {
+			deviceNames, err = GetDeviceNames()
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -281,55 +311,19 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	// Prepare the lock directory before any dynamic MIG operation. A stale
 	// lock can be left behind when the previous plugin process exits midway.
 	if err = CreateMigApplyLockDir(); err != nil {
-		klog.Fatalf("CreateMIGLockSubDir failed: %v", err)
+		return fmt.Errorf("create MIG lock directory: %w", err)
 	}
 	if err = RemoveMigApplyLock(); err != nil {
-		klog.Fatalf("RemoveMigApplyLock failed: %v", err)
+		return fmt.Errorf("remove MIG apply lock: %w", err)
 	}
 
-	deviceSupportMig := len(deviceNames) > 0
-	for _, name := range deviceNames {
-		supported := false
-		for _, allowlist := range plugin.schedulerConfig.MigProfileAllowlist {
-			if containsModel(name, allowlist.Models) {
-				supported = true
-				break
-			}
-		}
-		if !supported {
-			deviceSupportMig = false
-			break
-		}
-	}
-	if plugin.operatingMode == "mig" {
-		if deviceSupportMig {
-			inUse, detectErr := collectInUseGPUs(plugin.ctx, os.Getenv(util.NodeNameEnvName))
-			if detectErr != nil {
-				// Startup reset is destructive. If Kubernetes allocation state
-				// cannot be read reliably, preserve every GPU rather than risk
-				// removing an allocation that is still active.
-				klog.InfoS("mig init: allocation detection failed; preserving all GPUs", "err", detectErr)
-				for i := 0; i < deviceNumbers; i++ {
-					inUse[i] = struct{}{}
-				}
-			}
-			reset, err := plugin.migMgr.ResetIdleGPUs(deviceNumbers, inUse)
-			if err != nil {
-				klog.InfoS("mig init: failed to reset idle GPUs", "err", err)
-			}
-			klog.InfoS("mig init: resolved startup layout",
-				"inUseGPUs", sortedIntSetKeys(inUse),
-				"resetGPUs", reset)
-			if err := plugin.primeMigManagerFromAnnotations(deviceNames); err != nil {
-				klog.InfoS("mig init: failed to adopt active MIG allocations", "err", err)
-			}
-		}
+	if err = plugin.applyStartupMigMode(deviceNumbers, deviceNames); err != nil {
+		return err
 	}
 
 	err = plugin.Serve()
 	if err != nil {
 		klog.Infof("Could not start device plugin for '%s': %s", plugin.rm.Resource(), err)
-		plugin.cleanup()
 		return err
 	}
 	klog.Infof("Starting to serve '%s' on %s", plugin.rm.Resource(), plugin.socket)
@@ -337,39 +331,39 @@ func (plugin *NvidiaDevicePlugin) Start(kubeletSocket string) error {
 	err = plugin.Register(kubeletSocket)
 	if err != nil {
 		klog.Infof("Could not register device plugin: %s", err)
-		plugin.Stop()
 		return err
 	}
 	klog.Infof("Registered device plugin for '%s' with Kubelet", plugin.rm.Resource())
 
+	plugin.workers.Add(1)
 	go func() {
+		defer plugin.workers.Done()
 		err := plugin.rm.CheckHealth(plugin.stop, plugin.health, plugin.disableHealthChecks, plugin.ackDisableHealthChecks)
 		if err != nil {
 			klog.Infof("Failed to start health check: %v; continuing with health checks disabled", err)
 		}
 	}()
 
+	plugin.workers.Add(1)
 	go func() {
+		defer plugin.workers.Done()
 		plugin.WatchAndRegister(plugin.disableWatchAndRegister, plugin.ackDisableWatchAndRegister)
 	}()
 	if plugin.operatingMode == "mig" {
 		// Pod annotations are the allocation source of truth. Periodically
 		// reconcile the manager with live Pods so completed or deleted Pods
 		// release their exact profile+placement allocation.
-		go plugin.runMigAnnotationReconciler(5 * time.Second)
-		// The manager's NVML session is owned by the plugin's lifetime, not
-		// by individual Start/Stop cycles (Stop only restarts the gRPC
-		// server); release it once when the plugin is finally torn down.
+		plugin.workers.Add(1)
 		go func() {
-			<-plugin.ctx.Done()
-			plugin.migMgr.Shutdown()
+			defer plugin.workers.Done()
+			plugin.runMigAnnotationReconciler(5 * time.Second)
 		}()
 	}
 
 	return nil
 }
 
-func activeMigAllocationKeys(pods []corev1.Pod) (map[migAllocationKey]struct{}, error) {
+func (plugin *NvidiaDevicePlugin) activeMigAllocationKeys(pods []corev1.Pod) (map[migAllocationKey]struct{}, error) {
 	active := make(map[migAllocationKey]struct{})
 	for i := range pods {
 		pod := &pods[i]
@@ -381,7 +375,7 @@ func activeMigAllocationKeys(pods []corev1.Pod) (map[migAllocationKey]struct{}, 
 			return nil, fmt.Errorf("decode MIG allocations for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
 		for _, allocation := range allocations {
-			gpuIndex, ok := gpuUUIDToIndex(allocation.GPUUUID)
+			gpuIndex, ok := plugin.migMgr.gpuUUIDToIndex(allocation.GPUUUID)
 			if !ok {
 				return nil, fmt.Errorf("resolve active MIG parent GPU %q", allocation.GPUUUID)
 			}
@@ -398,7 +392,7 @@ func (plugin *NvidiaDevicePlugin) annotateMigRuntimeInfo(pod *corev1.Pod) error 
 	}
 	updated := false
 	for i := range allocations {
-		gpuIndex, ok := gpuUUIDToIndex(allocations[i].GPUUUID)
+		gpuIndex, ok := plugin.migMgr.gpuUUIDToIndex(allocations[i].GPUUUID)
 		if !ok {
 			return fmt.Errorf("resolve MIG parent GPU %q", allocations[i].GPUUUID)
 		}
@@ -429,7 +423,7 @@ func (plugin *NvidiaDevicePlugin) annotateMigRuntimeInfo(pod *corev1.Pod) error 
 	if err != nil {
 		return err
 	}
-	if _, err := client.GetClient().CoreV1().Pods(pod.Namespace).Patch(plugin.ctx, pod.Name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	if _, err := client.GetClient().CoreV1().Pods(pod.Namespace).Patch(plugin.operationContext(), pod.Name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		return err
 	}
 	pod.Annotations[nvidia.MigAllocationsAnnotation] = string(raw)
@@ -449,17 +443,17 @@ func (plugin *NvidiaDevicePlugin) reconcileActiveMigAllocations() error {
 }
 
 func (plugin *NvidiaDevicePlugin) listActiveMigAllocationKeys() (map[migAllocationKey]struct{}, error) {
-	pods, err := client.GetClient().CoreV1().Pods("").List(plugin.ctx, metav1.ListOptions{
+	pods, err := client.GetClient().CoreV1().Pods("").List(plugin.operationContext(), metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + os.Getenv(util.NodeNameEnvName),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return activeMigAllocationKeys(pods.Items)
+	return plugin.activeMigAllocationKeys(pods.Items)
 }
 
 func (plugin *NvidiaDevicePlugin) primeMigManagerFromAnnotations(_ []string) error {
-	pods, err := client.GetClient().CoreV1().Pods("").List(plugin.ctx, metav1.ListOptions{
+	pods, err := client.GetClient().CoreV1().Pods("").List(plugin.operationContext(), metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + os.Getenv(util.NodeNameEnvName),
 	})
 	if err != nil {
@@ -478,7 +472,7 @@ func (plugin *NvidiaDevicePlugin) primeMigManagerFromAnnotations(_ []string) err
 			if allocation.MigUUID == "" || allocation.GPUInstanceID == nil || allocation.ComputeInstanceID == nil {
 				return fmt.Errorf("active pod %s/%s MIG allocation lacks runtime identity", pod.Namespace, pod.Name)
 			}
-			gpuIndex, ok := gpuUUIDToIndex(allocation.GPUUUID)
+			gpuIndex, ok := plugin.migMgr.gpuUUIDToIndex(allocation.GPUUUID)
 			if !ok {
 				return fmt.Errorf("resolve active MIG parent GPU %q", allocation.GPUUUID)
 			}
@@ -502,7 +496,7 @@ func (plugin *NvidiaDevicePlugin) runMigAnnotationReconciler(interval time.Durat
 	defer ticker.Stop()
 	for {
 		select {
-		case <-plugin.ctx.Done():
+		case <-plugin.operationContext().Done():
 			return
 		case <-ticker.C:
 			if err := plugin.reconcileActiveMigAllocations(); err != nil {
@@ -514,18 +508,107 @@ func (plugin *NvidiaDevicePlugin) runMigAnnotationReconciler(interval time.Durat
 	}
 }
 
-// Stop stops the gRPC server.
-func (plugin *NvidiaDevicePlugin) Stop() error {
-	if plugin == nil || plugin.server == nil {
+func (plugin *NvidiaDevicePlugin) devicesSupportMig(deviceNames []string) bool {
+	if len(deviceNames) == 0 {
+		return false
+	}
+	for _, name := range deviceNames {
+		supported := false
+		for _, allowlist := range plugin.schedulerConfig.MigProfileAllowlist {
+			if containsModel(name, allowlist.Models) {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			return false
+		}
+	}
+	return true
+}
+
+// applyStartupMigMode prepares idle MIG-capable GPUs when operatingMode is mig.
+func (plugin *NvidiaDevicePlugin) applyStartupMigMode(deviceNumbers int, deviceNames []string) error {
+	if !plugin.devicesSupportMig(deviceNames) {
 		return nil
 	}
-	klog.Infof("Stopping to serve '%s' on %s", plugin.rm.Resource(), plugin.socket)
-	plugin.server.Stop()
-	if err := os.Remove(plugin.socket); err != nil && !os.IsNotExist(err) {
-		return err
+	if plugin.operatingMode != nvidia.MigMode {
+		return nil
+	}
+	if plugin.migMgr == nil {
+		return fmt.Errorf("MIG manager is not configured")
+	}
+	inUse, detectErr := plugin.migMgr.collectInUseGPUs(plugin.operationContext(), os.Getenv(util.NodeNameEnvName))
+	if detectErr != nil {
+		// Startup reset is destructive. If Kubernetes allocation state
+		// cannot be read reliably, preserve every GPU rather than risk
+		// removing an allocation that is still active.
+		klog.InfoS("mig init: allocation detection failed; preserving all GPUs", "err", detectErr)
+		if inUse == nil {
+			inUse = make(map[int]struct{})
+		}
+		for i := 0; i < deviceNumbers; i++ {
+			inUse[i] = struct{}{}
+		}
+	}
+	reset, err := plugin.migMgr.ResetIdleGPUs(deviceNumbers, inUse)
+	if err != nil {
+		klog.InfoS("mig init: failed to reset idle GPUs", "err", err)
+	}
+	klog.InfoS("mig init: resolved startup layout",
+		"inUseGPUs", sortedIntSetKeys(inUse),
+		"resetGPUs", reset)
+	if err := plugin.primeMigManagerFromAnnotations(deviceNames); err != nil {
+		klog.InfoS("mig init: failed to adopt active MIG allocations", "err", err)
+	}
+	return nil
+}
+
+// operationContext belongs to one start cycle; ctx remains the parent.
+func (plugin *NvidiaDevicePlugin) operationContext() context.Context {
+	if plugin.runCtx != nil {
+		return plugin.runCtx
+	}
+	if plugin.ctx != nil {
+		return plugin.ctx
+	}
+	return context.Background()
+}
+
+// Stop drains the current start cycle before releasing its NVML session.
+func (plugin *NvidiaDevicePlugin) Stop() error {
+	if plugin == nil {
+		return nil
+	}
+	plugin.lifecycleMu.Lock()
+	defer plugin.lifecycleMu.Unlock()
+	return plugin.stopLocked()
+}
+
+func (plugin *NvidiaDevicePlugin) stopLocked() error {
+	if plugin.cancelRun != nil {
+		plugin.cancelRun()
+	}
+	if plugin.stop != nil {
+		close(plugin.stop)
+	}
+	if plugin.server != nil {
+		// WaitForHandlers also waits for Allocate cleanup after RPC cancellation.
+		plugin.server.Stop()
+	}
+	plugin.workers.Wait()
+	if plugin.migMgr != nil {
+		plugin.migMgr.Shutdown()
+	}
+	var err error
+	if plugin.server != nil {
+		err = os.Remove(plugin.socket)
+		if os.IsNotExist(err) {
+			err = nil
+		}
 	}
 	plugin.cleanup()
-	return nil
+	return err
 }
 
 // Serve starts the gRPC server of the device plugin.
@@ -538,20 +621,30 @@ func (plugin *NvidiaDevicePlugin) Serve() error {
 
 	kubeletdevicepluginv1beta1.RegisterDevicePluginServer(plugin.server, plugin)
 
+	server := plugin.server
+	plugin.workers.Add(1)
 	go func() {
+		defer plugin.workers.Done()
 		lastCrashTime := time.Now()
 		restartCount := 0
 		for {
 			// restart if it has not been too often
 			// i.e. if server has crashed more than 5 times and it didn't last more than one hour each time
 			if restartCount > 5 {
-				// quit
-				klog.Fatalf("GRPC server for '%s' has repeatedly crashed recently. Quitting", plugin.rm.Resource())
+				// Stop must run outside this worker: it waits for workers and
+				// for any startup rollback to finish before releasing NVML.
+				go func() {
+					if err := plugin.Stop(); err != nil {
+						klog.ErrorS(err, "cleanup after repeated gRPC failure")
+					}
+					klog.Fatalf("GRPC server for '%s' has repeatedly crashed recently. Quitting", plugin.rm.Resource())
+				}()
+				return
 			}
 
 			klog.Infof("Starting GRPC server for '%s'", plugin.rm.Resource())
-			err := plugin.server.Serve(sock)
-			if err == nil {
+			err := server.Serve(sock)
+			if err == nil || errors.Is(err, grpc.ErrServerStopped) {
 				break
 			}
 
@@ -602,7 +695,9 @@ func (plugin *NvidiaDevicePlugin) Register(kubeletSocket string) error {
 		},
 	}
 
-	_, err = client.Register(context.Background(), reqt)
+	ctx, cancel := context.WithTimeout(plugin.operationContext(), 5*time.Second)
+	defer cancel()
+	_, err = client.Register(ctx, reqt)
 	if err != nil {
 		return err
 	}
@@ -1122,7 +1217,7 @@ func (plugin *NvidiaDevicePlugin) PreStartContainer(context.Context, *kubeletdev
 
 // dial establishes the gRPC communication with the registered device plugin.
 func (plugin *NvidiaDevicePlugin) dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error) {
-	ctx, cancel := context.WithTimeout(plugin.ctx, timeout)
+	ctx, cancel := context.WithTimeout(plugin.operationContext(), timeout)
 	defer cancel()
 	//nolint:staticcheck  // TODO: Switch to grpc.NewClient
 	c, err := grpc.DialContext(ctx, unixSocketPath,

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/util.go
@@ -148,6 +148,7 @@ func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
 		klog.Errorln("nvml Init err: ", nvret)
 		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
 	}
+	defer nvml.Shutdown()
 	originuuid := strings.Split(uuid, "[")[0]
 	ndev, ret := nvml.DeviceGetHandleByUUID(originuuid)
 	if ret != nvml.SUCCESS {
@@ -168,11 +169,11 @@ func GetMigGpuInstanceIdFromIndex(uuid string, idx int) (int, error) {
 }
 
 func GetDeviceNums() (int, error) {
-	defer nvml.Shutdown()
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
 		klog.Errorln("nvml Init err: ", nvret)
 		return 0, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
 	}
+	defer nvml.Shutdown()
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)
@@ -183,11 +184,11 @@ func GetDeviceNums() (int, error) {
 
 func GetDeviceNames() ([]string, error) {
 	names := []string{}
-	defer nvml.Shutdown()
 	if nvret := nvml.Init(); nvret != nvml.SUCCESS {
 		klog.Errorln("nvml Init err: ", nvret)
 		return names, fmt.Errorf("nvml Init err: %s", nvml.ErrorString(nvret))
 	}
+	defer nvml.Shutdown()
 	count, ret := nvml.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		klog.Error(`nvml get count error ret=`, ret)
@@ -326,7 +327,7 @@ func (nv *NvidiaDevicePlugin) GetContainerDeviceStrArray(c device.ContainerDevic
 		if reservation.GPUUUID != c[i].UUID {
 			return nil, fmt.Errorf("MIG reservation GPU %s does not match allocated GPU %s", reservation.GPUUUID, c[i].UUID)
 		}
-		gpuIndex, ok := gpuUUIDToIndex(reservation.GPUUUID)
+		gpuIndex, ok := nv.migMgr.gpuUUIDToIndex(reservation.GPUUUID)
 		if !ok {
 			return nil, fmt.Errorf("resolve parent GPU %s", reservation.GPUUUID)
 		}

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -96,7 +96,11 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		uuid, gi, ci, err := r.getDevicePlacement(d)
 		if err != nil {
 			klog.Warningf("Could not determine device placement for %v: %v; Marking it unhealthy.", d.ID, err)
-			unhealthy <- d
+			select {
+			case unhealthy <- d:
+			case <-stop:
+				return nil
+			}
 			continue
 		}
 		deviceIDToGiMap[d.ID] = gi
@@ -106,14 +110,22 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		gpu, ret := r.nvml.DeviceGetHandleByUUID(uuid)
 		if ret != nvml.SUCCESS {
 			klog.Infof("unable to get device handle from UUID: %v; marking it as unhealthy", ret)
-			unhealthy <- d
+			select {
+			case unhealthy <- d:
+			case <-stop:
+				return nil
+			}
 			continue
 		}
 
 		supportedEvents, ret := gpu.GetSupportedEventTypes()
 		if ret != nvml.SUCCESS {
 			klog.Infof("unable to determine the supported events for %v: %v; marking it as unhealthy", d.ID, ret)
-			unhealthy <- d
+			select {
+			case unhealthy <- d:
+			case <-stop:
+				return nil
+			}
 			continue
 		}
 
@@ -123,7 +135,11 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 			klog.Warningf("Device %v is too old to support healthchecking.", d.ID)
 		case ret != nvml.SUCCESS:
 			klog.Infof("Marking device %v as unhealthy: %v", d.ID, ret)
-			unhealthy <- d
+			select {
+			case unhealthy <- d:
+			case <-stop:
+				return nil
+			}
 		}
 	}
 
@@ -146,7 +162,11 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		if ret != nvml.SUCCESS {
 			klog.Infof("Error waiting for event: %v; Marking all devices as unhealthy", ret)
 			for _, d := range devices {
-				unhealthy <- d
+				select {
+				case unhealthy <- d:
+				case <-stop:
+					return nil
+				}
 			}
 			continue
 		}
@@ -167,7 +187,11 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 			// If we cannot reliably determine the device UUID, we mark all devices as unhealthy.
 			klog.Infof("Failed to determine uuid for event %v: %v; Marking all devices as unhealthy.", e, ret)
 			for _, d := range devices {
-				unhealthy <- d
+				select {
+				case unhealthy <- d:
+				case <-stop:
+					return nil
+				}
 			}
 			continue
 		}
@@ -188,7 +212,11 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		}
 
 		klog.Infof("XidCriticalError: Xid=%d on Device=%s; marking device as unhealthy.", e.EventData, d.ID)
-		unhealthy <- d
+		select {
+		case unhealthy <- d:
+		case <-stop:
+			return nil
+		}
 	}
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/nvml_manager.go
@@ -121,11 +121,19 @@ func (r *nvmlResourceManager) CheckHealth(stop <-chan interface{}, unhealthy cha
 		err := r.checkHealth(stop, r.devices, unhealthy, disableNVML)
 		// checkHealth returns nil when health checks are disabled or on shutdown.
 		if err != nil && err.Error() == "close signal received" {
-			ackDisableHealthChecks <- true
+			select {
+			case ackDisableHealthChecks <- true:
+			case <-stop:
+				return nil
+			}
 			klog.Info("Check Health has been closed")
 			// when disableNVML channel signal is pass restart, continue to restart checkHealth function
 			// when disableNVML channel signal is not pass restart, wait for restart signal
-			<-disableNVML
+			select {
+			case <-disableNVML:
+			case <-stop:
+				return nil
+			}
 			klog.Info("Restarting Check Health")
 			continue
 

--- a/pkg/device/nvidia/calculate_score.go
+++ b/pkg/device/nvidia/calculate_score.go
@@ -98,6 +98,11 @@ func (o *deviceListBuilder) build() (DeviceList, error) {
 		_ = o.nvmllib.Shutdown()
 	}()
 
+	return o.buildWithSession()
+}
+
+// buildWithSession borrows NVML; the caller owns its lifecycle.
+func (o *deviceListBuilder) buildWithSession() (DeviceList, error) {
 	nvmlDevices, err := o.devicelib.GetDevices()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get devices: %v", err)
@@ -179,6 +184,21 @@ func CalculateGPUScore(available []string) (ListDeviceScore, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	return scoreLinkedDevices(linkedDevices, available)
+}
+
+// CalculateGPUScoreWithNVML borrows an initialized NVML instance. The caller
+// must keep the session alive until this function returns.
+func CalculateGPUScoreWithNVML(lib nvml.Interface, available []string) (ListDeviceScore, bool, error) {
+	builder := &deviceListBuilder{nvmllib: lib, devicelib: device.New(lib)}
+	linkedDevices, err := builder.buildWithSession()
+	if err != nil {
+		return nil, false, err
+	}
+	return scoreLinkedDevices(linkedDevices, available)
+}
+
+func scoreLinkedDevices(linkedDevices DeviceList, available []string) (ListDeviceScore, bool, error) {
 	requiredDevices, err := linkedDevices.Filter(available)
 	if err != nil {
 		return nil, false, err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -43,6 +43,11 @@ func init() {
 }
 
 func GetNode(nodename string) (*corev1.Node, error) {
+	return GetNodeWithContext(context.Background(), nodename)
+}
+
+// GetNodeWithContext allows callers to cancel a node lookup during shutdown.
+func GetNodeWithContext(ctx context.Context, nodename string) (*corev1.Node, error) {
 	if nodename == "" {
 		klog.ErrorS(nil, "Node name is empty")
 		return nil, fmt.Errorf("nodename is empty")
@@ -54,7 +59,7 @@ func GetNode(nodename string) (*corev1.Node, error) {
 	}
 
 	klog.V(5).InfoS("Fetching node", "nodeName", nodename)
-	n, err := c.CoreV1().Nodes().Get(context.Background(), nodename, metav1.GetOptions{})
+	n, err := c.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
 	if err != nil {
 		switch {
 		case apierrors.IsNotFound(err):
@@ -137,6 +142,11 @@ func GetAllocatePodByNode(ctx context.Context, nodeName string) (*corev1.Pod, er
 }
 
 func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) error {
+	return PatchNodeAnnotationsWithContext(context.Background(), node, annotations)
+}
+
+// PatchNodeAnnotationsWithContext allows callers to cancel registration on shutdown.
+func PatchNodeAnnotationsWithContext(ctx context.Context, node *corev1.Node, annotations map[string]string) error {
 	if node == nil {
 		return fmt.Errorf("node is nil")
 	}
@@ -159,7 +169,7 @@ func PatchNodeAnnotations(node *corev1.Node, annotations map[string]string) erro
 		return err
 	}
 	_, err = c.CoreV1().Nodes().
-		Patch(context.Background(), node.Name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
+		Patch(ctx, node.Name, k8stypes.MergePatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Infoln("annotations=", annotations)
 		klog.Infof("patch node %v failed, %v", node.Name, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Give each plugin start cycle one MigInstanceManager NVML session so registration and allocation borrow it, and Stop or a failed Start always releases that session exactly once. This will reduce nvml.init() overhead.
 
**Which issue(s) this PR fixes**:
Fixes #2832 

**Special notes for your reviewer**:

This PR written by codex and tested on A100 instance. Valuable sections to review are `Init()`, `beginOperation()` and `Shutdown()` in `migmgr.go` and new and start procedure in `server.go`.

**Does this PR introduce a user-facing change?**:

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device plugin startup and shutdown reliability, including cleanup after startup failures.
  - Prevented shutdown from hanging while waiting for health checks, registration, or worker operations.
  - Enabled safe repeated start/stop cycles and ensured active operations finish before resources are released.
  - Improved cancellation handling for Kubernetes and gRPC operations.

- **Documentation**
  - Documented NVML session ownership and lifecycle behavior for dynamic MIG management.

- **New Features**
  - Added context-aware node lookup and annotation updates.
  - Added GPU scoring support using an existing NVML session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->