### PR TITLE
feat(scheduler): validate device resource names and defaults at startup

### DIFF
--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -19,11 +19,16 @@ package config
 import (
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
+	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
@@ -254,13 +259,18 @@ func InitDevicesWithConfig(config *Config) error {
 		return fmt.Errorf("errors occurred during initialization: %v", initErrors)
 	}
 
+	if err := validateRegisteredDevices(device.DevicesMap); err != nil {
+		return fmt.Errorf("invalid device configuration: %w", err)
+	}
+
 	klog.Info("All devices initialized successfully")
 	return nil
 }
 
-// validateConfig validates the configuration object to ensure it is complete.
-func validateConfig(config *Config) error {
-	if !reflect.DeepEqual(config.NvidiaConfig, nvidia.NvidiaConfig{}) ||
+// anyDeviceConfigured reports whether at least one backend has been given a
+// configuration block.
+func anyDeviceConfigured(config *Config) bool {
+	return !reflect.DeepEqual(config.NvidiaConfig, nvidia.NvidiaConfig{}) ||
 		!reflect.DeepEqual(config.CambriconConfig, cambricon.CambriconConfig{}) ||
 		!reflect.DeepEqual(config.HygonConfig, hygon.HygonConfig{}) ||
 		len(config.IluvatarConfig) > 0 ||
@@ -272,10 +282,85 @@ func validateConfig(config *Config) error {
 		!reflect.DeepEqual(config.AMDGPUConfig, amd.AMDConfig{}) ||
 		!reflect.DeepEqual(config.VastaiConfig, vastai.VastaiConfig{}) ||
 		!reflect.DeepEqual(config.BirenConfig, biren.BirenConfig{}) ||
-		len(config.VNPUs.Configs) > 0 {
-		return nil
+		len(config.VNPUs.Configs) > 0
+}
+
+// validateConfig validates the configuration object to ensure it is complete.
+//
+// It checks only the values that no backend can reinterpret later. Resource
+// names are deliberately left to validateRegisteredDevices, which reads them
+// back after each backend has applied its own defaults.
+func validateConfig(config *Config) error {
+	if !anyDeviceConfigured(config) {
+		return fmt.Errorf("all configurations are empty")
 	}
-	return fmt.Errorf("all configurations are empty")
+
+	var errs []error
+	// defaultCores is injected as a percentage of one GPU, so a value outside
+	// 0-100 can never be satisfied. Zero is valid and means "do not inject".
+	if config.NvidiaConfig.DefaultCores < 0 || config.NvidiaConfig.DefaultCores > 100 {
+		errs = append(errs, fmt.Errorf("nvidia: defaultCores is a percentage and must be between 0 and 100, got %d", config.NvidiaConfig.DefaultCores))
+	}
+	if config.NvidiaConfig.DefaultMemory < 0 {
+		errs = append(errs, fmt.Errorf("nvidia: defaultMemory must not be negative, got %d", config.NvidiaConfig.DefaultMemory))
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// validateRegisteredDevices checks the resource names the backends advertise
+// once initialization has applied each backend's own defaults.
+//
+// Reading the names back through GetResourceNames keeps this uniform across
+// backends whose configuration structs differ, covers the ones that register
+// more than one device from a single configuration block, and sees the value a
+// backend substituted for an empty field rather than the empty field itself.
+//
+// An empty name is not an error: it means the backend does not offer that
+// dimension, or has not been configured at all, and the default configuration
+// registers several backends in exactly that state.
+func validateRegisteredDevices(devices map[string]device.Devices) error {
+	var errs []error
+	owners := make(map[string]string, len(devices))
+
+	for _, commonWord := range slices.Sorted(maps.Keys(devices)) {
+		dev := devices[commonWord]
+		if dev == nil {
+			continue
+		}
+		names := dev.GetResourceNames()
+
+		for _, named := range []struct{ field, value string }{
+			{"resourceCountName", names.ResourceCountName},
+			{"resourceMemoryName", names.ResourceMemoryName},
+			{"resourceCoreName", names.ResourceCoreName},
+		} {
+			if named.value == "" {
+				continue
+			}
+			// A malformed name is reported rather than rejected: it cannot
+			// match a node resource, but it is the operator's name to choose
+			// and failing startup over it would be a breaking change.
+			if reasons := validation.IsQualifiedName(named.value); len(reasons) > 0 {
+				klog.ErrorS(nil, "Device resource name is not a valid Kubernetes qualified name and can never match a node resource",
+					"device", commonWord, "field", named.field, "value", named.value, "reason", strings.Join(reasons, "; "))
+			}
+		}
+
+		if names.MemoryFactor < 0 {
+			errs = append(errs, fmt.Errorf("%s: memoryFactor must not be negative, got %d", commonWord, names.MemoryFactor))
+		}
+
+		if names.ResourceCountName == "" {
+			continue
+		}
+		if previous, taken := owners[names.ResourceCountName]; taken {
+			errs = append(errs, fmt.Errorf("%s and %s both claim resource %q; a container requesting it would be allocated devices by both", previous, commonWord, names.ResourceCountName))
+			continue
+		}
+		owners[names.ResourceCountName] = commonWord
+	}
+
+	return utilerrors.NewAggregate(errs)
 }
 
 func InitDevices() {

--- a/pkg/scheduler/config/config_test.go
+++ b/pkg/scheduler/config/config_test.go
@@ -514,26 +514,193 @@ func Test_validateConfig(t *testing.T) {
 		BirenConfig: biren.BirenConfig{ResourceCountName: "birentech.com/gpu"},
 	}
 
+	coresTooHigh := &Config{
+		NvidiaConfig: nvidia.NvidiaConfig{ResourceCountName: "nvidia.com/gpu", DefaultCores: 101},
+	}
+	coresNegative := &Config{
+		NvidiaConfig: nvidia.NvidiaConfig{ResourceCountName: "nvidia.com/gpu", DefaultCores: -1},
+	}
+	memoryNegative := &Config{
+		NvidiaConfig: nvidia.NvidiaConfig{ResourceCountName: "nvidia.com/gpu", DefaultMemory: -1},
+	}
+	// DefaultGPUNum is zero whenever the key is omitted, and nvidia reads it as
+	// "do not inject a default", so it must stay acceptable.
+	noDefaultGPUNum := &Config{
+		NvidiaConfig: nvidia.NvidiaConfig{ResourceCountName: "nvidia.com/gpu", DefaultGPUNum: 0},
+	}
+
 	tests := []struct {
-		name        string
-		config      *Config
-		expectError bool
+		name    string
+		config  *Config
+		wantErr string
 	}{
-		{"Valid config", validConfig, false},
-		{"Empty config", emptyConfig, true},
-		{"Vastai only", vastaiOnly, false},
-		{"Biren only", birenOnly, false},
+		{"Valid config", validConfig, ""},
+		{"Empty config", emptyConfig, "all configurations are empty"},
+		{"Vastai only", vastaiOnly, ""},
+		{"Biren only", birenOnly, ""},
+		{"DefaultCores above 100", coresTooHigh, "defaultCores is a percentage"},
+		{"DefaultCores negative", coresNegative, "defaultCores is a percentage"},
+		{"DefaultMemory negative", memoryNegative, "defaultMemory must not be negative"},
+		{"DefaultGPUNum zero is accepted", noDefaultGPUNum, ""},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateConfig(test.config)
-			if test.expectError {
-				assert.ErrorContains(t, err, "all configurations are empty")
-			} else {
+			if test.wantErr == "" {
 				assert.NilError(t, err)
+				return
 			}
+			assert.ErrorContains(t, err, test.wantErr)
 		})
+	}
+}
+
+func Test_validateConfig_ReportsEveryViolation(t *testing.T) {
+	err := validateConfig(&Config{
+		NvidiaConfig: nvidia.NvidiaConfig{
+			ResourceCountName: "nvidia.com/gpu",
+			DefaultCores:      101,
+			DefaultMemory:     -1,
+		},
+	})
+	assert.ErrorContains(t, err, "defaultCores is a percentage")
+	assert.ErrorContains(t, err, "defaultMemory must not be negative")
+}
+
+// stubDevices is a device.Devices whose only meaningful behaviour is the
+// resource names it advertises, which is all validateRegisteredDevices reads.
+// Real backends set package-level globals in their constructors, which would
+// leak between tests.
+type stubDevices struct {
+	names device.ResourceNames
+}
+
+func (s stubDevices) GetResourceNames() device.ResourceNames { return s.names }
+func (s stubDevices) CommonWord() string                     { return "stub" }
+func (s stubDevices) NodeCleanUp(nn string) error            { return nil }
+
+func (s stubDevices) MutateAdmission(ctr *corev1.Container, pod *corev1.Pod) (bool, error) {
+	return false, nil
+}
+func (s stubDevices) CheckHealth(devType string, n *corev1.Node) (bool, bool) { return true, true }
+func (s stubDevices) GetNodeDevices(n corev1.Node) ([]*device.DeviceInfo, error) {
+	return nil, nil
+}
+func (s stubDevices) LockNode(n *corev1.Node, p *corev1.Pod) error        { return nil }
+func (s stubDevices) ReleaseNodeLock(n *corev1.Node, p *corev1.Pod) error { return nil }
+func (s stubDevices) GenerateResourceRequests(ctr *corev1.Container) device.ContainerDeviceRequest {
+	return device.ContainerDeviceRequest{}
+}
+
+func (s stubDevices) PatchAnnotations(pod *corev1.Pod, annoinput *map[string]string, pd device.PodDevices) map[string]string {
+	return *annoinput
+}
+
+func (s stubDevices) ScoreNode(node *corev1.Node, podDevices device.PodSingleDevice, previous []*device.DeviceUsage, policy string) float32 {
+	return 0
+}
+
+func (s stubDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceUsage, ctr *device.ContainerDevice) error {
+	return nil
+}
+
+func (s stubDevices) Fit(devices []*device.DeviceUsage, request device.ContainerDeviceRequest, pod *corev1.Pod, nodeInfo *device.NodeInfo, allocated *device.PodDevices) (bool, map[string]device.ContainerDevices, string) {
+	return false, nil, ""
+}
+
+func Test_validateRegisteredDevices(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices map[string]device.Devices
+		wantErr string
+	}{
+		{
+			name:    "no devices registered",
+			devices: map[string]device.Devices{},
+		},
+		{
+			name: "distinct resource names",
+			devices: map[string]device.Devices{
+				"A": stubDevices{names: device.ResourceNames{ResourceCountName: "a.com/gpu"}},
+				"B": stubDevices{names: device.ResourceNames{ResourceCountName: "b.com/gpu"}},
+			},
+		},
+		{
+			name: "two backends claiming one resource",
+			devices: map[string]device.Devices{
+				"A": stubDevices{names: device.ResourceNames{ResourceCountName: "shared.com/gpu"}},
+				"B": stubDevices{names: device.ResourceNames{ResourceCountName: "shared.com/gpu"}},
+			},
+			wantErr: `A and B both claim resource "shared.com/gpu"`,
+		},
+		{
+			// Unconfigured backends advertise no count name. The default
+			// configuration registers several of them, so this must not be
+			// mistaken for a collision.
+			name: "unconfigured backends are not a collision",
+			devices: map[string]device.Devices{
+				"A": stubDevices{names: device.ResourceNames{}},
+				"B": stubDevices{names: device.ResourceNames{}},
+			},
+		},
+		{
+			name: "negative memory factor",
+			devices: map[string]device.Devices{
+				"A": stubDevices{names: device.ResourceNames{ResourceCountName: "a.com/gpu", MemoryFactor: -1}},
+			},
+			wantErr: "memoryFactor must not be negative",
+		},
+		{
+			// A malformed name cannot match a node resource, but it is the
+			// operator's to choose, so it is logged and not rejected.
+			name: "malformed resource name is reported, not rejected",
+			devices: map[string]device.Devices{
+				"A": stubDevices{names: device.ResourceNames{ResourceCountName: "not a valid name"}},
+			},
+		},
+		{
+			name: "nil backend is skipped",
+			devices: map[string]device.Devices{
+				"A": nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateRegisteredDevices(test.devices)
+			if test.wantErr == "" {
+				assert.NilError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// Test_InitDevicesWithConfig_RejectsDuplicateResourceName covers the wiring:
+// the collision is only caught if InitDevicesWithConfig calls the check after
+// the backends have registered.
+func Test_InitDevicesWithConfig_RejectsDuplicateResourceName(t *testing.T) {
+	err := InitDevicesWithConfig(&Config{
+		AMDGPUConfig: amd.AMDConfig{ResourceCountName: "shared.com/gpu"},
+		BirenConfig:  biren.BirenConfig{ResourceCountName: "shared.com/gpu"},
+	})
+	assert.ErrorContains(t, err, "invalid device configuration")
+	assert.ErrorContains(t, err, `both claim resource "shared.com/gpu"`)
+}
+
+func Test_validateRegisteredDevices_CollisionMessageIsStable(t *testing.T) {
+	// Map iteration is random, so the pair is sorted before reporting to keep
+	// the message reproducible across runs.
+	devices := map[string]device.Devices{
+		"Zebra": stubDevices{names: device.ResourceNames{ResourceCountName: "shared.com/gpu"}},
+		"Alpha": stubDevices{names: device.ResourceNames{ResourceCountName: "shared.com/gpu"}},
+	}
+	for range 20 {
+		err := validateRegisteredDevices(devices)
+		assert.ErrorContains(t, err, `Alpha and Zebra both claim resource "shared.com/gpu"`)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**

Previously, `validateConfig` only checked whether at least one backend configuration existed. It did not validate the actual values inside those configurations.

This PR adds validation for configuration values that can cause the scheduler to behave incorrectly.

The scheduler now **rejects the configuration at startup** when:

* Two device backends use the same `ResourceCountName`. This can cause multiple backends to handle the same container resource.
* `MemoryFactor` is negative.
* `nvidia.defaultCores` is outside the `0-100` range.
* `nvidia.defaultMemory` is negative.

The scheduler also **logs an error but continues starting** when a configured resource name is not a valid Kubernetes qualified name. This is reported because the name cannot match a Kubernetes resource, but the operator should still be able to choose the resource name.

**Which issue(s) does this PR fix?**

Fixes #3009

**Special notes for the reviewer**

While implementing the validation, I checked each proposed rule against the existing code. Two rules from the original issue turned out to be incorrect, so they are not included in this PR:

1. **`ResourceCountName` cannot always be required.**

   Some backends are registered even when they are not configured. In that case, an empty `ResourceCountName` means the backend is simply inactive.

   For example, the default configuration leaves Biren, Enflame GCU, Metax-SGPU, and Vastai unconfigured. Requiring a non-empty value would break the default installation.

2. **`DefaultGPUNum` does not need to be greater than `0`.**

   For NVIDIA, `0` is intentionally used to mean that no default GPU count should be added.

   The code already checks:

   ```go
   if dev.config.DefaultGPUNum > 0
   ```

   So changing this to require a value greater than `0` would change the existing behavior.

I also checked #2889. It was not caused by an empty resource name simply failing to match a request. The issue was that Ascend could create a `Limits[""]` entry. Its fix explicitly skips the empty resource name, which is another indication that an empty resource name can be valid for an inactive or specific device configuration.

**How the validation works**

The backend configurations are different from each other, so there is no single common configuration structure that can validate everything.

Instead, resource names are checked **after the devices are initialized** using the existing `GetResourceNames()` method from the `device.Devices` interface.

This has two benefits:

* It validates the final values after backend-specific defaults have been applied.
* It works consistently across all backends, including backends that can register multiple devices from one configuration.

The NVIDIA-specific numeric checks remain in `validateConfig`, because those values are only available in the NVIDIA configuration.

`anyDeviceConfigured` is simply the existing configuration check extracted into a variable so that validation can continue after determining that at least one backend is configured. Its behavior is unchanged.

**Does this PR introduce a user-facing change?**

```release-note
The scheduler now rejects invalid device configuration when resource count names are duplicated, or when nvidia defaultCores, nvidia defaultMemory, or a backend memoryFactor is out of range. Invalid Kubernetes resource names are logged as errors but do not prevent startup.
```

**AI assistance disclosure**

I used an AI assistant to verify the implementation and test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and initializing Remote GPU devices.
  - Added configuration options for device extender binding and device plugin settings.

- **Bug Fixes**
  - Configuration validation now rejects empty configurations, invalid NVIDIA defaults, negative memory settings, and out-of-range core values.
  - Reports all detected configuration violations together for easier troubleshooting.
  - Detects conflicting device resource names, invalid memory factors, malformed resource names, and missing device backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->