### PR TITLE
Change deviceListStrategy from 'envvar' to 'volume-mounts'

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -440,7 +440,7 @@ devicePlugin:
   migStrategy: "none"
   disablecorelimit: "false"
   passDeviceSpecsEnabled: true
-  deviceListStrategy: "envvar"
+  deviceListStrategy: "volume-mounts"
   nvidiaHookPath: null
   # Root of the NVIDIA driver on the host. Set to "auto" to read the driver
   # and device roots from GPU Operator's driver-ready contract. If the


### PR DESCRIPTION
**What type of PR is this?**

bug fixing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**: To resolve the error “bash: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory” when using Hami 

**Which issue(s) this PR fixes**:
Fixes # replacing value of deviceListStrategy from 'envvar' to 'volume-mounts'

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NVIDIA device discovery to use volume mounts, improving device visibility for supported workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->