### PR TITLE
fix(device): align sparse init-container annotations from the end

### DIFF
--- a/pkg/device/initContainer.go
+++ b/pkg/device/initContainer.go
@@ -43,6 +43,25 @@ func isSidecarAt(pod *corev1.Pod, cidx int) bool {
 	return util.IsSidecarContainer(&pod.Spec.InitContainers[cidx])
 }
 
+// alignOffset maps a sparse annotation back onto container order. The encoder
+// is expected to emit a placeholder per container, but older annotations omit
+// leading non-GPU init entries, so index 0 would misclassify the first app
+// entry as init and clear exclusive usage. Trim the encoder's trailing empty
+// (exactly the surplus beyond total containers) and align any remainder
+// shortfall from the end.
+func alignOffset(podSingle PodSingleDevice, numInit, numApp int) (PodSingleDevice, int) {
+	total := numInit + numApp
+	end := len(podSingle)
+	for end > total && len(podSingle[end-1]) == 0 {
+		end--
+	}
+	trimmed := podSingle[:end]
+	if offset := total - len(trimmed); offset > 0 {
+		return trimmed, offset
+	}
+	return trimmed, 0
+}
+
 // CollapseInitContainerUsage returns the effective device usage for a pod.
 func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	if raw == nil {
@@ -68,9 +87,11 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 			return s
 		}
 
-		for cidx, ctrDevs := range podSingle {
+		entries, offset := alignOffset(podSingle, numInit, len(pod.Spec.Containers))
+		for cidx, ctrDevs := range entries {
+			eidx := cidx + offset
 			switch {
-			case cidx < numInit && isSidecarAt(pod, cidx):
+			case eidx < numInit && isSidecarAt(pod, eidx):
 				for _, dev := range ctrDevs {
 					s := get(dev.UUID)
 					// A sidecar starts and never exits: it permanently
@@ -82,7 +103,7 @@ func CollapseInitContainerUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 					s.peak.cores = max(s.peak.cores, s.sc.cores)
 					s.peak.slots = max(s.peak.slots, s.sc.slots)
 				}
-			case cidx < numInit:
+			case eidx < numInit:
 				for _, dev := range ctrDevs {
 					s := get(dev.UUID)
 					s.peak.mem = max(s.peak.mem, s.sc.mem+dev.Usedmem)
@@ -128,8 +149,11 @@ func SteadyStateDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 	collapsed := make(PodDevices)
 	for devType, podSingle := range raw {
 		sums := make(map[string]usage)
-		for cidx, ctrDevs := range podSingle {
-			if cidx < numInit && !isSidecarAt(pod, cidx) {
+		numApp := len(pod.Spec.Containers)
+		entries, offset := alignOffset(podSingle, numInit, numApp)
+		for cidx, ctrDevs := range entries {
+			eidx := cidx + offset
+			if eidx < numInit && !isSidecarAt(pod, eidx) {
 				continue
 			}
 			for _, dev := range ctrDevs {
@@ -138,6 +162,38 @@ func SteadyStateDeviceUsage(pod *corev1.Pod, raw PodDevices) PodDevices {
 				s.cores += dev.Usedcores
 				s.slots += slotsOf(dev)
 				sums[dev.UUID] = s
+			}
+		}
+		// Decoded sparse annotations carry the encoder's trailing empty on top
+		// of a missing leading init placeholder (len == total, last empty).
+		// The base pass then skips the only app entry as init and clears
+		// usage. Retry as sparse when the base sums nothing but raw is non-empty.
+		if len(sums) == 0 && len(entries) > 0 && len(entries[len(entries)-1]) == 0 {
+			hasData := false
+			for _, ctrDevs := range podSingle {
+				if len(ctrDevs) > 0 {
+					hasData = true
+					break
+				}
+			}
+			if hasData {
+				sparse := entries[:len(entries)-1]
+				sparseOffset := numInit + numApp - len(sparse)
+				if sparseOffset < 0 {
+					sparseOffset = 0
+				}
+				for cidx, ctrDevs := range sparse {
+					if cidx+sparseOffset < numInit && !isSidecarAt(pod, cidx+sparseOffset) {
+						continue
+					}
+					for _, dev := range ctrDevs {
+						s := sums[dev.UUID]
+						s.mem += dev.Usedmem
+						s.cores += dev.Usedcores
+						s.slots += slotsOf(dev)
+						sums[dev.UUID] = s
+					}
+				}
 			}
 		}
 		collapsedSingle := make(PodSingleDevice, 1)

--- a/pkg/device/initContainer_test.go
+++ b/pkg/device/initContainer_test.go
@@ -597,3 +597,32 @@ func TestCollapseInitContainerUsage_LateSidecarDoesNotInflatePeak(t *testing.T) 
 	}
 	assert.DeepEqual(t, expectedSteady, SteadyStateDeviceUsage(pod, raw))
 }
+
+// Sparse annotation without a placeholder for a non-GPU init container
+// (issue #2965): a single segment holds the app usage and must not be
+// mistaken for init usage, which previously cleared exclusive occupancy.
+func TestSteadyStateDeviceUsage_SparseInitWithoutPlaceholder(t *testing.T) {
+	pod := makePod("test", 1, 1)
+	raw := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 100, Usedcores: 10}},
+		},
+	}
+	expected := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 100, Usedcores: 10, Slots: 1}},
+		},
+	}
+	assert.DeepEqual(t, expected, SteadyStateDeviceUsage(pod, raw))
+	assert.DeepEqual(t, expected, CollapseInitContainerUsage(pod, raw))
+
+	// Same shape as decoded from the wire: the encoder's trailing ";" adds
+	// one extra empty entry on top of the missing init placeholder.
+	decoded := PodDevices{
+		"NVIDIA": PodSingleDevice{
+			{ContainerDevice{UUID: "gpu0", Type: "NVIDIA", Usedmem: 100, Usedcores: 10}},
+			{},
+		},
+	}
+	assert.DeepEqual(t, expected, SteadyStateDeviceUsage(pod, decoded))
+}


### PR DESCRIPTION
@archlitchi 
Fixes #2965

Summary:
SteadyStateDeviceUsage treated annotation index as container order. A pod with a non-GPU init container and a GPU app container decodes to a single segment, which was skipped as init, returning empty occupancy and clearing exclusive GPU usage. Align sparse entries from the end after trimming the encoder trailing empty, with a steady-state retry for decoded sparse shapes.

Test plan:
- New regression TestSteadyStateDeviceUsage_SparseInitWithoutPlaceholder (direct and decoded shapes)
- go test ./pkg/device -count=1 -short passes
- go vet ./pkg/device clean; scheduler package does not build on Windows due to go-nvml (pre-existing, unrelated)

Validation:
- Scheduler-extender scoped change, verified with unit tests (no GPU hardware available).

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected device usage accounting for sparse annotations when init containers lack placeholder entries.
  - Preserved application container resource usage instead of incorrectly clearing it.
  - Improved handling of device usage data with trailing empty entries.

- **Tests**
  - Added regression coverage for sparse init-container annotations, including wire-decoded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->