### PR TITLE
Change default deviceListStrategy from envvar to volume-mounts

### DIFF
--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -440,7 +440,7 @@ devicePlugin:
   migStrategy: "none"
   disablecorelimit: "false"
   passDeviceSpecsEnabled: true
-  deviceListStrategy: "envvar"
+  deviceListStrategy: "volume-mounts"
   nvidiaHookPath: null
   # Root of the NVIDIA driver on the host. Set to "auto" to read the driver
   # and device roots from GPU Operator's driver-ready contract. If the


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
This PR changes the default value of `deviceListStrategy` from `envvar` to `volume-mounts`.

The `envvar` strategy passes the device list to the container via the `NVIDIA_VISIBLE_DEVICES` environment variable. In multi-tenant clusters, this environment variable can be overridden from inside an untrusted container image, allowing a workload to request access to GPUs it was not allocated. This has been raised as a concern in NVIDIA/k8s-device-plugin#1282, where `volume-mounts` is recommended specifically because it does not expose this override path and is required for secure GPU isolation in shared environments.

Since HAMi is commonly deployed in multi-tenant clusters where device isolation between workloads matters, defaulting to `volume-mounts` gives users a safer out-of-the-box configuration without requiring them to discover and manually override this setting.

**Which issue(s) this PR fixes**:
Related: NVIDIA/k8s-device-plugin#1282

**Special notes for your reviewer**:
- Users who rely on the current `envvar` default (for example, in combination with Dynamic MIG per Project-HAMi/HAMi#1903) can still explicitly set `deviceListStrategy: envvar` in their values.yaml — this PR only changes the default, not the available options.
- Happy to also update the chart README / docs/config.md if this direction is agreed on.

**Does this PR introduce a user-facing change?**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Changed the default NVIDIA device list strategy to use volume mounts instead of environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->