### PR TITLE
feat(nvidia): allow a pod to prefer a MIG profile over 3g via annotation.

### DIFF
--- a/charts/hami/templates/scheduler/device-configmap.yaml
+++ b/charts/hami/templates/scheduler/device-configmap.yaml
@@ -36,19 +36,19 @@ data:
       - models: [ "A30" ]
         profiles: [ "1g.6gb", "2g.12gb", "4g.24gb" ]
       - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB"]
-        profiles: [ "1g.5gb", "2g.10gb", "3g.20gb", "7g.40gb" ]
+        profiles: [ "1g.5gb", "2g.10gb", "3g.20gb", "4g.20gb", "7g.40gb" ]
       - models: [ "A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"]
-        profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "7g.79gb" ]
+        profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "4g.40gb", "7g.79gb" ]
       - models: [ "H100-PCIE-80GB", "H100-SXM5-80GB"]
-        profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "7g.80gb" ]
+        profiles: [ "1g.10gb", "2g.20gb", "3g.40gb", "4g.40gb", "7g.80gb" ]
       - models: [ "H100-PCIE-94GB", "H100-SXM5-94GB"]
-        profiles: [ "1g.12gb", "2g.24gb", "3g.47gb", "7g.94gb" ]
+        profiles: [ "1g.12gb", "2g.24gb", "3g.47gb", "4g.47gb", "7g.94gb" ]
       - models: [ "H20", "H100 on GH200"]
-        profiles: [ "1g.12gb", "2g.24gb", "3g.48gb", "7g.96gb" ]
+        profiles: [ "1g.12gb", "2g.24gb", "3g.48gb", "4g.48gb", "7g.96gb" ]
       - models: [ "H200 NVL", "H200-SXM5"]
-        profiles: [ "1g.18gb", "2g.35gb", "3g.71gb", "7g.141gb" ]
+        profiles: [ "1g.18gb", "2g.35gb", "3g.71gb", "4g.71gb", "7g.141gb" ]
       - models: [ "B200" ]
-        profiles: [ "1g.23gb", "2g.45gb", "3g.90gb", "7g.180gb" ]
+        profiles: [ "1g.23gb", "2g.45gb", "3g.90gb", "4g.90gb", "7g.180gb" ]
       - models: [ "RTX PRO 6000 Blackwell Server Edition" ]
         profiles: [ "1g.24gb", "2g.48gb", "4g.96gb" ]
     cambricon:
@@ -273,3 +273,4 @@ data:
             aiCore: 10
             aiCPU: 3
   {{ end }}
+  

--- a/docs/develop/dynamic-mig-migration.md
+++ b/docs/develop/dynamic-mig-migration.md
@@ -238,6 +238,37 @@ spec:
 
 This example validates resource allocation and device injection only. A production canary should use a trusted image with CUDA or NVML tools and run an actual GPU workload.
 
+### Preferring a MIG profile
+
+Profile selection is memory-only: the scheduler picks the smallest allowlisted profile whose memory covers the request. Because MIG couples memory and compute, two profiles can cover the same request with different compute shares; on an A100-40GB a 20 GB request always resolves to `3g.20gb` even when `4g.20gb` is allowed. A Pod that wants the extra compute can set the `nvidia.com/mig-profile-preference` annotation to an ordered, comma-separated list of profiles:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mig-prefer-4g
+  annotations:
+    nvidia.com/vgpu-mode: "mig"
+    nvidia.com/mig-profile-preference: "4g"
+spec:
+  containers:
+    - name: workload
+      image: ubuntu:22.04
+      command: ["bash", "-c", "sleep 3600"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+          nvidia.com/gpumem: 20000
+```
+
+An entry either names a profile exactly (`4g.20gb`) or names a slice class (`4g`), which matches that class on every GPU model, so one value covers A100 and H100 nodes. Preferred profiles are tried first, in the listed order, before the default smallest-first order. The preference is a bias, not a requirement:
+
+- it never selects a profile smaller than the memory request;
+- it only applies to profiles in the GPU's `migProfileAllowlist`; an entry that matches nothing on a GPU is ignored there;
+- if the preferred profile has no free placement, or the preferred layout does not fit the container's slices on that GPU, the scheduler falls back to the default order rather than rejecting the GPU.
+
+The admission webhook rejects a value that matches no profile in any `migProfileAllowlist` entry, so typos are reported when the Pod is created.
+
 ### Reclamation and recovery
 
 - Deleting the canary Pod releases its CI/GI without affecting instances owned by other Pods.
@@ -291,7 +322,7 @@ The legacy index describes a logical position in a scheduler template. Across GP
 
 ### Must users change their workload YAML?
 
-Usually not. Users continue to request `nvidia.com/gpu` and `nvidia.com/gpumem` and select `nvidia.com/vgpu-mode: "mig"`. The scheduler and device plugin manage `hami.io/vgpu-mig-allocations`; it is not a user-facing API.
+Usually not. Users continue to request `nvidia.com/gpu` and `nvidia.com/gpumem` and select `nvidia.com/vgpu-mode: "mig"`. Pods that want a specific profile among those covering their request can add `nvidia.com/mig-profile-preference`, see [Preferring a MIG profile](#preferring-a-mig-profile). The scheduler and device plugin manage `hami.io/vgpu-mig-allocations`; it is not a user-facing API.
 
 ## Conclusion
 

--- a/docs/develop/mig-dynamic-deallocate.md
+++ b/docs/develop/mig-dynamic-deallocate.md
@@ -127,7 +127,7 @@ The device plugin discovers the allowlisted profile set through NVML and publish
 
 ### Scheduling and reservation
 
-The scheduler rebuilds occupancy from active Pod reservations. Each placement occupies the interval `[start, start + size)`. Profile selection follows workload capacity, and placement selection follows deterministic packing. Capacity pressure keeps the workload in the Kubernetes Pending phase.
+The scheduler rebuilds occupancy from active Pod reservations. Each placement occupies the interval `[start, start + size)`. Profile selection follows workload capacity, smallest covering profile first unless the Pod biases the order with the `nvidia.com/mig-profile-preference` annotation, and placement selection follows deterministic packing. Capacity pressure keeps the workload in the Kubernetes Pending phase.
 
 ### Runtime realization
 

--- a/examples/nvidia/dynamic_mig_profile_preference.yaml
+++ b/examples/nvidia/dynamic_mig_profile_preference.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod-prefer-4g
+  annotations:
+    nvidia.com/vgpu-mode: "mig"
+    nvidia.com/mig-profile-preference: "4g"
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:18.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+          nvidia.com/gpumem: 20000

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -639,6 +639,18 @@ func queuedMigMemories(toAllocate device.ContainerDevices, uuid string) []int32 
 	return memories
 }
 
+// plannedMigProfile returns the profile a new slice of memory MB gets on dev when planned
+// together with the slices this container has already queued on it.
+func plannedMigProfile(dev *device.DeviceUsage, queued device.ContainerDevices, memory int32, preferred []string) (device.MigProfile, bool) {
+	memories := queuedMigMemories(queued, dev.ID)
+	memories = append(memories, memory)
+	profiles, _, ok := planMigContainer(dev.MigProfiles, occupiedMigPlacements(dev.MigAllocationsInUse), memories, preferred)
+	if !ok {
+		return device.MigProfile{}, false
+	}
+	return profiles[len(profiles)-1], true
+}
+
 // migProfilesByMemory returns the profiles ordered smallest first.
 func migProfilesByMemory(profiles []device.MigProfile) []device.MigProfile {
 	candidates := append([]device.MigProfile(nil), profiles...)
@@ -944,7 +956,19 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 			//This incurs an issue
 			memreq = dev.Totalmem * k.MemPercentagereq / 100
 		}
-		if !fitQuota(pod, tmpDevs, allocated, pod.Namespace, dev.ID, int64(memreq), int64(k.Coresreq)) {
+		// A MIG slice is booked and charged its profile's capacity, not the raw request, so resolve
+		// the profile before the quota check and keep it on the tentative slice.
+		usedmem, usedcores := memreq, k.Coresreq
+		if dev.Mode == MigMode {
+			profile, ok := plannedMigProfile(dev, tmpDevs[k.Type], memreq, preferred)
+			if !ok {
+				reason[common.CardMigTopologyInfeasible]++
+				klog.V(5).InfoS(common.CardMigTopologyInfeasible, "pod", klog.KObj(pod), "device", dev.ID, "device index", i, "allocations", dev.MigAllocationsInUse)
+				continue
+			}
+			usedmem, usedcores = profile.MemoryMB, profile.Core
+		}
+		if !fitQuota(pod, tmpDevs, allocated, pod.Namespace, dev.ID, int64(usedmem), int64(usedcores)) {
 			reason[common.ResourceQuotaNotFit]++
 			klog.V(3).InfoS(common.ResourceQuotaNotFit, "pod", pod.Name, "memreq", memreq, "coresreq", k.Coresreq)
 			continue
@@ -998,8 +1022,8 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 				Idx:       int(dev.Index),
 				UUID:      dev.ID,
 				Type:      k.Type,
-				Usedmem:   memreq,
-				Usedcores: k.Coresreq,
+				Usedmem:   usedmem,
+				Usedcores: usedcores,
 			})
 		}
 		if k.Nums == 0 && !needTopology {

--- a/pkg/device/nvidia/device.go
+++ b/pkg/device/nvidia/device.go
@@ -339,6 +339,9 @@ func (dev *NvidiaGPUDevices) MutateAdmission(ctr *corev1.Container, p *corev1.Po
 	if err := dev.validateCores(ctr); err != nil {
 		return false, err
 	}
+	if err := dev.validateMigProfilePreference(p); err != nil {
+		return false, err
+	}
 	priority, ok := ctr.Resources.Limits[corev1.ResourceName(dev.config.ResourcePriority)]
 	if ok {
 		ctr.Env = append(ctr.Env, corev1.EnvVar{
@@ -613,27 +616,13 @@ func (dev *NvidiaGPUDevices) GenerateResourceRequests(ctr *corev1.Container) dev
 	return device.ContainerDeviceRequest{}
 }
 
-func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *device.PodDevices, request device.ContainerDeviceRequest, toAllocate device.ContainerDevices, devusage *device.DeviceUsage) bool {
+func (dev *NvidiaGPUDevices) CustomFilterRule(allocated *device.PodDevices, request device.ContainerDeviceRequest, toAllocate device.ContainerDevices, devusage *device.DeviceUsage, preferred []string) bool {
 	if devusage.Mode == MigMode {
 		occupied := occupiedMigPlacements(devusage.MigAllocationsInUse)
 		// Plan every slice of this container on this card together; reject only when no layout exists.
 		memories := queuedMigMemories(toAllocate, devusage.ID)
 		memories = append(memories, request.Memreq)
-		if _, _, ok := planMigAllocations(devusage.MigProfiles, occupied, memories); ok {
-			return true
-		}
-		// Fall back to the sequential path, which may upgrade a request to a larger profile.
-		for _, existing := range toAllocate {
-			if existing.UUID != devusage.ID {
-				continue
-			}
-			_, placement, ok := selectMigCandidate(devusage.MigProfiles, occupied, existing.Usedmem)
-			if !ok {
-				return false
-			}
-			occupied = append(occupied, placement)
-		}
-		_, _, ok := selectMigCandidate(devusage.MigProfiles, occupied, request.Memreq)
+		_, _, ok := planMigContainer(devusage.MigProfiles, occupied, memories, preferred)
 		return ok
 	}
 	return true
@@ -663,8 +652,8 @@ func migProfilesByMemory(profiles []device.MigProfile) []device.MigProfile {
 }
 
 // migProfileForMemory returns the smallest profile whose memory covers the request.
-func migProfileForMemory(profiles []device.MigProfile, memory int32) (device.MigProfile, bool) {
-	for _, profile := range migProfilesByMemory(profiles) {
+func migProfileForMemory(profiles []device.MigProfile, memory int32, preferred []string) (device.MigProfile, bool) {
+	for _, profile := range migProfileCandidates(profiles, preferred) {
 		if profile.MemoryMB >= memory {
 			return profile, true
 		}
@@ -673,8 +662,8 @@ func migProfileForMemory(profiles []device.MigProfile, memory int32) (device.Mig
 }
 
 // selectMigCandidate picks the smallest covering profile that still has a free placement, and its best placement.
-func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlacement, memory int32) (device.MigProfile, device.MigPlacement, bool) {
-	for _, profile := range migProfilesByMemory(profiles) {
+func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlacement, memory int32, preferred []string) (device.MigProfile, device.MigPlacement, bool) {
+	for _, profile := range migProfileCandidates(profiles, preferred) {
 		if profile.MemoryMB < memory {
 			continue
 		}
@@ -688,11 +677,11 @@ func selectMigCandidate(profiles []device.MigProfile, occupied []device.MigPlace
 
 // planMigAllocations maps each request to its smallest covering profile and places them all jointly.
 // The returned slices are aligned with memories.
-func planMigAllocations(profiles []device.MigProfile, occupied []device.MigPlacement, memories []int32) ([]device.MigProfile, []device.MigPlacement, bool) {
+func planMigAllocations(profiles []device.MigProfile, occupied []device.MigPlacement, memories []int32, preferred []string) ([]device.MigProfile, []device.MigPlacement, bool) {
 	chosen := make([]device.MigProfile, len(memories))
 	requested := make([]string, len(memories))
 	for i, memory := range memories {
-		profile, ok := migProfileForMemory(profiles, memory)
+		profile, ok := migProfileForMemory(profiles, memory, preferred)
 		if !ok {
 			return nil, nil, false
 		}
@@ -706,9 +695,41 @@ func planMigAllocations(profiles []device.MigProfile, occupied []device.MigPlace
 	return chosen, placements, true
 }
 
+func planMigSequentially(profiles []device.MigProfile, occupied []device.MigPlacement, memories []int32, preferred []string) ([]device.MigProfile, []device.MigPlacement, bool) {
+	occupied = slices.Clone(occupied)
+	chosen := make([]device.MigProfile, len(memories))
+	placements := make([]device.MigPlacement, len(memories))
+	for i, memory := range memories {
+		profile, placement, ok := selectMigCandidate(profiles, occupied, memory, preferred)
+		if !ok {
+			return nil, nil, false
+		}
+		chosen[i], placements[i] = profile, placement
+		occupied = append(occupied, placement)
+	}
+	return chosen, placements, true
+}
+
+func planMigContainer(profiles []device.MigProfile, occupied []device.MigPlacement, memories []int32, preferred []string) ([]device.MigProfile, []device.MigPlacement, bool) {
+	orders := [][]string{nil}
+	if len(preferred) > 0 {
+		orders = [][]string{preferred, nil}
+	}
+	for _, order := range orders {
+		if chosen, placements, ok := planMigAllocations(profiles, occupied, memories, order); ok {
+			return chosen, placements, true
+		}
+		// Fall back to the sequential path, which may upgrade a request to a larger profile.
+		if chosen, placements, ok := planMigSequentially(profiles, occupied, memories, order); ok {
+			return chosen, placements, true
+		}
+	}
+	return nil, nil, false
+}
+
 // recordMigPlans stores the jointly planned profile and placement on each tentative slice so AddResourceUsage commits that layout.
 // Slices on a card with no joint plan have any stale plan removed.
-func recordMigPlans(devices []*device.DeviceUsage, tentative device.ContainerDevices) {
+func recordMigPlans(devices []*device.DeviceUsage, tentative device.ContainerDevices, preferred []string) {
 	usageByID := make(map[string]*device.DeviceUsage, len(devices))
 	for _, dev := range devices {
 		if dev.Mode == MigMode {
@@ -733,7 +754,7 @@ func recordMigPlans(devices []*device.DeviceUsage, tentative device.ContainerDev
 		for i, idx := range indices {
 			memories[i] = tentative[idx].Usedmem
 		}
-		profiles, placements, ok := planMigAllocations(usage.MigProfiles, occupiedMigPlacements(usage.MigAllocationsInUse), memories)
+		profiles, placements, ok := planMigContainer(usage.MigProfiles, occupiedMigPlacements(usage.MigAllocationsInUse), memories, preferred)
 		for i, idx := range indices {
 			ctr := &tentative[idx]
 			if !ok {
@@ -781,7 +802,7 @@ func (dev *NvidiaGPUDevices) AddResourceUsage(pod *corev1.Pod, n *device.DeviceU
 		occupied := occupiedMigPlacements(n.MigAllocationsInUse)
 		profile, placement, ok := plannedMigAllocation(n.MigProfiles, occupied, ctr)
 		if !ok {
-			profile, placement, ok = selectMigCandidate(n.MigProfiles, occupied, ctr.Usedmem)
+			profile, placement, ok = selectMigCandidate(n.MigProfiles, occupied, ctr.Usedmem, podMigProfilePreference(pod))
 		}
 		if !ok {
 			return errors.New("MIG profile and placement allocation failed")
@@ -862,6 +883,10 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 	needTopology := util.PolicyContains(gpuPolicy, util.GPUSchedulerPolicyTopology)
 	isMutex := util.PolicyContains(gpuPolicy, util.GPUSchedulerPolicyMutex)
 	cordoned := cordonedDevices(nodeInfo)
+	preferred := migProfilePreference(pod.GetAnnotations())
+	if len(preferred) > 0 {
+		klog.V(4).InfoS("MIG profile preference", "pod", klog.KObj(pod), "preferred", preferred)
+	}
 	for i := len(devices) - 1; i >= 0; i-- {
 		dev := devices[i]
 		klog.V(4).InfoS("scoring pod", "pod", klog.KObj(pod), "device", dev.ID, "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i)
@@ -949,7 +974,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 		// CustomFilterRule must see the resolved memory request, not the raw (possibly zero) Memreq field.
 		resolvedReq := request
 		resolvedReq.Memreq = memreq
-		if !nv.CustomFilterRule(allocated, resolvedReq, tmpDevs[k.Type], dev) {
+		if !nv.CustomFilterRule(allocated, resolvedReq, tmpDevs[k.Type], dev, preferred) {
 			// In MIG mode, CustomFilterRule rejects when the requested memory
 			// does not fit an allowed profile with a free placement on this
 			// device. Surface this as a distinct reason so users can tell
@@ -979,7 +1004,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 		}
 		if k.Nums == 0 && !needTopology {
 			klog.V(4).InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
-			recordMigPlans(devices, tmpDevs[k.Type])
+			recordMigPlans(devices, tmpDevs[k.Type], preferred)
 			return true, tmpDevs, ""
 		}
 		if dev.Mode == "mig" {
@@ -989,7 +1014,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 	if needTopology {
 		if len(tmpDevs[k.Type]) == int(originReq) {
 			klog.V(5).InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
-			recordMigPlans(devices, tmpDevs[k.Type])
+			recordMigPlans(devices, tmpDevs[k.Type], preferred)
 			return true, tmpDevs, ""
 		}
 		if len(tmpDevs[k.Type]) > int(originReq) {
@@ -1011,7 +1036,7 @@ func (nv *NvidiaGPUDevices) Fit(devices []*device.DeviceUsage, request device.Co
 				tmpDevs[k.Type] = combination
 				klog.V(5).InfoS("device allocate success", "pod", klog.KObj(pod), "best device combination", tmpDevs)
 			}
-			recordMigPlans(devices, tmpDevs[k.Type])
+			recordMigPlans(devices, tmpDevs[k.Type], preferred)
 			return true, tmpDevs, ""
 		}
 	}

--- a/pkg/device/nvidia/device_test.go
+++ b/pkg/device/nvidia/device_test.go
@@ -2402,7 +2402,7 @@ func TestComputeBestCombination(t *testing.T) {
 func TestCustomFilterRule_NonMig(t *testing.T) {
 	dev := InitNvidiaDevice(NvidiaConfig{})
 	devusage := &device.DeviceUsage{Mode: ""}
-	result := dev.CustomFilterRule(nil, device.ContainerDeviceRequest{}, nil, devusage)
+	result := dev.CustomFilterRule(nil, device.ContainerDeviceRequest{}, nil, devusage, nil)
 	assert.Equal(t, result, true)
 }
 

--- a/pkg/device/nvidia/mig_capability_test.go
+++ b/pkg/device/nvidia/mig_capability_test.go
@@ -60,10 +60,10 @@ func TestCustomFilterUsesReportedPlacementCapacity(t *testing.T) {
 			{Profile: "2g.10gb", Placement: device.MigPlacement{Start: 4, Size: 2}},
 		},
 	}
-	if dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 10000}, nil, usage) {
+	if dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 10000}, nil, usage, nil) {
 		t.Fatal("fourth 2g request should not fit reported placements")
 	}
-	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, nil, usage) {
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, nil, usage, nil) {
 		t.Fatal("1g request should fit the remaining placement")
 	}
 }
@@ -79,11 +79,11 @@ func TestCustomFilterIgnoresQueuedAllocationsForOtherGPUs(t *testing.T) {
 		},
 	}
 	queued := device.ContainerDevices{{UUID: "GPU-b", Usedmem: 5000}}
-	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, queued, usage) {
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, queued, usage, nil) {
 		t.Fatal("allocation queued on another GPU consumed this GPU's remaining placement")
 	}
 	queued[0].UUID = "GPU-a"
-	if dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, queued, usage) {
+	if dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 5000}, queued, usage, nil) {
 		t.Fatal("two allocations on this GPU should not fit its single remaining placement")
 	}
 }
@@ -118,12 +118,12 @@ func TestCustomFilterPlansSlicesOfOneContainerJointly(t *testing.T) {
 	// The 5GB slice is queued first; placed sequentially it would take the
 	// 3g's last legal span. Planned jointly, the 3g goes first.
 	queued := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000}}
-	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, usage) {
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, usage, nil) {
 		t.Fatal("5GB + 20GB should fit next to a running 1g at slot 6 when planned together")
 	}
 	empty := &device.DeviceUsage{ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfiles()}
 	queued = device.ContainerDevices{{UUID: "GPU-a", Usedmem: 10000}, {UUID: "GPU-a", Usedmem: 10000}}
-	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, empty) {
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, queued, empty, nil) {
 		t.Fatal("10GB + 10GB + 20GB should fill an empty A100")
 	}
 }
@@ -135,7 +135,7 @@ func TestAddResourceUsageCommitsRecordedPlan(t *testing.T) {
 		MigAllocationsInUse: []device.MigAllocation{{Profile: "1g.5gb", Placement: device.MigPlacement{Start: 6, Size: 1}}},
 	}
 	tentative := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000}, {UUID: "GPU-a", Usedmem: 20000}}
-	recordMigPlans([]*device.DeviceUsage{usage}, tentative)
+	recordMigPlans([]*device.DeviceUsage{usage}, tentative, nil)
 	for i := range tentative {
 		if err := dev.AddResourceUsage(nil, usage, &tentative[i]); err != nil {
 			t.Fatalf("commit slice %d: %v", i, err)
@@ -179,7 +179,7 @@ func TestRecordMigPlansClearsStalePlanWhenInfeasible(t *testing.T) {
 		},
 	}
 	tentative := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 5000, CustomInfo: map[string]any{MigProfileCustomInfo: "1g.5gb"}}}
-	recordMigPlans([]*device.DeviceUsage{usage}, tentative)
+	recordMigPlans([]*device.DeviceUsage{usage}, tentative, nil)
 	if _, ok := tentative[0].CustomInfo[MigProfileCustomInfo]; ok {
 		t.Fatal("stale plan key should have been removed")
 	}

--- a/pkg/device/nvidia/mig_preference.go
+++ b/pkg/device/nvidia/mig_preference.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+const MigProfilePreference = "nvidia.com/mig-profile-preference"
+
+func migProfileSliceKey(profile string) string {
+	if idx := strings.Index(profile, "."); idx > 0 {
+		return profile[:idx]
+	}
+	return profile
+}
+
+func migProfileMatchesPreference(profile, entry string) bool {
+	return profile == entry || migProfileSliceKey(profile) == entry
+}
+
+// parseMigProfilePreference splits the annotation value into trimmed,
+// non-empty, de-duplicated entries in the order they were listed.
+func parseMigProfilePreference(raw string) []string {
+	var preferred []string
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || slices.Contains(preferred, entry) {
+			continue
+		}
+		preferred = append(preferred, entry)
+	}
+	return preferred
+}
+
+func migProfilePreference(annos map[string]string) []string {
+	raw, ok := annos[MigProfilePreference]
+	if !ok {
+		return nil
+	}
+	return parseMigProfilePreference(raw)
+}
+
+func podMigProfilePreference(pod *corev1.Pod) []string {
+	if pod == nil {
+		return nil
+	}
+	return migProfilePreference(pod.GetAnnotations())
+}
+
+func migProfileCandidates(profiles []device.MigProfile, preferred []string) []device.MigProfile {
+	ordered := migProfilesByMemory(profiles)
+	if len(preferred) == 0 {
+		return ordered
+	}
+	candidates := make([]device.MigProfile, 0, len(ordered))
+	taken := make([]bool, len(ordered))
+	for _, entry := range preferred {
+		for i, profile := range ordered {
+			if !taken[i] && migProfileMatchesPreference(profile.Name, entry) {
+				candidates = append(candidates, profile)
+				taken[i] = true
+			}
+		}
+	}
+	for i, profile := range ordered {
+		if !taken[i] {
+			candidates = append(candidates, profile)
+		}
+	}
+	return candidates
+}
+
+// migProfileAllowlisted reports whether entry matches a profile in any allowlist entry.
+func migProfileAllowlisted(allowlist []device.AllowedMigProfiles, entry string) bool {
+	for _, cfg := range allowlist {
+		for _, profile := range cfg.Profiles {
+			if migProfileMatchesPreference(profile, entry) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validateMigProfilePreference rejects a preference that no allowlisted profile can satisfy.
+func (dev *NvidiaGPUDevices) validateMigProfilePreference(pod *corev1.Pod) error {
+	if pod == nil {
+		return nil
+	}
+	raw, ok := pod.GetAnnotations()[MigProfilePreference]
+	if !ok {
+		return nil
+	}
+	preferred := parseMigProfilePreference(raw)
+	if len(preferred) == 0 {
+		return fmt.Errorf("invalid %s value %q: expected a comma-separated list of MIG profiles such as \"4g.20gb\" or \"4g\"", MigProfilePreference, raw)
+	}
+	for _, entry := range preferred {
+		if !migProfileAllowlisted(dev.config.MigProfileAllowlist, entry) {
+			return fmt.Errorf("invalid %s entry %q: it does not match any profile in migProfileAllowlist", MigProfilePreference, entry)
+		}
+	}
+	return nil
+}

--- a/pkg/device/nvidia/mig_preference_test.go
+++ b/pkg/device/nvidia/mig_preference_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidia
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Project-HAMi/HAMi/pkg/device"
+)
+
+// a100MigProfilesWith4g is the A100-40GB allowlist with 4g.20gb added: the same
+// memory as 3g.20gb, more compute, and a single legal placement at slot 0.
+func a100MigProfilesWith4g() []device.MigProfile {
+	return append(a100MigProfiles(), device.MigProfile{
+		Name: "4g.20gb", MemoryMB: 20480, Core: 52, SliceCount: 4, InstanceCount: 1,
+		Placements: []device.MigPlacement{{Start: 0, Size: 4}},
+	})
+}
+
+func migPod(preference string) *corev1.Pod {
+	annos := map[string]string{AllocateMode: MigMode}
+	if preference != "" {
+		annos[MigProfilePreference] = preference
+	}
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mig-pod", Annotations: annos}}
+}
+
+func migProfileNames(profiles []device.MigProfile) []string {
+	names := make([]string, len(profiles))
+	for i, profile := range profiles {
+		names[i] = profile.Name
+	}
+	return names
+}
+
+func TestParseMigProfilePreference(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want []string
+	}{
+		{raw: "4g.20gb", want: []string{"4g.20gb"}},
+		{raw: " 4g , 3g.20gb ,, 4g ", want: []string{"4g", "3g.20gb"}},
+		{raw: "", want: nil},
+		{raw: " , ", want: nil},
+	}
+	for _, tc := range cases {
+		if got := parseMigProfilePreference(tc.raw); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("parseMigProfilePreference(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestMigProfileSliceKey(t *testing.T) {
+	for profile, want := range map[string]string{"4g.20gb": "4g", "1g.10gb+me": "1g", "4g": "4g", ".5gb": ".5gb"} {
+		if got := migProfileSliceKey(profile); got != want {
+			t.Errorf("migProfileSliceKey(%q) = %q, want %q", profile, got, want)
+		}
+	}
+}
+
+func TestMigProfilePreferenceReadsTheAnnotation(t *testing.T) {
+	if got := migProfilePreference(nil); got != nil {
+		t.Fatalf("no annotations should prefer nothing, got %v", got)
+	}
+	if got := migProfilePreference(map[string]string{AllocateMode: MigMode}); got != nil {
+		t.Fatalf("missing annotation should prefer nothing, got %v", got)
+	}
+	if got := podMigProfilePreference(nil); got != nil {
+		t.Fatalf("nil pod should prefer nothing, got %v", got)
+	}
+	if got := podMigProfilePreference(migPod("4g.20gb,3g")); !reflect.DeepEqual(got, []string{"4g.20gb", "3g"}) {
+		t.Fatalf("pod preference = %v, want [4g.20gb 3g]", got)
+	}
+}
+
+func TestMigProfileCandidatesPutsPreferredFirst(t *testing.T) {
+	profiles := a100MigProfilesWith4g()
+	cases := []struct {
+		name      string
+		preferred []string
+		want      []string
+	}{
+		{name: "default is smallest first", preferred: nil, want: []string{"1g.5gb", "2g.10gb", "3g.20gb", "4g.20gb"}},
+		{name: "slice class", preferred: []string{"4g"}, want: []string{"4g.20gb", "1g.5gb", "2g.10gb", "3g.20gb"}},
+		{name: "exact names keep the listed order", preferred: []string{"3g.20gb", "1g.5gb"}, want: []string{"3g.20gb", "1g.5gb", "2g.10gb", "4g.20gb"}},
+		{name: "entries outside the card's allowlist are ignored", preferred: []string{"9g.99gb", "4g.40gb"}, want: []string{"1g.5gb", "2g.10gb", "3g.20gb", "4g.20gb"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := migProfileNames(migProfileCandidates(profiles, tc.preferred)); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("candidates = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectMigCandidateHonorsPreference(t *testing.T) {
+	profiles := a100MigProfilesWith4g()
+	profile, _, ok := selectMigCandidate(profiles, nil, 20000, nil)
+	if !ok || profile.Name != "3g.20gb" {
+		t.Fatalf("default 20GB profile = %s, want 3g.20gb", profile.Name)
+	}
+	profile, placement, ok := selectMigCandidate(profiles, nil, 20000, []string{"4g"})
+	if !ok || profile.Name != "4g.20gb" || placement != (device.MigPlacement{Start: 0, Size: 4}) {
+		t.Fatalf("preferred 20GB profile = %s at %+v, want 4g.20gb at slot 0", profile.Name, placement)
+	}
+	// A preference cannot shrink the request below its memory.
+	profile, _, ok = selectMigCandidate(profiles, nil, 20000, []string{"1g", "2g"})
+	if !ok || profile.Name != "3g.20gb" {
+		t.Fatalf("undersized preference resolved to %s, want 3g.20gb", profile.Name)
+	}
+	// The single 4g placement is blocked by a running 2g, so the default profile wins.
+	occupied := []device.MigPlacement{{Start: 0, Size: 2}}
+	profile, placement, ok = selectMigCandidate(profiles, occupied, 20000, []string{"4g"})
+	if !ok || profile.Name != "3g.20gb" || placement != (device.MigPlacement{Start: 4, Size: 4}) {
+		t.Fatalf("blocked preference resolved to %s at %+v, want 3g.20gb at slot 4", profile.Name, placement)
+	}
+}
+
+func TestPlanMigContainerNeverRejectsForAPreference(t *testing.T) {
+	profiles := a100MigProfilesWith4g()
+	// 20GB + 10GB + 10GB fill an empty A100 as 3g + 2g + 2g, but a 4g at slot 0
+	// leaves room for only one 2g. The preference must yield, not reject the card.
+	memories := []int32{20000, 10000, 10000}
+	chosen, placements, ok := planMigContainer(profiles, nil, memories, []string{"4g"})
+	if !ok {
+		t.Fatal("a preference that does not fit should fall back to the default layout, not reject the card")
+	}
+	if got := migProfileNames(chosen); !reflect.DeepEqual(got, []string{"3g.20gb", "2g.10gb", "2g.10gb"}) {
+		t.Fatalf("fallback profiles = %v, want [3g.20gb 2g.10gb 2g.10gb]", got)
+	}
+	if len(placements) != 3 {
+		t.Fatalf("placements = %+v, want one per request", placements)
+	}
+	if _, _, ok := planMigContainer(profiles, nil, []int32{20000, 20000, 20000}, []string{"4g"}); ok {
+		t.Fatal("three 20GB slices cannot fit an A100 in any order")
+	}
+}
+
+func TestPlanMigContainerFallsBackSequentiallyWhenJointFails(t *testing.T) {
+	profiles := a100MigProfilesWith4g()
+	// Two 20GB slices cannot both be 4g. Placed sequentially the first keeps the
+	// preference and the second takes the remaining 3g span.
+	chosen, placements, ok := planMigContainer(profiles, nil, []int32{20000, 20000}, []string{"4g"})
+	if !ok {
+		t.Fatal("4g + 3g should fit an empty A100")
+	}
+	if got := migProfileNames(chosen); !reflect.DeepEqual(got, []string{"4g.20gb", "3g.20gb"}) {
+		t.Fatalf("profiles = %v, want [4g.20gb 3g.20gb]", got)
+	}
+	want := []device.MigPlacement{{Start: 0, Size: 4}, {Start: 4, Size: 4}}
+	if !reflect.DeepEqual(placements, want) {
+		t.Fatalf("placements = %+v, want %+v", placements, want)
+	}
+}
+
+func TestCustomFilterRuleAndRecordMigPlansHonorPreference(t *testing.T) {
+	dev := &NvidiaGPUDevices{}
+	usage := &device.DeviceUsage{ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfilesWith4g()}
+	preferred := []string{"4g"}
+	if !dev.CustomFilterRule(nil, device.ContainerDeviceRequest{Memreq: 20000}, nil, usage, preferred) {
+		t.Fatal("a 20GB request should fit an empty A100")
+	}
+	tentative := device.ContainerDevices{{UUID: "GPU-a", Usedmem: 20000}}
+	recordMigPlans([]*device.DeviceUsage{usage}, tentative, preferred)
+	if tentative[0].CustomInfo[MigProfileCustomInfo] != "4g.20gb" || tentative[0].CustomInfo[MigPlacementCustomInfo] != (device.MigPlacement{Start: 0, Size: 4}) {
+		t.Fatalf("recorded plan = %+v, want 4g.20gb at slot 0", tentative[0].CustomInfo)
+	}
+	if err := dev.AddResourceUsage(migPod("4g"), usage, &tentative[0]); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if tentative[0].Usedmem != 20480 || tentative[0].Usedcores != 52 {
+		t.Fatalf("committed resources = (%d,%d), want the reported 4g metadata", tentative[0].Usedmem, tentative[0].Usedcores)
+	}
+	if len(usage.MigAllocationsInUse) != 1 || usage.MigAllocationsInUse[0].Profile != "4g.20gb" {
+		t.Fatalf("usage after commit = %+v, want one 4g.20gb allocation", usage.MigAllocationsInUse)
+	}
+}
+
+func TestAddResourceUsageFallsBackToPreferredProfile(t *testing.T) {
+	dev := &NvidiaGPUDevices{}
+	usage := &device.DeviceUsage{ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfilesWith4g()}
+	// No recorded plan: the pod annotation drives the fallback selection.
+	ctr := &device.ContainerDevice{UUID: "GPU-a", Usedmem: 20000}
+	if err := dev.AddResourceUsage(migPod("4g.20gb"), usage, ctr); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if ctr.CustomInfo[MigProfileCustomInfo] != "4g.20gb" || ctr.Usedcores != 52 {
+		t.Fatalf("fallback commit = %+v cores=%d, want 4g.20gb with 52 cores", ctr.CustomInfo, ctr.Usedcores)
+	}
+	// A nil pod keeps the default profile.
+	fresh := &device.DeviceUsage{ID: "GPU-a", Mode: MigMode, MigProfiles: a100MigProfilesWith4g()}
+	ctr = &device.ContainerDevice{UUID: "GPU-a", Usedmem: 20000}
+	if err := dev.AddResourceUsage(nil, fresh, ctr); err != nil {
+		t.Fatalf("commit without pod: %v", err)
+	}
+	if ctr.CustomInfo[MigProfileCustomInfo] != "3g.20gb" {
+		t.Fatalf("default commit = %+v, want 3g.20gb", ctr.CustomInfo)
+	}
+}
+
+func TestFitHonorsMigProfilePreference(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{})
+	newUsage := func() *device.DeviceUsage {
+		return &device.DeviceUsage{
+			ID: "GPU-a", Type: NvidiaGPUDevice, Mode: MigMode, Health: true,
+			Count: 7, Totalmem: 40960, Totalcore: 100, MigProfiles: a100MigProfilesWith4g(),
+		}
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: NvidiaGPUDevice, Memreq: 20000}
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{name: "no preference keeps the smallest profile", pod: migPod(""), want: "3g.20gb"},
+		{name: "slice class preference", pod: migPod("4g"), want: "4g.20gb"},
+		{name: "exact profile preference", pod: migPod("4g.20gb"), want: "4g.20gb"},
+		{name: "preference for another model's profile is ignored on this card", pod: migPod("4g.40gb"), want: "3g.20gb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fit, devs, reason := dev.Fit([]*device.DeviceUsage{newUsage()}, request, tc.pod, &device.NodeInfo{}, &device.PodDevices{})
+			if !fit {
+				t.Fatalf("20GB request should fit an empty A100: %s", reason)
+			}
+			got := devs[NvidiaGPUDevice]
+			if len(got) != 1 || got[0].CustomInfo[MigProfileCustomInfo] != tc.want {
+				t.Fatalf("fit allocated %+v, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateMigProfilePreference(t *testing.T) {
+	dev := &NvidiaGPUDevices{config: NvidiaConfig{MigProfileAllowlist: []device.AllowedMigProfiles{
+		{Models: []string{"A100-SXM4-40GB"}, Profiles: []string{"1g.5gb", "2g.10gb", "3g.20gb", "4g.20gb", "7g.40gb"}},
+		{Models: []string{"H100-SXM5-80GB"}, Profiles: []string{"1g.10gb", "3g.40gb", "4g.40gb", "7g.80gb"}},
+	}}}
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "exact name", value: "4g.20gb"},
+		{name: "slice class allowed on some model", value: "4g"},
+		{name: "ordered list mixing models", value: " 4g.40gb , 3g "},
+		{name: "profile allowed on no model", value: "5g.30gb", wantErr: true},
+		{name: "slice class allowed on no model", value: "6g", wantErr: true},
+		{name: "empty list", value: " , ", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := dev.validateMigProfilePreference(migPod(tc.value))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validate %q: err=%v, wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+	if err := dev.validateMigProfilePreference(nil); err != nil {
+		t.Fatalf("nil pod: %v", err)
+	}
+	if err := dev.validateMigProfilePreference(migPod("")); err != nil {
+		t.Fatalf("pod without the annotation: %v", err)
+	}
+	if _, err := dev.MutateAdmission(&corev1.Container{}, migPod("5g.30gb")); err == nil {
+		t.Fatal("admission should reject a preference that no allowlisted profile satisfies")
+	}
+	if _, err := dev.MutateAdmission(&corev1.Container{}, migPod("4g")); err != nil {
+		t.Fatalf("admission should accept an allowlisted preference: %v", err)
+	}
+}

--- a/pkg/device/nvidia/mig_preference_test.go
+++ b/pkg/device/nvidia/mig_preference_test.go
@@ -18,12 +18,15 @@ package nvidia
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Project-HAMi/HAMi/pkg/device"
+	"github.com/Project-HAMi/HAMi/pkg/device/common"
 )
 
 // a100MigProfilesWith4g is the A100-40GB allowlist with 4g.20gb added: the same
@@ -286,5 +289,51 @@ func TestValidateMigProfilePreference(t *testing.T) {
 	}
 	if _, err := dev.MutateAdmission(&corev1.Container{}, migPod("4g")); err != nil {
 		t.Fatalf("admission should accept an allowlisted preference: %v", err)
+	}
+}
+
+func TestFitChecksQuotaAgainstThePlannedMigProfile(t *testing.T) {
+	dev := InitNvidiaDevice(NvidiaConfig{
+		ResourceCountName: "nvidia.com/gpu", ResourceMemoryName: "nvidia.com/gpumem",
+		ResourceCoreName: "nvidia.com/gpucores", ResourceMemoryPercentageName: "nvidia.com/gpumem-percentage",
+		MemoryFactor: 1,
+	})
+	device.DevicesMap = map[string]device.Devices{NvidiaGPUDevice: dev}
+	device.NewQuotaManager().AddQuota(&corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-quota", Namespace: "mig-quota"},
+		Spec: corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{
+			corev1.ResourceName("limits.nvidia.com/gpumem"): resource.MustParse("10000"),
+		}},
+	})
+	newUsage := func() *device.DeviceUsage {
+		return &device.DeviceUsage{
+			ID: "GPU-a", Type: NvidiaGPUDevice, Mode: MigMode, Health: true,
+			Count: 7, Totalmem: 40960, Totalcore: 100, MigProfiles: a100MigProfilesWith4g(),
+		}
+	}
+	newPod := func(preference string) *corev1.Pod {
+		pod := migPod(preference)
+		pod.Namespace = "mig-quota"
+		pod.Spec.Containers = []corev1.Container{{Name: "workload"}}
+		return pod
+	}
+	request := device.ContainerDeviceRequest{Nums: 1, Type: NvidiaGPUDevice, Memreq: 5000}
+
+	// 5000MB fits the 10000MB quota, but the preferred 4g.20gb would charge 20480MB.
+	fit, _, reason := dev.Fit([]*device.DeviceUsage{newUsage()}, request, newPod("4g"), &device.NodeInfo{}, &device.PodDevices{})
+	if fit {
+		t.Fatal("a preferred profile larger than the quota must not fit")
+	}
+	if !strings.Contains(reason, common.ResourceQuotaNotFit) {
+		t.Fatalf("reason = %q, want %s", reason, common.ResourceQuotaNotFit)
+	}
+	// Without the preference the 1g.5gb slice charges 5120MB and fits, and the
+	// tentative slice already carries the profile capacity the quota was checked with.
+	fit, devs, reason := dev.Fit([]*device.DeviceUsage{newUsage()}, request, newPod(""), &device.NodeInfo{}, &device.PodDevices{})
+	if !fit {
+		t.Fatalf("1g.5gb should fit the quota: %s", reason)
+	}
+	if got := devs[NvidiaGPUDevice][0]; got.Usedmem != 5120 || got.Usedcores != 14 {
+		t.Fatalf("tentative slice = (%d,%d), want the 1g.5gb capacity (5120,14)", got.Usedmem, got.Usedcores)
 	}
 }

--- a/pkg/scheduler/score_test.go
+++ b/pkg/scheduler/score_test.go
@@ -3662,7 +3662,7 @@ func Test_fitInCertainDevice(t *testing.T) {
 						UUID:      "test-0",
 						Type:      nvidia.NvidiaGPUDevice,
 						Usedcores: int32(1),
-						Usedmem:   int32(1024),
+						Usedmem:   int32(2048),
 					},
 				},
 			},


### PR DESCRIPTION


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

right now MIG picks the smallest profile that fits the memory request on A100-40GB, 3g.20gb and 4g.20gb both have 20GB, and 3g is smaller, so 4g never gets selected even if it is in the allowlist. as i discussed with @FouoF in #2855 .
So this PR adds a pod annotation nvidia.com/mig-profile-preference. the user can write a profile name like 4g.20gb or just "4g" . The scheduler tries the preferred profile first, then falls back to the normal smallest-first order.
The preference is  a hint which will :
1> it never gives a profile smaller than the memory request
2> it only works for profiles in the allowlist
and  3 >if the preferred profile does not fit, the pod still gets scheduled with the normal profile, it is never rejected because of the preference. and i also added 4g profiles to the default chart allowlist, and the webhook
rejects the annotation if the profile is not in the allowlist at all.
**Which issue(s) this PR fixes**:
Fixes #2950 


Ai Disclosure :- used the LLM for research , code understanding and optimization and  writing the tests .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pods can request a preferred NVIDIA MIG profile using the `nvidia.com/mig-profile-preference` annotation.
  * MIG allocation prioritizes the requested profile when feasible, with fallback when unavailable or unsuitable.
  * Added an example Pod configuration demonstrating MIG profile preferences.
  * Expanded supported `4g` MIG profiles for several NVIDIA GPU models.

* **Documentation**
  * Added guidance on configuring, validating, and scheduling preferred MIG profiles.

* **Bug Fixes**
  * Invalid MIG profile preferences are rejected during Pod admission.
  * MIG quota checks now account for the selected profile’s capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->