### PR TITLE
test(scheduler): add tests for LoadConfig

### DIFF
--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"testing"
 
@@ -785,4 +786,49 @@ func Test_Resourcereqs(t *testing.T) {
 			assert.DeepEqual(t, test.want, got)
 		})
 	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		_, err := LoadConfig("/nonexistent/path/config.yaml")
+		assert.ErrorContains(t, err, "no such file or directory")
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		path := t.TempDir() + "/config.yaml"
+		assert.NilError(t, os.WriteFile(path, []byte("nvidia: [this is not a map"), 0600))
+
+		_, err := LoadConfig(path)
+		assert.ErrorContains(t, err, "yaml")
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		path := t.TempDir() + "/config.yaml"
+		assert.NilError(t, os.WriteFile(path, []byte(""), 0600))
+
+		cfg, err := LoadConfig(path)
+		assert.NilError(t, err)
+		assert.Equal(t, cfg.NvidiaConfig.ResourceCountName, "")
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		path := t.TempDir() + "/config.yaml"
+		content := `
+nvidia:
+  resourceCountName: nvidia.com/gpu
+  resourceMemoryName: nvidia.com/gpumem
+  defaultMemory: 3000
+  defaultCores: 0
+hygon:
+  resourceCountName: hygon.com/dcunum
+`
+		assert.NilError(t, os.WriteFile(path, []byte(content), 0600))
+
+		cfg, err := LoadConfig(path)
+		assert.NilError(t, err)
+		assert.Equal(t, cfg.NvidiaConfig.ResourceCountName, "nvidia.com/gpu")
+		assert.Equal(t, cfg.NvidiaConfig.ResourceMemoryName, "nvidia.com/gpumem")
+		assert.Equal(t, cfg.NvidiaConfig.DefaultMemory, int32(3000))
+		assert.Equal(t, cfg.HygonConfig.ResourceCountName, "hygon.com/dcunum")
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
LoadConfig reads and parses the scheduler's YAML config file but had no test
coverage: not for a missing file, not for invalid YAML, not for the success
path every scheduler component depends on at startup. Adds TestLoadConfig
with four subtests: file not found, invalid YAML, an empty file (valid YAML,
zero-value config), and a valid config asserting the parsed nvidia and hygon
fields.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test-only change, no production code touched. Ran go build, go vet, and the
full pkg/scheduler/config test suite locally, all pass.

**Does this PR introduce a user-facing change?**
No

This PR was written primarily by Claude Code, an AI coding assistant, under
my direction and review. I have read, tested, and take responsibility for
this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded configuration loading coverage for missing files, invalid YAML, empty configurations, and valid Nvidia and Hygon settings.
  * Added verification that configuration parsing returns appropriate errors and correctly preserves supported hardware settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->