### PR TITLE
Cleanup: Replace %v with %w in fmt.Errorf() for better error handling

### DIFF
--- a/pkg/monitor/nvidia/cudevshr.go
+++ b/pkg/monitor/nvidia/cudevshr.go
@@ -187,7 +187,7 @@ func (l *ContainerLister) Update() error {
 
 	pods, err := l.podLister.List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to list pods: %v", err)
+		return fmt.Errorf("failed to list pods: %w", err)
 	}
 
 	podUIDs := make(map[string]bool, len(pods))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -387,14 +387,14 @@ func (s *Scheduler) Start() error {
 		DeleteFunc: s.onDelPod,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to register pod event handler: %v", err)
+		return fmt.Errorf("failed to register pod event handler: %w", err)
 	}
 	nodeEventHandlerRegistration, err := informerFactory.Core().V1().Nodes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { s.doNodeNotify() },
 		DeleteFunc: s.onDelNode,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to register node event handler: %v", err)
+		return fmt.Errorf("failed to register node event handler: %w", err)
 	}
 	resourceQuotaEventHandlerRegistration, err := informerFactory.Core().V1().ResourceQuotas().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    s.onAddQuota,
@@ -402,7 +402,7 @@ func (s *Scheduler) Start() error {
 		DeleteFunc: s.onDelQuota,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to register resource quota event handler: %v", err)
+		return fmt.Errorf("failed to register resource quota event handler: %w", err)
 	}
 
 	informerFactory.Start(s.stopCh)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -65,7 +65,7 @@ func GetNode(nodename string) (*corev1.Node, error) {
 			return nil, fmt.Errorf("unauthorized to access node %s", nodename)
 		default:
 			klog.ErrorS(err, "Failed to get node", "nodeName", nodename)
-			return nil, fmt.Errorf("failed to get node %s: %v", nodename, err)
+			return nil, fmt.Errorf("failed to get node %s: %w", nodename, err)
 		}
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,10 +59,10 @@ func GetNode(nodename string) (*corev1.Node, error) {
 		switch {
 		case apierrors.IsNotFound(err):
 			klog.ErrorS(err, "Node not found", "nodeName", nodename)
-			return nil, fmt.Errorf("node %s not found", nodename)
+			return nil, fmt.Errorf("node %s not found: %w", nodename, err)
 		case apierrors.IsUnauthorized(err):
 			klog.ErrorS(err, "Unauthorized to access node", "nodeName", nodename)
-			return nil, fmt.Errorf("unauthorized to access node %s", nodename)
+			return nil, fmt.Errorf("unauthorized to access node %s: %w", nodename, err)
 		default:
 			klog.ErrorS(err, "Failed to get node", "nodeName", nodename)
 			return nil, fmt.Errorf("failed to get node %s: %w", nodename, err)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -1048,6 +1049,7 @@ func TestGetNode(t *testing.T) {
 		nodeName    string
 		wantErr     bool
 		checkNode   func(*testing.T, *corev1.Node)
+		checkErr    func(*testing.T, error)
 	}{
 		{
 			name: "empty node name",
@@ -1068,10 +1070,23 @@ func TestGetNode(t *testing.T) {
 		{
 			name: "node not found",
 			setupClient: func() kubernetes.Interface {
-				return fake.NewClientset()
+				clientset := fake.NewClientset()
+				return clientset
 			},
 			nodeName: "non-existent-node",
 			wantErr:  true,
+			checkErr: func(t *testing.T, err error) {
+				var statusErr *apierrors.StatusError
+				if !errors.As(err, &statusErr) {
+					t.Fatalf("errors.As(*StatusError) = false; want true (got type %T)", err)
+				}
+				if !apierrors.IsNotFound(statusErr) {
+					t.Errorf("expected unwrapped error to be NotFound, got %v", statusErr)
+				}
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("apierrors.IsNotFound(wrappedErr) = false; wrapping with %%w is required to preserve the error chain")
+				}
+			},
 		},
 		{
 			name: "success",
@@ -1093,24 +1108,46 @@ func TestGetNode(t *testing.T) {
 			setupClient: func() kubernetes.Interface {
 				clientset := fake.NewClientset()
 				clientset.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
-					return false, nil, apierrors.NewUnauthorized("get nodes")
+					return true, nil, apierrors.NewUnauthorized("get nodes")
 				})
 				return clientset
 			},
 			nodeName: "test-node",
 			wantErr:  true,
+			checkErr: func(t *testing.T, err error) {
+				var statusErr *apierrors.StatusError
+				if !errors.As(err, &statusErr) {
+					t.Fatalf("errors.As(*StatusError) = false; want true (got type %T)", err)
+				}
+				if !apierrors.IsUnauthorized(statusErr) {
+					t.Errorf("expected unwrapped error to be Unauthorized, got %v", statusErr)
+				}
+				if !apierrors.IsUnauthorized(err) {
+					t.Errorf("apierrors.IsUnauthorized(wrappedErr) = false; wrapping with %%w is required to preserve the error chain")
+				}
+			},
 		},
 		{
 			name: "generic error",
 			setupClient: func() kubernetes.Interface {
 				clientset := fake.NewClientset()
 				clientset.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
-					return false, nil, apierrors.NewBadRequest("generic error")
+					return true, nil, apierrors.NewBadRequest("generic error")
 				})
 				return clientset
 			},
 			nodeName: "test-node",
 			wantErr:  true,
+			checkErr: func(t *testing.T, err error) {
+				var statusErr *apierrors.StatusError
+				if !errors.As(err, &statusErr) {
+					t.Errorf("expected error to wrap *apierrors.StatusError, got %T", err)
+					return
+				}
+				if !apierrors.IsBadRequest(statusErr) {
+					t.Errorf("expected wrapped error to be BadRequest, got %v", statusErr)
+				}
+			},
 		},
 	}
 
@@ -1124,6 +1161,9 @@ func TestGetNode(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetNode() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.wantErr && tt.checkErr != nil {
+				tt.checkErr(t, err)
 			}
 			if !tt.wantErr && tt.checkNode != nil {
 				tt.checkNode(t, got)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR replaces several instances of `%v` with `%w` when wrapping errors using `fmt.Errorf()` in `pkg/scheduler/scheduler.go`, `pkg/util/util.go`, and `pkg/monitor/nvidia/cudevshr.go`. 

Using `%v` formats the original error as a generic string, which breaks the error chain and prevents upstream callers from inspecting the root cause of the error using `errors.Is()` or `errors.As()`. By adopting `%w` (introduced in Go 1.13), we preserve the original error identity. This enables better downstream error handling, such as allowing the scheduler or API clients to reliably distinguish between transient network timeouts, permission errors, or resources not being found (e.g., when calling `GetNode`), rather than parsing string outputs.

```bash
--- Testing with %w ---
Error string: failed to get node gpu-node-01: connection timeout
Result: errors.Is correctly identified ErrTimeout! ✅

--- Testing with %v ---
Error string: failed to get node gpu-node-01: connection timeout
Result: errors.Is failed to identify ErrTimeout! ❌
```

**Which issue(s) this PR fixes**:
Fixes #2992 

**Special notes for your reviewer**:
> This PR is authored in assistance with Gemini 3.1, I have fully reviewed and tested all logics and generated code, and understood the codebase and fmt.Error().

**Does this PR introduce a user-facing change?**:
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved underlying error details when pod, node, resource quota, and node-listing operations fail.
  * Improved error inspection and handling through standard error unwrapping, without changing displayed error messages.
  * Error causes can now be reliably identified for more accurate troubleshooting and programmatic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->