### PR TITLE
test(util): cover EmitNodeWarningEvent client-filter and nil-client paths

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -923,6 +923,73 @@ func TestEmitNodeWarningEvent(t *testing.T) {
 		// Old event still present plus one new event.
 		assert.Equal(t, 2, len(events.Items))
 	})
+
+	t.Run("uninitialized client is a no-op", func(t *testing.T) {
+		oldClient := client.KubeClient
+		client.KubeClient = nil
+		t.Cleanup(func() { client.KubeClient = oldClient })
+
+		EmitNodeWarningEvent(node, reason, msg1, dedupWindow)
+	})
+
+	t.Run("multiple existing events update only the most recent matching one", func(t *testing.T) {
+		older := metav1.NewTime(time.Now().Add(-45 * time.Minute))
+		newer := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+		olderMatch := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-older", Namespace: corev1.NamespaceDefault},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node", Name: nodeName, UID: nodeUID,
+			},
+			Reason: reason, Message: msg1, Count: 1,
+			FirstTimestamp: older, LastTimestamp: older,
+		}
+		newerMatch := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-newer", Namespace: corev1.NamespaceDefault},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node", Name: nodeName, UID: nodeUID,
+			},
+			Reason: reason, Message: msg1, Count: 2,
+			FirstTimestamp: newer, LastTimestamp: newer,
+		}
+		otherReason := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-other-reason", Namespace: corev1.NamespaceDefault},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node", Name: nodeName, UID: nodeUID,
+			},
+			Reason: "SomethingElse", Message: msg1, Count: 1,
+			FirstTimestamp: newer, LastTimestamp: newer,
+		}
+		otherUID := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName + "-other-uid", Namespace: corev1.NamespaceDefault},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Node", Name: nodeName, UID: types.UID("some-other-uid"),
+			},
+			Reason: reason, Message: msg1, Count: 1,
+			FirstTimestamp: newer, LastTimestamp: newer,
+		}
+		client.KubeClient = fake.NewClientset(olderMatch, newerMatch, otherReason, otherUID)
+
+		EmitNodeWarningEvent(node, reason, msg2, dedupWindow)
+
+		events, err := client.KubeClient.CoreV1().Events(corev1.NamespaceDefault).List(
+			context.TODO(), metav1.ListOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, 4, len(events.Items))
+		for i := range events.Items {
+			ev := &events.Items[i]
+			switch ev.Name {
+			case newerMatch.Name:
+				assert.Equal(t, int32(3), ev.Count)
+				assert.Equal(t, msg2, ev.Message)
+			case olderMatch.Name:
+				assert.Equal(t, int32(1), ev.Count)
+				assert.Equal(t, msg1, ev.Message)
+			case otherReason.Name, otherUID.Name:
+				assert.Equal(t, int32(1), ev.Count)
+				assert.Equal(t, msg1, ev.Message)
+			}
+		}
+	})
 }
 
 func TestIsSidecarContainer(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

EmitNodeWarningEvent has a client-side filter that walks every existing event and keeps the one with the latest LastTimestamp among those matching the node UID and reason, plus an early return when no Kubernetes client is set. Neither path had a test: existing tests only ever had zero or one matching event in the fake client, so the loop that picks the most recent match and skips events with a different UID or reason never actually branched. This adds a case with several events, including ones that must be ignored by UID or reason, and a case for the uninitialized client early return.

This PR was written primarily by Claude Code, reviewed and tested locally before submitting.

**Which issue(s) this PR fixes**:
Fixes #

No existing issue tracks this, found while reading pkg/util/util.go for test coverage gaps.

**Special notes for your reviewer**:

Verified by temporarily breaking the filter logic (skipping the UID/reason check) and confirming the new test fails, then restoring it. go test ./pkg/util/... -run TestEmitNodeWarningEvent passes with all 5 subtests.

**Does this PR introduce a user-facing change?**:
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage ensuring node warning event emission safely handles an unavailable Kubernetes client.
  - Added coverage verifying that only the latest matching event is updated, while unrelated or older events remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->