### PR TITLE
fix(scheduler): validate the scheduler policy flags at startup

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -109,7 +110,34 @@ func injectProfilingRoute(router *httprouter.Router) {
 	})
 }
 
+// validateSchedulerPolicyFlags rejects an unrecognized --node-scheduler-policy
+// or --gpu-scheduler-policy. Both values reach a whole-string comparison with an
+// unconditional else (NodeScoreList.Less, DeviceUsageList.Less), so an
+// unrecognized value is not ignored, it selects the other policy with nothing
+// logged. #2769 already refuses to act on an unrecognized value for the
+// equivalent per-pod annotations. The node value is trimmed for the same reason
+// resolveNodeSchedulerPolicy trims an accepted annotation: NodeScoreList.Less
+// compares the whole string.
+func validateSchedulerPolicyFlags() error {
+	if !util.IsValidNodeSchedulerPolicy(config.NodeSchedulerPolicy) {
+		return fmt.Errorf("invalid --node-scheduler-policy %q, want %s or %s",
+			config.NodeSchedulerPolicy, util.NodeSchedulerPolicyBinpack, util.NodeSchedulerPolicySpread)
+	}
+	config.NodeSchedulerPolicy = strings.TrimSpace(config.NodeSchedulerPolicy)
+
+	if !util.IsValidGPUSchedulerPolicy(device.GPUSchedulerPolicy) {
+		return fmt.Errorf("invalid --gpu-scheduler-policy %q, want a comma-separated list of %s, %s, %s, %s, %s",
+			device.GPUSchedulerPolicy, util.GPUSchedulerPolicyBinpack, util.GPUSchedulerPolicySpread,
+			util.GPUSchedulerPolicyNuma, util.GPUSchedulerPolicyMutex, util.GPUSchedulerPolicyTopology)
+	}
+	return nil
+}
+
 func start() error {
+	if err := validateSchedulerPolicyFlags(); err != nil {
+		return err
+	}
+
 	// Initialize node lock timeout from config
 	nodelock.NodeLockTimeout = config.NodeLockTimeout
 	klog.InfoS("Set node lock timeout", "timeout", nodelock.NodeLockTimeout)

--- a/cmd/scheduler/main_test.go
+++ b/cmd/scheduler/main_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/scheduler/config"
+)
+
+func TestValidateSchedulerPolicyFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodePolicy     string
+		gpuPolicy      string
+		wantErr        bool
+		wantNodePolicy string
+	}{
+		{name: "defaults", nodePolicy: "binpack", gpuPolicy: "spread", wantNodePolicy: "binpack"},
+		{name: "spread node policy", nodePolicy: "spread", gpuPolicy: "binpack", wantNodePolicy: "spread"},
+		{name: "gpu policy chain", nodePolicy: "binpack", gpuPolicy: "binpack,numa", wantNodePolicy: "binpack"},
+		{name: "padded node policy is canonicalized", nodePolicy: " spread ", gpuPolicy: "spread", wantNodePolicy: "spread"},
+		{name: "wrong case node policy", nodePolicy: "Spread", gpuPolicy: "spread", wantErr: true},
+		{name: "misspelled node policy", nodePolicy: "spraed", gpuPolicy: "spread", wantErr: true},
+		{name: "empty node policy", nodePolicy: "", gpuPolicy: "spread", wantErr: true},
+		{name: "wrong case gpu policy", nodePolicy: "binpack", gpuPolicy: "Binpack", wantErr: true},
+		{name: "misspelled gpu policy", nodePolicy: "binpack", gpuPolicy: "binpak", wantErr: true},
+		{name: "misspelled gpu policy in chain", nodePolicy: "binpack", gpuPolicy: "binpack,nmua", wantErr: true},
+		{name: "empty gpu policy", nodePolicy: "binpack", gpuPolicy: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.NodeSchedulerPolicy = tt.nodePolicy
+			device.GPUSchedulerPolicy = tt.gpuPolicy
+
+			err := validateSchedulerPolicyFlags()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "invalid --")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantNodePolicy, config.NodeSchedulerPolicy)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`--node-scheduler-policy` and `--gpu-scheduler-policy` are plain `StringVar`s and the existing validators are only reached from the annotation path, so an unrecognized value reaches a whole-string comparison with an unconditional else and selects the opposite policy. `start()` now runs both through `IsValidNodeSchedulerPolicy` / `IsValidGPUSchedulerPolicy` and fails, and trims the node value because `NodeScoreList.Less` compares the whole string. This is the flag-side counterpart of #2769.

If you would rather not fail startup, a warning plus the documented default is a small change from here.

**Which issue(s) this PR fixes**:
Fixes #2995

**Special notes for your reviewer**:

AI-assisted. I reviewed every line of this diff before submitting.

**Does this PR introduce a user-facing change?**:

A scheduler configured with an unrecognized `--node-scheduler-policy` or `--gpu-scheduler-policy` now fails to start instead of silently running the opposite policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler startup now rejects invalid node and GPU scheduling policy values with descriptive errors.
  * Node scheduling policy values are normalized by trimming surrounding whitespace.
  * Validation covers malformed policy names, casing errors, empty values, and invalid entries in GPU policy chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->