### PR TITLE
fix(device-plugin): propagate GPU health events to every replica

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/devices.go
@@ -268,7 +268,7 @@ func (d Device) AlignedAllocationSupported() bool {
 }
 
 // IsMigDevice returns checks whether d is a MIG device or not.
-func (d Device) IsMigDevice() bool {
+func (d *Device) IsMigDevice() bool {
 	return strings.Contains(d.Index, ":")
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health.go
@@ -87,7 +87,7 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		_ = eventSet.Free()
 	}()
 
-	parentToDeviceMap := make(map[string]*Device)
+	parentToDeviceMap := make(map[string][]*Device)
 	deviceIDToGiMap := make(map[string]uint32)
 	deviceIDToCiMap := make(map[string]uint32)
 
@@ -101,7 +101,7 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		}
 		deviceIDToGiMap[d.ID] = gi
 		deviceIDToCiMap[d.ID] = ci
-		parentToDeviceMap[uuid] = d
+		parentToDeviceMap[uuid] = append(parentToDeviceMap[uuid], d)
 
 		gpu, ret := r.nvml.DeviceGetHandleByUUID(uuid)
 		if ret != nvml.SUCCESS {
@@ -172,23 +172,25 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 			continue
 		}
 
-		d, exists := parentToDeviceMap[eventUUID]
+		affectedDevices, exists := parentToDeviceMap[eventUUID]
 		if !exists {
 			klog.Infof("Ignoring event for unexpected device: %v", eventUUID)
 			continue
 		}
 
-		if d.IsMigDevice() && e.GpuInstanceId != 0xFFFFFFFF && e.ComputeInstanceId != 0xFFFFFFFF {
-			gi := deviceIDToGiMap[d.ID]
-			ci := deviceIDToCiMap[d.ID]
-			if gi != e.GpuInstanceId || ci != e.ComputeInstanceId {
-				continue
+		for _, d := range affectedDevices {
+			if d.IsMigDevice() && e.GpuInstanceId != 0xFFFFFFFF && e.ComputeInstanceId != 0xFFFFFFFF {
+				gi := deviceIDToGiMap[d.ID]
+				ci := deviceIDToCiMap[d.ID]
+				if gi != e.GpuInstanceId || ci != e.ComputeInstanceId {
+					continue
+				}
+				klog.Infof("Event for mig device %v (gi=%v, ci=%v)", d.ID, gi, ci)
 			}
-			klog.Infof("Event for mig device %v (gi=%v, ci=%v)", d.ID, gi, ci)
-		}
 
-		klog.Infof("XidCriticalError: Xid=%d on Device=%s; marking device as unhealthy.", e.EventData, d.ID)
-		unhealthy <- d
+			klog.Infof("XidCriticalError: Xid=%d on Device=%s; marking device as unhealthy.", e.EventData, d.ID)
+			unhealthy <- d
+		}
 	}
 }
 

--- a/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_mig_fanout_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/rm/health_mig_fanout_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rm
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	mock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/stretchr/testify/require"
+	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// IsMigDevice reads only the immutable index. A value receiver would copy
+// Health while the device-plugin notification loop updates it concurrently.
+func TestIsMigDeviceConcurrentHealthUpdate(t *testing.T) {
+	d := &Device{Index: "0:1"}
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 0; i < 1000; i++ {
+			d.Health = kubeletdevicepluginv1beta1.Unhealthy
+		}
+	}()
+	for i := 0; i < 1000; i++ {
+		require.True(t, d.IsMigDevice())
+	}
+	writer.Wait()
+}
+
+func TestCheckHealthMIGFanout(t *testing.T) {
+	const allInstances = uint32(0xFFFFFFFF)
+	tests := []struct {
+		name   string
+		parent string
+		gi, ci uint32
+		xid    uint64
+		want   []string
+	}{
+		{name: "parent failure reaches every slice", parent: "GPU-a", gi: allInstances, ci: allInstances, xid: 79,
+			want: []string{"MIG-a-1", "MIG-a-2", "MIG-a-3", "MIG-a-4", "MIG-a-5", "MIG-a-6", "MIG-a-7"}},
+		{name: "other parent is isolated", parent: "GPU-b", gi: allInstances, ci: allInstances, xid: 79, want: []string{"MIG-b-1"}},
+		{name: "unknown parent is ignored", parent: "GPU-unknown", gi: allInstances, ci: allInstances, xid: 79},
+		{name: "different compute instance is ignored", parent: "GPU-a", gi: 1, ci: 7, xid: 79},
+		{name: "disabled xid is ignored", parent: "GPU-a", gi: allInstances, ci: allInstances, xid: 13},
+	}
+	for gi := uint32(1); gi <= 7; gi++ {
+		tests = append(tests, struct {
+			name   string
+			parent string
+			gi, ci uint32
+			xid    uint64
+			want   []string
+		}{name: fmt.Sprintf("instance %d is selected", gi), parent: "GPU-a", gi: gi, ci: 0, xid: 79,
+			want: []string{fmt.Sprintf("MIG-a-%d", gi)}})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envDisableHealthChecks, "")
+			t.Setenv(envEnableHealthChecks, "")
+			stop := make(chan interface{})
+			eventSet := &mock.EventSet{
+				FreeFunc: func() nvml.Return { return nvml.SUCCESS },
+				WaitFunc: func(uint32) (nvml.EventData, nvml.Return) {
+					close(stop)
+					return nvml.EventData{
+						Device:    &mock.Device{GetUUIDFunc: func() (string, nvml.Return) { return tt.parent, nvml.SUCCESS }},
+						EventType: nvml.EventTypeXidCriticalError, EventData: tt.xid,
+						GpuInstanceId: tt.gi, ComputeInstanceId: tt.ci,
+					}, nvml.SUCCESS
+				},
+			}
+			handles := map[string]nvml.Device{}
+			for _, parent := range []string{"GPU-a", "GPU-b"} {
+				handles[parent] = &mock.Device{
+					GetUUIDFunc:                func() (string, nvml.Return) { return parent, nvml.SUCCESS },
+					GetSupportedEventTypesFunc: func() (uint64, nvml.Return) { return nvml.EventTypeXidCriticalError, nvml.SUCCESS },
+					RegisterEventsFunc:         func(uint64, nvml.EventSet) nvml.Return { return nvml.SUCCESS },
+				}
+			}
+			devices := Devices{}
+			for gi := 1; gi <= 8; gi++ {
+				parent, instance := "GPU-a", gi
+				if gi == 8 {
+					parent, instance = "GPU-b", 1
+				}
+				id := fmt.Sprintf("MIG-%s-%d", parent[4:], instance)
+				handles[id] = &mock.Device{
+					GetDeviceHandleFromMigDeviceHandleFunc: func() (nvml.Device, nvml.Return) { return handles[parent], nvml.SUCCESS },
+					GetGpuInstanceIdFunc:                   func() (int, nvml.Return) { return instance, nvml.SUCCESS },
+					GetComputeInstanceIdFunc:               func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+				}
+				devices[id] = &Device{Device: kubeletdevicepluginv1beta1.Device{ID: id, Health: kubeletdevicepluginv1beta1.Healthy}, Index: fmt.Sprintf("0:%d", instance)}
+			}
+			r := &nvmlResourceManager{nvml: &mock.Interface{
+				InitFunc:           func() nvml.Return { return nvml.SUCCESS },
+				ShutdownFunc:       func() nvml.Return { return nvml.SUCCESS },
+				EventSetCreateFunc: func() (nvml.EventSet, nvml.Return) { return eventSet, nvml.SUCCESS },
+				DeviceGetHandleByUUIDFunc: func(id string) (nvml.Device, nvml.Return) {
+					return handles[id], nvml.SUCCESS
+				},
+			}}
+			unhealthy := make(chan *Device, len(devices))
+			require.NoError(t, r.checkHealth(stop, devices, unhealthy, make(chan bool)))
+			var got []string
+			for len(unhealthy) > 0 {
+				got = append(got, (<-unhealthy).ID)
+			}
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckHealthReplicaFanout(t *testing.T) {
+	t.Setenv(envDisableHealthChecks, "")
+	t.Setenv(envEnableHealthChecks, "")
+	stop := make(chan interface{})
+	parent := &mock.Device{
+		GetUUIDFunc:                func() (string, nvml.Return) { return "GPU-a", nvml.SUCCESS },
+		GetSupportedEventTypesFunc: func() (uint64, nvml.Return) { return nvml.EventTypeXidCriticalError, nvml.SUCCESS },
+		RegisterEventsFunc:         func(uint64, nvml.EventSet) nvml.Return { return nvml.SUCCESS },
+	}
+	eventSet := &mock.EventSet{
+		FreeFunc: func() nvml.Return { return nvml.SUCCESS },
+		WaitFunc: func(uint32) (nvml.EventData, nvml.Return) {
+			close(stop)
+			return nvml.EventData{Device: parent, EventType: nvml.EventTypeXidCriticalError, EventData: 79,
+				GpuInstanceId: 0xFFFFFFFF, ComputeInstanceId: 0xFFFFFFFF}, nvml.SUCCESS
+		},
+	}
+	r := &nvmlResourceManager{nvml: &mock.Interface{
+		InitFunc:                  func() nvml.Return { return nvml.SUCCESS },
+		ShutdownFunc:              func() nvml.Return { return nvml.SUCCESS },
+		EventSetCreateFunc:        func() (nvml.EventSet, nvml.Return) { return eventSet, nvml.SUCCESS },
+		DeviceGetHandleByUUIDFunc: func(string) (nvml.Device, nvml.Return) { return parent, nvml.SUCCESS },
+	}}
+	devices := Devices{}
+	var want []string
+	for replica := 0; replica < 4; replica++ {
+		id := string(NewAnnotatedID("GPU-a", replica))
+		devices[id] = &Device{Device: kubeletdevicepluginv1beta1.Device{ID: id, Health: kubeletdevicepluginv1beta1.Healthy}, Index: "0", Replicas: 4}
+		want = append(want, id)
+	}
+	unhealthy := make(chan *Device, len(devices))
+	require.NoError(t, r.checkHealth(stop, devices, unhealthy, make(chan bool)))
+	var got []string
+	for len(unhealthy) > 0 {
+		got = append(got, (<-unhealthy).ID)
+	}
+	require.ElementsMatch(t, want, got)
+}


### PR DESCRIPTION
## What changed

A critical NVML event from a physical GPU previously reached only the last device stored for that parent UUID. Track every logical device for each parent and notify all affected MIG slices and time-sliced replicas. A MIG-scoped event still filters by GPU and compute instance; unrelated parents, unknown devices, and disabled XIDs remain excluded.

Use a pointer receiver for `Device.IsMigDevice` so the health reader does not copy the concurrently updated `Health` field. Add parent-wide, MIG-scoped, unrelated-device, disabled-event, replica, and concurrent-health-update regressions.

## Validation

- `go test -race ./pkg/device-plugin/nvidiadevice/nvinternal/rm` passes on the submitted sources, including the new receiver regression.
- Earlier Linux integration exercised the actual device-plugin gRPC `ListAndWatch` path with injected NVML events: expected scenarios improved from **16/39 to 39/39**. All seven MIG slices under one parent and all four sharing replicas received the expected state. The fixed receiver passed the integration race check.
- The events were injected through the NVML interface; no physical XID fault was induced. This is a health-propagation correctness result, with no model-throughput or scheduler-performance claim.

`make verify` passed with golangci-lint 2.13.1, including the full-tree staticcheck, license-header, import-alias, and RBAC checks. The initial dependency download timeout was resolved before the successful rerun.
