### PR TITLE
fix(device): enforce min limit across multiple ResourceQuota objects

### DIFF
--- a/pkg/device/quota.go
+++ b/pkg/device/quota.go
@@ -39,7 +39,15 @@ type DeviceQuota map[string]*Quota
 
 type QuotaManager struct {
 	Quotas map[string]*DeviceQuota
-	mutex  sync.RWMutex
+	// objectLimits records what each ResourceQuota object contributes:
+	// namespace -> object name -> resource -> limit. Kubernetes enforces every
+	// ResourceQuota object in a namespace independently, so the effective limit
+	// for a resource is the minimum across all objects. Storing per object (not
+	// a single slot) keeps the derived state a pure function of the current set
+	// of objects, so the result no longer depends on informer event order or on
+	// which object happened to be added/removed last.
+	objectLimits map[string]map[string]map[string]int64
+	mutex        sync.RWMutex
 }
 
 var localCache QuotaManager
@@ -53,7 +61,8 @@ var once sync.Once
 func NewQuotaManager() *QuotaManager {
 	once.Do(func() {
 		localCache = QuotaManager{
-			Quotas: make(map[string]*DeviceQuota),
+			Quotas:       make(map[string]*DeviceQuota),
+			objectLimits: make(map[string]map[string]map[string]int64),
 		}
 	})
 	return &localCache
@@ -238,51 +247,101 @@ func (q *QuotaManager) UpdateQuota(oldQuota, newQuota *corev1.ResourceQuota) {
 	q.logQuotasLocked()
 }
 
-// addQuotaLocked requires q.mutex to be held.
+// addQuotaLocked requires q.mutex to be held. It records the object's limits
+// under its name and recomputes the effective limit for every resource the
+// object (previously or now) carries.
 func (q *QuotaManager) addQuotaLocked(quota *corev1.ResourceQuota) {
+	newLimits := make(map[string]int64)
 	for idx, val := range quota.Spec.Hard {
 		value, ok := val.AsInt64()
-		if ok {
-			dn, ok := managedQuotaName(idx)
-			if !ok {
-				continue
-			}
-			if q.Quotas[quota.Namespace] == nil {
-				q.Quotas[quota.Namespace] = &DeviceQuota{}
-			}
-			dp := q.Quotas[quota.Namespace]
-			_, ok = (*dp)[dn]
-			if !ok {
-				(*dp)[dn] = &Quota{
-					Used:  0,
-					Limit: value,
-				}
-			}
-			(*dp)[dn].Limit = value
-			(*dp)[dn].LimitSet = true
-			klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
+		if !ok {
+			continue
+		}
+		dn, ok := managedQuotaName(idx)
+		if !ok {
+			continue
+		}
+		newLimits[dn] = value
+		klog.V(4).InfoS("quota set:", "idx=", idx, "val", value)
+	}
+	if q.objectLimits == nil {
+		q.objectLimits = make(map[string]map[string]map[string]int64)
+	}
+	if q.objectLimits[quota.Namespace] == nil {
+		q.objectLimits[quota.Namespace] = make(map[string]map[string]int64)
+	}
+	// Replace the object's entry wholesale so resources dropped from its spec
+	// are released rather than left at their old values.
+	recomputed := make(map[string]struct{})
+	for dn := range q.objectLimits[quota.Namespace][quota.Name] {
+		recomputed[dn] = struct{}{}
+	}
+	q.objectLimits[quota.Namespace][quota.Name] = newLimits
+	for dn := range newLimits {
+		recomputed[dn] = struct{}{}
+	}
+	for dn := range recomputed {
+		q.recalcLimitLocked(quota.Namespace, dn)
+	}
+}
+
+// delQuotaLocked requires q.mutex to be held. It removes the object's recorded
+// limits for the resources its spec mentions and recomputes the effective
+// limit from the remaining objects. Deletion is driven by the spec so an
+// object that was never added (or a stale event) cannot wipe another object's
+// recorded limits.
+func (q *QuotaManager) delQuotaLocked(quota *corev1.ResourceQuota) {
+	obj, ok := q.objectLimits[quota.Namespace][quota.Name]
+	if !ok {
+		return
+	}
+	for idx := range quota.Spec.Hard {
+		dn, ok := managedQuotaName(idx)
+		if !ok {
+			continue
+		}
+		if _, recorded := obj[dn]; !recorded {
+			continue
+		}
+		delete(obj, dn)
+		klog.V(4).InfoS("quota remove:", "resource", dn, "obj", quota.Name)
+		q.recalcLimitLocked(quota.Namespace, dn)
+	}
+	if len(obj) == 0 {
+		delete(q.objectLimits[quota.Namespace], quota.Name)
+		if len(q.objectLimits[quota.Namespace]) == 0 {
+			delete(q.objectLimits, quota.Namespace)
 		}
 	}
 }
 
-// delQuotaLocked requires q.mutex to be held.
-func (q *QuotaManager) delQuotaLocked(quota *corev1.ResourceQuota) {
-	for idx, val := range quota.Spec.Hard {
-		value, ok := val.AsInt64()
-		if ok {
-			dn, ok := managedQuotaName(idx)
-			if !ok {
-				continue
-			}
-			klog.V(4).InfoS("quota remove:", "idx=", idx, "val", value)
-			if dq, ok := q.Quotas[quota.Namespace]; ok {
-				if quotaInfo, ok := (*dq)[dn]; ok {
-					quotaInfo.Limit = 0
-					quotaInfo.LimitSet = false
-				}
-			}
+// recalcLimitLocked requires q.mutex to be held. It derives the effective limit
+// for a resource as the minimum across all ResourceQuota objects that set it —
+// a pod must satisfy every object, so the tightest one wins. With no objects
+// left the resource reads as unset (Limit 0, LimitSet false).
+func (q *QuotaManager) recalcLimitLocked(namespace, deviceResource string) {
+	limit := int64(0)
+	found := false
+	for _, res := range q.objectLimits[namespace] {
+		if v, ok := res[deviceResource]; ok && (!found || v < limit) {
+			limit = v
+			found = true
 		}
 	}
+	if q.Quotas[namespace] == nil {
+		q.Quotas[namespace] = &DeviceQuota{}
+	}
+	dp := q.Quotas[namespace]
+	quotaInfo, ok := (*dp)[deviceResource]
+	if !ok {
+		quotaInfo = &Quota{
+			Used:  0,
+			Limit: 0,
+		}
+		(*dp)[deviceResource] = quotaInfo
+	}
+	quotaInfo.Limit = limit
+	quotaInfo.LimitSet = found
 }
 
 // managedQuotaName maps a ResourceQuota key to the device resource it limits,

--- a/pkg/device/quota_test.go
+++ b/pkg/device/quota_test.go
@@ -243,6 +243,221 @@ func TestIsManagedQuota(t *testing.T) {
 	}
 }
 
+// Multiple ResourceQuota objects in one namespace must all be enforced: a pod
+// has to satisfy every object, so the effective limit is the minimum. This is
+// the core scenario from the multi-quota bug: before the fix, the last-added
+// object's limit won regardless of whether it was the tighter one.
+func TestMultipleQuotaObjectsTakeMin(t *testing.T) {
+	initTest()
+	ns := "multi-obj"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	rqWith := func(name string, mem int64) *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					"limits.nvidia.com/gpumem": *resource.NewQuantity(mem, resource.DecimalSI),
+				},
+			},
+		}
+	}
+
+	strict, loose := rqWith("strict", 1000), rqWith("loose", 5000)
+
+	// Either add order must converge on the tighter limit.
+	for _, order := range [][]*corev1.ResourceQuota{{strict, loose}, {loose, strict}} {
+		qm.AddQuota(order[0])
+		qm.AddQuota(order[1])
+		if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 1000 {
+			t.Errorf("effective limit = %d, want 1000 (the tighter object)", got)
+		}
+		if qm.FitQuota(ns, 3000, 1, 0, "NVIDIA") {
+			t.Error("FitQuota admitted a 3000 request; the strict 1000 limit must hold")
+		}
+		if !qm.FitQuota(ns, 500, 1, 0, "NVIDIA") {
+			t.Error("FitQuota rejected a 500 request under the 1000 limit")
+		}
+		// Reset for the second order.
+		qm.DelQuota(strict)
+		qm.DelQuota(loose)
+		if (*qm.Quotas[ns])["nvidia.com/gpumem"].LimitSet {
+			t.Fatal("LimitSet still true after deleting every quota object")
+		}
+	}
+}
+
+// Deleting one of two quota objects must recompute from the survivors, not
+// drop enforcement. Both directions are covered: removing the larger limit
+// keeps the smaller one, removing the smaller one lets the limit rise.
+func TestDelQuotaRecomputesFromRemainingObjects(t *testing.T) {
+	initTest()
+	ns := "del-recompute"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	rqWith := func(name string, mem int64) *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					"limits.nvidia.com/gpumem": *resource.NewQuantity(mem, resource.DecimalSI),
+				},
+			},
+		}
+	}
+	strict, loose := rqWith("strict", 1000), rqWith("loose", 5000)
+	qm.AddQuota(strict)
+	qm.AddQuota(loose)
+
+	// Deleting the looser object keeps the strict limit enforced.
+	qm.DelQuota(loose)
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 1000 {
+		t.Errorf("limit after deleting the looser object = %d, want 1000", got)
+	}
+	if qm.FitQuota(ns, 1001, 1, 0, "NVIDIA") {
+		t.Error("FitQuota admitted past the surviving strict limit")
+	}
+
+	// Deleting the strict one then lifts the limit to the remaining object.
+	qm.AddQuota(loose)
+	qm.DelQuota(strict)
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 5000 {
+		t.Errorf("limit after deleting the stricter object = %d, want 5000", got)
+	}
+
+	// Deleting the last object unsets the limit but keeps the slot for usage.
+	qm.DelQuota(loose)
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"]; got == nil || got.LimitSet {
+		t.Errorf("quota after deleting every object = %+v, want LimitSet=false", got)
+	}
+}
+
+// Updating one object's limit in place must follow the change immediately.
+func TestUpdateQuotaObjectFollowsLimitChange(t *testing.T) {
+	initTest()
+	ns := "obj-update"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	rqWith := func(name string, mem int64) *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					"limits.nvidia.com/gpumem": *resource.NewQuantity(mem, resource.DecimalSI),
+				},
+			},
+		}
+	}
+	a, b := rqWith("a", 2000), rqWith("b", 3000)
+	qm.AddQuota(a)
+	qm.AddQuota(b)
+
+	// Raise a's limit: effective stays at b's 3000.
+	qm.UpdateQuota(rqWith("a", 2000), rqWith("a", 4000))
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 3000 {
+		t.Errorf("limit = %d, want 3000 after raising a above b", got)
+	}
+
+	// Lower a back down: effective follows immediately.
+	qm.UpdateQuota(rqWith("a", 4000), rqWith("a", 1500))
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 1500 {
+		t.Errorf("limit = %d, want 1500 after lowering a below b", got)
+	}
+
+	// An update that drops the resource from the object's spec releases it.
+	qm.UpdateQuota(rqWith("a", 1500), &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: ns},
+		Spec:       corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{}},
+	})
+	if got := (*qm.Quotas[ns])["nvidia.com/gpumem"].Limit; got != 3000 {
+		t.Errorf("limit = %d, want 3000 once a stops setting the resource", got)
+	}
+}
+
+// An explicit "0" from one object must block everything even when another
+// object allows more: min(0, x) = 0.
+func TestMultipleQuotaObjectsExplicitZeroBlocks(t *testing.T) {
+	initTest()
+	ns := "zero-and-more"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	zero := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "block-all", Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				"limits.nvidia.com/gpumem": *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
+	}
+	loose := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "loose", Namespace: ns},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				"limits.nvidia.com/gpumem": *resource.NewQuantity(5000, resource.DecimalSI),
+			},
+		},
+	}
+	qm.AddQuota(zero)
+	qm.AddQuota(loose)
+
+	if qm.FitQuota(ns, 1, 1, 0, "NVIDIA") {
+		t.Error("FitQuota admitted a request while one object set an explicit 0 limit")
+	}
+}
+
+// The same object set must produce the same final state regardless of the
+// order events arrive in — scheduler restarts replay the full set, and the
+// old last-writer-wins behavior could flip the effective limit across restarts.
+func TestQuotaStateOrderIndependent(t *testing.T) {
+	initTest()
+	ns := "order-independent"
+	qm := NewQuotaManager()
+	t.Cleanup(func() { delete(qm.Quotas, ns) })
+
+	rqWith := func(name string, mem int64) *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					"limits.nvidia.com/gpumem": *resource.NewQuantity(mem, resource.DecimalSI),
+				},
+			},
+		}
+	}
+	objects := []*corev1.ResourceQuota{rqWith("a", 800), rqWith("b", 3000), rqWith("c", 1200)}
+
+	snapshot := func() (int64, bool) {
+		q := (*qm.Quotas[ns])["nvidia.com/gpumem"]
+		return q.Limit, q.LimitSet
+	}
+
+	var wantLimit int64
+	var wantSet bool
+	first := true
+	// Forward, reverse, and rotated orders must all converge.
+	for _, perm := range [][]int{{0, 1, 2}, {2, 1, 0}, {1, 2, 0}} {
+		for _, i := range perm {
+			qm.AddQuota(objects[i])
+		}
+		gotLimit, gotSet := snapshot()
+		if first {
+			wantLimit, wantSet, first = gotLimit, gotSet, false
+		} else if gotLimit != wantLimit || gotSet != wantSet {
+			t.Errorf("state = (%d, %v), want (%d, %v): add order changed the effective limit", gotLimit, gotSet, wantLimit, wantSet)
+		}
+		for _, obj := range objects {
+			qm.DelQuota(obj)
+		}
+	}
+	if wantLimit != 800 || !wantSet {
+		t.Errorf("converged state = (%d, %v), want (800, true)", wantLimit, wantSet)
+	}
+}
+
 func TestAddQuotaAndDelQuota(t *testing.T) {
 	initTest()
 	qm := NewQuotaManager()


### PR DESCRIPTION
## Summary

Fixes #2997

`QuotaManager` kept a single limit slot per `(namespace, resource)`, and `addQuotaLocked`/`delQuotaLocked` overwrote/zeroed it unconditionally. When two `ResourceQuota` objects in one namespace both set e.g. `limits.hami.io/gpumem`, the surviving limit was decided purely by informer event order and flipped across scheduler restarts — deleting the larger-limit object left the resource effectively unlimited even though the stricter object still existed.

This PR records limits **per ResourceQuota object** (`namespace -> object name -> resource`) and derives the effective limit as the **minimum** across all objects, matching upstream kube quota semantics where each object is enforced independently and a pod must satisfy all of them.

## Design notes

- `Used` stays namespace-scoped: usage is a property of the pods in the namespace, not of any quota object, so it does not need per-object bookkeeping (and keeping it shared avoids losing usage when the last object is deleted).
- `FitQuota` is untouched — it keeps reading the derived `(Limit, LimitSet)`, so the scheduling hot path and the webhook check are unchanged.
- `UpdateQuota`'s atomic swap (the fix from #2386) is preserved: the swap now updates one entry in the per-object map, and an update that drops a resource from an object's spec releases that object's claim.
- Deleting an object's limits is driven by its spec, so a stale/never-added object cannot wipe another object's recorded limits.
- An explicit `"0"` from one object blocks the namespace even when other objects allow more (`min(0, x) = 0`), preserving the explicit-zero semantics from the existing `LimitSet` handling.

## Known limitation (unchanged, deterministic now)

`Spec.Scopes` / `ScopeSelector` are still not consulted. A scoped quota's limit is applied namespace-wide via the min — but the previous last-writer-wins behavior had the same over-restriction risk, this just makes it deterministic. Proper scope support (filter objects by scope when computing the min, check pods against matching scopes in `FitQuota`) is left as a follow-up.

## Tests

New cases in `pkg/device/quota_test.go`:

1. two objects, different limits → effective = min, in **both add orders**
2. delete the looser object → strict limit stays enforced (the bug scenario)
3. delete the stricter object → limit rises to the remaining value
4. in-place update of one object's limit → effective follows; dropping a resource from the spec releases it
5. delete all objects → `LimitSet=false`, usage slot preserved
6. order-independence: same object set added in forward/reverse/rotated orders → identical final state
7. explicit `0` + large limit from another object → still blocked

All pass with `-short --race -count=1`. Existing tests (`TestUpdateQuotaKeepsLimitEnforced`, `TestDelQuotaNonLimitsKey`, `TestUpdateQuota`, …) pass unmodified.

## AI Assistance Disclosure

Per CONTRIBUTING.md: this PR was developed with AI coding assistance (Kscc / Claude Code); the design was proposed and reviewed by @lj361588364.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resource quota limits are now calculated as the most restrictive limit across all applicable quota objects.
  - Updating or removing a quota object correctly recalculates available capacity without affecting remaining quotas.
  - Quota results no longer depend on the order in which quota objects are processed.
  - Explicit zero limits are correctly enforced, preventing requests when any applicable quota blocks the resource.
  - Removing stale, unrelated, or emptied quota objects no longer leaves behind incorrect resource limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->